### PR TITLE
License under Apache 2

### DIFF
--- a/.github/workflows/licence.yml
+++ b/.github/workflows/licence.yml
@@ -1,0 +1,16 @@
+name: License checks
+
+on:
+  pull_request:
+    branches: [ main ]
+  push:
+    branches: [ main ]
+
+jobs:
+  spdx:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check SPDX headers
+        run: |
+          ./scripts/check-spdx.sh

--- a/Contributing.md
+++ b/Contributing.md
@@ -1,0 +1,37 @@
+# Contributing to SwarmCLI
+
+First of all: thank you for your interest in contributing! ❤️  
+SwarmCLI is an open-source project, and we truly appreciate bug reports,
+ideas, documentation improvements, and code contributions.
+
+## License
+
+SwarmCLI is licensed under the Apache License, Version 2.0.
+
+By submitting a contribution (code, documentation, or anything else),
+you agree that your contribution will be licensed under the same
+Apache 2.0 license.
+
+You retain copyright to your contribution.
+
+## How to contribute
+
+There is no complicated process:
+
+- Open an issue for bugs or feature ideas
+- Open a pull request with your changes
+- Keep changes focused and easy to review
+- Add unit tests where possible, and integration tests where applicable
+- Be kind and constructive — we value collaboration over perfection
+
+If you’re unsure about anything, feel free to open a draft pull request or ask in an issue.
+
+## Commit messages
+
+We don’t enforce a strict commit message format, but we put value into clarity and conciseness.
+
+If you prefer, you may add a sign-off to your commits using:
+
+```bash
+git commit -s
+```

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,177 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,4 @@
+Copyright © 2026 Eldara Tech
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -126,3 +126,13 @@ The logs for the integration tests can be enabled with:
 ```bash
 TEST_LOG=1 ./test-setup/testenv.sh test
 ```
+
+## License
+
+Copyright © 2026 Eldara Tech
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0

--- a/app/app.go
+++ b/app/app.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package app
 
 import (

--- a/app/initialsnapshot.go
+++ b/app/initialsnapshot.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package app
 
 import (

--- a/app/model.go
+++ b/app/model.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package app
 
 import (

--- a/app/tick.go
+++ b/app/tick.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package app
 
 import (

--- a/app/update.go
+++ b/app/update.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package app
 
 import (

--- a/app/view.go
+++ b/app/view.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package app
 
 import (

--- a/args/args.go
+++ b/args/args.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package args
 
 import "fmt"

--- a/commands/api/api.go
+++ b/commands/api/api.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package api
 
 import (

--- a/commands/api/error.go
+++ b/commands/api/error.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package api
 
 import "fmt"

--- a/commands/api/parse.go
+++ b/commands/api/parse.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package api
 
 import (

--- a/commands/autoload.go
+++ b/commands/autoload.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package commands
 
 import (

--- a/commands/command/alias.go
+++ b/commands/command/alias.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package command
 
 import (

--- a/commands/command/contexts.go
+++ b/commands/command/contexts.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package command
 
 import (

--- a/commands/command/docker/config/ls.go
+++ b/commands/command/docker/config/ls.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package config
 
 import (

--- a/commands/command/docker/docker_stack_ls.go
+++ b/commands/command/docker/docker_stack_ls.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package docker
 
 import (

--- a/commands/command/docker/network/ls.go
+++ b/commands/command/docker/network/ls.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package network
 
 import (

--- a/commands/command/docker/node/ls.go
+++ b/commands/command/docker/node/ls.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package node
 
 import (

--- a/commands/command/docker/secret/ls.go
+++ b/commands/command/docker/secret/ls.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package secret
 
 import (

--- a/commands/command/help.go
+++ b/commands/command/help.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package command
 
 import (

--- a/commands/init.go
+++ b/commands/init.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package commands
 
 import (

--- a/core/primitives/hash/hash.go
+++ b/core/primitives/hash/hash.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package hash
 
 import (

--- a/docker/client.go
+++ b/docker/client.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package docker
 
 import (

--- a/docker/config.go
+++ b/docker/config.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package docker
 
 import (

--- a/docker/context.go
+++ b/docker/context.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package docker
 
 import (

--- a/docker/events.go
+++ b/docker/events.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package docker
 
 import (

--- a/docker/hostname.go
+++ b/docker/hostname.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package docker
 
 import (

--- a/docker/info.go
+++ b/docker/info.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package docker
 
 import (

--- a/docker/inspect.go
+++ b/docker/inspect.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package docker
 
 import (

--- a/docker/network.go
+++ b/docker/network.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package docker
 
 import (

--- a/docker/node.go
+++ b/docker/node.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package docker
 
 import (

--- a/docker/secret.go
+++ b/docker/secret.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package docker
 
 import (

--- a/docker/service.go
+++ b/docker/service.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package docker
 
 import (

--- a/docker/service_helpers.go
+++ b/docker/service_helpers.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package docker
 
 import (

--- a/docker/snapshot.go
+++ b/docker/snapshot.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package docker
 
 import (

--- a/docker/stack.go
+++ b/docker/stack.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package docker
 
 // Stack represents a unique Docker stack.

--- a/docker/task.go
+++ b/docker/task.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package docker
 
 import (

--- a/docker/utils.go
+++ b/docker/utils.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package docker
 
 import (

--- a/integration-tests/docker/config/config_delete_test.go
+++ b/integration-tests/docker/config/config_delete_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 //go:build integration
 
 package config

--- a/integration-tests/docker/config/config_lifecycle_test.go
+++ b/integration-tests/docker/config/config_lifecycle_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 //go:build integration
 
 package config

--- a/integration-tests/docker/config/helper.go
+++ b/integration-tests/docker/config/helper.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 //go:build integration
 
 package config

--- a/integration-tests/docker/get_context_test.go
+++ b/integration-tests/docker/get_context_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 //go:build integration
 
 package docker

--- a/integration-tests/docker/list_stacks_test.go
+++ b/integration-tests/docker/list_stacks_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 //go:build integration
 
 package docker

--- a/integration-tests/docker/service/restart_service_and_wait_test.go
+++ b/integration-tests/docker/service/restart_service_and_wait_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 //go:build integration
 
 package service

--- a/integration-tests/docker/service/restart_service_test.go
+++ b/integration-tests/docker/service/restart_service_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 //go:build integration
 
 package service

--- a/integration-tests/docker/service/restart_service_with_progress_test.go
+++ b/integration-tests/docker/service/restart_service_with_progress_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 //go:build integration
 
 package service

--- a/integration-tests/docker/service/scale_test.go
+++ b/integration-tests/docker/service/scale_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 //go:build integration
 
 package service

--- a/main.go
+++ b/main.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package main
 
 import (

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package registry
 
 import (

--- a/scripts/add-spdx.sh
+++ b/scripts/add-spdx.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env sh
+set -eu
+
+YEAR=2026
+OWNER="Eldara Tech"
+
+add_go_header() {
+  file="$1"
+  if head -n 20 "$file" | grep -q "SPDX-License-Identifier"; then
+    return
+  fi
+
+  tmp="$(mktemp)"
+  {
+    echo "// SPDX-License-Identifier: Apache-2.0"
+    echo "// Copyright © $YEAR $OWNER"
+    echo
+    cat "$file"
+  } > "$tmp"
+  mv "$tmp" "$file"
+  echo "Added SPDX header: $file"
+}
+
+add_sh_header() {
+  file="$1"
+  if head -n 20 "$file" | grep -q "SPDX-License-Identifier"; then
+    return
+  fi
+
+  tmp="$(mktemp)"
+
+  read -r first_line < "$file" || true
+  if echo "$first_line" | grep -q '^#!'; then
+    {
+      echo "$first_line"
+      echo "# SPDX-License-Identifier: Apache-2.0"
+      echo "# Copyright © $YEAR $OWNER"
+      echo
+      tail -n +2 "$file"
+    } > "$tmp"
+  else
+    {
+      echo "# SPDX-License-Identifier: Apache-2.0"
+      echo "# Copyright © $YEAR $OWNER"
+      echo
+      cat "$file"
+    } > "$tmp"
+  fi
+
+  mv "$tmp" "$file"
+  echo "Added SPDX header: $file"
+}
+
+# Go files
+find . -type f -name '*.go' \
+  -not -path './vendor/*' \
+  -not -path './.git/*' \
+  | while read -r f; do
+      add_go_header "$f"
+    done
+
+# Shell scripts
+find . -type f -name '*.sh' \
+  -not -path './vendor/*' \
+  -not -path './.git/*' \
+  | while read -r f; do
+      add_sh_header "$f"
+    done

--- a/scripts/check-spdx.sh
+++ b/scripts/check-spdx.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env sh
+set -eu
+
+fail=0
+
+check_file () {
+  f="$1"
+  if ! head -n 20 "$f" | grep -q "SPDX-License-Identifier: Apache-2.0"; then
+    echo "Missing SPDX header: $f"
+    fail=1
+  fi
+}
+
+find . -type f \( -name '*.go' -o -name '*.sh' \) \
+  -not -path './vendor/*' \
+  -not -path './.git/*' \
+  | while read -r f; do
+      check_file "$f"
+    done
+
+exit "$fail"

--- a/test-setup/testenv.sh
+++ b/test-setup/testenv.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright © 2026 Eldara Tech
+
 set -euo pipefail
 
 # === Config ================================================================

--- a/ui/columns.go
+++ b/ui/columns.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package ui
 
 // DistributeColumns adjusts column widths to fit `totalWidth` after accounting

--- a/ui/components/errordialog/errordialog.go
+++ b/ui/components/errordialog/errordialog.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package errordialog
 
 import (

--- a/ui/components/filterable/list/applyfilter.go
+++ b/ui/components/filterable/list/applyfilter.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package filterlist
 
 func (f *FilterableList[T]) ApplyFilter() {

--- a/ui/components/filterable/list/filerablelist.go
+++ b/ui/components/filterable/list/filerablelist.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package filterlist
 
 import (

--- a/ui/components/filterable/list/handlekey.go
+++ b/ui/components/filterable/list/handlekey.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package filterlist
 
 import tea "github.com/charmbracelet/bubbletea"

--- a/ui/components/filterable/list/view.go
+++ b/ui/components/filterable/list/view.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package filterlist
 
 import (

--- a/ui/components/sorting/sort.go
+++ b/ui/components/sorting/sort.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package sorting
 
 import (

--- a/ui/framecalc.go
+++ b/ui/framecalc.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package ui
 
 import "strings"

--- a/ui/spinner.go
+++ b/ui/spinner.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package ui
 
 import (

--- a/ui/styles.go
+++ b/ui/styles.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package ui
 
 import (

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package ui
 
 import (

--- a/utils/log/logger.go
+++ b/utils/log/logger.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package swarmlog
 
 import (

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package utils
 
 import (

--- a/views/commandinput/commandinput.go
+++ b/views/commandinput/commandinput.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package commandinput
 
 import (

--- a/views/commandinput/messages.go
+++ b/views/commandinput/messages.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package commandinput
 
 import tea "github.com/charmbracelet/bubbletea"

--- a/views/commandinput/update.go
+++ b/views/commandinput/update.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package commandinput
 
 import (

--- a/views/commandinput/view.go
+++ b/views/commandinput/view.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package commandinput
 
 import (

--- a/views/configs/actions.go
+++ b/views/configs/actions.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package configsview
 
 import (

--- a/views/configs/configs.go
+++ b/views/configs/configs.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package configsview
 
 import swarmlog "swarmcli/utils/log"

--- a/views/configs/editcmd.go
+++ b/views/configs/editcmd.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package configsview
 
 import (

--- a/views/configs/messages.go
+++ b/views/configs/messages.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package configsview
 
 import (

--- a/views/configs/model.go
+++ b/views/configs/model.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package configsview
 
 import (

--- a/views/configs/update.go
+++ b/views/configs/update.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package configsview
 
 import (

--- a/views/configs/view.go
+++ b/views/configs/view.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package configsview
 
 import (

--- a/views/confirmdialog/confirmdialog.go
+++ b/views/confirmdialog/confirmdialog.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package confirmdialog
 
 import (

--- a/views/contexts/contexts.go
+++ b/views/contexts/contexts.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package contexts
 
 import swarmlog "swarmcli/utils/log"

--- a/views/contexts/messages.go
+++ b/views/contexts/messages.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package contexts
 
 import (

--- a/views/contexts/model.go
+++ b/views/contexts/model.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package contexts
 
 import (

--- a/views/contexts/update.go
+++ b/views/contexts/update.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package contexts
 
 import (

--- a/views/contexts/view.go
+++ b/views/contexts/view.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package contexts
 
 import (

--- a/views/help/help.go
+++ b/views/help/help.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package helpview
 
 const ViewName = "help"

--- a/views/help/model.go
+++ b/views/help/model.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package helpview
 
 import (

--- a/views/help/update.go
+++ b/views/help/update.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package helpview
 
 import (

--- a/views/help/view.go
+++ b/views/help/view.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package helpview
 
 import (

--- a/views/helpbar/helpbar.go
+++ b/views/helpbar/helpbar.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package helpbar
 
 import (

--- a/views/helpbar/style.go
+++ b/views/helpbar/style.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package helpbar
 
 import "github.com/charmbracelet/lipgloss"

--- a/views/inspect/handlekey.go
+++ b/views/inspect/handlekey.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package inspectview
 
 import (

--- a/views/inspect/inspect.go
+++ b/views/inspect/inspect.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package inspectview
 
 const ViewName = "inspect"

--- a/views/inspect/messages.go
+++ b/views/inspect/messages.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package inspectview
 
 type Msg struct {

--- a/views/inspect/model.go
+++ b/views/inspect/model.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package inspectview
 
 import (

--- a/views/inspect/parse.go
+++ b/views/inspect/parse.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package inspectview
 
 import (

--- a/views/inspect/update.go
+++ b/views/inspect/update.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package inspectview
 
 import (

--- a/views/inspect/view.go
+++ b/views/inspect/view.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package inspectview
 
 import (

--- a/views/loading/loading.go
+++ b/views/loading/loading.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package loadingview
 
 import (

--- a/views/logs/handlekey.go
+++ b/views/logs/handlekey.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package logsview
 
 import (

--- a/views/logs/logs.go
+++ b/views/logs/logs.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package logsview
 
 import swarmlog "swarmcli/utils/log"

--- a/views/logs/messages.go
+++ b/views/logs/messages.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package logsview
 
 type InitStreamMsg struct {

--- a/views/logs/model.go
+++ b/views/logs/model.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package logsview
 
 import (

--- a/views/logs/stream.go
+++ b/views/logs/stream.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package logsview
 
 import (

--- a/views/logs/update.go
+++ b/views/logs/update.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package logsview
 
 import (

--- a/views/logs/view.go
+++ b/views/logs/view.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package logsview
 
 import (

--- a/views/networks/actions.go
+++ b/views/networks/actions.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package networksview
 
 import (

--- a/views/networks/help.go
+++ b/views/networks/help.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package networksview
 
 import helpview "swarmcli/views/help"

--- a/views/networks/messages.go
+++ b/views/networks/messages.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package networksview
 
 import (

--- a/views/networks/model.go
+++ b/views/networks/model.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package networksview
 
 import (

--- a/views/networks/networks.go
+++ b/views/networks/networks.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package networksview
 
 import swarmlog "swarmcli/utils/log"

--- a/views/networks/update.go
+++ b/views/networks/update.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package networksview
 
 import (

--- a/views/networks/view.go
+++ b/views/networks/view.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package networksview
 
 import (

--- a/views/nodes/messages.go
+++ b/views/nodes/messages.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package nodesview
 
 import (

--- a/views/nodes/model.go
+++ b/views/nodes/model.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package nodesview
 
 import (

--- a/views/nodes/nodes.go
+++ b/views/nodes/nodes.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package nodesview
 
 import swarmlog "swarmcli/utils/log"

--- a/views/nodes/update.go
+++ b/views/nodes/update.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package nodesview
 
 import (

--- a/views/nodes/view.go
+++ b/views/nodes/view.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package nodesview
 
 import (

--- a/views/revealsecret/revealsecret.go
+++ b/views/revealsecret/revealsecret.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package revealsecretview
 
 import (

--- a/views/scaledialog/scaledialog.go
+++ b/views/scaledialog/scaledialog.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package scaledialog
 
 import (

--- a/views/secrets/actions.go
+++ b/views/secrets/actions.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package secretsview
 
 import (

--- a/views/secrets/messages.go
+++ b/views/secrets/messages.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package secretsview
 
 import (

--- a/views/secrets/model.go
+++ b/views/secrets/model.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package secretsview
 
 import (

--- a/views/secrets/secrets.go
+++ b/views/secrets/secrets.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package secretsview
 
 import swarmlog "swarmcli/utils/log"

--- a/views/secrets/update.go
+++ b/views/secrets/update.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package secretsview
 
 import (

--- a/views/secrets/view.go
+++ b/views/secrets/view.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package secretsview
 
 import (

--- a/views/services/messages.go
+++ b/views/services/messages.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package servicesview
 
 import (

--- a/views/services/model.go
+++ b/views/services/model.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package servicesview
 
 import (

--- a/views/services/service.go
+++ b/views/services/service.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package servicesview
 
 import (

--- a/views/services/stackservices.go
+++ b/views/services/stackservices.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package servicesview
 
 import swarmlog "swarmcli/utils/log"

--- a/views/services/update.go
+++ b/views/services/update.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package servicesview
 
 import (

--- a/views/services/view.go
+++ b/views/services/view.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package servicesview
 
 import (

--- a/views/stacks/messages.go
+++ b/views/stacks/messages.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package stacksview
 
 import (

--- a/views/stacks/model.go
+++ b/views/stacks/model.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package stacksview
 
 import (

--- a/views/stacks/stacks.go
+++ b/views/stacks/stacks.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package stacksview
 
 import swarmlog "swarmcli/utils/log"

--- a/views/stacks/update.go
+++ b/views/stacks/update.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package stacksview
 
 import (

--- a/views/stacks/view.go
+++ b/views/stacks/view.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package stacksview
 
 import (

--- a/views/systeminfo/messages.go
+++ b/views/systeminfo/messages.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package systeminfoview
 
 import "time"

--- a/views/systeminfo/model.go
+++ b/views/systeminfo/model.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package systeminfoview
 
 import (

--- a/views/systeminfo/systeminfo.go
+++ b/views/systeminfo/systeminfo.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package systeminfoview
 
 import swarmlog "swarmcli/utils/log"

--- a/views/systeminfo/update.go
+++ b/views/systeminfo/update.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package systeminfoview
 
 import (

--- a/views/systeminfo/view.go
+++ b/views/systeminfo/view.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package systeminfoview
 
 import "swarmcli/ui"

--- a/views/tasks/messages.go
+++ b/views/tasks/messages.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package tasksview
 
 import (

--- a/views/tasks/model.go
+++ b/views/tasks/model.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package tasksview
 
 import (

--- a/views/tasks/tasks.go
+++ b/views/tasks/tasks.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package tasksview
 
 import (

--- a/views/tasks/update.go
+++ b/views/tasks/update.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package tasksview
 
 import (

--- a/views/tasks/view.go
+++ b/views/tasks/view.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package tasksview
 
 import (

--- a/views/view/constants.go
+++ b/views/view/constants.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package view
 
 // View name constants for type-safe navigation

--- a/views/view/factory.go
+++ b/views/view/factory.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package view
 
 import tea "github.com/charmbracelet/bubbletea"

--- a/views/view/interface.go
+++ b/views/view/interface.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package view
 
 import (

--- a/views/view/navigation.go
+++ b/views/view/navigation.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package view
 
 import tea "github.com/charmbracelet/bubbletea"

--- a/views/viewstack/viewstack.go
+++ b/views/viewstack/viewstack.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package viewstack
 
 import "swarmcli/views/view"


### PR DESCRIPTION
Adds Apache 2 License for the whole codebase. This retroactively applies to all commits and existing forks.

The PR also introduces scripts to automatically add the license header to `*.sh` and `*.go` files, and a CI check that fails if they are missing.