### PR TITLE
Fix stale error display in stacks view (#236)

### DIFF
--- a/views/stacks/model.go
+++ b/views/stacks/model.go
@@ -236,7 +236,7 @@ func (m *Model) checkStacksCmd(lastHash uint64, nodeID string) tea.Cmd {
 	}
 }
 
-func (m *Model) OnEnter() tea.Cmd { return nil }
+func (m *Model) OnEnter() tea.Cmd { return m.LoadStacksCmd(m.nodeID) }
 func (m *Model) OnExit() tea.Cmd  { return nil }
 
 func (m *Model) HasActiveFilter() bool {

--- a/views/stacks/model_test.go
+++ b/views/stacks/model_test.go
@@ -267,10 +267,10 @@ func TestShortHelpItems(t *testing.T) {
 	require.True(t, keys["?"])
 }
 
-func TestOnEnter_ReturnsNil(t *testing.T) {
+func TestOnEnter_ReturnsLoadCmd(t *testing.T) {
 	m := testModel()
 	cmd := m.OnEnter()
-	require.Nil(t, cmd)
+	require.NotNil(t, cmd)
 }
 
 func TestOnExit_ReturnsNil(t *testing.T) {


### PR DESCRIPTION
## Summary

- Fixes #236: after fixing a service error and navigating back, the stacks view still showed the old error
- Root cause: `goBack()` restores the previous model instance from the view stack, but `OnEnter()` returned `nil` — no data refresh was triggered, so `stackHasError`/`stackErrorText` maps retained stale values
- Additionally, `checkStacksCmd` hashes `StackEntry{Name, ServiceCount, NodeCount}` which doesn't include error state, so the polling loop couldn't detect error-only changes either
- Fix: `OnEnter()` now returns `LoadStacksCmd(m.nodeID)`, which unconditionally recomputes error maps from the current snapshot

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race -count=1 ./views/stacks/ -v`
- [x] `go test -race -count=1 ./...`
- [x] `golangci-lint run ./...` — 0 issues
- [x] Manual: deploy a broken service, observe error in stacks view, fix it, press Escape back — error should clear

🤖 Generated with [Claude Code](https://claude.com/claude-code)