### PR TITLE
Refactor FilterableList: centralize header, footer, and column width

### DIFF
--- a/ui/components/filterable/list/columns.go
+++ b/ui/components/filterable/list/columns.go
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package filterlist
+
+// ColumnDef describes a single column in the header.
+type ColumnDef struct {
+	Label    string // Base label, e.g. "STACK"
+	Pct      int    // Width as % of total (0 = not percentage-based)
+	MinWidth int    // Floor for column width (0 = no minimum)
+	// If Pct == 0, column participates in equal distribution of remaining width.
+}
+
+// HeaderConfig holds column definitions and sort state for header rendering.
+type HeaderConfig struct {
+	Columns []ColumnDef
+
+	// SortIndicator returns (columnIndex, ascending) for the current sort.
+	// Return colIndex -1 to hide all arrows.
+	SortIndicator func() (colIndex int, ascending bool)
+
+	// DynamicLabel optionally overrides a column's label at render time.
+	// Return "" to keep the base label. Nil means no overrides.
+	DynamicLabel func(colIndex int, baseLabel string) string
+
+	// ColWidthsFunc, when non-nil, overrides the default column width
+	// computation. Receives effective width, returns widths per column.
+	// Escape hatch for views with custom layout algorithms (services).
+	ColWidthsFunc func(width int) []int
+}
+
+// FooterConfig controls footer rendering.
+type FooterConfig struct {
+	ItemLabel string // e.g. "Stack", "Secret" — used in "Stack 3 of 10"
+
+	// Override, when non-nil, replaces the standard footer entirely.
+	Override func(cursor, filteredCount int, mode ModeType, query string) string
+}
+
+// computeColWidths calculates column widths from ColumnDef definitions.
+func computeColWidths(cols []ColumnDef, totalWidth int) []int {
+	n := len(cols)
+	if n == 0 {
+		return nil
+	}
+	if totalWidth < 1 {
+		totalWidth = 80
+	}
+
+	widths := make([]int, n)
+
+	// Allocate percentage-based columns first
+	pctUsed := 0
+	var equalCols []int
+	for i, c := range cols {
+		if c.Pct > 0 {
+			widths[i] = (totalWidth * c.Pct) / 100
+			pctUsed += widths[i]
+		} else {
+			equalCols = append(equalCols, i)
+		}
+	}
+
+	// Distribute remaining width equally among Pct==0 columns
+	remaining := max(totalWidth-pctUsed, 0)
+	if len(equalCols) > 0 {
+		base := remaining / len(equalCols)
+		rem := remaining - base*len(equalCols)
+		for j, idx := range equalCols {
+			widths[idx] = base
+			if j < rem {
+				widths[idx]++
+			}
+		}
+	}
+
+	// Apply MinWidth floors: steal from larger columns if needed
+	for i, c := range cols {
+		if c.MinWidth > 0 && widths[i] < c.MinWidth {
+			deficit := c.MinWidth - widths[i]
+			// Steal from earlier columns that can spare it
+			for j := i - 1; j >= 0 && deficit > 0; j-- {
+				floor := max(5, cols[j].MinWidth)
+				spare := widths[j] - floor
+				if spare <= 0 {
+					continue
+				}
+				take := min(deficit, spare)
+				widths[j] -= take
+				deficit -= take
+			}
+			widths[i] = c.MinWidth
+		}
+	}
+
+	// Floor all widths to 1
+	for i := range widths {
+		if widths[i] < 1 {
+			widths[i] = 1
+		}
+	}
+
+	return widths
+}

--- a/ui/components/filterable/list/filerablelist.go
+++ b/ui/components/filterable/list/filerablelist.go
@@ -31,7 +31,58 @@ type FilterableList[T any] struct {
 	// where the cursor position doesn't reflect the actual line being viewed.
 	SkipOffsetAdjustment bool
 
-	colWidth int
+	// Header configures column headers with sort indicators.
+	// Nil means no header is rendered by RenderHeader/RenderFramedView.
+	Header *HeaderConfig
+
+	// Footer configures the status bar and filter line.
+	// Nil means no footer is rendered by RenderFooter/RenderFramedView.
+	Footer *FooterConfig
+
+	outerWidth  int
+	outerHeight int
+	colWidth    int
+}
+
+// SetOuterSize stores fallback dimensions from tea.WindowSizeMsg.
+func (f *FilterableList[T]) SetOuterSize(width, height int) {
+	f.outerWidth = width
+	f.outerHeight = height
+}
+
+// effectiveWidth returns the best available width.
+func (f *FilterableList[T]) effectiveWidth() int {
+	if f.Viewport.Width > 0 {
+		return f.Viewport.Width
+	}
+	if f.outerWidth > 0 {
+		return f.outerWidth
+	}
+	return 80
+}
+
+// effectiveHeight returns the best available height.
+func (f *FilterableList[T]) effectiveHeight() int {
+	if f.Viewport.Height > 0 {
+		return f.Viewport.Height
+	}
+	if f.outerHeight > 0 {
+		return f.outerHeight
+	}
+	return 20
+}
+
+// ColWidths returns column widths for the current header configuration.
+// Returns nil when Header is nil.
+func (f *FilterableList[T]) ColWidths() []int {
+	if f.Header == nil {
+		return nil
+	}
+	w := f.effectiveWidth()
+	if f.Header.ColWidthsFunc != nil {
+		return f.Header.ColWidthsFunc(w)
+	}
+	return computeColWidths(f.Header.Columns, w)
 }
 
 type ModeType int

--- a/ui/components/filterable/list/list_test.go
+++ b/ui/components/filterable/list/list_test.go
@@ -1,0 +1,415 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package filterlist
+
+import (
+	"strings"
+	"swarmcli/ui"
+	"testing"
+
+	"github.com/charmbracelet/bubbles/viewport"
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// --- Column computation ---
+
+func TestComputeColWidths_EqualDistribution(t *testing.T) {
+	cols := []ColumnDef{
+		{Label: "A"}, {Label: "B"}, {Label: "C"}, {Label: "D"},
+	}
+	widths := computeColWidths(cols, 100)
+	if len(widths) != 4 {
+		t.Fatalf("expected 4 widths, got %d", len(widths))
+	}
+	total := 0
+	for _, w := range widths {
+		total += w
+	}
+	if total != 100 {
+		t.Errorf("total width %d, want 100", total)
+	}
+	// Each should be 25
+	for i, w := range widths {
+		if w != 25 {
+			t.Errorf("widths[%d] = %d, want 25", i, w)
+		}
+	}
+}
+
+func TestComputeColWidths_Percentage(t *testing.T) {
+	cols := []ColumnDef{
+		{Label: "A", Pct: 25},
+		{Label: "B", Pct: 10},
+		{Label: "C", Pct: 10},
+		{Label: "D", Pct: 55},
+	}
+	widths := computeColWidths(cols, 200)
+	if widths[0] != 50 {
+		t.Errorf("widths[0] = %d, want 50", widths[0])
+	}
+	if widths[1] != 20 {
+		t.Errorf("widths[1] = %d, want 20", widths[1])
+	}
+	if widths[2] != 20 {
+		t.Errorf("widths[2] = %d, want 20", widths[2])
+	}
+	if widths[3] != 110 {
+		t.Errorf("widths[3] = %d, want 110", widths[3])
+	}
+}
+
+func TestComputeColWidths_MinWidth(t *testing.T) {
+	// 3 equal cols in 30 width = 10 each. MinWidth 15 on col 2 should
+	// steal from earlier cols.
+	cols := []ColumnDef{
+		{Label: "A"},
+		{Label: "B"},
+		{Label: "C", MinWidth: 15},
+	}
+	widths := computeColWidths(cols, 30)
+	if widths[2] != 15 {
+		t.Errorf("widths[2] = %d, want 15", widths[2])
+	}
+	total := 0
+	for _, w := range widths {
+		total += w
+	}
+	// Total should still be 30 (stolen from earlier columns)
+	if total != 30 {
+		t.Errorf("total = %d, want 30", total)
+	}
+}
+
+func TestComputeColWidths_ColWidthsFunc(t *testing.T) {
+	custom := func(w int) []int { return []int{w / 2, w / 2} }
+	fl := FilterableList[string]{
+		Viewport: viewport.New(100, 10),
+		Header: &HeaderConfig{
+			Columns:       []ColumnDef{{Label: "A"}, {Label: "B"}},
+			ColWidthsFunc: custom,
+		},
+	}
+	cw := fl.ColWidths()
+	if len(cw) != 2 || cw[0] != 50 || cw[1] != 50 {
+		t.Errorf("ColWidths() = %v, want [50 50]", cw)
+	}
+}
+
+func TestComputeColWidths_ZeroWidth(t *testing.T) {
+	cols := []ColumnDef{{Label: "A"}, {Label: "B"}}
+	widths := computeColWidths(cols, 0)
+	total := 0
+	for _, w := range widths {
+		total += w
+	}
+	if total != 80 {
+		t.Errorf("total = %d, want 80 (default)", total)
+	}
+}
+
+func TestComputeColWidths_Nil(t *testing.T) {
+	widths := computeColWidths(nil, 100)
+	if widths != nil {
+		t.Errorf("expected nil, got %v", widths)
+	}
+}
+
+// --- Header rendering ---
+
+func TestRenderHeader_NilConfig(t *testing.T) {
+	fl := FilterableList[string]{}
+	if got := fl.RenderHeader(); got != "" {
+		t.Errorf("RenderHeader() = %q, want empty", got)
+	}
+}
+
+func TestRenderHeader_BasicLabels(t *testing.T) {
+	fl := FilterableList[string]{
+		Viewport: viewport.New(80, 10),
+		Header: &HeaderConfig{
+			Columns: []ColumnDef{{Label: "NAME"}, {Label: "ID"}},
+		},
+	}
+	got := fl.RenderHeader()
+	if got == "" {
+		t.Fatal("expected non-empty header")
+	}
+	// Should contain both labels
+	if !strings.Contains(got, "NAME") || !strings.Contains(got, "ID") {
+		t.Errorf("header missing labels: %q", got)
+	}
+}
+
+func TestRenderHeader_SortArrow(t *testing.T) {
+	fl := FilterableList[string]{
+		Viewport: viewport.New(80, 10),
+		Header: &HeaderConfig{
+			Columns:       []ColumnDef{{Label: "NAME"}, {Label: "ID"}},
+			SortIndicator: func() (int, bool) { return 0, true },
+		},
+	}
+	got := fl.RenderHeader()
+	if !strings.Contains(got, "▲") {
+		t.Errorf("expected ascending arrow in header: %q", got)
+	}
+}
+
+func TestRenderHeader_DynamicLabel(t *testing.T) {
+	fl := FilterableList[string]{
+		Viewport: viewport.New(80, 10),
+		Header: &HeaderConfig{
+			Columns: []ColumnDef{{Label: "NAME"}, {Label: "ERROR"}},
+			DynamicLabel: func(idx int, base string) string {
+				if idx == 1 {
+					return "ERROR: 3"
+				}
+				return ""
+			},
+		},
+	}
+	got := fl.RenderHeader()
+	if !strings.Contains(got, "ERROR: 3") {
+		t.Errorf("expected dynamic label in header: %q", got)
+	}
+}
+
+// --- Footer rendering ---
+
+func TestRenderFooter_NilConfig(t *testing.T) {
+	fl := FilterableList[string]{}
+	if got := fl.RenderFooter(); got != "" {
+		t.Errorf("RenderFooter() = %q, want empty", got)
+	}
+}
+
+func TestRenderFooter_Standard(t *testing.T) {
+	fl := FilterableList[string]{
+		Filtered: []string{"a", "b", "c"},
+		Cursor:   2,
+		Footer:   &FooterConfig{ItemLabel: "Item"},
+	}
+	got := fl.RenderFooter()
+	if !strings.Contains(got, "Item 3 of 3") {
+		t.Errorf("footer = %q, want 'Item 3 of 3'", got)
+	}
+}
+
+func TestRenderFooter_Searching(t *testing.T) {
+	fl := FilterableList[string]{
+		Filtered: []string{"a"},
+		Cursor:   0,
+		Mode:     ModeSearching,
+		Query:    "test",
+		Footer:   &FooterConfig{ItemLabel: "Item"},
+	}
+	got := fl.RenderFooter()
+	if !strings.Contains(got, "Filter (type then Enter): test") {
+		t.Errorf("footer = %q, want filter line", got)
+	}
+}
+
+func TestRenderFooter_EmptyList(t *testing.T) {
+	fl := FilterableList[string]{
+		Items:    []string{},
+		Filtered: []string{},
+		Footer:   &FooterConfig{ItemLabel: "Secret"},
+	}
+	got := fl.RenderFooter()
+	if !strings.Contains(got, "No Secrets found") {
+		t.Errorf("footer = %q, want 'No Secrets found'", got)
+	}
+}
+
+func TestRenderFooter_Override(t *testing.T) {
+	called := false
+	fl := FilterableList[string]{
+		Filtered: []string{"a"},
+		Footer: &FooterConfig{
+			Override: func(cursor, count int, mode ModeType, query string) string {
+				called = true
+				return "custom footer"
+			},
+		},
+	}
+	got := fl.RenderFooter()
+	if !called {
+		t.Error("Override was not called")
+	}
+	if got != "custom footer" {
+		t.Errorf("footer = %q, want 'custom footer'", got)
+	}
+}
+
+// --- Nil-slice safety ---
+
+func TestHandleKey_NilFiltered(t *testing.T) {
+	fl := FilterableList[string]{
+		Viewport: viewport.New(80, 10),
+	}
+	// Should not panic
+	fl.HandleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
+	fl.HandleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'k'}})
+}
+
+func TestApplyFilter_NilItems(t *testing.T) {
+	fl := FilterableList[string]{
+		Viewport: viewport.New(80, 10),
+		Match:    func(s string, q string) bool { return strings.Contains(s, q) },
+	}
+	// Items is nil
+	fl.ApplyFilter()
+	if fl.Filtered != nil {
+		t.Errorf("expected Filtered to be nil when Items is nil, got %v", fl.Filtered)
+	}
+}
+
+func TestEnsureCursorVisible_Empty(t *testing.T) {
+	fl := FilterableList[string]{
+		Viewport: viewport.New(80, 10),
+	}
+	// Should not panic
+	fl.ensureCursorVisible()
+}
+
+func TestVisibleContent_NilItems(t *testing.T) {
+	fl := FilterableList[string]{
+		Viewport: viewport.New(80, 10),
+	}
+	// Items is nil — should show viewport content (loading placeholder)
+	got := fl.VisibleContent(5)
+	// Should not panic; return value depends on viewport state
+	_ = got
+}
+
+// --- ColWidths ---
+
+func TestColWidths_NilHeader(t *testing.T) {
+	fl := FilterableList[string]{}
+	if got := fl.ColWidths(); got != nil {
+		t.Errorf("ColWidths() = %v, want nil", got)
+	}
+}
+
+func TestColWidths_MatchesHeader(t *testing.T) {
+	fl := FilterableList[string]{
+		Viewport: viewport.New(100, 10),
+		Header: &HeaderConfig{
+			Columns: []ColumnDef{
+				{Label: "A", Pct: 50},
+				{Label: "B", Pct: 50},
+			},
+		},
+	}
+	cw := fl.ColWidths()
+	if len(cw) != 2 {
+		t.Fatalf("expected 2 widths, got %d", len(cw))
+	}
+	if cw[0] != 50 || cw[1] != 50 {
+		t.Errorf("ColWidths() = %v, want [50 50]", cw)
+	}
+}
+
+// --- RenderFramedView ---
+
+func TestRenderFramedView_Full(t *testing.T) {
+	fl := FilterableList[string]{
+		Viewport: viewport.New(60, 15),
+		Items:    []string{"alpha", "beta", "gamma"},
+		Filtered: []string{"alpha", "beta", "gamma"},
+		Header: &HeaderConfig{
+			Columns: []ColumnDef{{Label: "NAME"}},
+		},
+		Footer: &FooterConfig{ItemLabel: "Item"},
+		RenderItem: func(item string, selected bool, _ int) string {
+			return item
+		},
+		Match: func(s string, q string) bool { return true },
+	}
+	framed, frame := fl.RenderFramedView("Test Title")
+	if framed == "" {
+		t.Fatal("expected non-empty framed view")
+	}
+	if !strings.Contains(framed, "Test Title") {
+		t.Error("framed view missing title")
+	}
+	if !strings.Contains(framed, "NAME") {
+		t.Error("framed view missing header")
+	}
+	if !strings.Contains(framed, "Item 1 of 3") {
+		t.Error("framed view missing footer")
+	}
+	if frame.FrameWidth <= 0 {
+		t.Error("frame width should be positive")
+	}
+}
+
+// --- SetOuterSize / effectiveWidth / effectiveHeight ---
+
+func TestEffectiveWidth_Fallback(t *testing.T) {
+	fl := FilterableList[string]{}
+	if got := fl.effectiveWidth(); got != 80 {
+		t.Errorf("effectiveWidth() = %d, want 80", got)
+	}
+	fl.SetOuterSize(120, 30)
+	if got := fl.effectiveWidth(); got != 120 {
+		t.Errorf("effectiveWidth() = %d, want 120", got)
+	}
+	fl.Viewport = viewport.New(100, 10)
+	if got := fl.effectiveWidth(); got != 100 {
+		t.Errorf("effectiveWidth() = %d, want 100", got)
+	}
+}
+
+func TestEffectiveHeight_Fallback(t *testing.T) {
+	fl := FilterableList[string]{}
+	if got := fl.effectiveHeight(); got != 20 {
+		t.Errorf("effectiveHeight() = %d, want 20", got)
+	}
+	fl.SetOuterSize(120, 30)
+	if got := fl.effectiveHeight(); got != 30 {
+		t.Errorf("effectiveHeight() = %d, want 30", got)
+	}
+	fl.Viewport = viewport.New(100, 25)
+	if got := fl.effectiveHeight(); got != 25 {
+		t.Errorf("effectiveHeight() = %d, want 25", got)
+	}
+}
+
+// --- RenderFramedView with empty list ---
+
+func TestRenderFramedView_Empty(t *testing.T) {
+	fl := FilterableList[string]{
+		Viewport: viewport.New(60, 15),
+		Items:    []string{},
+		Filtered: []string{},
+		Header: &HeaderConfig{
+			Columns: []ColumnDef{{Label: "NAME"}},
+		},
+		Footer: &FooterConfig{ItemLabel: "Widget"},
+		RenderItem: func(item string, selected bool, _ int) string {
+			return item
+		},
+	}
+	framed, frame := fl.RenderFramedView("Empty List")
+	if !strings.Contains(framed, "No Widgets found") {
+		t.Errorf("expected 'No Widgets found' in footer, got:\n%s", framed)
+	}
+	_ = frame
+}
+
+// --- ComputeFrameDimensions integration ---
+
+func TestComputeFrameDimensions_WithHeaderFooter(t *testing.T) {
+	header := "HEADER LINE"
+	footer := "FOOTER LINE"
+	spec := ui.ComputeFrameDimensions(80, 20, 0, 0, header, footer)
+	// frameWidth = 80 + 4 = 84
+	if spec.FrameWidth != 84 {
+		t.Errorf("FrameWidth = %d, want 84", spec.FrameWidth)
+	}
+	// desiredContentLines = 20 - 2 - 1 (header) - 1 (footer) = 16
+	if spec.DesiredContentLines != 16 {
+		t.Errorf("DesiredContentLines = %d, want 16", spec.DesiredContentLines)
+	}
+}

--- a/ui/components/filterable/list/view.go
+++ b/ui/components/filterable/list/view.go
@@ -6,6 +6,8 @@ package filterlist
 import (
 	"fmt"
 	"strings"
+	"swarmcli/ui"
+	"swarmcli/ui/components/sorting"
 
 	"github.com/charmbracelet/lipgloss"
 )
@@ -52,6 +54,10 @@ func (f *FilterableList[T]) View() string {
 // ensureCursorVisible keeps the cursor in the visible viewport range
 // This now accounts for multi-line items
 func (f *FilterableList[T]) ensureCursorVisible() {
+	if len(f.Filtered) == 0 {
+		return
+	}
+
 	h := f.Viewport.Height
 	if h < 1 {
 		h = 1
@@ -121,4 +127,105 @@ func (f *FilterableList[T]) ComputeAndSetColWidth(renderName func(item T) string
 // GetColWidth returns the computed column width
 func (f *FilterableList[T]) GetColWidth() int {
 	return f.colWidth
+}
+
+// RenderHeader builds a styled column header from the Header config.
+// Returns "" when Header is nil.
+func (f *FilterableList[T]) RenderHeader() string {
+	if f.Header == nil {
+		return ""
+	}
+
+	colWidths := f.ColWidths()
+	cols := f.Header.Columns
+	labels := make([]string, len(cols))
+	for i, c := range cols {
+		labels[i] = c.Label
+	}
+
+	// Apply dynamic label overrides
+	if f.Header.DynamicLabel != nil {
+		for i, base := range labels {
+			if override := f.Header.DynamicLabel(i, base); override != "" {
+				labels[i] = override
+			}
+		}
+	}
+
+	// Apply sort arrow
+	if f.Header.SortIndicator != nil {
+		colIdx, asc := f.Header.SortIndicator()
+		if colIdx >= 0 && colIdx < len(labels) {
+			arrow := sorting.SortArrow(sorting.Ascending)
+			if !asc {
+				arrow = sorting.SortArrow(sorting.Descending)
+			}
+			labels[colIdx] = fmt.Sprintf("%s %s", labels[colIdx], arrow)
+		}
+	}
+
+	// Prefix first label with leading space (existing convention)
+	if len(labels) > 0 {
+		labels[0] = " " + labels[0]
+	}
+
+	return ui.RenderColumnHeader(labels, colWidths)
+}
+
+// RenderFooter builds the status bar and filter line from the Footer config.
+// Returns "" when Footer is nil.
+func (f *FilterableList[T]) RenderFooter() string {
+	if f.Footer == nil {
+		return ""
+	}
+
+	if f.Footer.Override != nil {
+		return f.Footer.Override(f.Cursor, len(f.Filtered), f.Mode, f.Query)
+	}
+
+	label := f.Footer.ItemLabel
+	if label == "" {
+		label = "Item"
+	}
+
+	var status string
+	if len(f.Filtered) == 0 {
+		status = fmt.Sprintf("No %ss found", label)
+	} else {
+		status = fmt.Sprintf("%s %d of %d", label, f.Cursor+1, len(f.Filtered))
+	}
+	statusBar := ui.StatusBarStyle.Render(status)
+
+	var filterLine string
+	if f.Mode == ModeSearching {
+		filterLine = ui.StatusBarStyle.Render("Filter (type then Enter): " + f.Query)
+	} else if f.Query != "" {
+		filterLine = ui.StatusBarStyle.Render("Filter: " + f.Query)
+	}
+
+	if filterLine != "" {
+		return statusBar + "\n" + filterLine
+	}
+	return statusBar
+}
+
+// RenderFramedView builds the complete framed view: title, header, content, footer.
+// Returns the rendered string and a FrameSpec for dialog overlay positioning.
+func (f *FilterableList[T]) RenderFramedView(title string) (string, ui.FrameSpec) {
+	header := f.RenderHeader()
+	footer := f.RenderFooter()
+
+	frame := ui.ComputeFrameDimensions(
+		f.Viewport.Width,
+		f.Viewport.Height,
+		f.outerWidth,
+		f.outerHeight,
+		header,
+		footer,
+	)
+
+	content := f.VisibleContent(frame.DesiredContentLines)
+	framed := ui.RenderFramedBox(title, header, content, footer, frame.FrameWidth)
+
+	return framed, frame
 }

--- a/views/configs/model.go
+++ b/views/configs/model.go
@@ -74,10 +74,6 @@ type Model struct {
 	usedByList       filterlist.FilterableList[usedByItem]
 	usedByConfigName string
 
-	// Cached column widths for header alignment
-	colNameWidth int
-	colIDWidth   int
-
 	// Spinner for slow-used-status indicator
 	spinner int
 
@@ -97,6 +93,16 @@ func New(width, height int) *Model {
 	vp := viewport.New(width, height)
 	vp.SetContent("")
 
+	m := &Model{
+		width:         width,
+		height:        height,
+		firstResize:   true,
+		state:         stateLoading,
+		visible:       true,
+		sortField:     SortByName,
+		sortAscending: true,
+	}
+
 	list := filterlist.FilterableList[configItem]{
 		Viewport: vp,
 		Match: func(c configItem, query string) bool {
@@ -104,7 +110,22 @@ func New(width, height int) *Model {
 			return strings.Contains(strings.ToLower(c.Name), q) ||
 				strings.Contains(strings.ToLower(c.ID), q)
 		},
+		Header: &filterlist.HeaderConfig{
+			Columns: []filterlist.ColumnDef{
+				{Label: "NAME"},
+				{Label: "ID"},
+				{Label: "CONFIG USED"},
+				{Label: "CREATED AT", MinWidth: 19},
+				{Label: "UPDATED AT", MinWidth: 19},
+				{Label: "LABELS"},
+			},
+			SortIndicator: func() (int, bool) {
+				return int(m.sortField), m.sortAscending
+			},
+		},
+		Footer: &filterlist.FooterConfig{ItemLabel: "Config"},
 	}
+	list.SetOuterSize(width, height)
 
 	// Initialize name input for create dialog
 	nameInput := textinput.New()
@@ -127,21 +148,14 @@ func New(width, height int) *Model {
 	labelsInput.CharLimit = 512
 	labelsInput.Width = 50
 
-	return &Model{
-		configsList:       list,
-		width:             width,
-		height:            height,
-		firstResize:       true,
-		state:             stateLoading,
-		visible:           true,
-		confirmDialog:     confirmdialog.New(0, 0),
-		loadingView:       loading.New(width, height, false, "Loading Docker configs..."),
-		createNameInput:   nameInput,
-		createFileInput:   fileInput,
-		createLabelsInput: labelsInput,
-		sortField:         SortByName,
-		sortAscending:     true,
-	}
+	m.configsList = list
+	m.confirmDialog = confirmdialog.New(0, 0)
+	m.loadingView = loading.New(width, height, false, "Loading Docker configs...")
+	m.createNameInput = nameInput
+	m.createFileInput = fileInput
+	m.createLabelsInput = labelsInput
+
+	return m
 }
 
 func (m *Model) Name() string { return ViewName }

--- a/views/configs/update.go
+++ b/views/configs/update.go
@@ -88,6 +88,12 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 		// msg.Height is already adjusted by the app to account for the
 		// systeminfo header; avoid subtracting extra lines here.
 		m.configsList.Viewport.Height = msg.Height
+		m.configsList.SetOuterSize(msg.Width, msg.Height)
+		if m.usedByViewActive {
+			m.usedByList.Viewport.Width = msg.Width
+			m.usedByList.Viewport.Height = msg.Height
+			m.usedByList.SetOuterSize(msg.Width, msg.Height)
+		}
 		// On first resize, reset YOffset to 0; on subsequent resizes, only reset if cursor is at top
 		if m.firstResize {
 			m.configsList.Viewport.YOffset = 0
@@ -315,28 +321,15 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 				return strings.Contains(strings.ToLower(item.StackName), strings.ToLower(query)) ||
 					strings.Contains(strings.ToLower(item.ServiceName), strings.ToLower(query))
 			},
+			Header: &filterlist.HeaderConfig{
+				Columns: []filterlist.ColumnDef{
+					{Label: "STACK NAME"},
+					{Label: "SERVICE NAME"},
+				},
+			},
+			Footer: &filterlist.FooterConfig{ItemLabel: "Stack"},
 			RenderItem: func(item usedByItem, selected bool, _ int) string {
-				// Compute proportional widths for two columns based on viewport
-				width := vp.Width
-				if width <= 0 {
-					width = 80
-				}
-				cols := 2
-				starts := make([]int, cols)
-				for i := 0; i < cols; i++ {
-					starts[i] = (i * width) / cols
-				}
-				colWidths := make([]int, cols)
-				for i := 0; i < cols; i++ {
-					if i == cols-1 {
-						colWidths[i] = width - starts[i]
-					} else {
-						colWidths[i] = starts[i+1] - starts[i]
-					}
-					if colWidths[i] < 1 {
-						colWidths[i] = 1
-					}
-				}
+				colWidths := m.usedByList.ColWidths()
 
 				// Prepare truncated texts
 				stackText := item.StackName
@@ -351,8 +344,7 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 				// Use bright white for content and reserve a leading space
 				itemStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("15"))
 				// Reserve one leading space for the first column so content aligns with headers
-				var col0 string
-				col0 = itemStyle.Render(fmt.Sprintf(" %-*s", colWidths[0]-1, stackText))
+				col0 := itemStyle.Render(fmt.Sprintf(" %-*s", colWidths[0]-1, stackText))
 				col1 := itemStyle.Render(fmt.Sprintf("%-*s", colWidths[1], svcText))
 				line := col0 + col1
 
@@ -367,6 +359,7 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 				return line
 			},
 		}
+		m.usedByList.SetOuterSize(w, h)
 
 		// Important: keep Items as a non-nil slice even when empty.
 		// If Items is nil, FilterableList.VisibleContent bypasses its padded empty-state,
@@ -376,9 +369,6 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 		if m.usedByList.Items == nil {
 			m.usedByList.Items = []usedByItem{}
 		}
-		// Keep viewport sizes in sync
-		m.usedByList.Viewport.Width = vp.Width
-		m.usedByList.Viewport.Height = vp.Height
 		m.usedByList.ApplyFilter()
 
 		m.usedByConfigName = msg.ConfigName
@@ -669,67 +659,7 @@ func (m *Model) setRenderItem() {
 	itemStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("15"))
 
 	m.configsList.RenderItem = func(cfg configItem, selected bool, _ int) string {
-		// Recompute proportional column widths on each render to adapt to viewport resizes.
-		width := m.configsList.Viewport.Width
-		if width <= 0 {
-			width = 80
-		}
-
-		// Columns: NAME | ID | USED | LABELS | CREATED | UPDATED
-		cols := 6
-		starts := make([]int, cols)
-		for i := 0; i < cols; i++ {
-			starts[i] = (i * width) / cols
-		}
-		colWidths := make([]int, cols)
-		for i := 0; i < cols; i++ {
-			if i == cols-1 {
-				colWidths[i] = width - starts[i]
-			} else {
-				colWidths[i] = starts[i+1] - starts[i]
-			}
-			if colWidths[i] < 1 {
-				colWidths[i] = 1
-			}
-		}
-
-		// Ensure CREATED and UPDATED columns have at least 19 chars
-		minTime := 19
-		// current sum of created + updated columns
-		cur := colWidths[3] + colWidths[4]
-		if cur < 2*minTime {
-			deficit := 2*minTime - cur
-			// steal space from earlier cols (prefer NAME then ID)
-			for i := 2; i >= 0 && deficit > 0; i-- {
-				take := deficit
-				if colWidths[i] > take+5 { // leave minimum 5 for each
-					colWidths[i] -= take
-					deficit = 0
-				} else {
-					take = colWidths[i] - 5
-					if take > 0 {
-						colWidths[i] -= take
-						deficit -= take
-					}
-				}
-			}
-			// recompute last two to have minTime each if possible
-			if colWidths[3] < minTime {
-				colWidths[3] = minTime
-			}
-			if colWidths[4] < minTime {
-				colWidths[4] = minTime
-			}
-		}
-
-		// Ensure USED column has at least 1 char
-		if colWidths[2] < 1 {
-			colWidths[2] = 1
-		}
-
-		// Update cached widths for header alignment
-		m.colNameWidth = colWidths[0]
-		m.colIDWidth = colWidths[1]
+		colWidths := m.configsList.ColWidths()
 
 		// Prepare cell texts (truncate where necessary)
 		// Reserve one character for the leading space in the first column

--- a/views/configs/view.go
+++ b/views/configs/view.go
@@ -11,8 +11,6 @@ import (
 	"swarmcli/docker"
 	"swarmcli/ui"
 	"swarmcli/ui/components/errordialog"
-	filterlist "swarmcli/ui/components/filterable/list"
-	"swarmcli/ui/components/sorting"
 	"time"
 
 	"github.com/charmbracelet/lipgloss"
@@ -111,33 +109,8 @@ func (m *Model) View() string {
 		width = m.width
 	}
 
-	header := m.renderConfigsHeader(m.configsList.Items, width)
-
-	// Fixme: https://github.com/mosonyi/swarmcli/issues/141
-	nameCol := m.colNameWidth
-	idCol := m.colIDWidth
-	if nameCol <= 0 {
-		nameCol = len("NAME")
-	}
-	if idCol <= 0 {
-		idCol = len("ID")
-	}
-	// column width calculations are handled in setRenderItem; the
-	// FilterableList's RenderItem now controls formatting.
-	for _, cfg := range m.configsList.Items {
-		if len(cfg.Name) > nameCol {
-			nameCol = len(cfg.Name)
-		}
-		if len(cfg.ID) > idCol {
-			idCol = len(cfg.ID)
-		}
-	}
-	// Render exactly desiredContentLines rows from the configs list without
-	// mutating the viewport height each render to prevent jitter.
-	// We'll compute desiredContentLines below and then call VisibleContent.
-	// (placeholder for content variable; actual value assigned later)
-	var content string
-	footer := m.renderConfigsFooter()
+	header := m.configsList.RenderHeader()
+	footer := m.configsList.RenderFooter()
 
 	frame := ui.ComputeFrameDimensions(
 		m.configsList.Viewport.Width,
@@ -148,11 +121,7 @@ func (m *Model) View() string {
 		footer,
 	)
 
-	// Use VisibleContent to get only the visible portion based on cursor position
-	// This ensures proper scrolling and that the cursor is always visible
-	// VisibleContent already returns exactly desiredContentLines, so we use
-	// RenderFramedBox instead of RenderFramedBoxHeight to avoid double-padding
-	content = m.configsList.VisibleContent(frame.DesiredContentLines)
+	content := m.configsList.VisibleContent(frame.DesiredContentLines)
 
 	// Apply overlays to content BEFORE framing
 	if m.fileBrowserActive {
@@ -176,108 +145,6 @@ func (m *Model) View() string {
 	view := ui.RenderFramedBox(title, header, content, footer, frame.FrameWidth)
 
 	return view
-}
-
-func (m *Model) renderConfigsHeader(items []configItem, width int) string {
-	if len(items) == 0 {
-		return "NAME         ID                 CONFIG USED    CREATED AT             UPDATED AT             LABELS"
-	}
-	if width <= 0 {
-		width = 80
-	}
-	cols := 6
-	starts := make([]int, cols)
-	for i := 0; i < cols; i++ {
-		starts[i] = (i * width) / cols
-	}
-	colWidths := make([]int, cols)
-	for i := 0; i < cols; i++ {
-		if i == cols-1 {
-			colWidths[i] = width - starts[i]
-		} else {
-			colWidths[i] = starts[i+1] - starts[i]
-		}
-		if colWidths[i] < 1 {
-			colWidths[i] = 1
-		}
-	}
-
-	// Ensure CREATED and UPDATED columns have at least 19 chars
-	minTime := 19
-	cur := colWidths[3] + colWidths[4]
-	if cur < 2*minTime {
-		deficit := 2*minTime - cur
-		for i := 2; i >= 0 && deficit > 0; i-- {
-			take := deficit
-			if colWidths[i] > take+5 {
-				colWidths[i] -= take
-				deficit = 0
-			} else {
-				take = colWidths[i] - 5
-				if take > 0 {
-					colWidths[i] -= take
-					deficit -= take
-				}
-			}
-		}
-		if colWidths[3] < minTime {
-			colWidths[3] = minTime
-		}
-		if colWidths[4] < minTime {
-			colWidths[4] = minTime
-		}
-	}
-
-	if colWidths[2] < 1 {
-		colWidths[2] = 1
-	}
-
-	// Prefix first label with a leading space to match item alignment
-	labels := []string{" NAME", "ID", "CONFIG USED", "CREATED AT", "UPDATED AT", "LABELS"}
-
-	// Add sort indicators
-	arrow := func() string {
-		if m.sortAscending {
-			return sorting.SortArrow(sorting.Ascending)
-		}
-		return sorting.SortArrow(sorting.Descending)
-	}
-	if m.sortField == SortByName {
-		labels[0] = fmt.Sprintf(" NAME %s", arrow())
-	}
-	if m.sortField == SortByID {
-		labels[1] = fmt.Sprintf("ID %s", arrow())
-	}
-	if m.sortField == SortByUsed {
-		labels[2] = fmt.Sprintf("CONFIG USED %s", arrow())
-	}
-	if m.sortField == SortByCreated {
-		labels[3] = fmt.Sprintf("CREATED AT %s", arrow())
-	}
-	if m.sortField == SortByUpdated {
-		labels[4] = fmt.Sprintf("UPDATED AT %s", arrow())
-	}
-	if m.sortField == SortByLabels {
-		labels[5] = fmt.Sprintf("LABELS %s", arrow())
-	}
-
-	return ui.RenderColumnHeader(labels, colWidths)
-}
-func (m *Model) renderConfigsFooter() string {
-	status := fmt.Sprintf("Config %d of %d", m.configsList.Cursor+1, len(m.configsList.Filtered))
-	statusBar := ui.StatusBarStyle.Render(status)
-
-	var footer string
-	if m.configsList.Mode == filterlist.ModeSearching {
-		footer = ui.StatusBarStyle.Render("Filter (type then Enter): " + m.configsList.Query)
-	} else if m.configsList.Query != "" {
-		footer = ui.StatusBarStyle.Render("Filter: " + m.configsList.Query)
-	}
-
-	if footer != "" {
-		return statusBar + "\n" + footer
-	}
-	return statusBar
 }
 
 func (m *Model) renderCreateDialog() string {
@@ -413,77 +280,9 @@ func (m *Model) renderUsedByView() string {
 		return "Error: UsedBy view not properly initialized"
 	}
 
-	header := m.renderUsedByHeader()
-	footer := m.renderUsedByFooter()
-
-	// Compute frame dimensions to get the exact number of content lines needed
-	frame := ui.ComputeFrameDimensions(
-		m.usedByList.Viewport.Width,
-		m.usedByList.Viewport.Height,
-		m.width,
-		m.height,
-		header,
-		footer,
-	)
-
-	// Use VisibleContent to get only the visible portion based on cursor position
-	// This ensures proper scrolling and that the cursor is always visible
-	content := m.usedByList.VisibleContent(frame.DesiredContentLines)
-
 	title := fmt.Sprintf("Config: %s - Used By Stacks (%d)", m.usedByConfigName, len(m.usedByList.Filtered))
-	return ui.RenderFramedBox(title, header, content, footer, frame.FrameWidth)
-}
-
-func (m *Model) renderUsedByHeader() string {
-	width := m.usedByList.Viewport.Width
-	if width <= 0 {
-		width = m.width
-	}
-	if width <= 0 {
-		width = 80
-	}
-	cols := 2
-	starts := make([]int, cols)
-	for i := 0; i < cols; i++ {
-		starts[i] = (i * width) / cols
-	}
-	colWidths := make([]int, cols)
-	for i := 0; i < cols; i++ {
-		if i == cols-1 {
-			colWidths[i] = width - starts[i]
-		} else {
-			colWidths[i] = starts[i+1] - starts[i]
-		}
-		if colWidths[i] < 1 {
-			colWidths[i] = 1
-		}
-	}
-
-	// Uppercase labels and prefix first label with a leading space to align
-	labels := []string{" STACK NAME", "SERVICE NAME"}
-	return ui.RenderColumnHeader(labels, colWidths)
-}
-
-func (m *Model) renderUsedByFooter() string {
-	totalStacks := len(m.usedByList.Items)
-	if totalStacks == 0 {
-		return ui.StatusBarStyle.Render("No stacks use this config")
-	}
-
-	status := fmt.Sprintf("Stack %d of %d", m.usedByList.Cursor+1, len(m.usedByList.Filtered))
-	statusBar := ui.StatusBarStyle.Render(status)
-
-	var footer string
-	if m.usedByList.Mode == filterlist.ModeSearching {
-		footer = ui.StatusBarStyle.Render("Filter (type then Enter): " + m.usedByList.Query)
-	} else if m.usedByList.Query != "" {
-		footer = ui.StatusBarStyle.Render("Filter: " + m.usedByList.Query)
-	}
-
-	if footer != "" {
-		return statusBar + "\n" + footer
-	}
-	return statusBar
+	framed, _ := m.usedByList.RenderFramedView(title)
+	return framed
 }
 
 // formatLabels formats labels map to sorted key=value string

--- a/views/contexts/model.go
+++ b/views/contexts/model.go
@@ -126,14 +126,7 @@ func New() *Model {
 	vp := viewport.New(80, 20)
 	vp.SetContent("")
 
-	list := filterlist.FilterableList[docker.ContextInfo]{
-		Viewport: vp,
-		Match: func(item docker.ContextInfo, query string) bool {
-			return strings.Contains(strings.ToLower(item.Name), strings.ToLower(query))
-		},
-	}
-
-	return &Model{
+	m := &Model{
 		Visible:          false,
 		contexts:         []docker.ContextInfo{},
 		cursor:           0,
@@ -148,10 +141,35 @@ func New() *Model {
 		createCertInput:  createCertInput,
 		createKeyInput:   createKeyInput,
 		editDescInput:    editDescInput,
-		List:             list,
 		sortField:        SortByName,
 		sortAscending:    true,
 	}
+
+	list := filterlist.FilterableList[docker.ContextInfo]{
+		Viewport: vp,
+		Match: func(item docker.ContextInfo, query string) bool {
+			return strings.Contains(strings.ToLower(item.Name), strings.ToLower(query))
+		},
+		Header: &filterlist.HeaderConfig{
+			Columns: []filterlist.ColumnDef{
+				{Label: " NAME"}, {Label: "TLS"}, {Label: "DESCRIPTION"}, {Label: "ENDPOINT"}, {Label: "ERROR"},
+			},
+			SortIndicator: func() (int, bool) {
+				colMap := map[SortField]int{
+					SortByName: 0, SortByStatus: 1, SortByDescription: 2, SortByEndpoint: 3,
+				}
+				col, ok := colMap[m.sortField]
+				if !ok {
+					return -1, true
+				}
+				return col, m.sortAscending
+			},
+		},
+	}
+	list.SetOuterSize(80, 20)
+
+	m.List = list
+	return m
 }
 
 func (m *Model) SetSize(width, height int) {

--- a/views/contexts/update.go
+++ b/views/contexts/update.go
@@ -49,6 +49,7 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 	case tea.WindowSizeMsg:
 		m.viewport.Width = msg.Width
 		m.viewport.Height = msg.Height
+		m.List.SetOuterSize(msg.Width, msg.Height)
 		// Keep the internal list viewport in sync with the new size so
 		// the framed box fills the area immediately.
 		if msg.Width > 0 {

--- a/views/contexts/view.go
+++ b/views/contexts/view.go
@@ -10,7 +10,6 @@ import (
 	"swarmcli/docker"
 	"swarmcli/ui"
 	"swarmcli/ui/components/errordialog"
-	"swarmcli/ui/components/sorting"
 
 	"github.com/charmbracelet/lipgloss"
 )
@@ -85,23 +84,11 @@ func (m *Model) View() string {
 
 	// Use FilterableList for the contexts content. Keep its viewport size
 	// in sync with the inner content area (DesiredContentLines), otherwise
-	// the list can effectively scroll past the top and “hide” the first rows.
+	// the list can effectively scroll past the top and "hide" the first rows.
 	m.List.Viewport.Width = width
 	m.List.Viewport.Height = frame.DesiredContentLines
 
-	// Compute column widths as five equal percentage chunks so columns
-	// start at 0%, 20%, 40%, 60% and 80% of the content width.
-	contentWidth := width
-	base := contentWidth / 5
-	colWidths := make([]int, 5)
-	for i := 0; i < 5; i++ {
-		colWidths[i] = base
-	}
-	// Distribute remainder to the leftmost columns
-	rem := contentWidth - base*5
-	for i := 0; i < rem && i < 5; i++ {
-		colWidths[i]++
-	}
+	colWidths := m.List.ColWidths()
 
 	// Now define render using those exact column widths so items align
 	m.List.RenderItem = func(ctx docker.ContextInfo, selected bool, _ int) string {
@@ -191,56 +178,11 @@ func (m *Model) View() string {
 		loadingLine := lipgloss.NewStyle().Foreground(lipgloss.Color("240")).Render("Loading contexts...")
 		content = ui.TrimOrPadContentToLines(loadingLine, frame.DesiredContentLines)
 	} else {
-		// Column header displayed in the frame header slot. Build it here
-		// so it aligns exactly with the row layout.
 		// VisibleContent returns exactly DesiredContentLines and keeps the cursor visible.
 		listContent := m.List.VisibleContent(frame.DesiredContentLines)
 
-		// Header: reserve two leading spaces so the NAME label lines up
-		// with the name text that starts after the current marker and a space.
-		nameLbl := "  NAME"
-		statusLbl := "TLS"
-		descLbl := "DESCRIPTION"
-		endpointLbl := "ENDPOINT"
-
-		// Add sort indicators
-		if m.sortField == SortByName {
-			arrow := sorting.SortArrow(sorting.Ascending)
-			if !m.sortAscending {
-				arrow = sorting.SortArrow(sorting.Descending)
-			}
-			nameLbl = fmt.Sprintf("  NAME %s", arrow)
-		}
-		if m.sortField == SortByStatus {
-			arrow := sorting.SortArrow(sorting.Ascending)
-			if !m.sortAscending {
-				arrow = sorting.SortArrow(sorting.Descending)
-			}
-			statusLbl = fmt.Sprintf("TLS %s", arrow)
-		}
-		if m.sortField == SortByDescription {
-			arrow := sorting.SortArrow(sorting.Ascending)
-			if !m.sortAscending {
-				arrow = sorting.SortArrow(sorting.Descending)
-			}
-			descLbl = fmt.Sprintf("DESCRIPTION %s", arrow)
-		}
-		if m.sortField == SortByEndpoint {
-			arrow := sorting.SortArrow(sorting.Ascending)
-			if !m.sortAscending {
-				arrow = sorting.SortArrow(sorting.Descending)
-			}
-			endpointLbl = fmt.Sprintf("ENDPOINT %s", arrow)
-		}
-
-		headerLine := fmt.Sprintf("%-*s%-*s%-*s%-*s%-*s",
-			colWidths[0], nameLbl,
-			colWidths[1], statusLbl,
-			colWidths[2], descLbl,
-			colWidths[3], endpointLbl,
-			colWidths[4], "ERROR",
-		)
-		headerRendered = ui.FrameHeaderStyle.Render(headerLine)
+		// Column header with sort arrows rendered by FilterableList
+		headerRendered = m.List.RenderHeader()
 
 		content = listContent
 	}

--- a/views/networks/model.go
+++ b/views/networks/model.go
@@ -103,21 +103,6 @@ func New(width, height int) *Model {
 	vp := viewport.New(width, height)
 	vp.SetContent("")
 
-	list := filterlist.FilterableList[networkItem]{
-		Viewport: vp,
-		Match: func(n networkItem, query string) bool {
-			q := strings.ToLower(query)
-			return strings.Contains(strings.ToLower(n.Name), q) ||
-				strings.Contains(strings.ToLower(n.ID), q) ||
-				strings.Contains(strings.ToLower(n.Driver), q) ||
-				strings.Contains(strings.ToLower(n.Scope), q)
-		},
-	}
-	// Important: make Items a non-nil slice so the FilterableList renderer pads
-	// content properly while loading (avoids truncated overlays / missing rows).
-	list.Items = []networkItem{}
-	list.Filtered = []networkItem{}
-
 	inspectVp := viewport.New(width, height)
 	inspectVp.SetContent("")
 
@@ -151,8 +136,7 @@ func New(width, height int) *Model {
 	ipv6Gateway.CharLimit = 64
 	ipv6Gateway.Width = 50
 
-	return &Model{
-		networksList:      list,
+	m := &Model{
 		width:             width,
 		height:            height,
 		firstResize:       true,
@@ -170,6 +154,50 @@ func New(width, height int) *Model {
 		createIPv6Subnet:  ipv6Subnet,
 		createIPv6Gateway: ipv6Gateway,
 	}
+
+	list := filterlist.FilterableList[networkItem]{
+		Viewport: vp,
+		Match: func(n networkItem, query string) bool {
+			q := strings.ToLower(query)
+			return strings.Contains(strings.ToLower(n.Name), q) ||
+				strings.Contains(strings.ToLower(n.ID), q) ||
+				strings.Contains(strings.ToLower(n.Driver), q) ||
+				strings.Contains(strings.ToLower(n.Scope), q)
+		},
+		Header: &filterlist.HeaderConfig{
+			Columns: []filterlist.ColumnDef{
+				{Label: "NAME"}, {Label: "DRIVER"}, {Label: "SCOPE"}, {Label: "USED"}, {Label: "ID"},
+			},
+			ColWidthsFunc: func(w int) []int {
+				nameW, driverW, scopeW, usedW, idW := m.networkColWidths(w)
+				return []int{nameW, driverW, scopeW, usedW, idW}
+			},
+			SortIndicator: func() (int, bool) {
+				colMap := map[SortField]int{
+					SortByName: 0, SortByDriver: 1, SortByScope: 2, SortByUsed: 3, SortByID: 4,
+				}
+				col, ok := colMap[m.sortField]
+				if !ok {
+					return -1, true
+				}
+				return col, m.sortAscending
+			},
+		},
+		Footer: &filterlist.FooterConfig{
+			ItemLabel: "Network",
+			Override: func(cursor, filteredCount int, mode filterlist.ModeType, query string) string {
+				return m.renderNetworksFooter()
+			},
+		},
+	}
+	// Important: make Items a non-nil slice so the FilterableList renderer pads
+	// content properly while loading (avoids truncated overlays / missing rows).
+	list.Items = []networkItem{}
+	list.Filtered = []networkItem{}
+	list.SetOuterSize(width, height)
+
+	m.networksList = list
+	return m
 }
 
 func (m *Model) Name() string { return ViewName }
@@ -313,10 +341,12 @@ func (m *Model) SetSize(width, height int) {
 	// do not subtract header/footer/help again.
 	m.networksList.Viewport.Width = width
 	m.networksList.Viewport.Height = height
+	m.networksList.SetOuterSize(width, height)
 
 	if m.usedByViewActive {
 		m.usedByList.Viewport.Width = width
 		m.usedByList.Viewport.Height = height
+		m.usedByList.SetOuterSize(width, height)
 	}
 }
 

--- a/views/networks/update.go
+++ b/views/networks/update.go
@@ -240,6 +240,7 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 		m.height = msg.Height
 		m.networksList.Viewport.Width = msg.Width
 		m.networksList.Viewport.Height = msg.Height
+		m.networksList.SetOuterSize(msg.Width, msg.Height)
 
 		// Inspect view uses its own viewport; keep it in sync with the window size.
 		inspectH := msg.Height - 4 // top+bottom borders + header + footer
@@ -252,6 +253,7 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 		if m.usedByViewActive {
 			m.usedByList.Viewport.Width = msg.Width
 			m.usedByList.Viewport.Height = msg.Height
+			m.usedByList.SetOuterSize(msg.Width, msg.Height)
 		}
 
 		if m.firstResize {
@@ -504,7 +506,31 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 				return strings.Contains(strings.ToLower(item.StackName), q) ||
 					strings.Contains(strings.ToLower(item.ServiceName), q)
 			},
+			Header: &filterlist.HeaderConfig{
+				Columns: []filterlist.ColumnDef{
+					{Label: "STACK"}, {Label: "SERVICE"},
+				},
+				ColWidthsFunc: func(width int) []int {
+					return []int{32, 50}
+				},
+			},
+			Footer: &filterlist.FooterConfig{
+				ItemLabel: "Service",
+				Override: func(cursor, filteredCount int, mode filterlist.ModeType, query string) string {
+					if mode == filterlist.ModeSearching {
+						return ui.StatusBarStyle.Render(fmt.Sprintf("Filter: %s", query))
+					}
+					if filteredCount == 0 {
+						return ui.StatusBarStyle.Render("No services using this network")
+					}
+					if query != "" {
+						return ui.StatusBarStyle.Render(fmt.Sprintf("%d/%d (filtered from %d)", cursor+1, filteredCount, len(m.usedByList.Items)))
+					}
+					return ui.StatusBarStyle.Render(fmt.Sprintf("%d/%d", cursor+1, len(m.usedByList.Items)))
+				},
+			},
 		}
+		m.usedByList.SetOuterSize(m.width, m.height)
 
 		m.usedByList.Items = msg.Services
 		m.setUsedByRenderItem()
@@ -1134,18 +1160,11 @@ func (m *Model) setRenderItem() {
 				Background(lipgloss.Color("63"))
 		}
 
-		width := colWidth
-		if width <= 0 {
-			width = m.networksList.Viewport.Width
+		colWidths := m.networksList.ColWidths()
+		if len(colWidths) < 5 {
+			return item.Name
 		}
-		if width <= 0 {
-			width = m.width
-		}
-		if width <= 0 {
-			width = 80
-		}
-
-		nameWidth, driverWidth, scopeWidth, usedWidth, idWidth := m.networkColWidths(width)
+		nameWidth, driverWidth, scopeWidth, usedWidth, idWidth := colWidths[0], colWidths[1], colWidths[2], colWidths[3], colWidths[4]
 		// Match header style: keep a small left padding for the first column so
 		// it doesn't touch the frame border.
 		innerNameWidth := nameWidth

--- a/views/networks/view.go
+++ b/views/networks/view.go
@@ -34,7 +34,7 @@ func (m *Model) View() string {
 	}
 
 	header := m.renderNetworksHeader(m.networksList.Items, width)
-	footer := m.renderNetworksFooter()
+	footer := m.networksList.RenderFooter()
 
 	frame := ui.ComputeFrameDimensions(
 		m.networksList.Viewport.Width,
@@ -207,11 +207,11 @@ func (m *Model) renderCreateNetworkDialog(width int) string {
 }
 
 func (m *Model) renderNetworksHeader(items []networkItem, width int) string {
-	if width <= 0 {
-		width = 80
+	colWidths := m.networksList.ColWidths()
+	if len(colWidths) < 5 {
+		return ""
 	}
-
-	nameWidth, driverWidth, scopeWidth, usedWidth, idWidth := m.networkColWidths(width)
+	nameWidth, driverWidth, scopeWidth, usedWidth, idWidth := colWidths[0], colWidths[1], colWidths[2], colWidths[3], colWidths[4]
 
 	// Store for rendering items (header alignment / other rendering)
 	m.colNameWidth = nameWidth
@@ -300,8 +300,8 @@ func (m *Model) renderUsedByView() string {
 		width = m.width
 	}
 
-	header := m.renderUsedByHeader(width)
-	footer := m.renderUsedByFooter()
+	header := m.usedByList.RenderHeader()
+	footer := m.usedByList.RenderFooter()
 
 	frame := ui.ComputeFrameDimensions(
 		m.usedByList.Viewport.Width,
@@ -324,31 +324,6 @@ func (m *Model) renderUsedByView() string {
 	view := ui.RenderFramedBox(title, header, content, footer, frame.FrameWidth)
 
 	return view
-}
-
-func (m *Model) renderUsedByHeader(width int) string {
-	return ui.RenderColumnHeader([]string{" STACK", "SERVICE"}, []int{32, 50})
-}
-
-func (m *Model) renderUsedByFooter() string {
-	if m.usedByList.Mode == filterlist.ModeSearching {
-		prompt := fmt.Sprintf("Filter: %s", m.usedByList.Query)
-		return ui.StatusBarStyle.Render(prompt)
-	}
-
-	total := len(m.usedByList.Items)
-	filtered := len(m.usedByList.Filtered)
-	cursor := m.usedByList.Cursor + 1
-
-	if filtered == 0 {
-		return ui.StatusBarStyle.Render("No services using this network")
-	}
-
-	if len(m.usedByList.Query) > 0 {
-		return ui.StatusBarStyle.Render(fmt.Sprintf("%d/%d (filtered from %d)", cursor, filtered, total))
-	}
-
-	return ui.StatusBarStyle.Render(fmt.Sprintf("%d/%d", cursor, total))
 }
 
 func (m *Model) renderInspectView() string {

--- a/views/nodes/model.go
+++ b/views/nodes/model.go
@@ -59,15 +59,7 @@ func New(width, height int) *Model {
 	vp := viewport.New(width, height)
 	vp.SetContent("")
 
-	list := filterlist.FilterableList[docker.NodeEntry]{
-		Viewport: vp,
-		Match: func(n docker.NodeEntry, query string) bool {
-			return strings.Contains(strings.ToLower(n.Hostname), strings.ToLower(query))
-		},
-	}
-
-	return &Model{
-		List:          list,
+	m := &Model{
 		Visible:       false,
 		firstResize:   true,
 		width:         width,
@@ -76,6 +68,40 @@ func New(width, height int) *Model {
 		sortField:     SortByHostname,
 		sortAscending: true,
 	}
+
+	list := filterlist.FilterableList[docker.NodeEntry]{
+		Viewport: vp,
+		Match: func(n docker.NodeEntry, query string) bool {
+			return strings.Contains(strings.ToLower(n.Hostname), strings.ToLower(query))
+		},
+		Header: &filterlist.HeaderConfig{
+			Columns: []filterlist.ColumnDef{
+				{Label: "ID"}, {Label: "HOSTNAME"}, {Label: "ROLE"}, {Label: "STATE"},
+				{Label: "Availability"}, {Label: "MANAGER"}, {Label: "MGR STATUS"},
+				{Label: "VERSION"}, {Label: "ADDRESS"}, {Label: "LABELS"},
+			},
+			SortIndicator: func() (int, bool) {
+				sortColMap := map[SortField]int{
+					SortByHostname:     1,
+					SortByRole:         2,
+					SortByState:        3,
+					SortByAvailability: 4,
+					SortByVersion:      7,
+					SortByAddress:      8,
+					SortByLabels:       9,
+				}
+				col, ok := sortColMap[m.sortField]
+				if !ok {
+					return -1, true
+				}
+				return col, m.sortAscending
+			},
+		},
+		Footer: &filterlist.FooterConfig{ItemLabel: "Node"},
+	}
+	list.SetOuterSize(width, height)
+	m.List = list
+	return m
 }
 
 func (m *Model) Init() tea.Cmd {

--- a/views/nodes/update.go
+++ b/views/nodes/update.go
@@ -221,6 +221,7 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 	case tea.WindowSizeMsg:
 		m.List.Viewport.Width = msg.Width
 		m.List.Viewport.Height = msg.Height
+		m.List.SetOuterSize(msg.Width, msg.Height)
 		m.ready = true
 		// On first resize, reset YOffset to 0; on subsequent resizes, only reset if cursor is at top
 		if m.firstResize {
@@ -529,35 +530,13 @@ func (m *Model) SetContent(msg Msg) {
 }
 
 func (m *Model) setRenderItem() {
-	// Still need to call this for filterable list internals
-	m.List.ComputeAndSetColWidth(func(n docker.NodeEntry) string {
-		return n.ID
-	}, 15)
-
 	// Use bright white for content and reserve leading space in first column
 	itemStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("15"))
 
-	m.List.RenderItem = func(n docker.NodeEntry, selected bool, colWidth int) string {
-		// Compute proportional column widths for the current viewport width
-		width := m.List.Viewport.Width
-		if width <= 0 {
-			width = 80
-		}
-		cols := 10
-		starts := make([]int, cols)
-		for i := 0; i < cols; i++ {
-			starts[i] = (i * width) / cols
-		}
-		colWidths := make([]int, cols)
-		for i := 0; i < cols; i++ {
-			if i == cols-1 {
-				colWidths[i] = width - starts[i]
-			} else {
-				colWidths[i] = starts[i+1] - starts[i]
-			}
-			if colWidths[i] < 1 {
-				colWidths[i] = 1
-			}
+	m.List.RenderItem = func(n docker.NodeEntry, selected bool, _ int) string {
+		colWidths := m.List.ColWidths()
+		if len(colWidths) < 10 {
+			return n.Hostname
 		}
 		manager := "no"
 		if n.Manager {

--- a/views/nodes/view.go
+++ b/views/nodes/view.go
@@ -9,8 +9,6 @@ import (
 	"strings"
 	"swarmcli/docker"
 	"swarmcli/ui"
-	filterlist "swarmcli/ui/components/filterable/list"
-	"swarmcli/ui/components/sorting"
 
 	"github.com/charmbracelet/lipgloss"
 )
@@ -29,119 +27,8 @@ func (m *Model) View() string {
 	}
 
 	title := fmt.Sprintf("Nodes (%d total, %d manager%s)", total, managers, plural(managers))
-	// Add Manager Status column
-	labels := []string{"ID", "HOSTNAME", "ROLE", "STATE", "Availability", "MANAGER", "MGR STATUS", "VERSION", "ADDRESS", "LABELS"}
 
-	// Add sort indicators to labels
-	if m.sortField == SortByHostname {
-		arrow := sorting.SortArrow(sorting.Ascending)
-		if !m.sortAscending {
-			arrow = sorting.SortArrow(sorting.Descending)
-		}
-		labels[1] = fmt.Sprintf("HOSTNAME %s", arrow)
-	}
-	if m.sortField == SortByRole {
-		arrow := sorting.SortArrow(sorting.Ascending)
-		if !m.sortAscending {
-			arrow = sorting.SortArrow(sorting.Descending)
-		}
-		labels[2] = fmt.Sprintf("ROLE %s", arrow)
-	}
-	if m.sortField == SortByState {
-		arrow := sorting.SortArrow(sorting.Ascending)
-		if !m.sortAscending {
-			arrow = sorting.SortArrow(sorting.Descending)
-		}
-		labels[3] = fmt.Sprintf("STATE %s", arrow)
-	}
-	if m.sortField == SortByAvailability {
-		arrow := sorting.SortArrow(sorting.Ascending)
-		if !m.sortAscending {
-			arrow = sorting.SortArrow(sorting.Descending)
-		}
-		labels[4] = fmt.Sprintf("Availability %s", arrow)
-	}
-	if m.sortField == SortByVersion {
-		arrow := sorting.SortArrow(sorting.Ascending)
-		if !m.sortAscending {
-			arrow = sorting.SortArrow(sorting.Descending)
-		}
-		labels[6] = fmt.Sprintf("VERSION %s", arrow)
-	}
-	if m.sortField == SortByAddress {
-		arrow := sorting.SortArrow(sorting.Ascending)
-		if !m.sortAscending {
-			arrow = sorting.SortArrow(sorting.Descending)
-		}
-		labels[7] = fmt.Sprintf("ADDRESS %s", arrow)
-	}
-	if m.sortField == SortByLabels {
-		arrow := sorting.SortArrow(sorting.Ascending)
-		if !m.sortAscending {
-			arrow = sorting.SortArrow(sorting.Descending)
-		}
-		labels[8] = fmt.Sprintf("LABELS %s", arrow)
-	}
-	width := m.List.Viewport.Width
-	if width <= 0 {
-		if m.width > 0 {
-			width = m.width
-		} else {
-			width = 80
-		}
-	}
-	cols := 10
-	starts := make([]int, cols)
-	for i := 0; i < cols; i++ {
-		starts[i] = (i * width) / cols
-	}
-	colWidths := make([]int, cols)
-	for i := 0; i < cols; i++ {
-		if i == cols-1 {
-			colWidths[i] = width - starts[i]
-		} else {
-			colWidths[i] = starts[i+1] - starts[i]
-		}
-		if colWidths[i] < 1 {
-			colWidths[i] = 1
-		}
-	}
-	// Prefix first label with a leading space to match item alignment
-	labels[0] = " " + labels[0]
-	header := ui.RenderColumnHeader(labels, colWidths)
-
-	// Footer: cursor + optional search query
-	status := fmt.Sprintf("Node %d of %d", m.List.Cursor+1, len(m.List.Filtered))
-	statusBar := ui.StatusBarStyle.Render(status)
-
-	var footer string
-	if m.List.Mode == filterlist.ModeSearching {
-		footer = ui.StatusBarStyle.Render("Filter (type then Enter): " + m.List.Query)
-	} else if m.List.Query != "" {
-		footer = ui.StatusBarStyle.Render("Filter: " + m.List.Query)
-	}
-
-	if footer != "" {
-		footer = statusBar + "\n" + footer
-	} else {
-		footer = statusBar
-	}
-
-	frame := ui.ComputeFrameDimensions(
-		m.List.Viewport.Width,
-		m.List.Viewport.Height,
-		m.width,
-		m.height,
-		header,
-		footer,
-	)
-	if frame.DesiredContentLines < 1 {
-		frame.DesiredContentLines = 1
-	}
-
-	content := m.List.VisibleContent(frame.DesiredContentLines)
-
-	framed := ui.RenderFramedBox(title, header, content, footer, frame.FrameWidth)
+	framed, frame := m.List.RenderFramedView(title)
 
 	if m.labelInputDialog {
 		framed = ui.OverlayCentered(framed, m.renderLabelInputDialog(), frame.FrameWidth, frame.FrameHeight)

--- a/views/secrets/model.go
+++ b/views/secrets/model.go
@@ -74,10 +74,6 @@ type Model struct {
 	usedByList       filterlist.FilterableList[usedByItem]
 	usedBySecretName string
 
-	// Cached column widths for header alignment
-	colNameWidth int
-	colIDWidth   int
-
 	// Spinner for slow-used-status indicator
 	spinner int
 
@@ -99,6 +95,17 @@ func New(width, height int) *Model {
 	vp := viewport.New(width, height)
 	vp.SetContent("")
 
+	m := &Model{
+		width:              width,
+		height:             height,
+		firstResize:        true,
+		state:              stateLoading,
+		visible:            true,
+		sortField:          SortByName,
+		sortAscending:      true,
+		createEncodeSecret: true,
+	}
+
 	list := filterlist.FilterableList[secretItem]{
 		Viewport: vp,
 		Match: func(s secretItem, query string) bool {
@@ -106,7 +113,22 @@ func New(width, height int) *Model {
 			return strings.Contains(strings.ToLower(s.Name), q) ||
 				strings.Contains(strings.ToLower(s.ID), q)
 		},
+		Header: &filterlist.HeaderConfig{
+			Columns: []filterlist.ColumnDef{
+				{Label: "NAME"},
+				{Label: "ID"},
+				{Label: "SECRET USED"},
+				{Label: "CREATED AT", MinWidth: 19},
+				{Label: "UPDATED AT", MinWidth: 19},
+				{Label: "LABELS"},
+			},
+			SortIndicator: func() (int, bool) {
+				return int(m.sortField), m.sortAscending
+			},
+		},
+		Footer: &filterlist.FooterConfig{ItemLabel: "Secret"},
 	}
+	list.SetOuterSize(width, height)
 
 	// Initialize name input for create dialog
 	nameInput := textinput.New()
@@ -129,22 +151,14 @@ func New(width, height int) *Model {
 	labelsInput.CharLimit = 512
 	labelsInput.Width = 50
 
-	return &Model{
-		secretsList:        list,
-		width:              width,
-		height:             height,
-		firstResize:        true,
-		state:              stateLoading,
-		visible:            true,
-		confirmDialog:      confirmdialog.New(0, 0),
-		loadingView:        loading.New(width, height, false, "Loading Docker secrets..."),
-		createNameInput:    nameInput,
-		createFileInput:    fileInput,
-		createLabelsInput:  labelsInput,
-		createEncodeSecret: true, // Default to encoding
-		sortField:          SortByName,
-		sortAscending:      true,
-	}
+	m.secretsList = list
+	m.confirmDialog = confirmdialog.New(0, 0)
+	m.loadingView = loading.New(width, height, false, "Loading Docker secrets...")
+	m.createNameInput = nameInput
+	m.createFileInput = fileInput
+	m.createLabelsInput = labelsInput
+
+	return m
 }
 
 // HasActiveDialog returns true if any dialog is currently active

--- a/views/secrets/update.go
+++ b/views/secrets/update.go
@@ -90,6 +90,12 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 	case tea.WindowSizeMsg:
 		m.secretsList.Viewport.Width = msg.Width
 		m.secretsList.Viewport.Height = msg.Height
+		m.secretsList.SetOuterSize(msg.Width, msg.Height)
+		if m.usedByViewActive {
+			m.usedByList.Viewport.Width = msg.Width
+			m.usedByList.Viewport.Height = msg.Height
+			m.usedByList.SetOuterSize(msg.Width, msg.Height)
+		}
 		if m.firstResize {
 			m.secretsList.Viewport.YOffset = 0
 			m.firstResize = false
@@ -223,26 +229,17 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 				return strings.Contains(strings.ToLower(item.StackName), strings.ToLower(query)) ||
 					strings.Contains(strings.ToLower(item.ServiceName), strings.ToLower(query))
 			},
+			Header: &filterlist.HeaderConfig{
+				Columns: []filterlist.ColumnDef{
+					{Label: "STACK NAME"},
+					{Label: "SERVICE NAME"},
+				},
+			},
+			Footer: &filterlist.FooterConfig{ItemLabel: "Stack"},
 			RenderItem: func(item usedByItem, selected bool, _ int) string {
-				width := vp.Width
-				if width <= 0 {
-					width = 80
-				}
-				cols := 2
-				starts := make([]int, cols)
-				for i := 0; i < cols; i++ {
-					starts[i] = (i * width) / cols
-				}
-				colWidths := make([]int, cols)
-				for i := 0; i < cols; i++ {
-					if i == cols-1 {
-						colWidths[i] = width - starts[i]
-					} else {
-						colWidths[i] = starts[i+1] - starts[i]
-					}
-					if colWidths[i] < 1 {
-						colWidths[i] = 1
-					}
+				colWidths := m.usedByList.ColWidths()
+				if len(colWidths) < 2 {
+					return item.StackName
 				}
 
 				stackText := item.StackName
@@ -269,6 +266,7 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 				return line
 			},
 		}
+		m.usedByList.SetOuterSize(w, h)
 
 		// Important: keep Items as a non-nil slice even when empty.
 		// This ensures FilterableList.VisibleContent uses its padded empty-state rendering.
@@ -539,62 +537,10 @@ func (m *Model) setRenderItem() {
 	itemStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("15"))
 
 	m.secretsList.RenderItem = func(sec secretItem, selected bool, _ int) string {
-		width := m.secretsList.Viewport.Width
-		if width <= 0 {
-			width = 80
+		colWidths := m.secretsList.ColWidths()
+		if len(colWidths) < 6 {
+			return sec.Name
 		}
-
-		// Columns: NAME | ID | USED | LABELS | CREATED | UPDATED
-		cols := 6
-		starts := make([]int, cols)
-		for i := 0; i < cols; i++ {
-			starts[i] = (i * width) / cols
-		}
-		colWidths := make([]int, cols)
-		for i := 0; i < cols; i++ {
-			if i == cols-1 {
-				colWidths[i] = width - starts[i]
-			} else {
-				colWidths[i] = starts[i+1] - starts[i]
-			}
-			if colWidths[i] < 1 {
-				colWidths[i] = 1
-			}
-		}
-
-		// Ensure CREATED and UPDATED columns have at least 19 chars
-		minTime := 19
-		cur := colWidths[3] + colWidths[4]
-		if cur < 2*minTime {
-			deficit := 2*minTime - cur
-			for i := 2; i >= 0 && deficit > 0; i-- {
-				take := deficit
-				if colWidths[i] > take+5 {
-					colWidths[i] -= take
-					deficit = 0
-				} else {
-					take = colWidths[i] - 5
-					if take > 0 {
-						colWidths[i] -= take
-						deficit -= take
-					}
-				}
-			}
-			if colWidths[3] < minTime {
-				colWidths[3] = minTime
-			}
-			if colWidths[4] < minTime {
-				colWidths[4] = minTime
-			}
-		}
-
-		if colWidths[2] < 1 {
-			colWidths[2] = 1
-		}
-
-		// Update cached widths for header alignment
-		m.colNameWidth = colWidths[0]
-		m.colIDWidth = colWidths[1]
 
 		// Prepare cell texts
 		nameText := truncateWithEllipsis(sec.Name, colWidths[0]-1)

--- a/views/secrets/view.go
+++ b/views/secrets/view.go
@@ -11,8 +11,6 @@ import (
 	"swarmcli/docker"
 	"swarmcli/ui"
 	"swarmcli/ui/components/errordialog"
-	filterlist "swarmcli/ui/components/filterable/list"
-	"swarmcli/ui/components/sorting"
 	"time"
 
 	"github.com/charmbracelet/lipgloss"
@@ -104,35 +102,8 @@ func (m *Model) View() string {
 		return m.renderUsedByView()
 	}
 
-	width := 80
-	if m.secretsList.Viewport.Width > 0 {
-		width = m.secretsList.Viewport.Width
-	} else if m.width > 0 {
-		width = m.width
-	}
-
-	header := m.renderSecretsHeader(m.secretsList.Items, width)
-
-	// column width calculations are handled in setRenderItem
-	nameCol := m.colNameWidth
-	idCol := m.colIDWidth
-	if nameCol <= 0 {
-		nameCol = len("NAME")
-	}
-	if idCol <= 0 {
-		idCol = len("ID")
-	}
-	for _, sec := range m.secretsList.Items {
-		if len(sec.Name) > nameCol {
-			nameCol = len(sec.Name)
-		}
-		if len(sec.ID) > idCol {
-			idCol = len(sec.ID)
-		}
-	}
-
-	var content string
-	footer := m.renderSecretsFooter()
+	header := m.secretsList.RenderHeader()
+	footer := m.secretsList.RenderFooter()
 
 	frame := ui.ComputeFrameDimensions(
 		m.secretsList.Viewport.Width,
@@ -143,7 +114,8 @@ func (m *Model) View() string {
 		footer,
 	)
 
-	content = m.secretsList.VisibleContent(frame.DesiredContentLines)
+	width := frame.FrameWidth
+	content := m.secretsList.VisibleContent(frame.DesiredContentLines)
 
 	// Apply overlays to content BEFORE framing
 	if m.fileBrowserActive {
@@ -167,109 +139,6 @@ func (m *Model) View() string {
 	view := ui.RenderFramedBox(title, header, content, footer, frame.FrameWidth)
 
 	return view
-}
-
-func (m *Model) renderSecretsHeader(items []secretItem, width int) string {
-	if len(items) == 0 {
-		return "NAME         ID                 SECRET USED    CREATED AT             UPDATED AT             LABELS"
-	}
-	if width <= 0 {
-		width = 80
-	}
-	cols := 6
-	starts := make([]int, cols)
-	for i := 0; i < cols; i++ {
-		starts[i] = (i * width) / cols
-	}
-	colWidths := make([]int, cols)
-	for i := 0; i < cols; i++ {
-		if i == cols-1 {
-			colWidths[i] = width - starts[i]
-		} else {
-			colWidths[i] = starts[i+1] - starts[i]
-		}
-		if colWidths[i] < 1 {
-			colWidths[i] = 1
-		}
-	}
-
-	// Ensure CREATED and UPDATED columns have at least 19 chars
-	minTime := 19
-	cur := colWidths[3] + colWidths[4]
-	if cur < 2*minTime {
-		deficit := 2*minTime - cur
-		for i := 2; i >= 0 && deficit > 0; i-- {
-			take := deficit
-			if colWidths[i] > take+5 {
-				colWidths[i] -= take
-				deficit = 0
-			} else {
-				take = colWidths[i] - 5
-				if take > 0 {
-					colWidths[i] -= take
-					deficit -= take
-				}
-			}
-		}
-		if colWidths[3] < minTime {
-			colWidths[3] = minTime
-		}
-		if colWidths[4] < minTime {
-			colWidths[4] = minTime
-		}
-	}
-
-	if colWidths[2] < 1 {
-		colWidths[2] = 1
-	}
-
-	// Prefix first label with a leading space to match item alignment
-	labels := []string{" NAME", "ID", "SECRET USED", "CREATED AT", "UPDATED AT", "LABELS"}
-
-	// Add sort indicators
-	arrow := func() string {
-		if m.sortAscending {
-			return sorting.SortArrow(sorting.Ascending)
-		}
-		return sorting.SortArrow(sorting.Descending)
-	}
-	if m.sortField == SortByName {
-		labels[0] = fmt.Sprintf(" NAME %s", arrow())
-	}
-	if m.sortField == SortByID {
-		labels[1] = fmt.Sprintf("ID %s", arrow())
-	}
-	if m.sortField == SortByUsed {
-		labels[2] = fmt.Sprintf("SECRET USED %s", arrow())
-	}
-	if m.sortField == SortByCreated {
-		labels[3] = fmt.Sprintf("CREATED AT %s", arrow())
-	}
-	if m.sortField == SortByUpdated {
-		labels[4] = fmt.Sprintf("UPDATED AT %s", arrow())
-	}
-	if m.sortField == SortByLabels {
-		labels[5] = fmt.Sprintf("LABELS %s", arrow())
-	}
-
-	return ui.RenderColumnHeader(labels, colWidths)
-}
-
-func (m *Model) renderSecretsFooter() string {
-	status := fmt.Sprintf("Secret %d of %d", m.secretsList.Cursor+1, len(m.secretsList.Filtered))
-	statusBar := ui.StatusBarStyle.Render(status)
-
-	var footer string
-	if m.secretsList.Mode == filterlist.ModeSearching {
-		footer = ui.StatusBarStyle.Render("Filter (type then Enter): " + m.secretsList.Query)
-	} else if m.secretsList.Query != "" {
-		footer = ui.StatusBarStyle.Render("Filter: " + m.secretsList.Query)
-	}
-
-	if footer != "" {
-		return statusBar + "\n" + footer
-	}
-	return statusBar
 }
 
 func (m *Model) renderCreateDialog() string {
@@ -487,74 +356,7 @@ func (m *Model) renderUsedByView() string {
 		return "Error: UsedBy view not properly initialized"
 	}
 
-	header := m.renderUsedByHeader()
-	footer := m.renderUsedByFooter()
-
-	// Compute frame dimensions to get the exact number of content lines needed
-	frame := ui.ComputeFrameDimensions(
-		m.usedByList.Viewport.Width,
-		m.usedByList.Viewport.Height,
-		m.width,
-		m.height,
-		header,
-		footer,
-	)
-
-	// Use VisibleContent to get only the visible portion based on cursor position
-	content := m.usedByList.VisibleContent(frame.DesiredContentLines)
-
 	title := fmt.Sprintf("Secret: %s - Used By Stacks (%d)", m.usedBySecretName, len(m.usedByList.Filtered))
-	return ui.RenderFramedBox(title, header, content, footer, frame.FrameWidth)
-}
-
-func (m *Model) renderUsedByHeader() string {
-	width := m.usedByList.Viewport.Width
-	if width <= 0 {
-		width = m.width
-	}
-	if width <= 0 {
-		width = 80
-	}
-	cols := 2
-	starts := make([]int, cols)
-	for i := 0; i < cols; i++ {
-		starts[i] = (i * width) / cols
-	}
-	colWidths := make([]int, cols)
-	for i := 0; i < cols; i++ {
-		if i == cols-1 {
-			colWidths[i] = width - starts[i]
-		} else {
-			colWidths[i] = starts[i+1] - starts[i]
-		}
-		if colWidths[i] < 1 {
-			colWidths[i] = 1
-		}
-	}
-
-	// Uppercase labels and prefix first label with a leading space to align
-	labels := []string{" STACK NAME", "SERVICE NAME"}
-	return ui.RenderColumnHeader(labels, colWidths)
-}
-
-func (m *Model) renderUsedByFooter() string {
-	totalStacks := len(m.usedByList.Items)
-	if totalStacks == 0 {
-		return ui.StatusBarStyle.Render("No stacks use this secret")
-	}
-
-	status := fmt.Sprintf("Stack %d of %d", m.usedByList.Cursor+1, len(m.usedByList.Filtered))
-	statusBar := ui.StatusBarStyle.Render(status)
-
-	var footer string
-	if m.usedByList.Mode == filterlist.ModeSearching {
-		footer = ui.StatusBarStyle.Render("Filter (type then Enter): " + m.usedByList.Query)
-	} else if m.usedByList.Query != "" {
-		footer = ui.StatusBarStyle.Render("Filter: " + m.usedByList.Query)
-	}
-
-	if footer != "" {
-		return statusBar + "\n" + footer
-	}
-	return statusBar
+	framed, _ := m.usedByList.RenderFramedView(title)
+	return framed
 }

--- a/views/services/model.go
+++ b/views/services/model.go
@@ -93,15 +93,7 @@ func (m *Model) SetPendingSelectServiceName(serviceName string) {
 func New(width, height int) *Model {
 	vp := viewport.New(width, height)
 
-	list := filterlist.FilterableList[docker.ServiceEntry]{
-		Viewport: vp,
-		Match: func(s docker.ServiceEntry, query string) bool {
-			return strings.Contains(strings.ToLower(s.ServiceName), strings.ToLower(query))
-		},
-	}
-
-	return &Model{
-		List:              list,
+	m := &Model{
 		Visible:           false,
 		firstResize:       true,
 		width:             width,
@@ -116,6 +108,37 @@ func New(width, height int) *Model {
 		sortField:         SortByName,
 		sortAscending:     true,
 	}
+
+	list := filterlist.FilterableList[docker.ServiceEntry]{
+		Viewport: vp,
+		Match: func(s docker.ServiceEntry, query string) bool {
+			return strings.Contains(strings.ToLower(s.ServiceName), strings.ToLower(query))
+		},
+		Header: &filterlist.HeaderConfig{
+			Columns: []filterlist.ColumnDef{
+				{Label: "SERVICE"}, {Label: "STACK"}, {Label: "REPLICAS"},
+				{Label: "STATUS"}, {Label: "MODE"}, {Label: "IMAGE"},
+				{Label: "PORTS"}, {Label: "CREATED"}, {Label: "UPDATED"}, {Label: "ERROR"},
+			},
+			ColWidthsFunc: m.computeColWidths,
+			SortIndicator: func() (int, bool) {
+				colMap := map[SortField]int{
+					SortByName: 0, SortByStatus: 3, SortByImage: 5,
+					SortByPorts: 6, SortByCreated: 7, SortByUpdated: 8, SortByError: 9,
+				}
+				col, ok := colMap[m.sortField]
+				if !ok {
+					return -1, true
+				}
+				return col, m.sortAscending
+			},
+		},
+		Footer: &filterlist.FooterConfig{ItemLabel: "Node"},
+	}
+	list.SetOuterSize(width, height)
+
+	m.List = list
+	return m
 }
 
 func (m *Model) Init() tea.Cmd {

--- a/views/services/update.go
+++ b/views/services/update.go
@@ -101,6 +101,7 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 	case tea.WindowSizeMsg:
 		m.List.Viewport.Width = msg.Width
 		m.List.Viewport.Height = msg.Height
+		m.List.SetOuterSize(msg.Width, msg.Height)
 		m.ready = true
 		// On first resize, reset YOffset to 0; on subsequent resizes, only reset if cursor is at top
 		if m.firstResize {
@@ -801,38 +802,13 @@ func (m *Model) computeColWidths(width int) []int {
 	return colWidths
 }
 
-// buildHeaderLine creates a header string using the same formatting rules as
-// the row renderer so labels line up exactly with data columns.
-func (m *Model) buildHeaderLine(labels []string, colWidths []int) string {
-	hdrs := make([]string, len(labels))
-	copy(hdrs, labels)
-	if len(hdrs) > 0 && !strings.HasPrefix(hdrs[0], " ") {
-		hdrs[0] = " " + hdrs[0]
-	}
-	line := make([]byte, 0, 256)
-	pos := 0
-	for i, h := range hdrs {
-		for len(line) < pos {
-			line = append(line, ' ')
-		}
-		s := fmt.Sprintf("%-*s", colWidths[i], h)
-		line = append(line, []byte(s)...)
-		pos += colWidths[i]
-	}
-	return string(line)
-}
-
 func (m *Model) setRenderItem() {
 	// Use shared computation for column widths to keep header and rows in sync
 	m.List.RenderItem = func(e docker.ServiceEntry, selected bool, _ int) string {
-		width := m.List.Viewport.Width
-		if width <= 0 {
-			width = 80
+		colWidths := m.List.ColWidths()
+		if len(colWidths) < 10 {
+			return e.ServiceName
 		}
-
-		colWidths := m.computeColWidths(width)
-		// sepLen := 2
-		// sep := strings.Repeat(" ", sepLen)
 
 		// Cache for header alignment
 		m.colServiceWidth = colWidths[0]

--- a/views/services/view.go
+++ b/views/services/view.go
@@ -4,95 +4,12 @@
 package servicesview
 
 import (
-	"fmt"
 	"swarmcli/ui"
-	filterlist "swarmcli/ui/components/filterable/list"
-	"swarmcli/ui/components/sorting"
 )
 
 func (m *Model) View() string {
-	width := m.List.Viewport.Width
-	if width <= 0 {
-		width = 80
-	}
-
-	// The header column widths are computed further down using the same
-	// effective-width logic as the renderer; see that computation below.
-	labels := []string{" SERVICE", "STACK", "REPLICAS", "STATUS", "MODE", "IMAGE", "PORTS", "CREATED", "UPDATED", "ERROR"}
-
-	// Add sort indicators to labels
-	if m.sortField == SortByName {
-		arrow := sorting.SortArrow(sorting.Ascending)
-		if !m.sortAscending {
-			arrow = sorting.SortArrow(sorting.Descending)
-		}
-		labels[0] = fmt.Sprintf(" SERVICE %s", arrow)
-	}
-	if m.sortField == SortByStatus {
-		arrow := sorting.SortArrow(sorting.Ascending)
-		if !m.sortAscending {
-			arrow = sorting.SortArrow(sorting.Descending)
-		}
-		labels[3] = fmt.Sprintf("STATUS %s", arrow)
-	}
-	if m.sortField == SortByImage {
-		arrow := sorting.SortArrow(sorting.Ascending)
-		if !m.sortAscending {
-			arrow = sorting.SortArrow(sorting.Descending)
-		}
-		labels[5] = fmt.Sprintf("IMAGE %s", arrow)
-	}
-	if m.sortField == SortByPorts {
-		arrow := sorting.SortArrow(sorting.Ascending)
-		if !m.sortAscending {
-			arrow = sorting.SortArrow(sorting.Descending)
-		}
-		labels[6] = fmt.Sprintf("PORTS %s", arrow)
-	}
-	if m.sortField == SortByCreated {
-		arrow := sorting.SortArrow(sorting.Ascending)
-		if !m.sortAscending {
-			arrow = sorting.SortArrow(sorting.Descending)
-		}
-		labels[7] = fmt.Sprintf("CREATED %s", arrow)
-	}
-	if m.sortField == SortByUpdated {
-		arrow := sorting.SortArrow(sorting.Ascending)
-		if !m.sortAscending {
-			arrow = sorting.SortArrow(sorting.Descending)
-		}
-		labels[8] = fmt.Sprintf("UPDATED %s", arrow)
-	}
-	if m.sortField == SortByError {
-		arrow := sorting.SortArrow(sorting.Ascending)
-		if !m.sortAscending {
-			arrow = sorting.SortArrow(sorting.Descending)
-		}
-		labels[9] = fmt.Sprintf("ERROR %s", arrow)
-	}
-	// Use the same column width computation as the renderer so header
-	// and rows stay perfectly aligned.
-	colWidths := m.computeColWidths(width)
-	headerLine := m.buildHeaderLine(labels, colWidths)
-	header := ui.FrameHeaderStyle.Render(headerLine)
-
-	// Footer: cursor + optional search query
-	status := fmt.Sprintf("Node %d of %d", m.List.Cursor+1, len(m.List.Filtered))
-	statusBar := ui.StatusBarStyle.Render(status)
-
-	var footer string
-	if m.List.Mode == filterlist.ModeSearching {
-		footer = ui.StatusBarStyle.Render("Filter (type then Enter): " + m.List.Query)
-	} else if m.List.Query != "" {
-		footer = ui.StatusBarStyle.Render("Filter: " + m.List.Query)
-	}
-
-	// Compose footer (status bar + optional filter line)
-	if footer != "" {
-		footer = statusBar + "\n" + footer
-	} else {
-		footer = statusBar
-	}
+	header := m.List.RenderHeader()
+	footer := m.List.RenderFooter()
 
 	frame := ui.ComputeFrameDimensions(
 		m.List.Viewport.Width,

--- a/views/stacks/model.go
+++ b/views/stacks/model.go
@@ -4,6 +4,7 @@
 package stacksview
 
 import (
+	"fmt"
 	"strings"
 	"swarmcli/core/primitives/hash"
 	"swarmcli/docker"
@@ -98,13 +99,54 @@ func New(width, height int) *Model {
 	vp.SetContent("")
 	vp.YOffset = 0
 
+	m := &Model{
+		Visible:           false,
+		firstResize:       true,
+		width:             width,
+		height:            height,
+		sortField:         SortByName,
+		sortAscending:     true,
+		expandedStacks:    make(map[string]bool),
+		stackTasks:        make(map[string][]docker.TaskEntry),
+		stackHasError:     make(map[string]bool),
+		stackErrorText:    make(map[string]string),
+		selectedTaskIndex: -1,
+		createDialogStep:  "source",
+		createStackSource: "file",
+	}
+
 	list := filterlist.FilterableList[docker.StackEntry]{
 		Viewport: vp,
 		// Render item will be initialized later after the column with is set
 		Match: func(s docker.StackEntry, query string) bool {
 			return strings.Contains(strings.ToLower(s.Name), strings.ToLower(query))
 		},
+		Header: &filterlist.HeaderConfig{
+			Columns: []filterlist.ColumnDef{
+				{Label: "STACK", Pct: 25},
+				{Label: "SERVICES", Pct: 10},
+				{Label: "TASKS", Pct: 10},
+				{Label: "ERROR", Pct: 55},
+			},
+			SortIndicator: func() (int, bool) {
+				return int(m.sortField), m.sortAscending
+			},
+			DynamicLabel: func(idx int, base string) string {
+				if idx == 3 {
+					count := 0
+					for _, v := range m.stackHasError {
+						if v {
+							count++
+						}
+					}
+					return fmt.Sprintf("ERROR: %d", count)
+				}
+				return ""
+			},
+		},
+		Footer: &filterlist.FooterConfig{ItemLabel: "Stack"},
 	}
+	list.SetOuterSize(width, height)
 
 	// Initialize name input for create dialog
 	nameInput := textinput.New()
@@ -120,25 +162,11 @@ func New(width, height int) *Model {
 	fileInput.CharLimit = 512
 	fileInput.Width = 50
 
-	return &Model{
-		List:              list,
-		Visible:           false,
-		firstResize:       true,
-		width:             width,
-		height:            height,
-		sortField:         SortByName,
-		sortAscending:     true,
-		expandedStacks:    make(map[string]bool),
-		stackTasks:        make(map[string][]docker.TaskEntry),
-		stackHasError:     make(map[string]bool),
-		stackErrorText:    make(map[string]string),
-		selectedTaskIndex: -1,
-		confirmDialog:     confirmdialog.New(width, height),
-		createNameInput:   nameInput,
-		createFileInput:   fileInput,
-		createDialogStep:  "source",
-		createStackSource: "file",
-	}
+	m.List = list
+	m.confirmDialog = confirmdialog.New(width, height)
+	m.createNameInput = nameInput
+	m.createFileInput = fileInput
+	return m
 }
 
 func (m *Model) Init() tea.Cmd {

--- a/views/stacks/update.go
+++ b/views/stacks/update.go
@@ -105,6 +105,7 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 		m.height = msg.Height
 		m.List.Viewport.Width = msg.Width
 		m.List.Viewport.Height = msg.Height
+		m.List.SetOuterSize(msg.Width, msg.Height)
 		m.ready = true
 
 		// On first resize (initialization), always reset YOffset to 0
@@ -1188,24 +1189,10 @@ func (m *Model) setRenderItem() {
 	itemStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("117"))
 
 	m.List.RenderItem = func(s docker.StackEntry, selected bool, _ int) string {
-		// Compute column widths similar to View()
-		width := m.List.Viewport.Width
-		if width <= 0 {
-			width = m.width
+		colWidths := m.List.ColWidths()
+		if len(colWidths) < 4 {
+			return s.Name
 		}
-		if width <= 0 {
-			width = 80
-		}
-		contentWidth := width
-		// STACK: 25%, SERVICES: 10%, TASKS: 10%, ERROR: 55% (remainder)
-		colWidths := make([]int, 4)
-		colWidths[0] = (contentWidth * 25) / 100
-		colWidths[1] = (contentWidth * 10) / 100
-		colWidths[2] = (contentWidth * 10) / 100
-		colWidths[3] = contentWidth - colWidths[0] - colWidths[1] - colWidths[2]
-
-		// Update cached width
-		m.width = width
 
 		// Prepare stack name
 		nameMax := colWidths[0] - 2

--- a/views/stacks/view.go
+++ b/views/stacks/view.go
@@ -7,8 +7,6 @@ import (
 	"fmt"
 	"strings"
 	"swarmcli/ui"
-	filterlist "swarmcli/ui/components/filterable/list"
-	"swarmcli/ui/components/sorting"
 
 	"github.com/charmbracelet/lipgloss"
 )
@@ -47,118 +45,11 @@ func (m *Model) View() string {
 		return ""
 	}
 
-	title := fmt.Sprintf("Stacks on Node (Total: %d)", len(m.List.Items))
-
-	// Compute four percentage-based column widths so columns start at
-	// 0%, 25%, 50%, 75% of the available content width.
-	width := m.List.Viewport.Width
-	if width <= 0 {
-		width = m.width
-	}
-	if width <= 0 {
-		width = 80
-	}
-	contentWidth := width
-
-	// Calculate column widths: allocate space for stack, services, tasks and error
-	// STACK: 25%, SERVICES: 10%, TASKS: 10%, ERROR: 55% (remainder)
-	colWidths := make([]int, 4)
-	colWidths[0] = (contentWidth * 25) / 100
-	colWidths[1] = (contentWidth * 10) / 100
-	colWidths[2] = (contentWidth * 10) / 100
-	colWidths[3] = contentWidth - colWidths[0] - colWidths[1] - colWidths[2]
-
-	// Build header using frame header style so it appears on the first
-	// line inside the framed box and aligns with rows below.
-	stackLabel := " STACK"
-	if m.sortField == SortByName {
-		arrow := sorting.SortArrow(sorting.Ascending)
-		if !m.sortAscending {
-			arrow = sorting.SortArrow(sorting.Descending)
-		}
-		stackLabel = fmt.Sprintf(" STACK %s", arrow)
-	}
-
-	servicesLabel := "SERVICES"
-	if m.sortField == SortByServices {
-		arrow := sorting.SortArrow(sorting.Ascending)
-		if !m.sortAscending {
-			arrow = sorting.SortArrow(sorting.Descending)
-		}
-		servicesLabel = fmt.Sprintf("SERVICES %s", arrow)
-	}
-
-	tasksLabel := "TASKS"
-	if m.sortField == SortByTasks {
-		arrow := sorting.SortArrow(sorting.Ascending)
-		if !m.sortAscending {
-			arrow = sorting.SortArrow(sorting.Descending)
-		}
-		tasksLabel = fmt.Sprintf("TASKS %s", arrow)
-	}
-
-	// Add ERROR column after TASKS with count of stacks having errors
-	errorCount := 0
-	for _, hasErr := range m.stackHasError {
-		if hasErr {
-			errorCount++
-		}
-	}
-	var errorLabel string
-	if m.sortField == SortByError {
-		arrow := sorting.SortArrow(sorting.Ascending)
-		if !m.sortAscending {
-			arrow = sorting.SortArrow(sorting.Descending)
-		}
-		errorLabel = fmt.Sprintf("ERROR: %d %s", errorCount, arrow)
-	} else {
-		errorLabel = fmt.Sprintf("ERROR: %d", errorCount)
-	}
-	headerLine := fmt.Sprintf("%-*s%-*s%-*s%-*s",
-		colWidths[0], stackLabel,
-		colWidths[1], servicesLabel,
-		colWidths[2], tasksLabel,
-		colWidths[3], errorLabel,
-	)
-	header := ui.FrameHeaderStyle.Render(headerLine)
-
-	// Footer: cursor + optional search query
-	status := fmt.Sprintf("Stack %d of %d", m.List.Cursor+1, len(m.List.Filtered))
-	statusBar := ui.StatusBarStyle.Render(status)
-
-	var footer string
-	if m.List.Mode == filterlist.ModeSearching {
-		footer = ui.StatusBarStyle.Render("Filter (type then Enter): " + m.List.Query)
-	} else if m.List.Query != "" {
-		footer = ui.StatusBarStyle.Render("Filter: " + m.List.Query)
-	}
-
-	if footer != "" {
-		footer = statusBar + "\n" + footer
-	} else {
-		footer = statusBar
-	}
-
 	// Ensure RenderItem can include expanded inline tasks
 	m.setRenderItem()
 
-	// Compute consistent frame sizing using shared helper (stacks is template)
-	frame := ui.ComputeFrameDimensions(
-		m.List.Viewport.Width,
-		m.List.Viewport.Height,
-		m.width,
-		m.height,
-		header,
-		footer,
-	)
-
-	// Use VisibleContent to get only the visible portion based on cursor position
-	// This ensures proper scrolling and that the cursor is always visible
-	// VisibleContent already returns exactly desiredContentLines, so we use
-	// RenderFramedBox instead of RenderFramedBoxHeight to avoid double-padding
-	content := m.List.VisibleContent(frame.DesiredContentLines)
-
-	framed := ui.RenderFramedBox(title, header, content, footer, frame.FrameWidth)
+	title := fmt.Sprintf("Stacks on Node (Total: %d)", len(m.List.Items))
+	framed, frame := m.List.RenderFramedView(title)
 
 	// Debug: log dialog states
 	l().Debugf("Rendering stacks view: createDialogActive=%v step=%s fileBrowserActive=%v",


### PR DESCRIPTION
## Summary
- Add `HeaderConfig`, `FooterConfig`, and `ColumnDef` types to `FilterableList` with `RenderHeader()`, `RenderFooter()`, `RenderFramedView()`, and `ColWidths()` methods
- Migrate all 7 views (nodes, stacks, secrets, configs, networks, contexts, services) to the new API, removing ~600 lines of duplicated header/footer/frame boilerplate
- Add nil-slice hardening for loading states (`ensureCursorVisible`, `RenderFooter` empty-list guard)
- Add 26 unit tests covering column computation, header/footer rendering, nil-safety, and integration

Closes #150, closes #151, closes #179.

## Test plan
- [x] `go build ./...` passes
- [x] `go test -race -count=1 ./...` — all tests pass (including 26 new FilterableList tests)
- [x] `golangci-lint run ./...` — 0 issues
- [x] Manual smoke test: verify header/footer rendering across all views
- [x] Manual smoke test: verify dialog overlays still render correctly
- [x] Manual smoke test: verify sort arrows update when toggling sort

🤖 Generated with [Claude Code](https://claude.com/claude-code)