### PR TITLE
Rename Describe to Inspect in stack view

### DIFF
--- a/views/stacks/model.go
+++ b/views/stacks/model.go
@@ -158,7 +158,7 @@ func (m *Model) ShortHelpItems() []helpbar.HelpEntry {
 		{Key: "n", Desc: "New stack"},
 		{Key: "e", Desc: "Edit"},
 		{Key: "i/enter", Desc: "Services"},
-		{Key: "d", Desc: "Describe"},
+		{Key: "d", Desc: "Inspect"},
 		{Key: "p", Desc: "Tasks"},
 		{Key: "ctrl+d", Desc: "Delete"},
 		{Key: "↑/↓", Desc: "Navigate"},

--- a/views/stacks/update.go
+++ b/views/stacks/update.go
@@ -1399,7 +1399,7 @@ func GetStacksHelpContent() []helpview.HelpCategory {
 			Title: "General",
 			Items: []helpview.HelpItem{
 				{Keys: "<i/enter>", Description: "Show services for Stack"},
-				{Keys: "<d>", Description: "Describe stack"},
+				{Keys: "<d>", Description: "Inspect stack"},
 				{Keys: "<e>", Description: "Edit stack (opens editor)"},
 				{Keys: "<p>", Description: "Show tasks for Stack"},
 				{Keys: "<n>", Description: "Create new stack"},


### PR DESCRIPTION
## Summary
- Renames "Describe" to "Inspect" in the stack view help bar and help screen

Closes #235

🤖 Generated with [Claude Code](https://claude.com/claude-code)