### PR TITLE
Inline command aliases in help view

### DIFF
--- a/commands/command/alias.go
+++ b/commands/command/alias.go
@@ -21,3 +21,6 @@ func (a aliasCommand) Description() string { return a.target.Description() }
 func (a aliasCommand) Execute(ctx any, args args.Args) tea.Cmd {
 	return a.target.Execute(ctx, args)
 }
+
+// AliasOf implements registry.Aliaser.
+func (a aliasCommand) AliasOf() string { return a.target.Name() }

--- a/commands/command/alias_test.go
+++ b/commands/command/alias_test.go
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package command
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAliasCommand_AliasOf(t *testing.T) {
+	a := aliasCommand{name: "ctx", target: contextsCmd}
+	require.Equal(t, contextsCmd.Name(), a.AliasOf())
+}

--- a/commands/command/help.go
+++ b/commands/command/help.go
@@ -31,10 +31,11 @@ func AllCommandInfos() []helpview.CommandInfo {
 	// Go technicality. Need to call `registry` directly.
 	// We can't depend on the parent package, as it creates
 	// a cycle.
-	for _, cmd := range registry.All() {
+	for _, cmd := range registry.PrimaryCommands() {
 		cmds = append(cmds, helpview.CommandInfo{
 			Name:        cmd.Name(),
 			Description: cmd.Description(),
+			Aliases:     cmd.Aliases,
 		})
 	}
 	return cmds

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -4,6 +4,7 @@
 package registry
 
 import (
+	"sort"
 	"strings"
 	"swarmcli/args"
 
@@ -39,6 +40,44 @@ func All() []Command {
 		cmds = append(cmds, c)
 	}
 	return cmds
+}
+
+// Aliaser is optionally implemented by alias commands to indicate
+// which primary command they delegate to.
+type Aliaser interface {
+	AliasOf() string
+}
+
+// CommandWithAliases pairs a primary command with its collected alias names.
+type CommandWithAliases struct {
+	Command
+	Aliases []string
+}
+
+// PrimaryCommands returns deduplicated commands with alias names collected.
+// Commands implementing Aliaser are folded into their target's Aliases slice.
+func PrimaryCommands() []CommandWithAliases {
+	aliases := map[string][]string{} // target name → alias names
+	primaries := map[string]Command{}
+
+	for _, cmd := range apiRegistry {
+		if a, ok := cmd.(Aliaser); ok {
+			aliases[a.AliasOf()] = append(aliases[a.AliasOf()], cmd.Name())
+		} else {
+			primaries[cmd.Name()] = cmd
+		}
+	}
+
+	out := make([]CommandWithAliases, 0, len(primaries))
+	for name, cmd := range primaries {
+		a := aliases[name]
+		sort.Strings(a)
+		out = append(out, CommandWithAliases{
+			Command: cmd,
+			Aliases: a,
+		})
+	}
+	return out
 }
 
 // Suggest returns all command names that start with a given prefix

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -88,3 +88,57 @@ func TestRegister_OverwritesSameName(t *testing.T) {
 	require.True(t, ok)
 	require.Equal(t, "second", cmd.Description())
 }
+
+// mockAlias implements Aliaser so PrimaryCommands can detect it.
+type mockAlias struct {
+	name       string
+	desc       string
+	aliasOfCmd string
+}
+
+func (m *mockAlias) Name() string                       { return m.name }
+func (m *mockAlias) Description() string                { return m.desc }
+func (m *mockAlias) Execute(_ any, _ args.Args) tea.Cmd { return nil }
+func (m *mockAlias) AliasOf() string                    { return m.aliasOfCmd }
+
+func TestPrimaryCommands_GroupsAliases(t *testing.T) {
+	Register(&mockCommand{name: "test_primary", desc: "primary cmd"})
+	Register(&mockAlias{name: "test_alias_a", desc: "primary cmd", aliasOfCmd: "test_primary"})
+	Register(&mockAlias{name: "test_alias_b", desc: "primary cmd", aliasOfCmd: "test_primary"})
+	defer cleanup("test_primary", "test_alias_a", "test_alias_b")
+
+	cmds := PrimaryCommands()
+
+	var found *CommandWithAliases
+	for i := range cmds {
+		if cmds[i].Name() == "test_primary" {
+			found = &cmds[i]
+			break
+		}
+	}
+	require.NotNil(t, found, "primary command should appear in PrimaryCommands()")
+	require.Equal(t, "primary cmd", found.Description())
+
+	sort.Strings(found.Aliases)
+	require.Equal(t, []string{"test_alias_a", "test_alias_b"}, found.Aliases)
+
+	// Aliases must not appear as top-level entries.
+	for _, c := range cmds {
+		require.NotEqual(t, "test_alias_a", c.Name())
+		require.NotEqual(t, "test_alias_b", c.Name())
+	}
+}
+
+func TestPrimaryCommands_NoAliases(t *testing.T) {
+	Register(&mockCommand{name: "test_noalias", desc: "solo"})
+	defer cleanup("test_noalias")
+
+	cmds := PrimaryCommands()
+	for _, c := range cmds {
+		if c.Name() == "test_noalias" {
+			require.Empty(t, c.Aliases)
+			return
+		}
+	}
+	t.Fatal("test_noalias not found in PrimaryCommands()")
+}

--- a/views/help/help_test.go
+++ b/views/help/help_test.go
@@ -1,6 +1,7 @@
 package helpview
 
 import (
+	"strings"
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -73,6 +74,26 @@ func TestView_CommandList(t *testing.T) {
 	out := m.View()
 	require.Contains(t, out, "stacks")
 	require.Contains(t, out, "List stacks")
+}
+
+func TestNew_AliasesRenderedInline(t *testing.T) {
+	cmds := []CommandInfo{
+		{Name: "contexts", Description: "List and switch Docker contexts", Aliases: []string{"ctx", "context"}},
+		{Name: "help", Description: "Show help"},
+	}
+	m := New(120, 24, cmds)
+	content := m.content
+	require.Contains(t, content, "aliases: ctx, context")
+	// Command without aliases should not contain "aliases:"
+	require.NotContains(t, content, "help"+strings.Repeat(" ", 10)+"Show help    aliases:")
+}
+
+func TestNew_NoAliases_NoSuffix(t *testing.T) {
+	cmds := []CommandInfo{
+		{Name: "stacks", Description: "List stacks"},
+	}
+	m := New(80, 24, cmds)
+	require.NotContains(t, m.content, "aliases:")
 }
 
 func TestView_Categorized(t *testing.T) {

--- a/views/help/help_test.go
+++ b/views/help/help_test.go
@@ -76,16 +76,26 @@ func TestView_CommandList(t *testing.T) {
 	require.Contains(t, out, "List stacks")
 }
 
-func TestNew_AliasesRenderedInline(t *testing.T) {
+func TestNew_AliasesTableLayout(t *testing.T) {
 	cmds := []CommandInfo{
 		{Name: "contexts", Description: "List and switch Docker contexts", Aliases: []string{"ctx", "context"}},
 		{Name: "help", Description: "Show help"},
 	}
 	m := New(120, 24, cmds)
 	content := m.content
-	require.Contains(t, content, "aliases: ctx, context")
-	// Command without aliases should not contain "aliases:"
-	require.NotContains(t, content, "help"+strings.Repeat(" ", 10)+"Show help    aliases:")
+	// Header line
+	require.Contains(t, content, "COMMAND")
+	require.Contains(t, content, "DESCRIPTION")
+	require.Contains(t, content, "ALIASES")
+	// Aliases column uses bare list, no "aliases:" prefix
+	require.Contains(t, content, "ctx, context")
+	require.NotContains(t, content, "aliases:")
+	// Command without aliases has no trailing text after description
+	for _, line := range strings.Split(content, "\n") {
+		if strings.Contains(line, ":help") {
+			require.NotContains(t, line, "ctx")
+		}
+	}
 }
 
 func TestNew_NoAliases_NoSuffix(t *testing.T) {
@@ -93,7 +103,17 @@ func TestNew_NoAliases_NoSuffix(t *testing.T) {
 		{Name: "stacks", Description: "List stacks"},
 	}
 	m := New(80, 24, cmds)
+	// Header still present
+	require.Contains(t, m.content, "ALIASES")
+	// No "aliases:" prefix anywhere
 	require.NotContains(t, m.content, "aliases:")
+	// Data row has no alias text
+	for _, line := range strings.Split(m.content, "\n") {
+		if strings.Contains(line, ":stacks") {
+			trimmed := strings.TrimRight(line, " \t")
+			require.True(t, strings.HasSuffix(trimmed, "List stacks"), "expected row to end with description, got: %q", trimmed)
+		}
+	}
 }
 
 func TestView_Categorized(t *testing.T) {

--- a/views/help/model.go
+++ b/views/help/model.go
@@ -47,6 +47,7 @@ type Model struct {
 type CommandInfo struct {
 	Name        string
 	Description string
+	Aliases     []string
 }
 
 type HelpCategory struct {
@@ -62,7 +63,11 @@ type HelpItem struct {
 func New(width, height int, cmds []CommandInfo) *Model {
 	var b strings.Builder
 	for _, c := range cmds {
-		fmt.Fprintf(&b, ":%-15s %s\n", c.Name, c.Description)
+		line := fmt.Sprintf(":%-15s %s", c.Name, c.Description)
+		if len(c.Aliases) > 0 {
+			line += "    aliases: " + strings.Join(c.Aliases, ", ")
+		}
+		fmt.Fprintln(&b, line)
 	}
 
 	vp := viewport.New(width, height)

--- a/views/help/model.go
+++ b/views/help/model.go
@@ -80,11 +80,11 @@ func New(width, height int, cmds []CommandInfo) *Model {
 
 	var b strings.Builder
 	if len(cmds) > 0 {
-		header := fmt.Sprintf("%-*s%s%-*s%s%s", cmdW, "COMMAND", gap, descW, "DESCRIPTION", gap, "ALIASES")
+		header := fmt.Sprintf(" %-*s%s%-*s%s%s", cmdW, "COMMAND", gap, descW, "DESCRIPTION", gap, "ALIASES")
 		fmt.Fprintln(&b, headerStyle.Render(header))
 	}
 	for _, c := range cmds {
-		fmt.Fprintf(&b, "%-*s%s%-*s%s%s\n", cmdW, ":"+c.Name, gap, descW, c.Description, gap, strings.Join(c.Aliases, ", "))
+		fmt.Fprintf(&b, " %-*s%s%-*s%s%s\n", cmdW, ":"+c.Name, gap, descW, c.Description, gap, strings.Join(c.Aliases, ", "))
 	}
 
 	vp := viewport.New(width, height)

--- a/views/help/model.go
+++ b/views/help/model.go
@@ -80,11 +80,11 @@ func New(width, height int, cmds []CommandInfo) *Model {
 
 	var b strings.Builder
 	if len(cmds) > 0 {
-		header := fmt.Sprintf(" %-*s%s%-*s%s%s", cmdW, "COMMAND", gap, descW, "DESCRIPTION", gap, "ALIASES")
+		header := fmt.Sprintf("%-*s%s%-*s%s%s", cmdW, "COMMAND", gap, descW, "DESCRIPTION", gap, "ALIASES")
 		fmt.Fprintln(&b, headerStyle.Render(header))
 	}
 	for _, c := range cmds {
-		fmt.Fprintf(&b, " %-*s%s%-*s%s%s\n", cmdW, ":"+c.Name, gap, descW, c.Description, gap, strings.Join(c.Aliases, ", "))
+		fmt.Fprintf(&b, "%-*s%s%-*s%s%s\n", cmdW, ":"+c.Name, gap, descW, c.Description, gap, strings.Join(c.Aliases, ", "))
 	}
 
 	vp := viewport.New(width, height)

--- a/views/help/model.go
+++ b/views/help/model.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/charmbracelet/bubbles/viewport"
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
 )
 
 // Help view provides a generic categorized help screen for any view.
@@ -72,12 +73,18 @@ func New(width, height int, cmds []CommandInfo) *Model {
 		}
 	}
 
+	const gap = "   "
+	headerStyle := lipgloss.NewStyle().
+		Foreground(lipgloss.Color("33")).
+		Bold(true)
+
 	var b strings.Builder
 	if len(cmds) > 0 {
-		fmt.Fprintf(&b, "%-*s %-*s %s\n", cmdW, "COMMAND", descW, "DESCRIPTION", "ALIASES")
+		header := fmt.Sprintf("%-*s%s%-*s%s%s", cmdW, "COMMAND", gap, descW, "DESCRIPTION", gap, "ALIASES")
+		fmt.Fprintln(&b, headerStyle.Render(header))
 	}
 	for _, c := range cmds {
-		fmt.Fprintf(&b, "%-*s %-*s %s\n", cmdW, ":"+c.Name, descW, c.Description, strings.Join(c.Aliases, ", "))
+		fmt.Fprintf(&b, "%-*s%s%-*s%s%s\n", cmdW, ":"+c.Name, gap, descW, c.Description, gap, strings.Join(c.Aliases, ", "))
 	}
 
 	vp := viewport.New(width, height)

--- a/views/help/model.go
+++ b/views/help/model.go
@@ -61,13 +61,23 @@ type HelpItem struct {
 }
 
 func New(width, height int, cmds []CommandInfo) *Model {
-	var b strings.Builder
+	cmdW := 16
+	descW := 20
 	for _, c := range cmds {
-		line := fmt.Sprintf(":%-15s %s", c.Name, c.Description)
-		if len(c.Aliases) > 0 {
-			line += "    aliases: " + strings.Join(c.Aliases, ", ")
+		if w := len(c.Name) + 1; w > cmdW { // +1 for ':'
+			cmdW = w
 		}
-		fmt.Fprintln(&b, line)
+		if w := len(c.Description); w > descW {
+			descW = w
+		}
+	}
+
+	var b strings.Builder
+	if len(cmds) > 0 {
+		fmt.Fprintf(&b, "%-*s %-*s %s\n", cmdW, "COMMAND", descW, "DESCRIPTION", "ALIASES")
+	}
+	for _, c := range cmds {
+		fmt.Fprintf(&b, "%-*s %-*s %s\n", cmdW, ":"+c.Name, descW, c.Description, strings.Join(c.Aliases, ", "))
 	}
 
 	vp := viewport.New(width, height)

--- a/views/help/view.go
+++ b/views/help/view.go
@@ -22,7 +22,7 @@ func (m *Model) View() string {
 	}
 
 	// Command help (":help") should render like every other view: full-width framed box.
-	header := ui.FrameHeaderStyle.Render("Available Commands")
+	header := " " + ui.FrameHeaderStyle.Render("Available Commands")
 	footer := ui.StatusBarStyle.Render("Press <esc> to go back")
 
 	frame := ui.ComputeFrameDimensions(
@@ -34,7 +34,9 @@ func (m *Model) View() string {
 		footer,
 	)
 
-	viewportContent := ui.TrimOrPadContentToLines(m.Viewable.View(), frame.DesiredContentLines)
+	viewportContent := " " + strings.ReplaceAll(
+		ui.TrimOrPadContentToLines(m.Viewable.View(), frame.DesiredContentLines),
+		"\n", "\n ")
 	return ui.RenderFramedBox("Help", header, viewportContent, footer, frame.FrameWidth)
 }
 


### PR DESCRIPTION
## Summary

- Aliases (e.g. `ctx`, `context`) no longer appear as separate rows in `:help`
- They are grouped with their primary command and rendered as a three-column table:
  ```
  COMMAND          DESCRIPTION                          ALIASES
  :contexts        List and switch Docker contexts       ctx, context
  :help            Show all available commands
  :stacks          List stacks
  ```
- Column widths computed dynamically from data; 3-space gap between columns
- Header styled bold blue (lipgloss color 33, matching categorized help keys)
- Adds `Aliaser` interface to registry so alias commands can self-identify

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./registry/ ./commands/command/ ./views/help/` — all pass
- [x] Verify `:help` output renders aligned table with blue header

Closes #191

🤖 Generated with [Claude Code](https://claude.com/claude-code)