### PR TITLE
Update go to 1.25

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/vscode/devcontainers/go:1.24
+FROM mcr.microsoft.com/vscode/devcontainers/go:1.25
 
 RUN apt-get update && apt-get install -y docker.io && rm -rf /var/lib/apt/lists/*
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,17 +17,8 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.23'
-
-    - name: Cache Go modules
-      uses: actions/cache@v4
-      with:
-        path: |
-          ~/go/pkg/mod
-          ~/.cache/go-build
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-go-
+        go-version-file: go.mod
+        cache: true
 
     - name: Install golangci-lint
       uses: golangci/golangci-lint-action@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
         cache: true
 
     - name: Install golangci-lint
-      uses: golangci/golangci-lint-action@v6
+      uses: golangci/golangci-lint-action@v9
       with:
         version: latest
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,8 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23'
+          go-version-file: go.mod
+          cache: true
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM golang:1.24
+FROM golang:1.25
 
 # Set working directory
 WORKDIR /app

--- a/docker/config.go
+++ b/docker/config.go
@@ -181,7 +181,7 @@ func RotateConfigInServices(ctx context.Context, oldCfg *swarm.Config, newCfg sw
 	if err != nil {
 		return fmt.Errorf("failed to get docker client: %w", err)
 	}
-	defer client.Close()
+	defer closeCli(client)
 
 	// --- 1. Find affected services
 	var services []swarm.Service

--- a/docker/config.go
+++ b/docker/config.go
@@ -89,7 +89,7 @@ func ListConfigs(ctx context.Context) ([]swarm.Config, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer cli.Close()
+	defer closeCli(cli)
 
 	configs, err := cli.ConfigList(ctx, swarm.ConfigListOptions{})
 	if err != nil {
@@ -105,6 +105,13 @@ func ListConfigs(ctx context.Context) ([]swarm.Config, error) {
 	return configs, nil
 }
 
+func closeCli(cli *client.Client) {
+	err := cli.Close()
+	if err != nil {
+		l().Errorf("failed to close client: %v", err)
+	}
+}
+
 // InspectConfig fetches and returns the config data.
 func InspectConfig(ctx context.Context, nameOrID string) (*ConfigWithDecodedData, error) {
 	l().Debugf("[InspectConfig] Inspecting config: %s", nameOrID)
@@ -113,7 +120,7 @@ func InspectConfig(ctx context.Context, nameOrID string) (*ConfigWithDecodedData
 	if err != nil {
 		return nil, err
 	}
-	defer cli.Close()
+	defer closeCli(cli)
 
 	cfg, _, err := cli.ConfigInspectWithRaw(ctx, nameOrID)
 	if err != nil {
@@ -134,7 +141,7 @@ func CreateConfigVersion(ctx context.Context, baseConfig swarm.Config, newData [
 	if err != nil {
 		return swarm.Config{}, err
 	}
-	defer cli.Close()
+	defer closeCli(cli)
 
 	spec := swarm.ConfigSpec{
 		Annotations: swarm.Annotations{
@@ -225,7 +232,7 @@ func DeleteConfig(ctx context.Context, nameOrID string) error {
 	if err != nil {
 		return err
 	}
-	defer cli.Close()
+	defer closeCli(cli)
 
 	svcs, err := listServicesUsingConfig(ctx, cli, cfg.Config.ID)
 	if err != nil {

--- a/docker/info.go
+++ b/docker/info.go
@@ -242,7 +242,6 @@ func GetSwarmMemUsage() (string, error) {
 
 			var s container.StatsResponse
 			decodeErr := json.NewDecoder(stats.Body).Decode(&s)
-			stats.Body.Close()
 
 			if decodeErr != nil {
 				l().Infof("GetSwarmMemUsage: Decode error for %s: %v", containerID[:12], decodeErr)

--- a/docker/info.go
+++ b/docker/info.go
@@ -141,7 +141,6 @@ func GetSwarmCPUUsage() (string, error) {
 
 			var s container.StatsResponse
 			decodeErr := json.NewDecoder(stats.Body).Decode(&s)
-			stats.Body.Close()
 
 			if decodeErr != nil {
 				l().Infof("GetSwarmCPUUsage: Decode error for %s: %v", containerID[:12], decodeErr)

--- a/docker/node.go
+++ b/docker/node.go
@@ -12,7 +12,7 @@ func GetNodeIDToHostnameMapFromDocker() (map[string]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer c.Close()
+	defer closeCli(c)
 
 	nodes, err := c.NodeList(context.Background(), swarm.NodeListOptions{})
 	if err != nil {

--- a/docker/service.go
+++ b/docker/service.go
@@ -90,7 +90,7 @@ func ScaleService(serviceID string, replicas uint64) error {
 	if err != nil {
 		return fmt.Errorf("docker client: %w", err)
 	}
-	defer c.Close()
+	defer closeCli(c)
 
 	ctx := context.Background()
 
@@ -107,7 +107,7 @@ func ScaleServiceByName(serviceName string, replicas uint64) error {
 	if err != nil {
 		return fmt.Errorf("docker client: %w", err)
 	}
-	defer c.Close()
+	defer closeCli(c)
 
 	ctx := context.Background()
 	svc, err := findServiceByName(ctx, c, serviceName)
@@ -123,7 +123,7 @@ func RestartService(serviceName string) error {
 	if err != nil {
 		return fmt.Errorf("docker client: %w", err)
 	}
-	defer c.Close()
+	defer closeCli(c)
 
 	ctx := context.Background()
 	svc, err := findServiceByName(ctx, c, serviceName)

--- a/docker/service.go
+++ b/docker/service.go
@@ -152,7 +152,7 @@ func restartServiceAndWaitInternal(ctx context.Context, serviceName string, prog
 	if err != nil {
 		return fmt.Errorf("docker client: %w", err)
 	}
-	defer cli.Close()
+	defer closeCli(cli)
 
 	svc, err := findServiceByName(ctx, cli, serviceName)
 	if err != nil {

--- a/docker/snapshot.go
+++ b/docker/snapshot.go
@@ -65,7 +65,7 @@ func RefreshSnapshot() (*SwarmSnapshot, error) {
 	if err != nil {
 		return nil, fmt.Errorf("docker client: %w", err)
 	}
-	defer c.Close()
+	defer closeCli(c)
 
 	ctx := context.Background()
 

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module swarmcli
 
-go 1.24.2
-
-toolchain go1.24.3
+go 1.25
 
 require (
 	github.com/briandowns/spinner v1.23.2


### PR DESCRIPTION
For a go update, we need to update the go version in 3 places:

1. In the go.mod file with `go mod edit -go=1.25`. (It will go will automatically download the update with the next go command if it is not already installed.
2. In the devcontainer
3. In the DockerFile

