### PR TITLE
fix flaky lint

### DIFF
--- a/commands/api/parse.go
+++ b/commands/api/parse.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright © 2026 Eldara Tech
 
-package api
+package api //nolint:revive // standard short package name
 
 import (
 	"strings"


### PR DESCRIPTION
Reason for the flakiness:

api.go and error.go already have //nolint:revive on their package declarations, but parse.go is missing it. That's the flakiness: golangci-lint only reports the issue for the first file it encounters from the package, and which file that is can vary between runs depending on filesystem ordering.