### PR TITLE
Fix keys silently ignored after startup (#199)

### DIFF
--- a/views/services/register.go
+++ b/views/services/register.go
@@ -4,6 +4,7 @@
 package servicesview
 
 import (
+	"swarmcli/core/primitives/hash"
 	"swarmcli/docker"
 	"swarmcli/views/view"
 
@@ -57,13 +58,17 @@ func factory(deps docker.Deps, w, h int, payload any) (view.View, tea.Cmd) {
 
 	entries, title := v.loadServicesForView(filterType, nodeID, stackName)
 
-	return v, func() tea.Msg {
-		return Msg{
-			Title:      title,
-			Entries:    entries,
-			FilterType: filterType,
-			NodeID:     nodeID,
-			StackName:  stackName,
-		}
+	// Apply data directly so keys work immediately (no race with async Cmd).
+	msg := Msg{
+		Title:      title,
+		Entries:    entries,
+		FilterType: filterType,
+		NodeID:     nodeID,
+		StackName:  stackName,
 	}
+	v.lastSnapshot, _ = hash.Compute(entries)
+	v.SetContent(msg)
+	v.Visible = true
+
+	return v, tickCmd()
 }

--- a/views/stacks/register.go
+++ b/views/stacks/register.go
@@ -4,6 +4,7 @@
 package stacksview
 
 import (
+	"swarmcli/core/primitives/hash"
 	"swarmcli/docker"
 	"swarmcli/views/view"
 
@@ -22,5 +23,14 @@ func factory(deps docker.Deps, w, h int, payload any) (view.View, tea.Cmd) {
 	model := New(w, h)
 	model.deps = deps
 	model.Visible = true
+
+	// Pre-populate from cached snapshot so keys work immediately.
+	if snap := deps.Snapshot.GetSnapshot(); snap != nil {
+		stacks := snap.ToStackEntries()
+		model.lastSnapshot, _ = hash.Compute(stacks)
+		model.nodeID = nodeID
+		model.setStacks(stacks)
+	}
+
 	return model, tea.Batch(model.Init(), model.LoadStacksCmd(nodeID))
 }


### PR DESCRIPTION
## Summary

- Fixes #199: keys (`p`, `l`, `enter`, etc.) silently ignored after app startup or view navigation until background data loading completes
- **Services view**: apply `SetContent` + `Visible = true` directly in factory instead of wrapping in a deferred `tea.Cmd`
- **Stacks view**: pre-populate list from snapshot cache synchronously in factory so `List.Filtered` is non-empty before keys arrive

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race -count=1 ./views/services/`
- [x] `go test -race -count=1 ./views/stacks/`
- [x] `go test -race -count=1 ./...`
- [x] `golangci-lint run ./...` — 0 issues
- [x] Manual: launch against large swarm, verify `p`/`l`/`enter` respond immediately on stacks/services views

🤖 Generated with [Claude Code](https://claude.com/claude-code)