### PR TITLE
Cache Docker client as package-level singleton

### DIFF
--- a/app/update.go
+++ b/app/update.go
@@ -158,6 +158,8 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case contextsview.ContextChangedNotification:
 		// Context has changed - show loading view then navigate to stacks
+		// Close cached Docker client so a fresh one is created for the new context
+		docker.ResetClient()
 		// Invalidate snapshot cache so stacks load fresh data for new context
 		docker.InvalidateSnapshot()
 		cmd := m.replaceView(loadingview.ViewName, map[string]string{

--- a/docker/client.go
+++ b/docker/client.go
@@ -11,9 +11,15 @@ import (
 	"os/exec"
 	"path/filepath"
 	swarmlog "swarmcli/utils/log"
+	"sync"
 	"time"
 
 	"github.com/docker/docker/client"
+)
+
+var (
+	cachedClient *client.Client
+	clientMu     sync.Mutex
 )
 
 func l() *swarmlog.SwarmLogger {
@@ -33,10 +39,41 @@ type dockerContext struct {
 }
 
 // GetClient returns a Docker SDK client configured based on the current Docker context.
+// The client is cached as a package-level singleton; subsequent calls return the
+// cached instance without spawning subprocesses or pinging the daemon. Call
+// ResetClient to force a fresh client (e.g. after a context switch).
 func GetClient() (*client.Client, error) {
-	// Determine the Docker context to use. Prefer the `DOCKER_CONTEXT`
-	// environment variable (useful for CI/dev), otherwise fall back to the
-	// currently active Docker context reported by `docker context show`.
+	clientMu.Lock()
+	defer clientMu.Unlock()
+
+	if cachedClient != nil {
+		return cachedClient, nil
+	}
+
+	cli, err := buildClient()
+	if err != nil {
+		return nil, err
+	}
+	cachedClient = cli
+	return cachedClient, nil
+}
+
+// ResetClient closes the cached client (if any) and clears the cache so the
+// next GetClient call creates a fresh connection. Safe to call when no client
+// has been cached yet.
+func ResetClient() {
+	clientMu.Lock()
+	defer clientMu.Unlock()
+
+	if cachedClient != nil {
+		_ = cachedClient.Close()
+		cachedClient = nil
+	}
+}
+
+// buildClient performs the actual work of resolving the Docker context,
+// creating an SDK client, and pinging the daemon.
+func buildClient() (*client.Client, error) {
 	ctxName, err := GetContextFromEnv()
 	if err != nil {
 		return nil, err

--- a/docker/config.go
+++ b/docker/config.go
@@ -101,7 +101,6 @@ func ListConfigs(ctx context.Context) ([]swarm.Config, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer closeCli(cli)
 
 	configs, err := cli.ConfigList(ctx, swarm.ConfigListOptions{})
 	if err != nil {
@@ -130,13 +129,6 @@ func ListConfigs(ctx context.Context) ([]swarm.Config, error) {
 	return fullConfigs, nil
 }
 
-func closeCli(cli *client.Client) {
-	err := cli.Close()
-	if err != nil {
-		l().Errorf("failed to close client: %v", err)
-	}
-}
-
 // InspectConfig fetches and returns the config data.
 func InspectConfig(ctx context.Context, nameOrID string) (*ConfigWithDecodedData, error) {
 	l().Debugf("[InspectConfig] Inspecting config: %s", nameOrID)
@@ -145,7 +137,6 @@ func InspectConfig(ctx context.Context, nameOrID string) (*ConfigWithDecodedData
 	if err != nil {
 		return nil, err
 	}
-	defer closeCli(cli)
 
 	cfg, _, err := cli.ConfigInspectWithRaw(ctx, nameOrID)
 	if err != nil {
@@ -206,7 +197,6 @@ func createConfigWithSpec(ctx context.Context, spec swarm.ConfigSpec, logPrefix 
 	if err != nil {
 		return swarm.Config{}, err
 	}
-	defer closeCli(cli)
 
 	cfgName := spec.Name
 
@@ -237,7 +227,6 @@ func RotateConfigInServices(ctx context.Context, oldCfg *swarm.Config, newCfg sw
 	if err != nil {
 		return fmt.Errorf("failed to get docker client: %w", err)
 	}
-	defer closeCli(client)
 
 	// --- 1. Find affected services
 	var services []swarm.Service
@@ -288,7 +277,6 @@ func DeleteConfig(ctx context.Context, nameOrID string) error {
 	if err != nil {
 		return err
 	}
-	defer closeCli(cli)
 
 	svcs, err := listServicesUsingConfig(ctx, cli, cfg.Config.ID)
 	if err != nil {

--- a/docker/context.go
+++ b/docker/context.go
@@ -162,8 +162,6 @@ func ValidateContext(contextName string) error {
 		_ = UseContext(currentCtx)
 		return fmt.Errorf("failed to connect to context %s: %w", contextName, err)
 	}
-	defer func() { _ = cli.Close() }()
-
 	// Verify connection with ping
 	ctx := context.Background()
 	if _, err := cli.Ping(ctx); err != nil {

--- a/docker/events.go
+++ b/docker/events.go
@@ -28,8 +28,6 @@ func WatchEventsCmd() tea.Cmd {
 		if err != nil {
 			return EventMsg{Err: err}
 		}
-		defer closeCli(cli)
-
 		ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 		defer cancel()
 

--- a/docker/node.go
+++ b/docker/node.go
@@ -15,7 +15,6 @@ func GetNodeIDToHostnameMapFromDocker() (map[string]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer closeCli(c)
 
 	nodes, err := c.NodeList(context.Background(), swarm.NodeListOptions{})
 	if err != nil {
@@ -35,7 +34,6 @@ func DemoteNode(ctx context.Context, nodeID string) error {
 	if err != nil {
 		return err
 	}
-	defer closeCli(c)
 
 	// Fetch current node to get the version and current spec
 	node, _, err := c.NodeInspectWithRaw(ctx, nodeID)
@@ -60,7 +58,6 @@ func PromoteNode(ctx context.Context, nodeID string) error {
 	if err != nil {
 		return err
 	}
-	defer closeCli(c)
 
 	// Fetch current node to get the version and current spec
 	node, _, err := c.NodeInspectWithRaw(ctx, nodeID)
@@ -85,7 +82,6 @@ func SetNodeAvailability(ctx context.Context, nodeID string, availability swarm.
 	if err != nil {
 		return err
 	}
-	defer closeCli(c)
 
 	// Fetch current node to get the version and current spec
 	node, _, err := c.NodeInspectWithRaw(ctx, nodeID)
@@ -110,7 +106,6 @@ func AddNodeLabel(ctx context.Context, nodeID string, key string, value string) 
 	if err != nil {
 		return err
 	}
-	defer closeCli(c)
 
 	// Fetch current node to get the version and current spec
 	node, _, err := c.NodeInspectWithRaw(ctx, nodeID)
@@ -138,7 +133,6 @@ func RemoveNodeLabel(ctx context.Context, nodeID string, key string) error {
 	if err != nil {
 		return err
 	}
-	defer closeCli(c)
 
 	// Fetch current node to get the version and current spec
 	node, _, err := c.NodeInspectWithRaw(ctx, nodeID)
@@ -165,7 +159,6 @@ func RemoveNode(ctx context.Context, nodeID string, force bool) error {
 	if err != nil {
 		return err
 	}
-	defer closeCli(c)
 
 	opts := swarm.NodeRemoveOptions{Force: force}
 	if err := c.NodeRemove(ctx, nodeID, opts); err != nil {

--- a/docker/secret.go
+++ b/docker/secret.go
@@ -72,7 +72,6 @@ func ListSecrets(ctx context.Context) ([]swarm.Secret, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer closeCli(cli)
 
 	secrets, err := cli.SecretList(ctx, swarm.SecretListOptions{})
 	if err != nil {
@@ -110,7 +109,6 @@ func InspectSecret(ctx context.Context, nameOrID string) (*SecretWithDecodedData
 	if err != nil {
 		return nil, err
 	}
-	defer closeCli(cli)
 
 	sec, _, err := cli.SecretInspectWithRaw(ctx, nameOrID)
 	if err != nil {
@@ -172,7 +170,6 @@ func createSecretWithSpec(ctx context.Context, spec swarm.SecretSpec, logPrefix 
 	if err != nil {
 		return swarm.Secret{}, err
 	}
-	defer closeCli(cli)
 
 	secName := spec.Name
 
@@ -203,7 +200,6 @@ func RotateSecretInServices(ctx context.Context, oldSec *swarm.Secret, newSec sw
 	if err != nil {
 		return fmt.Errorf("failed to get docker client: %w", err)
 	}
-	defer closeCli(client)
 
 	// --- 1. Find affected services
 	var services []swarm.Service
@@ -254,7 +250,6 @@ func DeleteSecret(ctx context.Context, nameOrID string) error {
 	if err != nil {
 		return err
 	}
-	defer closeCli(cli)
 
 	svcs, err := listServicesUsingSecret(ctx, cli, sec.Secret.ID)
 	if err != nil {

--- a/docker/service.go
+++ b/docker/service.go
@@ -101,7 +101,6 @@ func ScaleService(serviceID string, replicas uint64) error {
 	if err != nil {
 		return fmt.Errorf("docker client: %w", err)
 	}
-	defer closeCli(c)
 
 	ctx := context.Background()
 
@@ -118,7 +117,6 @@ func ScaleServiceByName(serviceName string, replicas uint64) error {
 	if err != nil {
 		return fmt.Errorf("docker client: %w", err)
 	}
-	defer closeCli(c)
 
 	ctx := context.Background()
 	svc, err := findServiceByName(ctx, c, serviceName)
@@ -134,7 +132,6 @@ func RestartService(serviceName string) error {
 	if err != nil {
 		return fmt.Errorf("docker client: %w", err)
 	}
-	defer closeCli(c)
 
 	ctx := context.Background()
 	svc, err := findServiceByName(ctx, c, serviceName)
@@ -150,7 +147,6 @@ func RemoveService(serviceName string) error {
 	if err != nil {
 		return fmt.Errorf("docker client: %w", err)
 	}
-	defer closeCli(c)
 
 	ctx := context.Background()
 	svc, err := findServiceByName(ctx, c, serviceName)
@@ -172,7 +168,6 @@ func RollbackService(serviceName string) error {
 	if err != nil {
 		return fmt.Errorf("docker client: %w", err)
 	}
-	defer closeCli(c)
 
 	ctx := context.Background()
 	svc, err := findServiceByName(ctx, c, serviceName)
@@ -222,7 +217,6 @@ func restartServiceAndWaitInternal(ctx context.Context, serviceName string, prog
 	if err != nil {
 		return fmt.Errorf("docker client: %w", err)
 	}
-	defer closeCli(cli)
 
 	svc, err := findServiceByName(ctx, cli, serviceName)
 	if err != nil {
@@ -647,7 +641,6 @@ func GetServiceTaskDiagnostics(ctx context.Context, serviceID string) (string, e
 	if err != nil {
 		return "", fmt.Errorf("docker client: %w", err)
 	}
-	defer closeCli(cli)
 
 	tasks, err := cli.TaskList(ctx, swarm.TaskListOptions{})
 	if err != nil {

--- a/docker/snapshot.go
+++ b/docker/snapshot.go
@@ -82,8 +82,6 @@ func RefreshSnapshot() (*SwarmSnapshot, error) {
 	if err != nil {
 		return nil, fmt.Errorf("docker client: %w", err)
 	}
-	defer closeCli(c)
-
 	ctx := context.Background()
 
 	nodes, err := c.NodeList(ctx, swarm.NodeListOptions{})

--- a/docker/stack_remove.go
+++ b/docker/stack_remove.go
@@ -16,8 +16,6 @@ func RemoveStack(stackName string) error {
 	if err != nil {
 		return fmt.Errorf("docker client: %w", err)
 	}
-	defer closeCli(c)
-
 	ctx := context.Background()
 
 	// List all services in the stack

--- a/integration-tests/docker/config/helper.go
+++ b/integration-tests/docker/config/helper.go
@@ -36,7 +36,7 @@ func (e *testEnv) cleanupAll(t *testing.T) {
 	for _, fn := range e.cleanup {
 		fn()
 	}
-	_ = e.cli.Close()
+	docker.ResetClient()
 }
 
 func (e *testEnv) registerConfigCleanup(id string) {

--- a/integration-tests/docker/secret/helper.go
+++ b/integration-tests/docker/secret/helper.go
@@ -32,7 +32,7 @@ func (e *testEnv) cleanupAll(t *testing.T) {
 	for _, fn := range e.cleanup {
 		fn()
 	}
-	_ = e.cli.Close()
+	docker.ResetClient()
 }
 
 func (e *testEnv) registerSecretCleanup(id string) {


### PR DESCRIPTION
 GetClient() was creating a brand-new Docker SDK client on every call — spawning 1–2 subprocesses (docker context show, docker context inspect), loading TLS certs from disk, and pinging the daemon with a 5s timeout. With 50+ call sites across the codebase, this happened on virtually every user action in the TUI, adding hundreds of milliseconds of latency and unnecessary process churn.

Closes #101