### PR TITLE
Refactor UI: FrameProvider interface, centralized framing, universal fullscreen

### DIFF
--- a/app/model.go
+++ b/app/model.go
@@ -34,6 +34,9 @@ type Model struct {
 	// Terminal dimensions
 	terminalWidth  int
 	terminalHeight int
+
+	// Fullscreen mode — hides helpbar/stackbar, uses full terminal
+	fullscreen bool
 }
 
 var depsTransform func(docker.Deps) docker.Deps

--- a/app/update.go
+++ b/app/update.go
@@ -11,7 +11,6 @@ import (
 	"swarmcli/views/commandinput"
 	contextsview "swarmcli/views/contexts"
 	loadingview "swarmcli/views/loading"
-	logsview "swarmcli/views/logs"
 	nodesview "swarmcli/views/nodes"
 	stacksview "swarmcli/views/stacks"
 	systeminfoview "swarmcli/views/systeminfo"
@@ -82,14 +81,6 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case tea.WindowSizeMsg:
 		cmd := m.updateForResize(msg)
-		return m, cmd
-
-	case logsview.FullscreenToggledMsg:
-		// Trigger a resize to recalculate the available space
-		cmd := m.updateForResize(tea.WindowSizeMsg{
-			Width:  m.terminalWidth,
-			Height: m.terminalHeight,
-		})
 		return m, cmd
 
 	case tea.KeyMsg:
@@ -206,11 +197,7 @@ func (m *Model) updateForResize(msg tea.WindowSizeMsg) tea.Cmd {
 	m.terminalWidth = msg.Width
 	m.terminalHeight = msg.Height
 
-	// Check if current view is in fullscreen mode
-	isFullscreen := false
-	if logsView, ok := m.currentView.(interface{ GetFullscreen() bool }); ok {
-		isFullscreen = logsView.GetFullscreen()
-	}
+	isFullscreen := m.fullscreen
 
 	var usableWidth, usableHeight int
 	if isFullscreen {
@@ -281,6 +268,16 @@ func (m *Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	}
 	// Check if current view is in fullscreen or search mode before handling global esc
 	if msg.Type == tea.KeyEsc || msg.String() == "esc" {
+		// If in fullscreen, exit fullscreen first
+		if m.fullscreen {
+			m.fullscreen = false
+			cmd := m.updateForResize(tea.WindowSizeMsg{
+				Width:  m.terminalWidth,
+				Height: m.terminalHeight,
+			})
+			return m, cmd
+		}
+
 		// If a view is actively searching/filtering, let it handle ESC (and other keys)
 		if searchView, ok := m.currentView.(interface{ IsSearching() bool }); ok {
 			if searchView.IsSearching() {
@@ -309,13 +306,12 @@ func (m *Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				return m, cmd
 			}
 		}
-		// Check if logs view is in fullscreen or search mode
+		// Check if logs view is in search mode
 		if logsView, ok := m.currentView.(interface {
-			GetFullscreen() bool
 			GetSearchMode() bool
 		}); ok {
-			if logsView.GetFullscreen() || logsView.GetSearchMode() {
-				// Let the view handle esc to exit fullscreen or search mode
+			if logsView.GetSearchMode() {
+				// Let the view handle esc to exit search mode
 				cmd := m.currentView.Update(msg)
 				return m, cmd
 			}
@@ -357,6 +353,21 @@ func (m *Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		cmd := m.goBack()
+		return m, cmd
+	}
+
+	// Global fullscreen toggle
+	if msg.String() == "f" {
+		// Don't intercept if view is searching
+		if searchView, ok := m.currentView.(interface{ IsSearching() bool }); ok && searchView.IsSearching() {
+			cmd := m.currentView.Update(msg)
+			return m, cmd
+		}
+		m.fullscreen = !m.fullscreen
+		cmd := m.updateForResize(tea.WindowSizeMsg{
+			Width:  m.terminalWidth,
+			Height: m.terminalHeight,
+		})
 		return m, cmd
 	}
 

--- a/app/view.go
+++ b/app/view.go
@@ -49,15 +49,18 @@ func (m *Model) View() string {
 	// Subtract help bar (systeminfoview.Height) and stack bar (1 line) from the
 	// viewport height so the frame fits between chrome elements.
 	frameHeight := m.viewport.Height - systeminfoview.Height - 1
-	if frameHeight < 1 {
-		frameHeight = 1
-	}
-	framedView := ui.RenderViewFrame(title, header, content, footer, m.viewport.Width, frameHeight, false)
 
 	if m.commandInput.Visible() {
-		// Render a framed 3-line command box between the header and main view.
+		// Reserve 3 lines for the command frame so the main view shrinks.
+		const cmdFrameHeight = 3
+		frameHeight -= cmdFrameHeight
+		if frameHeight < 1 {
+			frameHeight = 1
+		}
+		framedView := ui.RenderViewFrame(title, header, content, footer, m.viewport.Width, frameHeight, false)
+
 		frameWidth := m.viewport.Width + 4
-		cmdFrame := ui.RenderFramedBoxHeight("", "", m.commandInput.View(), "", frameWidth, 3)
+		cmdFrame := ui.RenderFramedBoxHeight("", "", m.commandInput.View(), "", frameWidth, cmdFrameHeight)
 
 		return lipgloss.JoinVertical(
 			lipgloss.Left,
@@ -67,6 +70,11 @@ func (m *Model) View() string {
 			m.renderStackBar(),
 		)
 	}
+
+	if frameHeight < 1 {
+		frameHeight = 1
+	}
+	framedView := ui.RenderViewFrame(title, header, content, footer, m.viewport.Width, frameHeight, false)
 
 	return lipgloss.JoinVertical(
 		lipgloss.Left,

--- a/app/view.go
+++ b/app/view.go
@@ -44,7 +44,6 @@ func (m *Model) View() string {
 	title := m.currentView.FrameTitle()
 	header := m.currentView.FrameHeader()
 	content := m.currentView.FrameContent()
-	content = ui.LeftPadContent(content)
 	footer := m.currentView.FrameFooter()
 	// Subtract help bar (systeminfoview.Height) and stack bar (1 line) from the
 	// viewport height so the frame fits between chrome elements.

--- a/app/view.go
+++ b/app/view.go
@@ -13,16 +13,21 @@ import (
 )
 
 func (m *Model) View() string {
-	// Check if current view has fullscreen mode enabled
-	if logsView, ok := m.currentView.(interface{ GetFullscreen() bool }); ok && logsView.GetFullscreen() {
-		// Fullscreen mode: show only the current view (no helpbar, no stackbar)
-		return m.currentView.View()
+	// Fullscreen mode: show only the current view (no helpbar, no stackbar)
+	if m.fullscreen {
+		title := m.currentView.FrameTitle()
+		header := m.currentView.FrameHeader()
+		content := m.currentView.FrameContent()
+		return ui.RenderViewFrame(title, header, content, "", m.terminalWidth, m.terminalHeight, true)
 	}
 
 	systemInfo := m.systemInfo.View()
 
 	// Build global help - exclude "?" when already in help view
-	globalHelp := []helpbar.HelpEntry{{Key: "?", Desc: "Help"}}
+	globalHelp := []helpbar.HelpEntry{
+		{Key: "f", Desc: "Fullscreen"},
+		{Key: "?", Desc: "Help"},
+	}
 	if m.currentView.Name() == view.NameHelp {
 		globalHelp = []helpbar.HelpEntry{}
 	}
@@ -35,23 +40,30 @@ func (m *Model) View() string {
 		WithViewHelp(m.currentView.ShortHelpItems()).
 		View(systemInfo, hasError)
 
+	// Build the framed view from components
+	title := m.currentView.FrameTitle()
+	header := m.currentView.FrameHeader()
+	content := m.currentView.FrameContent()
+	content = ui.LeftPadContent(content)
+	footer := m.currentView.FrameFooter()
+	// Subtract help bar (systeminfoview.Height) and stack bar (1 line) from the
+	// viewport height so the frame fits between chrome elements.
+	frameHeight := m.viewport.Height - systeminfoview.Height - 1
+	if frameHeight < 1 {
+		frameHeight = 1
+	}
+	framedView := ui.RenderViewFrame(title, header, content, footer, m.viewport.Width, frameHeight, false)
+
 	if m.commandInput.Visible() {
 		// Render a framed 3-line command box between the header and main view.
-		// Use the viewport width (which is usable width) and add 4 to match
-		// the frame sizing used by views that render full-width frames.
 		frameWidth := m.viewport.Width + 4
-		// Render the normal framed command box then post-process the top
-		// border to replace corner glyphs so it visually integrates with
-		// the header above.
 		cmdFrame := ui.RenderFramedBoxHeight("", "", m.commandInput.View(), "", frameWidth, 3)
-
-		// Use the framed command box as rendered (keep corner glyphs)
 
 		return lipgloss.JoinVertical(
 			lipgloss.Left,
 			help,
 			cmdFrame,
-			m.currentView.View(),
+			framedView,
 			m.renderStackBar(),
 		)
 	}
@@ -59,7 +71,7 @@ func (m *Model) View() string {
 	return lipgloss.JoinVertical(
 		lipgloss.Left,
 		help,
-		m.currentView.View(),
+		framedView,
 		m.renderStackBar(),
 	)
 }

--- a/ui/components/errordialog/errordialog.go
+++ b/ui/components/errordialog/errordialog.go
@@ -5,7 +5,7 @@ package errordialog
 
 import (
 	"fmt"
-	"strings"
+	"swarmcli/ui"
 
 	"github.com/charmbracelet/lipgloss"
 )
@@ -38,7 +38,7 @@ func Render(errorMsg string) string {
 	lines = append(lines, itemStyle.Render(""))
 
 	maxWidth := 70
-	wrappedLines := wrapText(errorMsg, maxWidth)
+	wrappedLines := ui.WrapText(errorMsg, maxWidth)
 	for _, line := range wrappedLines {
 		lines = append(lines, itemStyle.Render(line))
 	}
@@ -52,35 +52,4 @@ func Render(errorMsg string) string {
 
 	content := lipgloss.JoinVertical(lipgloss.Left, lines...)
 	return borderStyle.Render(content)
-}
-
-func wrapText(text string, width int) []string {
-	if len(text) <= width {
-		return []string{text}
-	}
-
-	var lines []string
-	words := strings.Fields(text)
-	currentLine := ""
-
-	for _, word := range words {
-		if len(currentLine)+len(word)+1 <= width {
-			if currentLine == "" {
-				currentLine = word
-			} else {
-				currentLine += " " + word
-			}
-		} else {
-			if currentLine != "" {
-				lines = append(lines, currentLine)
-			}
-			currentLine = word
-		}
-	}
-
-	if currentLine != "" {
-		lines = append(lines, currentLine)
-	}
-
-	return lines
 }

--- a/ui/components/filterable/list/view.go
+++ b/ui/components/filterable/list/view.go
@@ -209,8 +209,8 @@ func (f *FilterableList[T]) RenderFooter() string {
 	return statusBar
 }
 
-// RenderFramedView builds the complete framed view: title, header, content, footer.
-// Returns the rendered string and a FrameSpec for dialog overlay positioning.
+// Deprecated: RenderFramedView builds the complete framed view. Use FrameTitle/FrameHeader/
+// FrameFooter/FrameContent on the parent view and let the app assemble the frame instead.
 func (f *FilterableList[T]) RenderFramedView(title string) (string, ui.FrameSpec) {
 	header := f.RenderHeader()
 	footer := f.RenderFooter()

--- a/ui/dialog/styles.go
+++ b/ui/dialog/styles.go
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package dialog
+
+import "github.com/charmbracelet/lipgloss"
+
+// Shared dialog styles used across views for consistent dialog rendering.
+var (
+	TitleStyle = lipgloss.NewStyle().
+			Bold(true).
+			Foreground(lipgloss.Color("15")).
+			Background(lipgloss.Color("63")).
+			Padding(0, 1)
+
+	BorderStyle = lipgloss.NewStyle().
+			Border(lipgloss.RoundedBorder()).
+			BorderForeground(lipgloss.Color("117"))
+
+	ItemStyle = lipgloss.NewStyle().
+			Padding(0, 1)
+
+	SelectedStyle = lipgloss.NewStyle().
+			Foreground(lipgloss.Color("15")).
+			Background(lipgloss.Color("63")).
+			Padding(0, 1)
+
+	HelpStyle = lipgloss.NewStyle().
+			Foreground(lipgloss.Color("240")).
+			Padding(0, 1)
+
+	KeyStyle = lipgloss.NewStyle().
+			Foreground(lipgloss.Color("63")).
+			Bold(true)
+)

--- a/ui/framedbox.go
+++ b/ui/framedbox.go
@@ -26,6 +26,15 @@ func RenderViewFrame(title, header, content, footer string, width, height int, f
 		return titleLine + "\n" + content
 	}
 
+	// Pad header, content, and footer uniformly so columns align inside the frame.
+	if header != "" {
+		header = LeftPadContent(header)
+	}
+	content = LeftPadContent(content)
+	if footer != "" {
+		footer = LeftPadContent(footer)
+	}
+
 	frame := ComputeFrameDimensions(width, height, width, height, header, footer)
 	trimmed := TrimOrPadContentToLines(content, frame.DesiredContentLines)
 	return RenderFramedBox(title, header, trimmed, footer, frame.FrameWidth)

--- a/ui/framedbox.go
+++ b/ui/framedbox.go
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package ui
+
+import (
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+// RenderViewFrame composes a complete framed view from its parts.
+// It computes frame dimensions, trims/pads content to fit, and renders
+// the bordered frame. When fullscreen is true, only a centered title
+// line and raw content are returned (no borders).
+func RenderViewFrame(title, header, content, footer string, width, height int, fullscreen bool) string {
+	if fullscreen {
+		titleText := FrameTitleStyle.Render(title)
+		titleLine := lipgloss.NewStyle().
+			Width(width).
+			Align(lipgloss.Center).
+			Render(titleText)
+		if header != "" {
+			return titleLine + "\n" + header + "\n" + content
+		}
+		return titleLine + "\n" + content
+	}
+
+	frame := ComputeFrameDimensions(width, height, width, height, header, footer)
+	trimmed := TrimOrPadContentToLines(content, frame.DesiredContentLines)
+	return RenderFramedBox(title, header, trimmed, footer, frame.FrameWidth)
+}
+
+// LeftPadContent prepends a single space to each line of content.
+func LeftPadContent(content string) string {
+	lines := strings.Split(content, "\n")
+	for i, line := range lines {
+		lines[i] = " " + line
+	}
+	return strings.Join(lines, "\n")
+}

--- a/ui/text.go
+++ b/ui/text.go
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package ui
+
+import "strings"
+
+// WrapText wraps text to the specified width, breaking on word boundaries.
+func WrapText(text string, width int) []string {
+	if len(text) <= width {
+		return []string{text}
+	}
+
+	var lines []string
+	words := strings.Fields(text)
+	if len(words) == 0 {
+		return []string{text}
+	}
+
+	currentLine := ""
+	for _, word := range words {
+		if len(currentLine)+len(word)+1 > width {
+			if currentLine != "" {
+				lines = append(lines, currentLine)
+				currentLine = word
+			} else {
+				lines = append(lines, word)
+			}
+		} else {
+			if currentLine == "" {
+				currentLine = word
+			} else {
+				currentLine += " " + word
+			}
+		}
+	}
+	if currentLine != "" {
+		lines = append(lines, currentLine)
+	}
+
+	return lines
+}

--- a/views/configs/view.go
+++ b/views/configs/view.go
@@ -11,39 +11,11 @@ import (
 	"swarmcli/docker"
 	"swarmcli/ui"
 	"swarmcli/ui/components/errordialog"
+	"swarmcli/ui/dialog"
 	"time"
 
 	"github.com/charmbracelet/lipgloss"
 	"github.com/docker/docker/api/types/swarm"
-)
-
-// Shared dialog styles
-var (
-	dialogTitleStyle = lipgloss.NewStyle().
-				Bold(true).
-				Foreground(lipgloss.Color("15")).
-				Background(lipgloss.Color("63")).
-				Padding(0, 1)
-
-	dialogBorderStyle = lipgloss.NewStyle().
-				Border(lipgloss.RoundedBorder()).
-				BorderForeground(lipgloss.Color("117"))
-
-	dialogItemStyle = lipgloss.NewStyle().
-			Padding(0, 1)
-
-	dialogSelectedStyle = lipgloss.NewStyle().
-				Foreground(lipgloss.Color("15")).
-				Background(lipgloss.Color("63")).
-				Padding(0, 1)
-
-	dialogHelpStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("240")).
-			Padding(0, 1)
-
-	dialogKeyStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("63")).
-			Bold(true)
 )
 
 type configItem struct {
@@ -96,10 +68,36 @@ func configItemFromSwarm(ctx context.Context, c swarm.Config) configItem {
 	}
 }
 
-func (m *Model) View() string {
-	// If in UsedBy view, render it instead of the main configs view
+func (m *Model) FrameTitle() string {
 	if m.usedByViewActive {
-		return m.renderUsedByView()
+		return fmt.Sprintf("Config: %s - Used By Stacks (%d)", m.usedByConfigName, len(m.usedByList.Filtered))
+	}
+	return fmt.Sprintf("Docker Configs (%d)", len(m.configsList.Filtered))
+}
+
+func (m *Model) FrameHeader() string {
+	if m.usedByViewActive {
+		return m.usedByList.RenderHeader()
+	}
+	return m.configsList.RenderHeader()
+}
+
+func (m *Model) FrameFooter() string {
+	if m.usedByViewActive {
+		return m.usedByList.RenderFooter()
+	}
+	return m.configsList.RenderFooter()
+}
+
+func (m *Model) FrameContent() string {
+	if m.usedByViewActive {
+		header := m.usedByList.RenderHeader()
+		footer := m.usedByList.RenderFooter()
+		frame := ui.ComputeFrameDimensions(
+			m.usedByList.Viewport.Width, m.usedByList.Viewport.Height,
+			m.width, m.height, header, footer,
+		)
+		return m.usedByList.VisibleContent(frame.DesiredContentLines)
 	}
 
 	width := 80
@@ -111,19 +109,12 @@ func (m *Model) View() string {
 
 	header := m.configsList.RenderHeader()
 	footer := m.configsList.RenderFooter()
-
 	frame := ui.ComputeFrameDimensions(
-		m.configsList.Viewport.Width,
-		m.configsList.Viewport.Height,
-		m.width,
-		m.height,
-		header,
-		footer,
+		m.configsList.Viewport.Width, m.configsList.Viewport.Height,
+		m.width, m.height, header, footer,
 	)
-
 	content := m.configsList.VisibleContent(frame.DesiredContentLines)
 
-	// Apply overlays to content BEFORE framing
 	if m.fileBrowserActive {
 		fileBrowserDialog := ui.RenderFileBrowserDialog("Select File", m.fileBrowserPath, m.fileBrowserFiles, m.fileBrowserCursor)
 		content = ui.OverlayCentered(content, fileBrowserDialog, width, 0)
@@ -141,10 +132,15 @@ func (m *Model) View() string {
 		content = ui.OverlayCentered(content, loadingView, width, 0)
 	}
 
-	title := fmt.Sprintf("Docker Configs (%d)", len(m.configsList.Filtered))
-	view := ui.RenderFramedBox(title, header, content, footer, frame.FrameWidth)
+	return content
+}
 
-	return view
+func (m *Model) View() string {
+	if m.usedByViewActive {
+		return m.renderUsedByView()
+	}
+	return ui.RenderViewFrame(m.FrameTitle(), m.FrameHeader(), m.FrameContent(), m.FrameFooter(),
+		m.configsList.Viewport.Width, m.configsList.Viewport.Height, false)
 }
 
 func (m *Model) renderCreateDialog() string {
@@ -152,34 +148,34 @@ func (m *Model) renderCreateDialog() string {
 
 	switch m.createDialogStep {
 	case "source":
-		lines = append(lines, dialogTitleStyle.Render(" Create Config - Choose Source "))
-		lines = append(lines, dialogItemStyle.Render(""))
-		lines = append(lines, dialogItemStyle.Render("How would you like to create the config?"))
-		lines = append(lines, dialogItemStyle.Render(""))
+		lines = append(lines, dialog.TitleStyle.Render(" Create Config - Choose Source "))
+		lines = append(lines, dialog.ItemStyle.Render(""))
+		lines = append(lines, dialog.ItemStyle.Render("How would you like to create the config?"))
+		lines = append(lines, dialog.ItemStyle.Render(""))
 
 		if m.createConfigSource == "file" {
-			lines = append(lines, dialogSelectedStyle.Render("→ From file"))
+			lines = append(lines, dialog.SelectedStyle.Render("→ From file"))
 		} else {
-			lines = append(lines, dialogItemStyle.Render("  From file"))
+			lines = append(lines, dialog.ItemStyle.Render("  From file"))
 		}
 
 		if m.createConfigSource == "inline" {
-			lines = append(lines, dialogSelectedStyle.Render("→ Inline editor"))
+			lines = append(lines, dialog.SelectedStyle.Render("→ Inline editor"))
 		} else {
-			lines = append(lines, dialogItemStyle.Render("  Inline editor"))
+			lines = append(lines, dialog.ItemStyle.Render("  Inline editor"))
 		}
 
-		lines = append(lines, dialogItemStyle.Render(""))
+		lines = append(lines, dialog.ItemStyle.Render(""))
 		helpText := fmt.Sprintf(" %s Select • %s / %s Navigate • %s Cancel",
-			dialogKeyStyle.Render("<Enter>"),
-			dialogKeyStyle.Render("<↑>"),
-			dialogKeyStyle.Render("<↓>"),
-			dialogKeyStyle.Render("<Esc>"))
-		lines = append(lines, dialogHelpStyle.Render(helpText))
+			dialog.KeyStyle.Render("<Enter>"),
+			dialog.KeyStyle.Render("<↑>"),
+			dialog.KeyStyle.Render("<↓>"),
+			dialog.KeyStyle.Render("<Esc>"))
+		lines = append(lines, dialog.HelpStyle.Render(helpText))
 
 	case "details-file":
-		lines = append(lines, dialogTitleStyle.Render(" Create Config from File "))
-		lines = append(lines, dialogItemStyle.Render(""))
+		lines = append(lines, dialog.TitleStyle.Render(" Create Config from File "))
+		lines = append(lines, dialog.ItemStyle.Render(""))
 
 		// Show error if present
 		if m.createDialogError != "" {
@@ -187,42 +183,42 @@ func (m *Model) renderCreateDialog() string {
 				Foreground(lipgloss.Color("196")).
 				Padding(0, 1)
 			lines = append(lines, errorStyle.Render("⚠ "+m.createDialogError))
-			lines = append(lines, dialogItemStyle.Render(""))
+			lines = append(lines, dialog.ItemStyle.Render(""))
 		}
 
-		lines = append(lines, dialogItemStyle.Render(m.createNameInput.View()))
-		lines = append(lines, dialogItemStyle.Render(""))
+		lines = append(lines, dialog.ItemStyle.Render(m.createNameInput.View()))
+		lines = append(lines, dialog.ItemStyle.Render(""))
 
 		// Show file path input with browse indicator when focused
 		fileLine := m.createFileInput.View()
 		if m.createInputFocus == 1 {
-			fileLine += "  " + dialogKeyStyle.Render("[f: Browse]")
+			fileLine += "  " + dialog.KeyStyle.Render("[f: Browse]")
 		}
-		lines = append(lines, dialogItemStyle.Render(fileLine))
-		lines = append(lines, dialogItemStyle.Render(""))
+		lines = append(lines, dialog.ItemStyle.Render(fileLine))
+		lines = append(lines, dialog.ItemStyle.Render(""))
 
 		// Show labels input
-		lines = append(lines, dialogItemStyle.Render(m.createLabelsInput.View()))
-		lines = append(lines, dialogItemStyle.Render(""))
+		lines = append(lines, dialog.ItemStyle.Render(m.createLabelsInput.View()))
+		lines = append(lines, dialog.ItemStyle.Render(""))
 
 		// Change help text based on error state
 		var helpText string
 		if m.createDialogError != "" {
 			helpText = fmt.Sprintf(" %s Fix error • %s Navigate • %s Cancel",
-				dialogKeyStyle.Render("<Enter>"),
-				dialogKeyStyle.Render("<Tab>"),
-				dialogKeyStyle.Render("<Esc>"))
+				dialog.KeyStyle.Render("<Enter>"),
+				dialog.KeyStyle.Render("<Tab>"),
+				dialog.KeyStyle.Render("<Esc>"))
 		} else {
 			helpText = fmt.Sprintf(" %s Confirm • %s Navigate • %s Cancel",
-				dialogKeyStyle.Render("<Enter>"),
-				dialogKeyStyle.Render("<Tab>"),
-				dialogKeyStyle.Render("<Esc>"))
+				dialog.KeyStyle.Render("<Enter>"),
+				dialog.KeyStyle.Render("<Tab>"),
+				dialog.KeyStyle.Render("<Esc>"))
 		}
-		lines = append(lines, dialogHelpStyle.Render(helpText))
+		lines = append(lines, dialog.HelpStyle.Render(helpText))
 
 	case "details-inline":
-		lines = append(lines, dialogTitleStyle.Render(" Create Config - Inline Editor "))
-		lines = append(lines, dialogItemStyle.Render(""))
+		lines = append(lines, dialog.TitleStyle.Render(" Create Config - Inline Editor "))
+		lines = append(lines, dialog.ItemStyle.Render(""))
 
 		// Show error if present
 		if m.createDialogError != "" {
@@ -230,11 +226,11 @@ func (m *Model) renderCreateDialog() string {
 				Foreground(lipgloss.Color("196")).
 				Padding(0, 1)
 			lines = append(lines, errorStyle.Render("⚠ "+m.createDialogError))
-			lines = append(lines, dialogItemStyle.Render(""))
+			lines = append(lines, dialog.ItemStyle.Render(""))
 		}
 
-		lines = append(lines, dialogItemStyle.Render(m.createNameInput.View()))
-		lines = append(lines, dialogItemStyle.Render(""))
+		lines = append(lines, dialog.ItemStyle.Render(m.createNameInput.View()))
+		lines = append(lines, dialog.ItemStyle.Render(""))
 
 		// Show editor status with edit hint when focused
 		editorStatus := "Content: "
@@ -244,33 +240,33 @@ func (m *Model) renderCreateDialog() string {
 			editorStatus += "(empty)"
 		}
 		if m.createInputFocus == 1 {
-			editorStatus += "  " + dialogKeyStyle.Render("[e: Edit]")
+			editorStatus += "  " + dialog.KeyStyle.Render("[e: Edit]")
 		}
-		lines = append(lines, dialogItemStyle.Render(editorStatus))
-		lines = append(lines, dialogItemStyle.Render(""))
+		lines = append(lines, dialog.ItemStyle.Render(editorStatus))
+		lines = append(lines, dialog.ItemStyle.Render(""))
 
 		// Show labels input
-		lines = append(lines, dialogItemStyle.Render(m.createLabelsInput.View()))
-		lines = append(lines, dialogItemStyle.Render(""))
+		lines = append(lines, dialog.ItemStyle.Render(m.createLabelsInput.View()))
+		lines = append(lines, dialog.ItemStyle.Render(""))
 
 		// Change help text based on error state
 		var helpText string
 		if m.createDialogError != "" {
 			helpText = fmt.Sprintf(" %s Fix error • %s Navigate • %s Cancel",
-				dialogKeyStyle.Render("<Enter>"),
-				dialogKeyStyle.Render("<Tab>"),
-				dialogKeyStyle.Render("<Esc>"))
+				dialog.KeyStyle.Render("<Enter>"),
+				dialog.KeyStyle.Render("<Tab>"),
+				dialog.KeyStyle.Render("<Esc>"))
 		} else {
 			helpText = fmt.Sprintf(" %s Confirm • %s Navigate • %s Cancel",
-				dialogKeyStyle.Render("<Enter>"),
-				dialogKeyStyle.Render("<Tab>"),
-				dialogKeyStyle.Render("<Esc>"))
+				dialog.KeyStyle.Render("<Enter>"),
+				dialog.KeyStyle.Render("<Tab>"),
+				dialog.KeyStyle.Render("<Esc>"))
 		}
-		lines = append(lines, dialogHelpStyle.Render(helpText))
+		lines = append(lines, dialog.HelpStyle.Render(helpText))
 	}
 
 	content := lipgloss.JoinVertical(lipgloss.Left, lines...)
-	return dialogBorderStyle.Render(content)
+	return dialog.BorderStyle.Render(content)
 }
 
 func (m *Model) renderUsedByView() string {

--- a/views/contexts/view.go
+++ b/views/contexts/view.go
@@ -27,6 +27,8 @@ func (m *Model) FrameHeader() string {
 		header = fmt.Sprintf("Error: %s", err)
 	} else if msg := m.GetSuccess(); msg != "" {
 		header = msg
+	} else {
+		return m.List.RenderHeader()
 	}
 	return ui.FrameHeaderStyle.Render(header)
 }

--- a/views/contexts/view.go
+++ b/views/contexts/view.go
@@ -10,53 +10,15 @@ import (
 	"swarmcli/docker"
 	"swarmcli/ui"
 	"swarmcli/ui/components/errordialog"
+	"swarmcli/ui/dialog"
 
 	"github.com/charmbracelet/lipgloss"
 )
 
-// Shared dialog styles
-var (
-	dialogTitleStyle = lipgloss.NewStyle().
-				Bold(true).
-				Foreground(lipgloss.Color("15")).
-				Background(lipgloss.Color("63")).
-				Padding(0, 1)
+func (m *Model) FrameTitle() string { return "Docker Contexts" }
 
-	dialogBorderStyle = lipgloss.NewStyle().
-				Border(lipgloss.RoundedBorder()).
-				BorderForeground(lipgloss.Color("117"))
-
-	dialogItemStyle = lipgloss.NewStyle().
-			Padding(0, 1)
-
-	dialogSelectedStyle = lipgloss.NewStyle().
-				Foreground(lipgloss.Color("15")).
-				Background(lipgloss.Color("63")).
-				Padding(0, 1)
-
-	dialogHelpStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("240")).
-			Padding(0, 1)
-
-	dialogKeyStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("63")).
-			Bold(true)
-)
-
-func (m *Model) View() string {
-	if !m.Visible {
-		return ""
-	}
-
-	width := m.viewport.Width
-	if width <= 0 {
-		width = 80
-	}
-
-	title := "Docker Contexts"
-	// Default header is empty; only show it for loading/switch/error/success
+func (m *Model) FrameHeader() string {
 	header := ""
-
 	if m.IsLoading() {
 		header = "Loading contexts..."
 	} else if m.IsSwitchPending() {
@@ -66,38 +28,36 @@ func (m *Model) View() string {
 	} else if msg := m.GetSuccess(); msg != "" {
 		header = msg
 	}
+	return ui.FrameHeaderStyle.Render(header)
+}
 
-	// We'll render the column header in the frame header slot so it
-	// appears directly under the top border and aligns with content.
-	headerRendered := ui.FrameHeaderStyle.Render(header)
-	footerRendered := ""
+func (m *Model) FrameFooter() string { return "" }
 
-	// Compute consistent frame sizing (same helper/pattern as stacks/configs).
+func (m *Model) FrameContent() string {
+	width := m.viewport.Width
+	if width <= 0 {
+		width = 80
+	}
+
+	headerRendered := m.FrameHeader()
+	footerRendered := m.FrameFooter()
+
 	frame := ui.ComputeFrameDimensions(
-		m.viewport.Width,
-		m.viewport.Height,
-		m.viewport.Width,
-		m.viewport.Height,
-		headerRendered,
-		footerRendered,
+		m.viewport.Width, m.viewport.Height,
+		m.viewport.Width, m.viewport.Height,
+		headerRendered, footerRendered,
 	)
 
-	// Use FilterableList for the contexts content. Keep its viewport size
-	// in sync with the inner content area (DesiredContentLines), otherwise
-	// the list can effectively scroll past the top and "hide" the first rows.
 	m.List.Viewport.Width = width
 	m.List.Viewport.Height = frame.DesiredContentLines
 
 	colWidths := m.List.ColWidths()
 
-	// Now define render using those exact column widths so items align
 	m.List.RenderItem = func(ctx docker.ContextInfo, selected bool, _ int) string {
 		current := " "
 		if ctx.Current {
 			current = "*"
 		}
-
-		// Prepare name with room for the current marker and a space
 		nameMax := colWidths[0] - 2
 		if nameMax < 0 {
 			nameMax = 0
@@ -156,8 +116,6 @@ func (m *Model) View() string {
 			}
 		}
 
-		// Build the line with exact column widths and no extra spacing so
-		// each column starts at the expected percent positions.
 		line := fmt.Sprintf("%-*s%-*s%-*s%-*s%-*s",
 			colWidths[0], firstCol,
 			colWidths[1], tlsChar,
@@ -171,25 +129,15 @@ func (m *Model) View() string {
 		return line
 	}
 
-	// If we're still loading, show a loading placeholder to avoid flashing
-	// "No items found." before the async load completes.
 	var content string
 	if m.IsLoading() {
 		loadingLine := lipgloss.NewStyle().Foreground(lipgloss.Color("240")).Render("Loading contexts...")
 		content = ui.TrimOrPadContentToLines(loadingLine, frame.DesiredContentLines)
 	} else {
-		// VisibleContent returns exactly DesiredContentLines and keeps the cursor visible.
-		listContent := m.List.VisibleContent(frame.DesiredContentLines)
-
-		// Column header with sort arrows rendered by FilterableList
-		headerRendered = m.List.RenderHeader()
-
-		content = listContent
+		content = m.List.VisibleContent(frame.DesiredContentLines)
 	}
 
-	// Overlay dialogs on content BEFORE framing
 	if m.certFileBrowserActive {
-		// Cert file browser has highest priority when open
 		certFileBrowserDialog := m.renderCertFileBrowserDialog()
 		content = ui.OverlayCentered(content, certFileBrowserDialog, width, 0)
 	} else if m.createDialogActive {
@@ -212,24 +160,56 @@ func (m *Model) View() string {
 		content = ui.OverlayCentered(content, dialogView, width, 0)
 	}
 
-	rendered := ui.RenderFramedBox(
-		title,
+	return content
+}
+
+func (m *Model) View() string {
+	if !m.Visible {
+		return ""
+	}
+
+	width := m.viewport.Width
+	if width <= 0 {
+		width = 80
+	}
+
+	// Contexts view has a dynamic header that changes based on list loading state
+	headerRendered := m.FrameHeader()
+	footerRendered := m.FrameFooter()
+
+	frame := ui.ComputeFrameDimensions(
+		m.viewport.Width, m.viewport.Height,
+		m.viewport.Width, m.viewport.Height,
+		headerRendered, footerRendered,
+	)
+
+	m.List.Viewport.Width = width
+	m.List.Viewport.Height = frame.DesiredContentLines
+
+	// Get content via FrameContent (which also sets up RenderItem)
+	content := m.FrameContent()
+
+	// After FrameContent, header may have changed to list header
+	if !m.IsLoading() {
+		headerRendered = m.List.RenderHeader()
+	}
+
+	return ui.RenderFramedBox(
+		m.FrameTitle(),
 		headerRendered,
 		content,
 		footerRendered,
 		frame.FrameWidth,
 	)
-
-	return rendered
 }
 
 func (m *Model) renderImportDialog() string {
 	contentWidth := 60
 
-	titleStyleWithWidth := dialogTitleStyle.Width(contentWidth)
-	itemStyleWithWidth := dialogItemStyle.Width(contentWidth)
-	borderStyleWithWidth := dialogBorderStyle.Width(contentWidth + 2)
-	helpStyleWithWidth := dialogHelpStyle.Width(contentWidth)
+	titleStyleWithWidth := dialog.TitleStyle.Width(contentWidth)
+	itemStyleWithWidth := dialog.ItemStyle.Width(contentWidth)
+	borderStyleWithWidth := dialog.BorderStyle.Width(contentWidth + 2)
+	helpStyleWithWidth := dialog.HelpStyle.Width(contentWidth)
 
 	var lines []string
 	lines = append(lines, titleStyleWithWidth.Render(" Import Docker Context "))
@@ -239,8 +219,8 @@ func (m *Model) renderImportDialog() string {
 	lines = append(lines, itemStyleWithWidth.Render(""))
 
 	helpText := fmt.Sprintf(" %s Confirm • %s Cancel",
-		dialogKeyStyle.Render("<Enter>"),
-		dialogKeyStyle.Render("<Esc>"))
+		dialog.KeyStyle.Render("<Enter>"),
+		dialog.KeyStyle.Render("<Esc>"))
 	lines = append(lines, helpStyleWithWidth.Render(helpText))
 
 	content := lipgloss.JoinVertical(lipgloss.Left, lines...)
@@ -250,19 +230,19 @@ func (m *Model) renderImportDialog() string {
 // renderCreateDialog renders the create context dialog
 func (m *Model) renderCreateDialog() string {
 	var lines []string
-	lines = append(lines, dialogTitleStyle.Render(" Create Docker Context "))
-	lines = append(lines, dialogItemStyle.Render(""))
-	lines = append(lines, dialogItemStyle.Render(m.createNameInput.View()))
-	lines = append(lines, dialogItemStyle.Render(m.createDescInput.View()))
-	lines = append(lines, dialogItemStyle.Render(m.createHostInput.View()))
-	lines = append(lines, dialogItemStyle.Render(""))
+	lines = append(lines, dialog.TitleStyle.Render(" Create Docker Context "))
+	lines = append(lines, dialog.ItemStyle.Render(""))
+	lines = append(lines, dialog.ItemStyle.Render(m.createNameInput.View()))
+	lines = append(lines, dialog.ItemStyle.Render(m.createDescInput.View()))
+	lines = append(lines, dialog.ItemStyle.Render(m.createHostInput.View()))
+	lines = append(lines, dialog.ItemStyle.Render(""))
 
 	// TLS checkbox
 	checkbox := "[ ]"
 	if m.createTLSEnabled {
 		checkbox = "[✓]"
 	}
-	checkboxStyle := dialogItemStyle
+	checkboxStyle := dialog.ItemStyle
 	if m.createInputFocus == 3 {
 		checkboxStyle = lipgloss.NewStyle().
 			Padding(0, 1).
@@ -273,28 +253,28 @@ func (m *Model) renderCreateDialog() string {
 
 	// Show cert file inputs only if TLS is enabled
 	if m.createTLSEnabled {
-		lines = append(lines, dialogItemStyle.Render(""))
+		lines = append(lines, dialog.ItemStyle.Render(""))
 
 		// CA file with browse button indicator
 		caLine := m.createCAInput.View()
 		if m.createInputFocus == 4 {
-			caLine += "  " + dialogKeyStyle.Render("[f: Browse]")
+			caLine += "  " + dialog.KeyStyle.Render("[f: Browse]")
 		}
-		lines = append(lines, dialogItemStyle.Render(caLine))
+		lines = append(lines, dialog.ItemStyle.Render(caLine))
 
 		// Cert file with browse button indicator
 		certLine := m.createCertInput.View()
 		if m.createInputFocus == 5 {
-			certLine += "  " + dialogKeyStyle.Render("[f: Browse]")
+			certLine += "  " + dialog.KeyStyle.Render("[f: Browse]")
 		}
-		lines = append(lines, dialogItemStyle.Render(certLine))
+		lines = append(lines, dialog.ItemStyle.Render(certLine))
 
 		// Key file with browse button indicator
 		keyLine := m.createKeyInput.View()
 		if m.createInputFocus == 6 {
-			keyLine += "  " + dialogKeyStyle.Render("[f: Browse]")
+			keyLine += "  " + dialog.KeyStyle.Render("[f: Browse]")
 		}
-		lines = append(lines, dialogItemStyle.Render(keyLine))
+		lines = append(lines, dialog.ItemStyle.Render(keyLine))
 	}
 
 	// Show error message if present
@@ -303,38 +283,38 @@ func (m *Model) renderCreateDialog() string {
 		errorStyle := lipgloss.NewStyle().
 			Foreground(lipgloss.Color("196")).
 			Padding(0, 1)
-		lines = append(lines, dialogItemStyle.Render(""))
+		lines = append(lines, dialog.ItemStyle.Render(""))
 		lines = append(lines, errorStyle.Render(errorMsg))
 	}
 
-	lines = append(lines, dialogItemStyle.Render(""))
+	lines = append(lines, dialog.ItemStyle.Render(""))
 
 	// Adjust help text based on whether error is shown
 	var helpText string
 	if errorMsg != "" {
 		helpText = fmt.Sprintf(" %s Clear Error • %s Cancel",
-			dialogKeyStyle.Render("<Enter>"),
-			dialogKeyStyle.Render("<Esc>"))
+			dialog.KeyStyle.Render("<Enter>"),
+			dialog.KeyStyle.Render("<Esc>"))
 	} else {
 		helpText = fmt.Sprintf(" %s Create • %s Navigate • %s Toggle TLS • %s Browse • %s Cancel",
-			dialogKeyStyle.Render("<Enter>"),
-			dialogKeyStyle.Render("<Tab/↑/↓>"),
-			dialogKeyStyle.Render("<Space>"),
-			dialogKeyStyle.Render("<f>"),
-			dialogKeyStyle.Render("<Esc>"))
+			dialog.KeyStyle.Render("<Enter>"),
+			dialog.KeyStyle.Render("<Tab/↑/↓>"),
+			dialog.KeyStyle.Render("<Space>"),
+			dialog.KeyStyle.Render("<f>"),
+			dialog.KeyStyle.Render("<Esc>"))
 	}
-	lines = append(lines, dialogHelpStyle.Render(helpText))
+	lines = append(lines, dialog.HelpStyle.Render(helpText))
 
 	content := lipgloss.JoinVertical(lipgloss.Left, lines...)
-	return dialogBorderStyle.Render(content)
+	return dialog.BorderStyle.Render(content)
 }
 
 // renderEditDialog renders the edit context dialog (description only)
 func (m *Model) renderEditDialog() string {
 	var lines []string
-	lines = append(lines, dialogTitleStyle.Render(" Edit Context: "+m.editContextName+" "))
-	lines = append(lines, dialogItemStyle.Render(""))
-	lines = append(lines, dialogItemStyle.Render(m.editDescInput.View()))
+	lines = append(lines, dialog.TitleStyle.Render(" Edit Context: "+m.editContextName+" "))
+	lines = append(lines, dialog.ItemStyle.Render(""))
+	lines = append(lines, dialog.ItemStyle.Render(m.editDescInput.View()))
 
 	// Show error message if present
 	errorMsg := m.GetError()
@@ -342,27 +322,27 @@ func (m *Model) renderEditDialog() string {
 		errorStyle := lipgloss.NewStyle().
 			Foreground(lipgloss.Color("196")).
 			Padding(0, 1)
-		lines = append(lines, dialogItemStyle.Render(""))
+		lines = append(lines, dialog.ItemStyle.Render(""))
 		lines = append(lines, errorStyle.Render(errorMsg))
 	}
 
-	lines = append(lines, dialogItemStyle.Render(""))
+	lines = append(lines, dialog.ItemStyle.Render(""))
 
 	// Adjust help text based on whether error is shown
 	var helpText string
 	if errorMsg != "" {
 		helpText = fmt.Sprintf(" %s Clear Error • %s Cancel",
-			dialogKeyStyle.Render("<Enter>"),
-			dialogKeyStyle.Render("<Esc>"))
+			dialog.KeyStyle.Render("<Enter>"),
+			dialog.KeyStyle.Render("<Esc>"))
 	} else {
 		helpText = fmt.Sprintf(" %s Update • %s Cancel",
-			dialogKeyStyle.Render("<Enter>"),
-			dialogKeyStyle.Render("<Esc>"))
+			dialog.KeyStyle.Render("<Enter>"),
+			dialog.KeyStyle.Render("<Esc>"))
 	}
-	lines = append(lines, dialogHelpStyle.Render(helpText))
+	lines = append(lines, dialog.HelpStyle.Render(helpText))
 
 	content := lipgloss.JoinVertical(lipgloss.Left, lines...)
-	return dialogBorderStyle.Render(content)
+	return dialog.BorderStyle.Render(content)
 }
 
 // renderCertFileBrowserDialog renders the certificate file browser dialog
@@ -384,9 +364,9 @@ func (m *Model) renderCertFileBrowserDialog() string {
 	}
 
 	var lines []string
-	lines = append(lines, dialogTitleStyle.Render(fmt.Sprintf(" Select %s ", fileTypeLabel)))
-	lines = append(lines, dialogItemStyle.Render(fmt.Sprintf("Directory: %s (%d files)", m.fileBrowserPath, fileCount)))
-	lines = append(lines, dialogItemStyle.Render(""))
+	lines = append(lines, dialog.TitleStyle.Render(fmt.Sprintf(" Select %s ", fileTypeLabel)))
+	lines = append(lines, dialog.ItemStyle.Render(fmt.Sprintf("Directory: %s (%d files)", m.fileBrowserPath, fileCount)))
+	lines = append(lines, dialog.ItemStyle.Render(""))
 
 	// Show files with cursor
 	maxVisible := 10
@@ -416,22 +396,22 @@ func (m *Model) renderCertFileBrowserDialog() string {
 			}
 		}
 		if i == m.fileBrowserCursor {
-			lines = append(lines, dialogSelectedStyle.Render("→ "+displayName))
+			lines = append(lines, dialog.SelectedStyle.Render("→ "+displayName))
 		} else {
-			lines = append(lines, dialogItemStyle.Render("  "+displayName))
+			lines = append(lines, dialog.ItemStyle.Render("  "+displayName))
 		}
 	}
 
-	lines = append(lines, dialogItemStyle.Render(""))
+	lines = append(lines, dialog.ItemStyle.Render(""))
 	helpText := fmt.Sprintf(" %s Select/Navigate • %s / %s Move • %s Cancel",
-		dialogKeyStyle.Render("<Enter>"),
-		dialogKeyStyle.Render("<↑/↓>"),
-		dialogKeyStyle.Render("<PgUp/PgDn>"),
-		dialogKeyStyle.Render("<Esc>"))
-	lines = append(lines, dialogHelpStyle.Render(helpText))
+		dialog.KeyStyle.Render("<Enter>"),
+		dialog.KeyStyle.Render("<↑/↓>"),
+		dialog.KeyStyle.Render("<PgUp/PgDn>"),
+		dialog.KeyStyle.Render("<Esc>"))
+	lines = append(lines, dialog.HelpStyle.Render(helpText))
 
 	content := lipgloss.JoinVertical(lipgloss.Left, lines...)
-	return dialogBorderStyle.Render(content)
+	return dialog.BorderStyle.Render(content)
 }
 
 // renderErrorDialog renders the error dialog

--- a/views/help/view.go
+++ b/views/help/view.go
@@ -11,36 +11,38 @@ import (
 	"github.com/charmbracelet/lipgloss"
 )
 
+func (m *Model) FrameTitle() string { return "Help" }
+
+func (m *Model) FrameHeader() string {
+	if len(m.categories) > 0 {
+		return ""
+	}
+	return ui.FrameHeaderStyle.Render("Available Commands")
+}
+
+func (m *Model) FrameFooter() string {
+	return ui.StatusBarStyle.Render("Press <esc> to go back")
+}
+
+func (m *Model) FrameContent() string {
+	if len(m.categories) > 0 {
+		return m.buildCategorizedContent()
+	}
+	// Command help content
+	header := m.FrameHeader()
+	footer := m.FrameFooter()
+	frame := ui.ComputeFrameDimensions(m.Viewable.Width, m.Viewable.Height, m.width, m.height, header, footer)
+	return ui.TrimOrPadContentToLines(m.Viewable.View(), frame.DesiredContentLines)
+}
+
 func (m *Model) View() string {
 	if !m.Visible {
 		return ""
 	}
-
-	// Use categorized view if categories are provided
-	if len(m.categories) > 0 {
-		return m.renderCategorizedHelp()
-	}
-
-	// Command help (":help") should render like every other view: full-width framed box.
-	header := " " + ui.FrameHeaderStyle.Render("Available Commands")
-	footer := ui.StatusBarStyle.Render("Press <esc> to go back")
-
-	frame := ui.ComputeFrameDimensions(
-		m.Viewable.Width,
-		m.Viewable.Height,
-		m.width,
-		m.height,
-		header,
-		footer,
-	)
-
-	viewportContent := " " + strings.ReplaceAll(
-		ui.TrimOrPadContentToLines(m.Viewable.View(), frame.DesiredContentLines),
-		"\n", "\n ")
-	return ui.RenderFramedBox("Help", header, viewportContent, footer, frame.FrameWidth)
+	return ui.RenderViewFrame(m.FrameTitle(), m.FrameHeader(), m.FrameContent(), m.FrameFooter(), m.Viewable.Width, m.Viewable.Height, false)
 }
 
-func (m *Model) renderCategorizedHelp() string {
+func (m *Model) buildCategorizedContent() string {
 	width := m.Viewable.Width
 	if width <= 0 {
 		width = m.width
@@ -49,27 +51,24 @@ func (m *Model) renderCategorizedHelp() string {
 		width = 80
 	}
 
-	// Styles - use ANSI 256-color codes (k9s uses "green" = color 2)
 	categoryStyle := lipgloss.NewStyle().
 		Bold(true).
-		Foreground(lipgloss.Color("2")) // Standard green
+		Foreground(lipgloss.Color("2"))
 
 	keyStyle := lipgloss.NewStyle().
-		Foreground(lipgloss.Color("33")). // Dodger blue
+		Foreground(lipgloss.Color("33")).
 		Bold(true)
 
 	descStyle := lipgloss.NewStyle().
-		Foreground(lipgloss.Color("252")) // Light gray
+		Foreground(lipgloss.Color("252"))
 
-	// Calculate column widths
 	numCols := len(m.categories)
 	if numCols == 0 {
 		numCols = 1
 	}
 	colWidth := width / numCols
-	maxKeyWidth := 15 // Fixed width for keys
+	maxKeyWidth := 15
 
-	// Find max rows needed
 	maxRows := 0
 	for _, cat := range m.categories {
 		if len(cat.Items) > maxRows {
@@ -77,35 +76,28 @@ func (m *Model) renderCategorizedHelp() string {
 		}
 	}
 
-	// Build header row with category titles in GREEN
 	var headerParts []string
 	for _, cat := range m.categories {
 		titleText := strings.ToUpper(cat.Title)
-		// Pad to column width first, then apply style
 		paddedTitle := fmt.Sprintf("%-*s", colWidth, titleText)
 		styledTitle := categoryStyle.Render(paddedTitle)
 		headerParts = append(headerParts, styledTitle)
 	}
 	headerRow := strings.Join(headerParts, "")
 
-	// Build content rows
 	var contentLines []string
 	for row := 0; row < maxRows; row++ {
 		var rowParts []string
 		for _, cat := range m.categories {
 			if row < len(cat.Items) {
 				item := cat.Items[row]
-				// Format key and description with proper alignment
 				styledKey := keyStyle.Render(fmt.Sprintf("%-*s", maxKeyWidth, item.Keys))
 				styledDesc := descStyle.Render(item.Description)
 
-				// Combine and pad to column width
-				// Use lipgloss.Width for visual width calculation (handles Unicode properly)
 				plainText := fmt.Sprintf("%-*s %s", maxKeyWidth, item.Keys, item.Description)
 				plainTextWidth := lipgloss.Width(plainText)
 
 				if plainTextWidth > colWidth {
-					// Truncate description if too long
 					descWidth := colWidth - maxKeyWidth - 1
 					if descWidth > 0 && len(item.Description) > descWidth {
 						styledDesc = descStyle.Render(item.Description[:descWidth-3] + "...")
@@ -114,9 +106,7 @@ func (m *Model) renderCategorizedHelp() string {
 					}
 				}
 
-				// Now render styled version maintaining the same width
 				styledLine := styledKey + " " + styledDesc
-				// Add padding to match column width
 				paddingNeeded := colWidth - plainTextWidth
 				if paddingNeeded > 0 {
 					styledLine += strings.Repeat(" ", paddingNeeded)
@@ -124,33 +114,15 @@ func (m *Model) renderCategorizedHelp() string {
 
 				rowParts = append(rowParts, styledLine)
 			} else {
-				// Empty cell
 				rowParts = append(rowParts, strings.Repeat(" ", colWidth))
 			}
 		}
 		contentLines = append(contentLines, strings.Join(rowParts, ""))
 	}
 
-	// Combine header and content
 	fullContent := headerRow + "\n\n" + strings.Join(contentLines, "\n")
 
-	// Render with the shared frame sizing (same pattern as stacks/configs)
-	title := "Help"
-	header := ""
-	footer := ui.StatusBarStyle.Render("Press <esc> to go back")
-
-	frame := ui.ComputeFrameDimensions(
-		m.Viewable.Width,
-		m.Viewable.Height,
-		m.width,
-		m.height,
-		header,
-		footer,
-	)
-
-	// Trim content to fit frame (preserving ANSI codes)
-	viewportContent := ui.TrimOrPadContentToLines(fullContent, frame.DesiredContentLines)
-
-	// Render framed box
-	return ui.RenderFramedBox(title, header, viewportContent, footer, frame.FrameWidth)
+	footer := m.FrameFooter()
+	frame := ui.ComputeFrameDimensions(m.Viewable.Width, m.Viewable.Height, m.width, m.height, "", footer)
+	return ui.TrimOrPadContentToLines(fullContent, frame.DesiredContentLines)
 }

--- a/views/inspect/view.go
+++ b/views/inspect/view.go
@@ -8,58 +8,42 @@ import (
 	"swarmcli/ui"
 )
 
-func (m *Model) View() string {
-	width := m.viewport.Width
-	if width <= 0 {
-		width = 80
-	}
-
-	// ---- Build dynamic title ----
+func (m *Model) FrameTitle() string {
 	title := m.Title
 	if title == "" {
 		title = "Inspecting"
 	}
+	return title
+}
 
-	// ---- Format indicator ----
+func (m *Model) FrameHeader() string {
 	formatIndicator := "[YAML]"
 	if m.Format == "raw" {
 		formatIndicator = "[RAW]"
 	}
-
-	// ---- Build header ----
 	errorHint := ""
 	if m.ParseError != "" {
 		errorHint = " — Could not parse JSON, showing raw"
 	}
-
 	header := fmt.Sprintf("Inspecting %s%s", formatIndicator, errorHint)
-
 	if m.searchMode {
 		header = fmt.Sprintf("%s — Search: %s", header, m.SearchTerm)
 	}
+	return ui.FrameHeaderStyle.Render(header)
+}
 
-	headerRendered := ui.FrameHeaderStyle.Render(header)
+func (m *Model) FrameFooter() string { return "" }
 
-	frame := ui.ComputeFrameDimensions(
-		width,
-		m.viewport.Height,
-		width,
-		m.height,
-		headerRendered,
-		"",
-	)
+func (m *Model) FrameContent() string {
+	header := m.FrameHeader()
+	width := m.viewport.Width
+	if width <= 0 {
+		width = 80
+	}
+	frame := ui.ComputeFrameDimensions(width, m.viewport.Height, width, m.height, header, "")
+	return ui.TrimOrPadContentToLines(m.viewport.View(), frame.DesiredContentLines)
+}
 
-	// Get viewport content and truncate to fit the frame
-	viewportContent := ui.TrimOrPadContentToLines(m.viewport.View(), frame.DesiredContentLines)
-
-	// ---- Render framed box ----
-	content := ui.RenderFramedBox(
-		title,
-		headerRendered,
-		viewportContent,
-		"",
-		frame.FrameWidth,
-	)
-
-	return content
+func (m *Model) View() string {
+	return ui.RenderViewFrame(m.FrameTitle(), m.FrameHeader(), m.FrameContent(), m.FrameFooter(), m.viewport.Width, m.viewport.Height, false)
 }

--- a/views/loading/loading.go
+++ b/views/loading/loading.go
@@ -105,13 +105,33 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 	return nil
 }
 
+func (m *Model) FrameTitle() string  { return m.title }
+func (m *Model) FrameHeader() string { return m.header }
+func (m *Model) FrameFooter() string { return "" }
+
+func (m *Model) FrameContent() string {
+	if m.isError {
+		// Return empty content with error dialog overlay
+		frameWidth := m.width
+		if frameWidth < 0 {
+			frameWidth = 80
+		}
+		frame := ui.ComputeFrameDimensions(frameWidth-4, m.height, frameWidth-4, m.height, "", "")
+		emptyContent := ui.TrimOrPadContentToLines("", frame.DesiredContentLines)
+		errorDialog := m.renderErrorDialog()
+		return ui.OverlayCentered(emptyContent, errorDialog, frameWidth, 0)
+	}
+	spinnerChar := ui.SpinnerCharAt(m.spinner)
+	return strings.TrimSpace(fmt.Sprintf("%s  %s", spinnerChar, m.message))
+}
+
 func (m *Model) View() string {
 	if !m.visible {
 		return ""
 	}
 
 	if m.isError {
-		// Render error as a styled popup dialog
+		// Render error as a styled popup dialog (legacy path)
 		return m.renderErrorDialog()
 	}
 
@@ -119,7 +139,6 @@ func (m *Model) View() string {
 	spinnerChar := ui.SpinnerCharAt(m.spinner)
 	content := fmt.Sprintf("%s  %s", spinnerChar, m.message)
 	content = strings.TrimSpace(content)
-	// Use height-aware framed box with proper width
 	frameHeight := m.height
 	if frameHeight < 0 {
 		frameHeight = 0
@@ -161,7 +180,7 @@ func (m *Model) renderErrorDialog() string {
 
 	// Wrap error message if too long
 	maxWidth := 70
-	wrappedLines := wrapText(m.message, maxWidth)
+	wrappedLines := ui.WrapText(m.message, maxWidth)
 	for _, line := range wrappedLines {
 		lines = append(lines, itemStyle.Render(line))
 	}
@@ -176,38 +195,6 @@ func (m *Model) renderErrorDialog() string {
 	content := lipgloss.JoinVertical(lipgloss.Left, lines...)
 	dialog := borderStyle.Render(content)
 	return dialog
-}
-
-// wrapText wraps text to specified width
-func wrapText(text string, width int) []string {
-	if len(text) <= width {
-		return []string{text}
-	}
-
-	var lines []string
-	words := strings.Fields(text)
-	currentLine := ""
-
-	for _, word := range words {
-		if len(currentLine)+len(word)+1 <= width {
-			if currentLine == "" {
-				currentLine = word
-			} else {
-				currentLine += " " + word
-			}
-		} else {
-			if currentLine != "" {
-				lines = append(lines, currentLine)
-			}
-			currentLine = word
-		}
-	}
-
-	if currentLine != "" {
-		lines = append(lines, currentLine)
-	}
-
-	return lines
 }
 
 func (m *Model) ShortHelpItems() []helpbar.HelpEntry {

--- a/views/logs/handlekey.go
+++ b/views/logs/handlekey.go
@@ -116,15 +116,7 @@ func HandleKey(m *Model, k tea.KeyMsg) tea.Cmd {
 		m.Visible = false
 		return nil
 	case "esc":
-		// If in fullscreen, exit fullscreen instead of closing view
-		if m.getFullscreen() {
-			m.setFullscreen(false)
-			l().Infof("[logsview] 'esc' key pressed: exiting fullscreen")
-			return func() tea.Msg {
-				return FullscreenToggledMsg{}
-			}
-		}
-		// Otherwise, close the view
+		// Close the view
 		m.Visible = false
 		return nil
 	case "/":
@@ -154,15 +146,6 @@ func HandleKey(m *Model, k tea.KeyMsg) tea.Cmd {
 		m.setFollow(newFollow)
 		l().Infof("[logsview] 's' key pressed: follow %v -> %v", oldFollow, newFollow)
 		return nil
-	case "f":
-		// toggle fullscreen mode
-		oldFullscreen := m.getFullscreen()
-		newFullscreen := !oldFullscreen
-		m.setFullscreen(newFullscreen)
-		l().Infof("[logsview] 'f' key pressed: fullscreen %v -> %v", oldFullscreen, newFullscreen)
-		return func() tea.Msg {
-			return FullscreenToggledMsg{}
-		}
 	case "w":
 		// toggle wrap mode
 		oldWrap := m.getWrap()

--- a/views/logs/logs_test.go
+++ b/views/logs/logs_test.go
@@ -70,7 +70,6 @@ func TestNew(t *testing.T) {
 	require.Equal(t, "normal", m.mode)
 	require.True(t, m.getFollow())
 	require.True(t, m.getWrap())
-	require.False(t, m.getFullscreen())
 }
 
 func TestName(t *testing.T) {
@@ -92,13 +91,6 @@ func TestIsSearching_SearchMode(t *testing.T) {
 	m := testModel()
 	m.mode = "search"
 	require.True(t, m.IsSearching())
-}
-
-func TestGetFullscreen(t *testing.T) {
-	m := testModel()
-	require.False(t, m.GetFullscreen())
-	m.setFullscreen(true)
-	require.True(t, m.GetFullscreen())
 }
 
 func TestGetNodeSelectVisible(t *testing.T) {
@@ -140,7 +132,6 @@ func TestShortHelpItems_NormalMode(t *testing.T) {
 	require.True(t, keys["s"])
 	require.True(t, keys["w"])
 	require.True(t, keys["o"])
-	require.True(t, keys["f"])
 	require.True(t, keys["q"])
 }
 
@@ -294,30 +285,11 @@ func TestKey_W_TogglesWrap(t *testing.T) {
 	require.NotNil(t, cmd) // WrapToggledMsg
 }
 
-func TestKey_F_TogglesFullscreen(t *testing.T) {
-	m := testModel()
-	m.Visible = true
-	require.False(t, m.getFullscreen())
-	cmd := m.Update(key("f"))
-	require.True(t, m.getFullscreen())
-	require.NotNil(t, cmd) // FullscreenToggledMsg
-}
-
 func TestKey_Q_ClosesView(t *testing.T) {
 	m := testModel()
 	m.Visible = true
 	m.Update(key("q"))
 	require.False(t, m.Visible)
-}
-
-func TestKey_Esc_ExitsFullscreen(t *testing.T) {
-	m := testModel()
-	m.Visible = true
-	m.setFullscreen(true)
-	cmd := m.Update(key("esc"))
-	require.False(t, m.getFullscreen())
-	require.True(t, m.Visible) // view stays open
-	require.NotNil(t, cmd)
 }
 
 func TestKey_Esc_ClosesView(t *testing.T) {

--- a/views/logs/messages.go
+++ b/views/logs/messages.go
@@ -21,6 +21,4 @@ type StreamDoneMsg struct{}
 
 type WrapToggledMsg struct{}
 
-type FullscreenToggledMsg struct{}
-
 type NodeFilterToggledMsg struct{}

--- a/views/logs/model.go
+++ b/views/logs/model.go
@@ -50,8 +50,6 @@ type Model struct {
 	wrap bool
 	// horizontal scroll offset when wrap is off
 	horizontalOffset int
-	// fullscreen mode
-	fullscreen bool
 	// node filter - if set, only show logs from this node
 	nodeFilter string
 	// node selection dialog
@@ -80,7 +78,6 @@ func New(width, height int, maxLines int, service docker.ServiceEntry) *Model {
 		follow:            true, // auto-follow by default
 		wrap:              true, // wrap lines by default
 		horizontalOffset:  0,
-		fullscreen:        false,
 		nodeFilter:        "", // empty = show all nodes
 		nodeSelectVisible: false,
 		nodeSelectCursor:  0,
@@ -144,23 +141,6 @@ func (m *Model) getWrap() bool {
 	return m.wrap
 }
 
-func (m *Model) setFullscreen(f bool) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	m.fullscreen = f
-}
-
-func (m *Model) getFullscreen() bool {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	return m.fullscreen
-}
-
-// GetFullscreen is exported for app to check fullscreen status
-func (m *Model) GetFullscreen() bool {
-	return m.getFullscreen()
-}
-
 // GetSearchMode is exported for app to check search mode status
 func (m *Model) GetSearchMode() bool {
 	m.mu.Lock()
@@ -189,7 +169,6 @@ func (m *Model) ShortHelpItems() []helpbar.HelpEntry {
 		{Key: "s", Desc: "Toggle AutoScroll"},
 		{Key: "w", Desc: "Toggle wrap"},
 		{Key: "o", Desc: "Filter node"},
-		{Key: "f", Desc: "Fullscreen"},
 	}
 
 	// Show left/right help only when wrap is off

--- a/views/logs/update.go
+++ b/views/logs/update.go
@@ -151,11 +151,6 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 		}
 		return nil
 
-	case FullscreenToggledMsg:
-		// Fullscreen mode is handled in the View() method
-		// Just trigger a re-render
-		return nil
-
 	case NodeFilterToggledMsg:
 		// When node filter changes, we need to rebuild the content
 		// because existing lines need to be filtered/unfiltered

--- a/views/logs/view.go
+++ b/views/logs/view.go
@@ -5,23 +5,12 @@ package logsview
 
 import (
 	"fmt"
-	"strings"
 	"swarmcli/ui"
 
 	"github.com/charmbracelet/lipgloss"
 )
 
-func (m *Model) View() string {
-	if !m.Visible {
-		return ""
-	}
-
-	width := m.viewport.Width
-	if width <= 0 {
-		width = 80
-	}
-
-	// ---- Build dynamic title bar ----
+func (m *Model) FrameTitle() string {
 	followStatus := "off"
 	if m.getFollow() {
 		followStatus = "on"
@@ -35,199 +24,59 @@ func (m *Model) View() string {
 	if nodeFilter != "" {
 		filterStatus = fmt.Sprintf("node: %s", nodeFilter)
 	}
-
-	title := fmt.Sprintf(
+	return fmt.Sprintf(
 		"Service: %s • AutoScroll: %s • wrap: %s • Filter: %s",
 		m.ServiceEntry.ServiceName,
 		followStatus,
 		wrapStatus,
 		filterStatus,
 	)
+}
 
-	// ---- Build header ----
+func (m *Model) FrameHeader() string {
 	header := "Logs"
 	if m.mode == "search" {
 		header = fmt.Sprintf("Logs — Search: %s", m.searchTerm)
 	} else if m.searchTerm != "" && len(m.searchMatches) > 0 {
-		// Show search results when in normal mode but search is active
 		matchCount := len(m.searchMatches)
 		currentMatch := m.searchIndex + 1
 		header = fmt.Sprintf("Logs — Found %d matches (viewing %d/%d) • Press '/' to search, 'n'/'N' to navigate", matchCount, currentMatch, matchCount)
 	}
+	return ui.FrameHeaderStyle.Render(header)
+}
 
-	headerRendered := ui.FrameHeaderStyle.Render(header)
+func (m *Model) FrameFooter() string { return "" }
 
-	// ---- Render based on fullscreen mode ----
-	if m.fullscreen {
-		// In fullscreen: show centered title at top with same styling as frame title
-		titleText := ui.FrameTitleStyle.Render(title)
-		titleStyle := lipgloss.NewStyle().
-			Width(width).
-			Align(lipgloss.Center)
-		titleRendered := titleStyle.Render(titleText)
-
-		var content string
-		// If in search mode, show search header on second line
-		if m.mode == "search" {
-			searchHeader := ui.FrameHeaderStyle.Render(header)
-			content = titleRendered + "\n" + searchHeader + "\n" + m.viewport.View()
-		} else {
-			content = titleRendered + "\n" + m.viewport.View()
-		}
-
-		// Overlay node selection dialog if visible
-		if m.getNodeSelectVisible() {
-			availableHeight := m.viewport.Height
-			if availableHeight < 7 {
-				availableHeight = 7
-			}
-			dialog := m.renderNodeSelectDialog(availableHeight)
-			content = ui.OverlayCentered(content, dialog, width, m.viewport.Height+2)
-		}
-
-		return content
+func (m *Model) FrameContent() string {
+	width := m.viewport.Width
+	if width <= 0 {
+		width = 80
 	}
 
-	// ---- Normal mode: render framed box ----
+	headerRendered := m.FrameHeader()
 	frame := ui.ComputeFrameDimensions(
-		width,             // viewport width (already minus 4 from app)
-		m.viewport.Height, // adjusted height from app
-		width,             // fallback width
-		m.viewport.Height, // fallback height (viewport stores last known height)
-		headerRendered,
-		"",
+		width, m.viewport.Height,
+		width, m.viewport.Height,
+		headerRendered, "",
 	)
 
-	// Get viewport content and truncate to fit the frame
 	viewportContent := ui.TrimOrPadContentToLines(m.viewport.View(), frame.DesiredContentLines)
 
-	// If dialog is visible, overlay it on the viewport content BEFORE framing
-	if m.getNodeSelectVisible() {
-		// Use actual viewport height for dialog, ensuring it fits
+	if m.getNodeSelectVisible() && m.viewport.Height >= 5 {
 		availableHeight := m.viewport.Height
-		// Only render dialog if we have minimum space (at least 5 lines)
-		if m.viewport.Height >= 5 {
-			dialog := m.renderNodeSelectDialog(availableHeight)
-
-			// Manual overlay: preserve background and place dialog on top
-			viewportLines := strings.Split(viewportContent, "\n")
-			dialogLines := strings.Split(dialog, "\n")
-
-			// Calculate dialog position (centered)
-			dialogHeight := len(dialogLines)
-			dialogWidth := 0
-			for _, line := range dialogLines {
-				if w := lipgloss.Width(line); w > dialogWidth {
-					dialogWidth = w
-				}
-			}
-
-			startRow := (len(viewportLines) - dialogHeight) / 2
-			if startRow < 0 {
-				startRow = 0
-			}
-
-			startCol := (width - dialogWidth) / 2
-			if startCol < 0 {
-				startCol = 0
-			}
-
-			// IMPORTANT: RenderFramedBox will add padding (borderWidth = frameWidth - 2 = width + 2)
-			// This means content gets padded from 'width' to 'width + 2'
-			// The padding is added at the END, so our positions are correct
-			// BUT we calculated startCol based on 'width', which is correct for viewport
-			// No adjustment needed since padding is at the end, not distributed
-
-			// Overlay dialog lines onto viewport lines
-			for i, dialogLine := range dialogLines {
-				row := startRow + i
-				if row < 0 || row >= len(viewportLines) {
-					continue
-				}
-
-				baseLine := viewportLines[row]
-
-				// Work with visual widths and string slicing, accounting for ANSI codes
-				// We need to find the byte positions that correspond to visual positions
-				baseVisualWidth := lipgloss.Width(baseLine)
-				dialogVisualWidth := lipgloss.Width(dialogLine)
-
-				// Build new line preserving content around dialog
-				var newLine strings.Builder
-
-				// If base line is shorter than where dialog should start, pad it
-				if baseVisualWidth < startCol {
-					newLine.WriteString(baseLine)
-					newLine.WriteString(strings.Repeat(" ", startCol-baseVisualWidth))
-					newLine.WriteString(dialogLine)
-				} else {
-					// Need to extract left part (visual width = startCol)
-					// and right part (starting at visual position startCol + dialogVisualWidth)
-					leftPart := ""
-					rightPart := ""
-
-					// Extract left part up to startCol visual width
-					currentVisualPos := 0
-					currentBytePos := 0
-					inAnsi := false
-
-					for currentBytePos < len(baseLine) && currentVisualPos < startCol {
-						if baseLine[currentBytePos] == '\x1b' && currentBytePos+1 < len(baseLine) && baseLine[currentBytePos+1] == '[' {
-							inAnsi = true
-						}
-						if !inAnsi {
-							currentVisualPos++
-						}
-						currentBytePos++
-						if inAnsi && currentBytePos < len(baseLine) && baseLine[currentBytePos-1] == 'm' {
-							inAnsi = false
-						}
-					}
-					leftPart = baseLine[:currentBytePos]
-
-					// Extract right part starting at startCol + dialogVisualWidth
-					targetVisualPos := startCol + dialogVisualWidth
-					currentVisualPos = 0
-					currentBytePos = 0
-					inAnsi = false
-
-					for currentBytePos < len(baseLine) && currentVisualPos < targetVisualPos {
-						if baseLine[currentBytePos] == '\x1b' && currentBytePos+1 < len(baseLine) && baseLine[currentBytePos+1] == '[' {
-							inAnsi = true
-						}
-						if !inAnsi {
-							currentVisualPos++
-						}
-						currentBytePos++
-						if inAnsi && currentBytePos < len(baseLine) && baseLine[currentBytePos-1] == 'm' {
-							inAnsi = false
-						}
-					}
-					if currentBytePos < len(baseLine) {
-						rightPart = baseLine[currentBytePos:]
-					}
-
-					newLine.WriteString(leftPart)
-					newLine.WriteString(dialogLine)
-					newLine.WriteString(rightPart)
-				}
-
-				viewportLines[row] = newLine.String()
-			}
-
-			viewportContent = strings.Join(viewportLines, "\n")
-		}
+		dialog := m.renderNodeSelectDialog(availableHeight)
+		viewportContent = ui.OverlayCentered(viewportContent, dialog, width, 0)
 	}
 
-	content := ui.RenderFramedBox(
-		title,
-		headerRendered,
-		viewportContent,
-		"",
-		frame.FrameWidth,
-	)
+	return viewportContent
+}
 
-	return content
+func (m *Model) View() string {
+	if !m.Visible {
+		return ""
+	}
+	return ui.RenderViewFrame(m.FrameTitle(), m.FrameHeader(), m.FrameContent(), m.FrameFooter(),
+		m.viewport.Width, m.viewport.Height, false)
 }
 
 // renderNodeSelectDialog renders the node selection popup
@@ -315,9 +164,6 @@ func (m *Model) renderNodeSelectDialog(availableHeight int) string {
 	lines = append(lines, titleStyle.Render(" Select Node to Filter "))
 
 	// Calculate visible window for scrollable list
-	// Available height includes: border top (1) + title (1) + items + help (1) + border bottom (1) = 4 fixed
-	// So available for items = availableHeight - 4
-	// But if we need to show "more above/below" indicators, those take item slots too
 	maxVisibleItems := availableHeight - 4
 	if maxVisibleItems < 1 {
 		maxVisibleItems = 1
@@ -336,10 +182,8 @@ func (m *Model) renderNodeSelectDialog(availableHeight int) string {
 		}
 	} else {
 		// Scrolling needed - calculate visible window
-		// Reserve space for indicators if needed
 		effectiveVisibleItems := maxVisibleItems
 
-		// Keep cursor in view with some context
 		halfWindow := effectiveVisibleItems / 2
 		startIdx := cursor - halfWindow
 		if startIdx < 0 {
@@ -354,22 +198,18 @@ func (m *Model) renderNodeSelectDialog(availableHeight int) string {
 			}
 		}
 
-		// Track how many lines we've added
 		linesAdded := 0
 
-		// Show indicator if there are items above
 		if startIdx > 0 {
 			indicatorLine := fmt.Sprintf("   ↑ %d more above", startIdx)
 			lines = append(lines, itemStyle.Render(indicatorLine))
 			linesAdded++
 		}
 
-		// Show visible items (adjust count to fit within maxVisibleItems including indicators)
 		remainingSlots := maxVisibleItems - linesAdded
 		if endIdx > totalItems {
 			endIdx = totalItems
 		}
-		// Reserve 1 slot for "more below" indicator if needed
 		if endIdx < totalItems {
 			remainingSlots--
 		}
@@ -389,7 +229,6 @@ func (m *Model) renderNodeSelectDialog(availableHeight int) string {
 			linesAdded++
 		}
 
-		// Show indicator if there are items below
 		if actualEndIdx < totalItems {
 			indicatorLine := fmt.Sprintf("   ↓ %d more below", totalItems-actualEndIdx)
 			lines = append(lines, itemStyle.Render(indicatorLine))

--- a/views/networks/view.go
+++ b/views/networks/view.go
@@ -15,17 +15,104 @@ import (
 	"github.com/charmbracelet/lipgloss"
 )
 
-func (m *Model) View() string {
-	// If in UsedBy view, render it instead of the main networks view
+func (m *Model) FrameTitle() string {
 	if m.usedByViewActive {
-		return m.renderUsedByView()
+		return fmt.Sprintf("Network '%s' - Used By (%d)", m.usedByNetworkName, len(m.usedByList.Filtered))
 	}
-
-	// If in inspect view, render it
 	if m.inspectViewActive {
-		return m.renderInspectView()
+		return "Inspect Network"
+	}
+	return fmt.Sprintf("Docker Networks (%d)", len(m.networksList.Filtered))
+}
+
+func (m *Model) FrameHeader() string {
+	if m.usedByViewActive {
+		return m.usedByList.RenderHeader()
+	}
+	if m.inspectViewActive {
+		return ui.FrameHeaderStyle.Render("Network Details (JSON)")
+	}
+	width := 80
+	if m.networksList.Viewport.Width > 0 {
+		width = m.networksList.Viewport.Width
+	} else if m.width > 0 {
+		width = m.width
+	}
+	return m.renderNetworksHeader(m.networksList.Items, width)
+}
+
+func (m *Model) FrameFooter() string {
+	if m.usedByViewActive {
+		return m.usedByList.RenderFooter()
+	}
+	if m.inspectViewActive {
+		footerText := "↑/↓ Scroll | PgUp/PgDn Page | / Search | Esc Back"
+		if m.inspectSearchMode {
+			footerText = fmt.Sprintf("Search: %s  (Enter apply | Esc cancel)", m.inspectSearchTerm)
+		}
+		return ui.StatusBarStyle.Render(footerText)
+	}
+	return m.networksList.RenderFooter()
+}
+
+func (m *Model) FrameContent() string {
+	if m.usedByViewActive {
+		return m.buildUsedByContent()
+	}
+	if m.inspectViewActive {
+		return m.buildInspectContent()
+	}
+	return m.buildMainContent()
+}
+
+func (m *Model) buildUsedByContent() string {
+	width := 80
+	if m.usedByList.Viewport.Width > 0 {
+		width = m.usedByList.Viewport.Width
+	} else if m.width > 0 {
+		width = m.width
 	}
 
+	header := m.usedByList.RenderHeader()
+	footer := m.usedByList.RenderFooter()
+	frame := ui.ComputeFrameDimensions(
+		m.usedByList.Viewport.Width, m.usedByList.Viewport.Height,
+		m.width, m.height, header, footer,
+	)
+	content := m.usedByList.VisibleContent(frame.DesiredContentLines)
+
+	if m.errorDialogActive {
+		errorDialog := errordialog.Render(fmt.Sprintf("%v", m.err))
+		content = ui.OverlayCentered(content, errorDialog, width, 0)
+	}
+	return content
+}
+
+func (m *Model) buildInspectContent() string {
+	width := m.networksList.Viewport.Width
+	if width <= 0 {
+		width = m.width
+	}
+	if width <= 0 {
+		width = 80
+	}
+
+	header := m.FrameHeader()
+	footer := m.FrameFooter()
+	frame := ui.ComputeFrameDimensions(
+		width, m.networksList.Viewport.Height,
+		m.width, m.height, header, footer,
+	)
+	content := ui.TrimOrPadContentToLines(m.inspectViewport.View(), frame.DesiredContentLines)
+
+	if m.errorDialogActive {
+		errorDialog := errordialog.Render(fmt.Sprintf("%v", m.err))
+		content = ui.OverlayCentered(content, errorDialog, width, 0)
+	}
+	return content
+}
+
+func (m *Model) buildMainContent() string {
 	width := 80
 	if m.networksList.Viewport.Width > 0 {
 		width = m.networksList.Viewport.Width
@@ -33,21 +120,15 @@ func (m *Model) View() string {
 		width = m.width
 	}
 
-	header := m.renderNetworksHeader(m.networksList.Items, width)
-	footer := m.networksList.RenderFooter()
-
+	header := m.FrameHeader()
+	footer := m.FrameFooter()
 	frame := ui.ComputeFrameDimensions(
-		m.networksList.Viewport.Width,
-		m.networksList.Viewport.Height,
-		m.width,
-		m.height,
-		header,
-		footer,
+		m.networksList.Viewport.Width, m.networksList.Viewport.Height,
+		m.width, m.height, header, footer,
 	)
 
 	content := m.networksList.VisibleContent(frame.DesiredContentLines)
 	if m.state == stateLoading && len(m.networksList.Items) == 0 && m.networksList.Mode != filterlist.ModeSearching {
-		// Keep the normal frame + header, but show a loading message in the list area.
 		lines := frame.DesiredContentLines
 		if lines < 1 {
 			lines = 1
@@ -60,7 +141,6 @@ func (m *Model) View() string {
 		content = strings.Join(parts, "\n")
 	}
 
-	// Apply overlays to content BEFORE framing
 	if m.createDialogActive {
 		dialogView := m.renderCreateNetworkDialog(width)
 		content = ui.OverlayCentered(content, dialogView, width, 0)
@@ -71,11 +151,18 @@ func (m *Model) View() string {
 		errorDialog := errordialog.Render(fmt.Sprintf("%v", m.err))
 		content = ui.OverlayCentered(content, errorDialog, width, 0)
 	}
+	return content
+}
 
-	title := fmt.Sprintf("Docker Networks (%d)", len(m.networksList.Filtered))
-	view := ui.RenderFramedBox(title, header, content, footer, frame.FrameWidth)
-
-	return view
+func (m *Model) View() string {
+	if m.usedByViewActive {
+		return m.renderUsedByView()
+	}
+	if m.inspectViewActive {
+		return m.renderInspectView()
+	}
+	return ui.RenderViewFrame(m.FrameTitle(), m.FrameHeader(), m.FrameContent(), m.FrameFooter(),
+		m.networksList.Viewport.Width, m.networksList.Viewport.Height, false)
 }
 
 func (m *Model) renderCreateNetworkDialog(width int) string {

--- a/views/nodes/view.go
+++ b/views/nodes/view.go
@@ -13,11 +13,7 @@ import (
 	"github.com/charmbracelet/lipgloss"
 )
 
-func (m *Model) View() string {
-	if !m.Visible {
-		return ""
-	}
-
+func (m *Model) FrameTitle() string {
 	total := len(m.List.Items)
 	managers := 0
 	for _, n := range m.List.Items {
@@ -25,22 +21,42 @@ func (m *Model) View() string {
 			managers++
 		}
 	}
+	return fmt.Sprintf("Nodes (%d total, %d manager%s)", total, managers, plural(managers))
+}
 
-	title := fmt.Sprintf("Nodes (%d total, %d manager%s)", total, managers, plural(managers))
+func (m *Model) FrameHeader() string { return m.List.RenderHeader() }
+func (m *Model) FrameFooter() string { return m.List.RenderFooter() }
 
-	framed, frame := m.List.RenderFramedView(title)
+func (m *Model) FrameContent() string {
+	header := m.FrameHeader()
+	footer := m.FrameFooter()
+	frame := ui.ComputeFrameDimensions(
+		m.List.Viewport.Width, m.List.Viewport.Height,
+		m.List.Viewport.Width, m.List.Viewport.Height,
+		header, footer,
+	)
+	content := m.List.VisibleContent(frame.DesiredContentLines)
 
+	width := frame.FrameWidth
 	if m.labelInputDialog {
-		framed = ui.OverlayCentered(framed, m.renderLabelInputDialog(), frame.FrameWidth, frame.FrameHeight)
+		content = ui.OverlayCentered(content, m.renderLabelInputDialog(), width, 0)
 	} else if m.labelRemoveDialog {
-		framed = ui.OverlayCentered(framed, m.renderLabelRemoveDialog(), frame.FrameWidth, frame.FrameHeight)
+		content = ui.OverlayCentered(content, m.renderLabelRemoveDialog(), width, 0)
 	} else if m.availabilityDialog {
-		framed = ui.OverlayCentered(framed, m.renderAvailabilityDialog(), frame.FrameWidth, frame.FrameHeight)
+		content = ui.OverlayCentered(content, m.renderAvailabilityDialog(), width, 0)
 	} else if m.confirmDialog.Visible {
-		framed = ui.OverlayCentered(framed, m.confirmDialog.View(), frame.FrameWidth, frame.FrameHeight)
+		content = ui.OverlayCentered(content, m.confirmDialog.View(), width, 0)
 	}
 
-	return framed
+	return content
+}
+
+func (m *Model) View() string {
+	if !m.Visible {
+		return ""
+	}
+	return ui.RenderViewFrame(m.FrameTitle(), m.FrameHeader(), m.FrameContent(), m.FrameFooter(),
+		m.List.Viewport.Width, m.List.Viewport.Height, false)
 }
 
 func plural(n int) string {

--- a/views/secrets/view.go
+++ b/views/secrets/view.go
@@ -11,39 +11,11 @@ import (
 	"swarmcli/docker"
 	"swarmcli/ui"
 	"swarmcli/ui/components/errordialog"
+	"swarmcli/ui/dialog"
 	"time"
 
 	"github.com/charmbracelet/lipgloss"
 	"github.com/docker/docker/api/types/swarm"
-)
-
-// Shared dialog styles
-var (
-	dialogTitleStyle = lipgloss.NewStyle().
-				Bold(true).
-				Foreground(lipgloss.Color("15")).
-				Background(lipgloss.Color("63")).
-				Padding(0, 1)
-
-	dialogBorderStyle = lipgloss.NewStyle().
-				Border(lipgloss.RoundedBorder()).
-				BorderForeground(lipgloss.Color("117"))
-
-	dialogItemStyle = lipgloss.NewStyle().
-			Padding(0, 1)
-
-	dialogSelectedStyle = lipgloss.NewStyle().
-				Foreground(lipgloss.Color("15")).
-				Background(lipgloss.Color("63")).
-				Padding(0, 1)
-
-	dialogHelpStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("240")).
-			Padding(0, 1)
-
-	dialogKeyStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("63")).
-			Bold(true)
 )
 
 type secretItem struct {
@@ -96,28 +68,47 @@ func secretItemFromSwarm(ctx context.Context, s swarm.Secret) secretItem {
 	}
 }
 
-func (m *Model) View() string {
-	// If in UsedBy view, render it instead of the main secrets view
+func (m *Model) FrameTitle() string {
 	if m.usedByViewActive {
-		return m.renderUsedByView()
+		return fmt.Sprintf("Secret: %s - Used By Stacks (%d)", m.usedBySecretName, len(m.usedByList.Filtered))
+	}
+	return fmt.Sprintf("Docker Secrets (%d)", len(m.secretsList.Filtered))
+}
+
+func (m *Model) FrameHeader() string {
+	if m.usedByViewActive {
+		return m.usedByList.RenderHeader()
+	}
+	return m.secretsList.RenderHeader()
+}
+
+func (m *Model) FrameFooter() string {
+	if m.usedByViewActive {
+		return m.usedByList.RenderFooter()
+	}
+	return m.secretsList.RenderFooter()
+}
+
+func (m *Model) FrameContent() string {
+	if m.usedByViewActive {
+		header := m.usedByList.RenderHeader()
+		footer := m.usedByList.RenderFooter()
+		frame := ui.ComputeFrameDimensions(
+			m.usedByList.Viewport.Width, m.usedByList.Viewport.Height,
+			m.width, m.height, header, footer,
+		)
+		return m.usedByList.VisibleContent(frame.DesiredContentLines)
 	}
 
 	header := m.secretsList.RenderHeader()
 	footer := m.secretsList.RenderFooter()
-
 	frame := ui.ComputeFrameDimensions(
-		m.secretsList.Viewport.Width,
-		m.secretsList.Viewport.Height,
-		m.width,
-		m.height,
-		header,
-		footer,
+		m.secretsList.Viewport.Width, m.secretsList.Viewport.Height,
+		m.width, m.height, header, footer,
 	)
-
 	width := frame.FrameWidth
 	content := m.secretsList.VisibleContent(frame.DesiredContentLines)
 
-	// Apply overlays to content BEFORE framing
 	if m.fileBrowserActive {
 		fileBrowserDialog := ui.RenderFileBrowserDialog("Select File", m.fileBrowserPath, m.fileBrowserFiles, m.fileBrowserCursor)
 		content = ui.OverlayCentered(content, fileBrowserDialog, width, 0)
@@ -135,10 +126,15 @@ func (m *Model) View() string {
 		content = ui.OverlayCentered(content, loadingView, width, 0)
 	}
 
-	title := fmt.Sprintf("Docker Secrets (%d)", len(m.secretsList.Filtered))
-	view := ui.RenderFramedBox(title, header, content, footer, frame.FrameWidth)
+	return content
+}
 
-	return view
+func (m *Model) View() string {
+	if m.usedByViewActive {
+		return m.renderUsedByView()
+	}
+	return ui.RenderViewFrame(m.FrameTitle(), m.FrameHeader(), m.FrameContent(), m.FrameFooter(),
+		m.secretsList.Viewport.Width, m.secretsList.Viewport.Height, false)
 }
 
 func (m *Model) renderCreateDialog() string {
@@ -146,34 +142,34 @@ func (m *Model) renderCreateDialog() string {
 
 	switch m.createDialogStep {
 	case "source":
-		lines = append(lines, dialogTitleStyle.Render(" Create Secret - Choose Source "))
-		lines = append(lines, dialogItemStyle.Render(""))
-		lines = append(lines, dialogItemStyle.Render("How would you like to create the secret?"))
-		lines = append(lines, dialogItemStyle.Render(""))
+		lines = append(lines, dialog.TitleStyle.Render(" Create Secret - Choose Source "))
+		lines = append(lines, dialog.ItemStyle.Render(""))
+		lines = append(lines, dialog.ItemStyle.Render("How would you like to create the secret?"))
+		lines = append(lines, dialog.ItemStyle.Render(""))
 
 		if m.createSecretSource == "file" {
-			lines = append(lines, dialogSelectedStyle.Render("→ From file"))
+			lines = append(lines, dialog.SelectedStyle.Render("→ From file"))
 		} else {
-			lines = append(lines, dialogItemStyle.Render("  From file"))
+			lines = append(lines, dialog.ItemStyle.Render("  From file"))
 		}
 
 		if m.createSecretSource == "inline" {
-			lines = append(lines, dialogSelectedStyle.Render("→ Inline editor"))
+			lines = append(lines, dialog.SelectedStyle.Render("→ Inline editor"))
 		} else {
-			lines = append(lines, dialogItemStyle.Render("  Inline editor"))
+			lines = append(lines, dialog.ItemStyle.Render("  Inline editor"))
 		}
 
-		lines = append(lines, dialogItemStyle.Render(""))
+		lines = append(lines, dialog.ItemStyle.Render(""))
 		helpText := fmt.Sprintf(" %s Select • %s / %s Navigate • %s Cancel",
-			dialogKeyStyle.Render("<Enter>"),
-			dialogKeyStyle.Render("<↑>"),
-			dialogKeyStyle.Render("<↓>"),
-			dialogKeyStyle.Render("<Esc>"))
-		lines = append(lines, dialogHelpStyle.Render(helpText))
+			dialog.KeyStyle.Render("<Enter>"),
+			dialog.KeyStyle.Render("<↑>"),
+			dialog.KeyStyle.Render("<↓>"),
+			dialog.KeyStyle.Render("<Esc>"))
+		lines = append(lines, dialog.HelpStyle.Render(helpText))
 
 	case "details-file":
-		lines = append(lines, dialogTitleStyle.Render(" Create Secret from File "))
-		lines = append(lines, dialogItemStyle.Render(""))
+		lines = append(lines, dialog.TitleStyle.Render(" Create Secret from File "))
+		lines = append(lines, dialog.ItemStyle.Render(""))
 
 		// Show error if present
 		if m.createDialogError != "" {
@@ -181,23 +177,23 @@ func (m *Model) renderCreateDialog() string {
 				Foreground(lipgloss.Color("196")).
 				Padding(0, 1)
 			lines = append(lines, errorStyle.Render("⚠ "+m.createDialogError))
-			lines = append(lines, dialogItemStyle.Render(""))
+			lines = append(lines, dialog.ItemStyle.Render(""))
 		}
 
-		lines = append(lines, dialogItemStyle.Render(m.createNameInput.View()))
-		lines = append(lines, dialogItemStyle.Render(""))
+		lines = append(lines, dialog.ItemStyle.Render(m.createNameInput.View()))
+		lines = append(lines, dialog.ItemStyle.Render(""))
 
 		// Show file path input with browse indicator when focused
 		fileLine := m.createFileInput.View()
 		if m.createInputFocus == 1 {
-			fileLine += "  " + dialogKeyStyle.Render("[f: Browse]")
+			fileLine += "  " + dialog.KeyStyle.Render("[f: Browse]")
 		}
-		lines = append(lines, dialogItemStyle.Render(fileLine))
-		lines = append(lines, dialogItemStyle.Render(""))
+		lines = append(lines, dialog.ItemStyle.Render(fileLine))
+		lines = append(lines, dialog.ItemStyle.Render(""))
 
 		// Show labels input
-		lines = append(lines, dialogItemStyle.Render(m.createLabelsInput.View()))
-		lines = append(lines, dialogItemStyle.Render(""))
+		lines = append(lines, dialog.ItemStyle.Render(m.createLabelsInput.View()))
+		lines = append(lines, dialog.ItemStyle.Render(""))
 
 		// Show encode toggle
 		encodeText := "Encode secret: "
@@ -207,34 +203,34 @@ func (m *Model) renderCreateDialog() string {
 			encodeText += "OFF"
 		}
 		if m.createInputFocus == 3 {
-			encodeText = dialogSelectedStyle.Render(encodeText)
+			encodeText = dialog.SelectedStyle.Render(encodeText)
 		} else {
-			encodeText = dialogItemStyle.Render(encodeText)
+			encodeText = dialog.ItemStyle.Render(encodeText)
 		}
 		lines = append(lines, encodeText)
-		lines = append(lines, dialogItemStyle.Render("  (Secrets need to be base64 encoded. Disable this if already encoded.)"))
-		lines = append(lines, dialogItemStyle.Render(""))
+		lines = append(lines, dialog.ItemStyle.Render("  (Secrets need to be base64 encoded. Disable this if already encoded.)"))
+		lines = append(lines, dialog.ItemStyle.Render(""))
 
 		// Change help text based on error state
 		var helpText string
 		if m.createDialogError != "" {
 			helpText = fmt.Sprintf(" %s Fix error • %s Navigate • %s Toggle • %s Cancel",
-				dialogKeyStyle.Render("<Enter>"),
-				dialogKeyStyle.Render("<Tab>"),
-				dialogKeyStyle.Render("<Space>"),
-				dialogKeyStyle.Render("<Esc>"))
+				dialog.KeyStyle.Render("<Enter>"),
+				dialog.KeyStyle.Render("<Tab>"),
+				dialog.KeyStyle.Render("<Space>"),
+				dialog.KeyStyle.Render("<Esc>"))
 		} else {
 			helpText = fmt.Sprintf(" %s Confirm • %s Navigate • %s Toggle • %s Cancel",
-				dialogKeyStyle.Render("<Enter>"),
-				dialogKeyStyle.Render("<Tab>"),
-				dialogKeyStyle.Render("<Space>"),
-				dialogKeyStyle.Render("<Esc>"))
+				dialog.KeyStyle.Render("<Enter>"),
+				dialog.KeyStyle.Render("<Tab>"),
+				dialog.KeyStyle.Render("<Space>"),
+				dialog.KeyStyle.Render("<Esc>"))
 		}
-		lines = append(lines, dialogHelpStyle.Render(helpText))
+		lines = append(lines, dialog.HelpStyle.Render(helpText))
 
 	case "details-inline":
-		lines = append(lines, dialogTitleStyle.Render(" Create Secret - Inline Editor "))
-		lines = append(lines, dialogItemStyle.Render(""))
+		lines = append(lines, dialog.TitleStyle.Render(" Create Secret - Inline Editor "))
+		lines = append(lines, dialog.ItemStyle.Render(""))
 
 		// Show error if present
 		if m.createDialogError != "" {
@@ -242,11 +238,11 @@ func (m *Model) renderCreateDialog() string {
 				Foreground(lipgloss.Color("196")).
 				Padding(0, 1)
 			lines = append(lines, errorStyle.Render("⚠ "+m.createDialogError))
-			lines = append(lines, dialogItemStyle.Render(""))
+			lines = append(lines, dialog.ItemStyle.Render(""))
 		}
 
-		lines = append(lines, dialogItemStyle.Render(m.createNameInput.View()))
-		lines = append(lines, dialogItemStyle.Render(""))
+		lines = append(lines, dialog.ItemStyle.Render(m.createNameInput.View()))
+		lines = append(lines, dialog.ItemStyle.Render(""))
 
 		// Show editor status with edit hint when focused
 		editorStatus := "Content: "
@@ -256,14 +252,14 @@ func (m *Model) renderCreateDialog() string {
 			editorStatus += "(empty)"
 		}
 		if m.createInputFocus == 1 {
-			editorStatus += "  " + dialogKeyStyle.Render("[e: Edit]")
+			editorStatus += "  " + dialog.KeyStyle.Render("[e: Edit]")
 		}
-		lines = append(lines, dialogItemStyle.Render(editorStatus))
-		lines = append(lines, dialogItemStyle.Render(""))
+		lines = append(lines, dialog.ItemStyle.Render(editorStatus))
+		lines = append(lines, dialog.ItemStyle.Render(""))
 
 		// Show labels input
-		lines = append(lines, dialogItemStyle.Render(m.createLabelsInput.View()))
-		lines = append(lines, dialogItemStyle.Render(""))
+		lines = append(lines, dialog.ItemStyle.Render(m.createLabelsInput.View()))
+		lines = append(lines, dialog.ItemStyle.Render(""))
 
 		// Show encode toggle
 		encodeText := "Encode secret: "
@@ -273,34 +269,34 @@ func (m *Model) renderCreateDialog() string {
 			encodeText += "OFF"
 		}
 		if m.createInputFocus == 3 {
-			encodeText = dialogSelectedStyle.Render(encodeText)
+			encodeText = dialog.SelectedStyle.Render(encodeText)
 		} else {
-			encodeText = dialogItemStyle.Render(encodeText)
+			encodeText = dialog.ItemStyle.Render(encodeText)
 		}
 		lines = append(lines, encodeText)
-		lines = append(lines, dialogItemStyle.Render("  (Secrets need to be base64 encoded. Disable this if already encoded.)"))
-		lines = append(lines, dialogItemStyle.Render(""))
+		lines = append(lines, dialog.ItemStyle.Render("  (Secrets need to be base64 encoded. Disable this if already encoded.)"))
+		lines = append(lines, dialog.ItemStyle.Render(""))
 
 		// Change help text based on error state
 		var helpText string
 		if m.createDialogError != "" {
 			helpText = fmt.Sprintf(" %s Fix error • %s Navigate • %s Toggle • %s Cancel",
-				dialogKeyStyle.Render("<Enter>"),
-				dialogKeyStyle.Render("<Tab>"),
-				dialogKeyStyle.Render("<Space>"),
-				dialogKeyStyle.Render("<Esc>"))
+				dialog.KeyStyle.Render("<Enter>"),
+				dialog.KeyStyle.Render("<Tab>"),
+				dialog.KeyStyle.Render("<Space>"),
+				dialog.KeyStyle.Render("<Esc>"))
 		} else {
 			helpText = fmt.Sprintf(" %s Confirm • %s Navigate • %s Toggle • %s Cancel",
-				dialogKeyStyle.Render("<Enter>"),
-				dialogKeyStyle.Render("<Tab>"),
-				dialogKeyStyle.Render("<Space>"),
-				dialogKeyStyle.Render("<Esc>"))
+				dialog.KeyStyle.Render("<Enter>"),
+				dialog.KeyStyle.Render("<Tab>"),
+				dialog.KeyStyle.Render("<Space>"),
+				dialog.KeyStyle.Render("<Esc>"))
 		}
-		lines = append(lines, dialogHelpStyle.Render(helpText))
+		lines = append(lines, dialog.HelpStyle.Render(helpText))
 	}
 
 	content := lipgloss.JoinVertical(lipgloss.Left, lines...)
-	return dialogBorderStyle.Render(content)
+	return dialog.BorderStyle.Render(content)
 }
 
 // formatLabels formats labels map to sorted key=value string

--- a/views/services/view.go
+++ b/views/services/view.go
@@ -7,9 +7,13 @@ import (
 	"swarmcli/ui"
 )
 
-func (m *Model) View() string {
-	header := m.List.RenderHeader()
-	footer := m.List.RenderFooter()
+func (m *Model) FrameTitle() string  { return m.title }
+func (m *Model) FrameHeader() string { return m.List.RenderHeader() }
+func (m *Model) FrameFooter() string { return m.List.RenderFooter() }
+
+func (m *Model) FrameContent() string {
+	header := m.FrameHeader()
+	footer := m.FrameFooter()
 
 	frame := ui.ComputeFrameDimensions(
 		m.List.Viewport.Width,
@@ -24,27 +28,23 @@ func (m *Model) View() string {
 	if m.selectedTaskIndex >= 0 && m.List.Cursor < len(m.List.Filtered) {
 		entry := m.List.Filtered[m.List.Cursor]
 		if m.expandedServices[entry.ServiceID] {
-			// Skip VisibleContent's offset adjustment - we'll manage it manually
 			m.List.SkipOffsetAdjustment = true
 
-			// Calculate the line offset for the selected task
 			lineOffset := 0
 			for i := 0; i < m.List.Cursor; i++ {
 				e := m.List.Filtered[i]
-				lineOffset++ // service row
+				lineOffset++
 				if m.expandedServices[e.ServiceID] {
 					tasks := m.serviceTasks[e.ServiceID]
 					if len(tasks) > 0 {
-						lineOffset += 1 + len(tasks) // header + task rows
+						lineOffset += 1 + len(tasks)
 					} else {
-						lineOffset += 1 // "no tasks" row
+						lineOffset += 1
 					}
 				}
 			}
-			// Add service row + header + selected task
 			lineOffset += 2 + m.selectedTaskIndex
 
-			// Ensure the task line is visible
 			if lineOffset < m.List.Viewport.YOffset {
 				m.List.Viewport.YOffset = lineOffset
 			} else if lineOffset >= m.List.Viewport.YOffset+frame.DesiredContentLines {
@@ -55,25 +55,23 @@ func (m *Model) View() string {
 			}
 		}
 	} else {
-		// Not in task navigation - let VisibleContent handle offset
 		m.List.SkipOffsetAdjustment = false
 	}
 
-	// Use VisibleContent to get only the visible portion based on cursor position
-	// This ensures proper scrolling and that the cursor is always visible
-	// VisibleContent already returns exactly desiredContentLines, so we use
-	// RenderFramedBox instead of RenderFramedBoxHeight to avoid double-padding
 	content := m.List.VisibleContent(frame.DesiredContentLines)
 
-	framed := ui.RenderFramedBox(m.title, header, content, footer, frame.FrameWidth)
-
+	width := frame.FrameWidth
 	if m.confirmDialog.Visible {
-		framed = ui.OverlayCentered(framed, m.confirmDialog.View(), frame.FrameWidth, frame.FrameHeight)
+		content = ui.OverlayCentered(content, m.confirmDialog.View(), width, 0)
 	}
-
 	if m.scaleDialog.Visible {
-		framed = ui.OverlayCentered(framed, m.scaleDialog.View(), frame.FrameWidth, frame.FrameHeight)
+		content = ui.OverlayCentered(content, m.scaleDialog.View(), width, 0)
 	}
 
-	return framed
+	return content
+}
+
+func (m *Model) View() string {
+	return ui.RenderViewFrame(m.FrameTitle(), m.FrameHeader(), m.FrameContent(), m.FrameFooter(),
+		m.List.Viewport.Width, m.List.Viewport.Height, false)
 }

--- a/views/stacks/model_test.go
+++ b/views/stacks/model_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"swarmcli/docker"
+	"swarmcli/ui"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/stretchr/testify/require"
@@ -292,8 +293,8 @@ func TestFormatErrorWithScroll(t *testing.T) {
 }
 
 func TestWrapText(t *testing.T) {
-	require.Equal(t, []string{"short"}, wrapText("short", 20))
-	lines := wrapText("this is a longer sentence that wraps", 15)
+	require.Equal(t, []string{"short"}, ui.WrapText("short", 20))
+	lines := ui.WrapText("this is a longer sentence that wraps", 15)
 	require.True(t, len(lines) > 1)
 }
 

--- a/views/stacks/view.go
+++ b/views/stacks/view.go
@@ -5,66 +5,53 @@ package stacksview
 
 import (
 	"fmt"
-	"strings"
 	"swarmcli/ui"
+	"swarmcli/ui/dialog"
 
 	"github.com/charmbracelet/lipgloss"
 )
 
-// Shared dialog styles
-var (
-	dialogTitleStyle = lipgloss.NewStyle().
-				Bold(true).
-				Foreground(lipgloss.Color("15")).
-				Background(lipgloss.Color("63")).
-				Padding(0, 1)
+func (m *Model) FrameTitle() string {
+	return fmt.Sprintf("Stacks on Node (Total: %d)", len(m.List.Items))
+}
 
-	dialogBorderStyle = lipgloss.NewStyle().
-				Border(lipgloss.RoundedBorder()).
-				BorderForeground(lipgloss.Color("117"))
+func (m *Model) FrameHeader() string { return m.List.RenderHeader() }
+func (m *Model) FrameFooter() string { return m.List.RenderFooter() }
 
-	dialogItemStyle = lipgloss.NewStyle().
-			Padding(0, 1)
+func (m *Model) FrameContent() string {
+	m.setRenderItem()
 
-	dialogSelectedStyle = lipgloss.NewStyle().
-				Foreground(lipgloss.Color("15")).
-				Background(lipgloss.Color("63")).
-				Padding(0, 1)
+	header := m.FrameHeader()
+	footer := m.FrameFooter()
+	frame := ui.ComputeFrameDimensions(
+		m.List.Viewport.Width, m.List.Viewport.Height,
+		m.List.Viewport.Width, m.List.Viewport.Height,
+		header, footer,
+	)
+	content := m.List.VisibleContent(frame.DesiredContentLines)
 
-	dialogHelpStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("240")).
-			Padding(0, 1)
+	l().Debugf("Rendering stacks view: createDialogActive=%v step=%s fileBrowserActive=%v",
+		m.createDialogActive, m.createDialogStep, m.fileBrowserActive)
 
-	dialogKeyStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("63")).
-			Bold(true)
-)
+	width := frame.FrameWidth
+	if m.createDialogActive {
+		content = ui.OverlayCentered(content, m.renderCreateDialog(), width, 0)
+	} else if m.fileBrowserActive {
+		fileBrowserDialog := ui.RenderFileBrowserDialog("Select Compose File", m.fileBrowserPath, m.fileBrowserFiles, m.fileBrowserCursor)
+		content = ui.OverlayCentered(content, fileBrowserDialog, width, 0)
+	} else if m.confirmDialog.Visible {
+		content = ui.OverlayCentered(content, m.confirmDialog.View(), width, 0)
+	}
+
+	return content
+}
 
 func (m *Model) View() string {
 	if !m.Visible {
 		return ""
 	}
-
-	// Ensure RenderItem can include expanded inline tasks
-	m.setRenderItem()
-
-	title := fmt.Sprintf("Stacks on Node (Total: %d)", len(m.List.Items))
-	framed, frame := m.List.RenderFramedView(title)
-
-	// Debug: log dialog states
-	l().Debugf("Rendering stacks view: createDialogActive=%v step=%s fileBrowserActive=%v",
-		m.createDialogActive, m.createDialogStep, m.fileBrowserActive)
-
-	if m.createDialogActive {
-		framed = ui.OverlayCentered(framed, m.renderCreateDialog(), frame.FrameWidth, frame.FrameHeight)
-	} else if m.fileBrowserActive {
-		fileBrowserDialog := ui.RenderFileBrowserDialog("Select Compose File", m.fileBrowserPath, m.fileBrowserFiles, m.fileBrowserCursor)
-		framed = ui.OverlayCentered(framed, fileBrowserDialog, frame.FrameWidth, frame.FrameHeight)
-	} else if m.confirmDialog.Visible {
-		framed = ui.OverlayCentered(framed, m.confirmDialog.View(), frame.FrameWidth, frame.FrameHeight)
-	}
-
-	return framed
+	return ui.RenderViewFrame(m.FrameTitle(), m.FrameHeader(), m.FrameContent(), m.FrameFooter(),
+		m.List.Viewport.Width, m.List.Viewport.Height, false)
 }
 
 func (m *Model) renderCreateDialog() string {
@@ -75,34 +62,34 @@ func (m *Model) renderCreateDialog() string {
 
 	switch m.createDialogStep {
 	case "source":
-		lines = append(lines, dialogTitleStyle.Render(" Create Stack - Choose Source "))
-		lines = append(lines, dialogItemStyle.Render(""))
-		lines = append(lines, dialogItemStyle.Render("How would you like to create the stack?"))
-		lines = append(lines, dialogItemStyle.Render(""))
+		lines = append(lines, dialog.TitleStyle.Render(" Create Stack - Choose Source "))
+		lines = append(lines, dialog.ItemStyle.Render(""))
+		lines = append(lines, dialog.ItemStyle.Render("How would you like to create the stack?"))
+		lines = append(lines, dialog.ItemStyle.Render(""))
 
 		if m.createStackSource == "file" {
-			lines = append(lines, dialogSelectedStyle.Render("→ From compose file"))
+			lines = append(lines, dialog.SelectedStyle.Render("→ From compose file"))
 		} else {
-			lines = append(lines, dialogItemStyle.Render("  From compose file"))
+			lines = append(lines, dialog.ItemStyle.Render("  From compose file"))
 		}
 
 		if m.createStackSource == "inline" {
-			lines = append(lines, dialogSelectedStyle.Render("→ Inline editor"))
+			lines = append(lines, dialog.SelectedStyle.Render("→ Inline editor"))
 		} else {
-			lines = append(lines, dialogItemStyle.Render("  Inline editor"))
+			lines = append(lines, dialog.ItemStyle.Render("  Inline editor"))
 		}
 
-		lines = append(lines, dialogItemStyle.Render(""))
+		lines = append(lines, dialog.ItemStyle.Render(""))
 		helpText := fmt.Sprintf(" %s Select • %s / %s Navigate • %s Cancel",
-			dialogKeyStyle.Render("<Enter>"),
-			dialogKeyStyle.Render("<↑>"),
-			dialogKeyStyle.Render("<↓>"),
-			dialogKeyStyle.Render("<Esc>"))
-		lines = append(lines, dialogHelpStyle.Render(helpText))
+			dialog.KeyStyle.Render("<Enter>"),
+			dialog.KeyStyle.Render("<↑>"),
+			dialog.KeyStyle.Render("<↓>"),
+			dialog.KeyStyle.Render("<Esc>"))
+		lines = append(lines, dialog.HelpStyle.Render(helpText))
 
 	case "details-file":
-		lines = append(lines, dialogTitleStyle.Render(" Create Stack from Compose File "))
-		lines = append(lines, dialogItemStyle.Render(""))
+		lines = append(lines, dialog.TitleStyle.Render(" Create Stack from Compose File "))
+		lines = append(lines, dialog.ItemStyle.Render(""))
 
 		// Show error if present
 		if m.createDialogError != "" {
@@ -111,47 +98,47 @@ func (m *Model) renderCreateDialog() string {
 				Padding(0, 1).
 				Width(70)
 			// Wrap error message to multiple lines if needed
-			wrappedError := wrapText("⚠ "+m.createDialogError, 68) // 70 - 2 for padding
+			wrappedError := ui.WrapText("⚠ "+m.createDialogError, 68) // 70 - 2 for padding
 			for _, line := range wrappedError {
 				lines = append(lines, errorStyle.Render(line))
 			}
-			lines = append(lines, dialogItemStyle.Render(""))
+			lines = append(lines, dialog.ItemStyle.Render(""))
 		}
 
-		lines = append(lines, dialogItemStyle.Render(m.createNameInput.View()))
-		lines = append(lines, dialogItemStyle.Render(""))
+		lines = append(lines, dialog.ItemStyle.Render(m.createNameInput.View()))
+		lines = append(lines, dialog.ItemStyle.Render(""))
 
 		// Show file path input with browse indicator when focused
 		// Always reserve space for the hint to prevent dialog resizing
 		fileLine := m.createFileInput.View()
 		if m.createInputFocus == 1 {
-			fileLine += "  " + dialogKeyStyle.Render("[f: Browse]")
+			fileLine += "  " + dialog.KeyStyle.Render("[f: Browse]")
 		} else {
 			// Add invisible spacing to maintain consistent width
 			fileLine += "             " // 13 characters to match "  [f: Browse]"
 		}
-		lines = append(lines, dialogItemStyle.Render(fileLine))
-		lines = append(lines, dialogItemStyle.Render(""))
+		lines = append(lines, dialog.ItemStyle.Render(fileLine))
+		lines = append(lines, dialog.ItemStyle.Render(""))
 
 		// Change help text based on error state
 		var helpText string
 		if m.createDialogError != "" {
 			helpText = fmt.Sprintf(" %s Fix error • %s Navigate • %s Cancel",
-				dialogKeyStyle.Render("<Enter>"),
-				dialogKeyStyle.Render("<Tab>"),
-				dialogKeyStyle.Render("<Esc>"))
+				dialog.KeyStyle.Render("<Enter>"),
+				dialog.KeyStyle.Render("<Tab>"),
+				dialog.KeyStyle.Render("<Esc>"))
 		} else {
 			helpText = fmt.Sprintf(" %s Deploy • %s Navigate • %s Browse • %s Cancel",
-				dialogKeyStyle.Render("<Enter>"),
-				dialogKeyStyle.Render("<Tab>"),
-				dialogKeyStyle.Render("<f>"),
-				dialogKeyStyle.Render("<Esc>"))
+				dialog.KeyStyle.Render("<Enter>"),
+				dialog.KeyStyle.Render("<Tab>"),
+				dialog.KeyStyle.Render("<f>"),
+				dialog.KeyStyle.Render("<Esc>"))
 		}
-		lines = append(lines, dialogHelpStyle.Render(helpText))
+		lines = append(lines, dialog.HelpStyle.Render(helpText))
 
 	case "details-inline":
-		lines = append(lines, dialogTitleStyle.Render(" Create Stack - Inline Editor "))
-		lines = append(lines, dialogItemStyle.Render(""))
+		lines = append(lines, dialog.TitleStyle.Render(" Create Stack - Inline Editor "))
+		lines = append(lines, dialog.ItemStyle.Render(""))
 
 		// Show error if present
 		if m.createDialogError != "" {
@@ -160,15 +147,15 @@ func (m *Model) renderCreateDialog() string {
 				Padding(0, 1).
 				Width(70)
 			// Wrap error message to multiple lines if needed
-			wrappedError := wrapText("⚠ "+m.createDialogError, 68) // 70 - 2 for padding
+			wrappedError := ui.WrapText("⚠ "+m.createDialogError, 68) // 70 - 2 for padding
 			for _, line := range wrappedError {
 				lines = append(lines, errorStyle.Render(line))
 			}
-			lines = append(lines, dialogItemStyle.Render(""))
+			lines = append(lines, dialog.ItemStyle.Render(""))
 		}
 
-		lines = append(lines, dialogItemStyle.Render(m.createNameInput.View()))
-		lines = append(lines, dialogItemStyle.Render(""))
+		lines = append(lines, dialog.ItemStyle.Render(m.createNameInput.View()))
+		lines = append(lines, dialog.ItemStyle.Render(""))
 
 		// Show source file if content was loaded from a file
 		if m.createStackPath != "" {
@@ -176,7 +163,7 @@ func (m *Model) renderCreateDialog() string {
 				Foreground(lipgloss.Color("240")).
 				Padding(0, 1)
 			lines = append(lines, sourceStyle.Render(fmt.Sprintf("Source: %s", m.createStackPath)))
-			lines = append(lines, dialogItemStyle.Render(""))
+			lines = append(lines, dialog.ItemStyle.Render(""))
 		}
 
 		// Show editor status with edit hint when focused
@@ -188,69 +175,31 @@ func (m *Model) renderCreateDialog() string {
 			editorStatus += "(empty)"
 		}
 		if m.createInputFocus == 1 {
-			editorStatus += "  " + dialogKeyStyle.Render("[e: Edit]")
+			editorStatus += "  " + dialog.KeyStyle.Render("[e: Edit]")
 		} else {
 			// Add invisible spacing to maintain consistent width
 			editorStatus += "           " // 11 characters to match "  [e: Edit]"
 		}
-		lines = append(lines, dialogItemStyle.Render(editorStatus))
-		lines = append(lines, dialogItemStyle.Render(""))
+		lines = append(lines, dialog.ItemStyle.Render(editorStatus))
+		lines = append(lines, dialog.ItemStyle.Render(""))
 
 		// Change help text based on error state
 		var helpText string
 		if m.createDialogError != "" {
 			helpText = fmt.Sprintf(" %s Fix error • %s Navigate • %s Cancel",
-				dialogKeyStyle.Render("<Enter>"),
-				dialogKeyStyle.Render("<Tab>"),
-				dialogKeyStyle.Render("<Esc>"))
+				dialog.KeyStyle.Render("<Enter>"),
+				dialog.KeyStyle.Render("<Tab>"),
+				dialog.KeyStyle.Render("<Esc>"))
 		} else {
 			helpText = fmt.Sprintf(" %s Deploy • %s Navigate • %s Edit • %s Cancel",
-				dialogKeyStyle.Render("<Enter>"),
-				dialogKeyStyle.Render("<Tab>"),
-				dialogKeyStyle.Render("<e>"),
-				dialogKeyStyle.Render("<Esc>"))
+				dialog.KeyStyle.Render("<Enter>"),
+				dialog.KeyStyle.Render("<Tab>"),
+				dialog.KeyStyle.Render("<e>"),
+				dialog.KeyStyle.Render("<Esc>"))
 		}
-		lines = append(lines, dialogHelpStyle.Render(helpText))
+		lines = append(lines, dialog.HelpStyle.Render(helpText))
 	}
 
 	content := lipgloss.JoinVertical(lipgloss.Left, lines...)
-	return dialogBorderStyle.Render(content)
-}
-
-// wrapText wraps text to the specified width, breaking on word boundaries
-func wrapText(text string, width int) []string {
-	if len(text) <= width {
-		return []string{text}
-	}
-
-	var lines []string
-	words := strings.Fields(text)
-	if len(words) == 0 {
-		return []string{text}
-	}
-
-	currentLine := ""
-	for _, word := range words {
-		// If adding this word would exceed width
-		if len(currentLine)+len(word)+1 > width {
-			if currentLine != "" {
-				lines = append(lines, currentLine)
-				currentLine = word
-			} else {
-				// Word itself is longer than width, just add it
-				lines = append(lines, word)
-			}
-		} else {
-			if currentLine == "" {
-				currentLine = word
-			} else {
-				currentLine += " " + word
-			}
-		}
-	}
-	if currentLine != "" {
-		lines = append(lines, currentLine)
-	}
-
-	return lines
+	return dialog.BorderStyle.Render(content)
 }

--- a/views/tasks/view.go
+++ b/views/tasks/view.go
@@ -10,16 +10,25 @@ import (
 	"swarmcli/ui/components/sorting"
 )
 
+func (m *Model) FrameTitle() string {
+	return fmt.Sprintf("Tasks - Stack: %s (Total: %d)", m.stackName, len(m.tasks))
+}
+
+func (m *Model) FrameHeader() string { return "" }
+
+func (m *Model) FrameFooter() string {
+	return ui.StatusBarStyle.Render(fmt.Sprintf("Viewing %d tasks", len(m.tasks)))
+}
+
+func (m *Model) FrameContent() string {
+	return m.viewport.View()
+}
+
 func (m *Model) View() string {
 	if !m.visible {
 		return ""
 	}
-
-	title := fmt.Sprintf("Tasks - Stack: %s (Total: %d)", m.stackName, len(m.tasks))
-	content := m.viewport.View()
-	footer := ui.StatusBarStyle.Render(fmt.Sprintf("Viewing %d tasks", len(m.tasks)))
-
-	return ui.RenderFramedBox(title, "", content, footer, m.width)
+	return ui.RenderFramedBox(m.FrameTitle(), m.FrameHeader(), m.FrameContent(), m.FrameFooter(), m.width)
 }
 
 func (m *Model) renderTasks() string {

--- a/views/view/interface.go
+++ b/views/view/interface.go
@@ -22,4 +22,11 @@ type View interface {
 	OnExit() tea.Cmd  // Called when view is removed/replaced
 
 	HasErrors() bool // Returns true if the view has any errors to display
+
+	// Frame components — views return unframed content,
+	// app wraps with ui.RenderViewFrame.
+	FrameTitle() string   // text for frame title bar
+	FrameHeader() string  // rendered header line(s), "" if none
+	FrameFooter() string  // rendered footer line(s), "" if none
+	FrameContent() string // unframed content (may include dialog overlays)
 }

--- a/views/viewstack/viewstack_test.go
+++ b/views/viewstack/viewstack_test.go
@@ -20,6 +20,10 @@ func (m *mockView) OnEnter() tea.Cmd                    { return nil }
 func (m *mockView) OnExit() tea.Cmd                     { return nil }
 func (m *mockView) HasErrors() bool                     { return false }
 func (m *mockView) ShortHelpItems() []helpbar.HelpEntry { return nil }
+func (m *mockView) FrameTitle() string                  { return m.name }
+func (m *mockView) FrameHeader() string                 { return "" }
+func (m *mockView) FrameFooter() string                 { return "" }
+func (m *mockView) FrameContent() string                { return "" }
 
 func TestPush_And_Pop(t *testing.T) {
 	s := &Stack{}


### PR DESCRIPTION
## Summary

Closes #243.

- **FrameProvider interface**: Extends `View` with `FrameTitle()`, `FrameHeader()`, `FrameFooter()`, `FrameContent()` — views return unframed content, the app assembles the frame via `ui.RenderViewFrame()`
- **Universal fullscreen**: `f` key now works on any view (moved from logs-only to app level); helpbar/stackbar hidden in fullscreen mode
- **Dialog style consolidation**: Extracts duplicated `dialogTitleStyle`/`dialogBorderStyle`/etc. from stacks, secrets, configs, contexts into `ui/dialog/styles.go`
- **WrapText deduplication**: Consolidates 3 identical `wrapText` functions (stacks, loading, errordialog) into `ui.WrapText()`

25 files changed, ~830 insertions, ~970 deletions (net -140 lines).

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` — all tests pass
- [x] `golangci-lint run ./...` — 0 issues
- [x] Manual: frames render correctly with 1-space left padding
- [ ] Manual: all 12 views display properly
- [x] Manual: dialog overlays appear centered
- [x] Manual: `f` key toggles fullscreen on any view
- [x] Manual: helpbar/stackbar hidden in fullscreen

🤖 Generated with [Claude Code](https://claude.com/claude-code)