### PR TITLE
Rename Describe to Inspect in stack view

### DIFF
--- a/docker/stack_inspect.go
+++ b/docker/stack_inspect.go
@@ -10,8 +10,8 @@ import (
 	"time"
 )
 
-// StackDescription contains detailed information about a stack
-type StackDescription struct {
+// StackInspection contains detailed information about a stack
+type StackInspection struct {
 	Name         string           `json:"name"`
 	Services     []ServiceSummary `json:"services"`
 	Networks     []string         `json:"networks,omitempty"`
@@ -36,14 +36,14 @@ type ServiceSummary struct {
 	UpdatedAt time.Time         `json:"updated_at"`
 }
 
-// DescribeStack returns detailed information about a stack in JSON format
-func DescribeStack(stackName string) (string, error) {
+// GetStackInspection returns detailed information about a stack in JSON format
+func GetStackInspection(stackName string) (string, error) {
 	snap, err := GetOrRefreshSnapshot()
 	if err != nil {
 		return "", fmt.Errorf("failed to get snapshot: %w", err)
 	}
 
-	desc := StackDescription{
+	desc := StackInspection{
 		Name:     stackName,
 		Services: []ServiceSummary{},
 	}
@@ -180,7 +180,7 @@ func DescribeStack(stackName string) (string, error) {
 	// Marshal to JSON with indentation
 	jsonBytes, err := json.MarshalIndent(desc, "", "  ")
 	if err != nil {
-		return "", fmt.Errorf("failed to marshal stack description: %w", err)
+		return "", fmt.Errorf("failed to marshal stack inspection: %w", err)
 	}
 
 	return string(jsonBytes), nil

--- a/docker/stack_ops.go
+++ b/docker/stack_ops.go
@@ -9,7 +9,7 @@ type StackOps interface {
 	RemoveStackNetworks(stackName string) error
 	DeployStack(stackName string, yamlContent string) error
 	ValidateStackYAML(content string) error
-	DescribeStack(stackName string) (string, error)
+	InspectStack(stackName string) (string, error)
 	ReconstructStackCompose(stackName string) (string, error)
 }
 
@@ -31,8 +31,8 @@ func (defaultStackOps) ValidateStackYAML(content string) error {
 	return ValidateStackYAML(content)
 }
 
-func (defaultStackOps) DescribeStack(stackName string) (string, error) {
-	return DescribeStack(stackName)
+func (defaultStackOps) InspectStack(stackName string) (string, error) {
+	return GetStackInspection(stackName)
 }
 
 func (defaultStackOps) ReconstructStackCompose(stackName string) (string, error) {

--- a/integration-tests/docker/stack_inspect_test.go
+++ b/integration-tests/docker/stack_inspect_test.go
@@ -13,41 +13,41 @@ import (
 	"testing"
 )
 
-func TestDescribeStack(t *testing.T) {
+func TestInspectStack(t *testing.T) {
 	// This test assumes that the demo stack is already deployed
 	// (done by test-setup/testenv.sh deploy)
 	stackName := "demo"
 
-	jsonOutput, err := docker.DescribeStack(stackName)
+	jsonOutput, err := docker.GetStackInspection(stackName)
 	if err != nil {
-		t.Fatalf("Failed to describe stack: %v", err)
+		t.Fatalf("Failed to inspect stack: %v", err)
 	}
 
 	if jsonOutput == "" {
-		t.Fatal("Description output is empty")
+		t.Fatal("Inspection output is empty")
 	}
 
 	// Verify it's valid JSON
-	var desc docker.StackDescription
-	if err := json.Unmarshal([]byte(jsonOutput), &desc); err != nil {
+	var inspection docker.StackInspection
+	if err := json.Unmarshal([]byte(jsonOutput), &inspection); err != nil {
 		t.Fatalf("Failed to parse JSON output: %v", err)
 	}
 
 	// Verify basic fields
-	if desc.Name != stackName {
-		t.Errorf("Expected stack name %q, got %q", stackName, desc.Name)
+	if inspection.Name != stackName {
+		t.Errorf("Expected stack name %q, got %q", stackName, inspection.Name)
 	}
 
-	if desc.ServiceCount == 0 {
+	if inspection.ServiceCount == 0 {
 		t.Error("Expected non-zero service count")
 	}
 
-	if len(desc.Services) == 0 {
+	if len(inspection.Services) == 0 {
 		t.Error("Expected services to be non-empty")
 	}
 
 	// Check that services have expected fields
-	for _, svc := range desc.Services {
+	for _, svc := range inspection.Services {
 		if svc.Name == "" {
 			t.Error("Service missing name")
 		}
@@ -59,13 +59,13 @@ func TestDescribeStack(t *testing.T) {
 		}
 	}
 
-	t.Logf("Successfully described stack: %d services, %d tasks", desc.ServiceCount, desc.TaskCount)
+	t.Logf("Successfully inspected stack: %d services, %d tasks", inspection.ServiceCount, inspection.TaskCount)
 }
 
-func TestDescribeStack_NonExistent(t *testing.T) {
+func TestInspectStack_NonExistent(t *testing.T) {
 	stackName := "non-existent-stack-xyz123"
 
-	_, err := docker.DescribeStack(stackName)
+	_, err := docker.GetStackInspection(stackName)
 	if err == nil {
 		t.Fatal("Expected error for non-existent stack, got nil")
 	}

--- a/views/stacks/model.go
+++ b/views/stacks/model.go
@@ -185,8 +185,8 @@ func (m *Model) ShortHelpItems() []helpbar.HelpEntry {
 	return []helpbar.HelpEntry{
 		{Key: "n", Desc: "New stack"},
 		{Key: "e", Desc: "Edit"},
-		{Key: "i/enter", Desc: "Services"},
-		{Key: "d", Desc: "Inspect"},
+		{Key: "enter", Desc: "Services"},
+		{Key: "i", Desc: "Inspect"},
 		{Key: "p", Desc: "Tasks"},
 		{Key: "ctrl+d", Desc: "Delete"},
 		{Key: "↑/↓", Desc: "Navigate"},

--- a/views/stacks/model_test.go
+++ b/views/stacks/model_test.go
@@ -17,7 +17,7 @@ type mockStackOps struct {
 	removeStackNetworksFn     func(stackName string) error
 	deployStackFn             func(stackName string, yamlContent string) error
 	validateStackYAMLFn       func(content string) error
-	describeStackFn           func(stackName string) (string, error)
+	inspectStackFn            func(stackName string) (string, error)
 	reconstructStackComposeFn func(stackName string) (string, error)
 }
 
@@ -33,8 +33,8 @@ func (m *mockStackOps) DeployStack(stackName string, yamlContent string) error {
 func (m *mockStackOps) ValidateStackYAML(content string) error {
 	return m.validateStackYAMLFn(content)
 }
-func (m *mockStackOps) DescribeStack(stackName string) (string, error) {
-	return m.describeStackFn(stackName)
+func (m *mockStackOps) InspectStack(stackName string) (string, error) {
+	return m.inspectStackFn(stackName)
 }
 func (m *mockStackOps) ReconstructStackCompose(stackName string) (string, error) {
 	return m.reconstructStackComposeFn(stackName)
@@ -131,7 +131,7 @@ func noopStackOps() *mockStackOps {
 		removeStackNetworksFn:     func(_ string) error { return nil },
 		deployStackFn:             func(_ string, _ string) error { return nil },
 		validateStackYAMLFn:       func(_ string) error { return nil },
-		describeStackFn:           func(_ string) (string, error) { return "", nil },
+		inspectStackFn:            func(_ string) (string, error) { return "", nil },
 		reconstructStackComposeFn: func(_ string) (string, error) { return "", nil },
 	}
 }
@@ -262,7 +262,7 @@ func TestShortHelpItems(t *testing.T) {
 	}
 	require.True(t, keys["n"])
 	require.True(t, keys["e"])
-	require.True(t, keys["d"])
+	require.True(t, keys["i"])
 	require.True(t, keys["ctrl+d"])
 	require.True(t, keys["?"])
 }

--- a/views/stacks/update.go
+++ b/views/stacks/update.go
@@ -312,7 +312,7 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 		}
 
 		// Enter triggers navigation to services
-		if msg.String() == "i" || msg.String() == "enter" {
+		if msg.String() == "enter" {
 			if m.List.Cursor < len(m.List.Filtered) {
 				selected := m.List.Filtered[m.List.Cursor]
 				return func() tea.Msg {
@@ -346,28 +346,28 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 			}
 		}
 
-		// 'd' describes the stack (shows detailed YAML)
-		if msg.String() == "d" {
+		// 'i' inspects the stack (shows detailed JSON)
+		if msg.String() == "i" {
 			if m.List.Cursor < len(m.List.Filtered) {
 				selected := m.List.Filtered[m.List.Cursor]
 				stackName := selected.Name
 				stackOps := m.deps.Stacks
 				return func() tea.Msg {
-					l().Infof("Describing stack: %s", stackName)
-					yamlContent, err := stackOps.DescribeStack(stackName)
+					l().Infof("Inspecting stack: %s", stackName)
+					yamlContent, err := stackOps.InspectStack(stackName)
 					if err != nil {
-						l().Errorf("Failed to describe stack %s: %v", stackName, err)
+						l().Errorf("Failed to inspect stack %s: %v", stackName, err)
 						// Show error in inspect view
 						return view.NavigateToMsg{
 							ViewName: "inspect",
 							Payload: map[string]interface{}{
-								"title":  fmt.Sprintf("Stack: %s (describe failed)", stackName),
-								"json":   fmt.Sprintf("# Error describing stack:\n# %v", err),
+								"title":  fmt.Sprintf("Stack: %s (inspect failed)", stackName),
+								"json":   fmt.Sprintf("# Error inspecting stack:\n# %v", err),
 								"format": "raw",
 							},
 						}
 					}
-					l().Infof("Successfully described stack: %s (%d bytes)", stackName, len(yamlContent))
+					l().Infof("Successfully inspected stack: %s (%d bytes)", stackName, len(yamlContent))
 					return view.NavigateToMsg{
 						ViewName: "inspect",
 						Payload: map[string]interface{}{
@@ -1385,8 +1385,8 @@ func GetStacksHelpContent() []helpview.HelpCategory {
 		{
 			Title: "General",
 			Items: []helpview.HelpItem{
-				{Keys: "<i/enter>", Description: "Show services for Stack"},
-				{Keys: "<d>", Description: "Inspect stack"},
+				{Keys: "<enter>", Description: "Show services for Stack"},
+				{Keys: "<i>", Description: "Inspect stack"},
 				{Keys: "<e>", Description: "Edit stack (opens editor)"},
 				{Keys: "<p>", Description: "Show tasks for Stack"},
 				{Keys: "<n>", Description: "Create new stack"},

--- a/views/stacks/update_test.go
+++ b/views/stacks/update_test.go
@@ -218,18 +218,6 @@ func TestKey_P_TogglesExpand(t *testing.T) {
 	require.False(t, m.expandedStacks["s1"])
 }
 
-func TestKey_I_NavigatesToServices(t *testing.T) {
-	m := testModel()
-	loadStacks(m, fakeStacks("mystack"))
-	cmd := m.Update(key("i"))
-	msg := runCmd(cmd)
-	nav, ok := msg.(view.NavigateToMsg)
-	require.True(t, ok)
-	require.Equal(t, "services", nav.ViewName)
-	payload := nav.Payload.(map[string]any)
-	require.Equal(t, "mystack", payload["stackName"])
-}
-
 func TestKey_Enter_NavigatesToServices(t *testing.T) {
 	m := testModel()
 	loadStacks(m, fakeStacks("mystack"))
@@ -240,36 +228,36 @@ func TestKey_Enter_NavigatesToServices(t *testing.T) {
 	require.Equal(t, "services", nav.ViewName)
 }
 
-func TestKey_D_Describe(t *testing.T) {
-	described := ""
+func TestKey_I_Inspect(t *testing.T) {
+	inspected := ""
 	stackMock := noopStackOps()
-	stackMock.describeStackFn = func(name string) (string, error) {
-		described = name
+	stackMock.inspectStackFn = func(name string) (string, error) {
+		inspected = name
 		return "yaml-content", nil
 	}
 	m := testModel(func(m *Model) { m.deps.Stacks = stackMock })
 	loadStacks(m, fakeStacks("mystack"))
-	cmd := m.Update(key("d"))
+	cmd := m.Update(key("i"))
 	msg := runCmd(cmd)
-	require.Equal(t, "mystack", described)
+	require.Equal(t, "mystack", inspected)
 	nav, ok := msg.(view.NavigateToMsg)
 	require.True(t, ok)
 	require.Equal(t, "inspect", nav.ViewName)
 }
 
-func TestKey_D_DescribeError(t *testing.T) {
+func TestKey_I_InspectError(t *testing.T) {
 	stackMock := noopStackOps()
-	stackMock.describeStackFn = func(_ string) (string, error) {
+	stackMock.inspectStackFn = func(_ string) (string, error) {
 		return "", fmt.Errorf("not found")
 	}
 	m := testModel(func(m *Model) { m.deps.Stacks = stackMock })
 	loadStacks(m, fakeStacks("mystack"))
-	cmd := m.Update(key("d"))
+	cmd := m.Update(key("i"))
 	msg := runCmd(cmd)
 	nav, ok := msg.(view.NavigateToMsg)
 	require.True(t, ok)
 	payload := nav.Payload.(map[string]any)
-	require.Contains(t, payload["title"].(string), "describe failed")
+	require.Contains(t, payload["title"].(string), "inspect failed")
 }
 
 func TestKey_Help(t *testing.T) {


### PR DESCRIPTION
## Summary
- Rename "Describe" → "Inspect" throughout the stack view (keybinding, help entries, code, tests)
- Rebind stack inspect from `d` to `i`; simplify services navigation from `i/enter` to `enter` only
- Rename `StackDescription` → `StackInspection`, `DescribeStack()` → `GetStackInspection()` / `InspectStack` (interface method)

Closes #235

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [ ] `golangci-lint run ./... --build-tags=integration` passes
- [ ] Verify `i` key inspects the selected stack in the TUI
- [ ] Verify `enter` navigates to services (and `i` no longer does)

🤖 Generated with [Claude Code](https://claude.com/claude-code)