### PR TITLE
Add Business Edition placeholders for Shell and Port Forward

### DIFF
--- a/views/helpbar/helpbar_test.go
+++ b/views/helpbar/helpbar_test.go
@@ -30,12 +30,12 @@ func TestView_WithEntries(t *testing.T) {
 func TestView_DisabledEntryNotBold(t *testing.T) {
 	m := New(200, 40)
 	m.WithViewHelp([]HelpEntry{
-		{Key: "x", Desc: "Reveal (Pro)", Disabled: true},
+		{Key: "x", Desc: "Reveal (BE)", Disabled: true},
 	})
 	out := m.View("", false)
 	// Disabled entries still appear in output, just styled differently
 	require.Contains(t, out, "x")
-	require.Contains(t, out, "Reveal (Pro)")
+	require.Contains(t, out, "Reveal (BE)")
 }
 
 func TestView_EmptyHelp_ReturnsSystemInfo(t *testing.T) {

--- a/views/secrets/model.go
+++ b/views/secrets/model.go
@@ -265,10 +265,7 @@ func (m *Model) HasErrors() bool {
 }
 
 func revealHelpDesc() string {
-	if view.HasAction("reveal-secret") {
-		return "Reveal"
-	}
-	return "Reveal (Pro)"
+	return view.BEHelpDesc("reveal-secret", "Reveal")
 }
 
 // validateSecretName validates a secret name

--- a/views/secrets/update.go
+++ b/views/secrets/update.go
@@ -390,7 +390,7 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 			}
 			action, ok := view.GetAction("reveal-secret")
 			if !ok {
-				m.err = fmt.Errorf("Reveal Secret is a Pro feature. Upgrade to SwarmCLI Pro for access.")
+				m.err = view.BEUnavailableErr("Reveal Secret")
 				m.errorDialogActive = true
 				return nil
 			}
@@ -1001,10 +1001,7 @@ func (m *Model) handleUsedByViewKey(msg tea.KeyMsg) tea.Cmd {
 }
 
 func revealDetailedHelpDesc() string {
-	if view.HasAction("reveal-secret") {
-		return "Reveal secret content"
-	}
-	return "Reveal secret content (Pro)"
+	return view.BEHelpDesc("reveal-secret", "Reveal secret content")
 }
 
 // GetSecretsHelpContent returns categorized help for the secrets view

--- a/views/secrets/update_test.go
+++ b/views/secrets/update_test.go
@@ -194,6 +194,8 @@ func TestKey_X_NoAction_ShowsError(t *testing.T) {
 	loadSecrets(m, fakeSecrets("s1"))
 	m.Update(key("x"))
 	require.True(t, m.errorDialogActive)
+	require.Contains(t, m.err.Error(), "Business Edition")
+	require.Contains(t, m.err.Error(), "swarmcli.io/be")
 }
 
 func TestKey_Help_NavigatesToHelp(t *testing.T) {

--- a/views/services/model.go
+++ b/views/services/model.go
@@ -10,6 +10,7 @@ import (
 	"swarmcli/views/confirmdialog"
 	"swarmcli/views/helpbar"
 	"swarmcli/views/scaledialog"
+	"swarmcli/views/view"
 	"time"
 
 	"github.com/charmbracelet/bubbles/viewport"
@@ -163,6 +164,8 @@ func (m *Model) ShortHelpItems() []helpbar.HelpEntry {
 		{Key: "ctrl+r", Desc: "Rollback service"},
 		{Key: "ctrl+d", Desc: "Remove service"},
 		{Key: "l", Desc: "View logs"},
+		{Key: "x", Desc: view.BEHelpDesc("shell", "Shell"), Disabled: !view.HasAction("shell")},
+		{Key: "w", Desc: view.BEHelpDesc("port-forward", "Port Forward"), Disabled: !view.HasAction("port-forward")},
 		{Key: "?", Desc: "Help"},
 		{Key: "q", Desc: "Close"},
 	}

--- a/views/services/model_test.go
+++ b/views/services/model_test.go
@@ -683,3 +683,80 @@ func TestFormatRelativeTime_Hours(t *testing.T) {
 	result := formatRelativeTime(time.Now().Add(-3 * time.Hour))
 	require.Contains(t, result, "h ago")
 }
+
+// --- Business Edition gating tests ---
+
+func TestShortHelpItems_IncludesShellAndPortForward(t *testing.T) {
+	m := testModel()
+	items := m.ShortHelpItems()
+	keys := make(map[string]string)
+	for _, item := range items {
+		keys[item.Key] = item.Desc
+	}
+	require.Contains(t, keys, "x")
+	require.Contains(t, keys["x"], "(BE)")
+	require.Contains(t, keys, "w")
+	require.Contains(t, keys["w"], "(BE)")
+}
+
+func TestKey_X_NoAction_ShowsBEDialog(t *testing.T) {
+	m := testModel()
+	loadServices(m, fakeEntries("web"))
+	m.Update(key("x"))
+	require.True(t, m.confirmDialog.Visible)
+	require.True(t, m.confirmDialog.ErrorMode)
+	require.Contains(t, m.confirmDialog.Message, "Shell")
+	require.Contains(t, m.confirmDialog.Message, "swarmcli.io/be")
+}
+
+func TestKey_W_NoAction_ShowsBEDialog(t *testing.T) {
+	m := testModel()
+	loadServices(m, fakeEntries("web"))
+	m.Update(key("w"))
+	require.True(t, m.confirmDialog.Visible)
+	require.True(t, m.confirmDialog.ErrorMode)
+	require.Contains(t, m.confirmDialog.Message, "Port Forward")
+	require.Contains(t, m.confirmDialog.Message, "swarmcli.io/be")
+}
+
+func TestKey_X_WithAction_CallsAction(t *testing.T) {
+	called := ""
+	view.RegisterAction("shell", func(name string) tea.Cmd {
+		return func() tea.Msg { called = name; return nil }
+	})
+	defer view.UnregisterActionForTest("shell")
+
+	m := testModel()
+	loadServices(m, fakeEntries("web"))
+	cmd := m.Update(key("x"))
+	require.NotNil(t, cmd)
+	runCmd(cmd)
+	require.Equal(t, "web", called)
+}
+
+func TestKey_W_WithAction_CallsAction(t *testing.T) {
+	called := ""
+	view.RegisterAction("port-forward", func(name string) tea.Cmd {
+		return func() tea.Msg { called = name; return nil }
+	})
+	defer view.UnregisterActionForTest("port-forward")
+
+	m := testModel()
+	loadServices(m, fakeEntries("web"))
+	cmd := m.Update(key("w"))
+	require.NotNil(t, cmd)
+	runCmd(cmd)
+	require.Equal(t, "web", called)
+}
+
+func TestGetServicesHelpContent_IncludesBEActions(t *testing.T) {
+	cats := GetServicesHelpContent()
+	found := map[string]bool{}
+	for _, cat := range cats {
+		for _, item := range cat.Items {
+			found[item.Keys] = true
+		}
+	}
+	require.True(t, found["<x>"])
+	require.True(t, found["<w>"])
+}

--- a/views/services/update.go
+++ b/views/services/update.go
@@ -451,6 +451,32 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 					}
 				}
 			}
+		case "x":
+			if m.List.Cursor >= len(m.List.Filtered) {
+				return nil
+			}
+			entry := m.List.Filtered[m.List.Cursor]
+			action, ok := view.GetAction("shell")
+			if !ok {
+				m.confirmDialog.Visible = true
+				m.confirmDialog.ErrorMode = true
+				m.confirmDialog.Message = view.BEUnavailableErr("Shell").Error()
+				return nil
+			}
+			return action(entry.ServiceName)
+		case "w":
+			if m.List.Cursor >= len(m.List.Filtered) {
+				return nil
+			}
+			entry := m.List.Filtered[m.List.Cursor]
+			action, ok := view.GetAction("port-forward")
+			if !ok {
+				m.confirmDialog.Visible = true
+				m.confirmDialog.ErrorMode = true
+				m.confirmDialog.Message = view.BEUnavailableErr("Port Forward").Error()
+				return nil
+			}
+			return action(entry.ServiceName)
 		case "q":
 			m.Visible = false
 			// Go back to stacks view
@@ -999,6 +1025,8 @@ func GetServicesHelpContent() []helpview.HelpCategory {
 				{Keys: "<r>", Description: "Restart service"},
 				{Keys: "<ctrl+r>", Description: "Rollback service"},
 				{Keys: "<ctrl+d>", Description: "Remove service"},
+				{Keys: "<x>", Description: view.BEHelpDesc("shell", "Open shell into service container")},
+				{Keys: "<w>", Description: view.BEHelpDesc("port-forward", "Forward service ports to localhost")},
 				{Keys: "</>", Description: "Filter"},
 			},
 		},

--- a/views/view/actions.go
+++ b/views/view/actions.go
@@ -20,3 +20,6 @@ func GetAction(name string) (Action, bool) { fn, ok := actionRegistry[name]; ret
 
 // HasAction reports whether an action is registered under the given name.
 func HasAction(name string) bool { _, ok := actionRegistry[name]; return ok }
+
+// UnregisterActionForTest removes a registered action. Test-only; not safe for concurrent use.
+func UnregisterActionForTest(name string) { delete(actionRegistry, name) }

--- a/views/view/edition.go
+++ b/views/view/edition.go
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package view
+
+import "fmt"
+
+// BEHelpDesc returns desc if the action is registered, or desc+" (BE)" if not.
+func BEHelpDesc(actionName, desc string) string {
+	if HasAction(actionName) {
+		return desc
+	}
+	return desc + " (BE)"
+}
+
+// BEUnavailableErr returns an error indicating a feature requires Business Edition.
+func BEUnavailableErr(featureName string) error {
+	return fmt.Errorf("%s is a Business Edition feature.\nFor more information, visit: https://swarmcli.io/be", featureName)
+}

--- a/views/view/edition.go
+++ b/views/view/edition.go
@@ -13,7 +13,11 @@ func BEHelpDesc(actionName, desc string) string {
 	return desc + " (BE)"
 }
 
+// BEUnavailableFormat is the format string used by BEUnavailableErr.
+// Contains one %s verb for the feature name. Override in init() to customise.
+var BEUnavailableFormat = "%s is a Business Edition feature.\nFor more information, visit: https://swarmcli.io/be"
+
 // BEUnavailableErr returns an error indicating a feature requires Business Edition.
 func BEUnavailableErr(featureName string) error {
-	return fmt.Errorf("%s is a Business Edition feature.\nFor more information, visit: https://swarmcli.io/be", featureName)
+	return fmt.Errorf(BEUnavailableFormat, featureName)
 }

--- a/views/view/edition_test.go
+++ b/views/view/edition_test.go
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package view
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBEHelpDesc_Registered(t *testing.T) {
+	RegisterAction("test-be-help", func(_ string) tea.Cmd { return nil })
+	defer UnregisterActionForTest("test-be-help")
+	require.Equal(t, "Reveal", BEHelpDesc("test-be-help", "Reveal"))
+}
+
+func TestBEHelpDesc_NotRegistered(t *testing.T) {
+	require.Equal(t, "Shell (BE)", BEHelpDesc("nonexistent-action", "Shell"))
+}
+
+func TestBEUnavailableErr_ContainsFeatureName(t *testing.T) {
+	err := BEUnavailableErr("Shell")
+	require.Contains(t, err.Error(), "Shell")
+}
+
+func TestBEUnavailableErr_ContainsURL(t *testing.T) {
+	err := BEUnavailableErr("Shell")
+	require.Contains(t, err.Error(), "https://swarmcli.io/be")
+}


### PR DESCRIPTION
## Summary
- Extract common BE gating helpers (`BEHelpDesc`, `BEUnavailableErr`) into `views/view/edition.go` (#225)
- Add Shell (`x`) and Port Forward (`w`) as BE-gated placeholder keybindings in services view (#237)
- Rename "Pro" terminology to "Business Edition" throughout secrets view

## Test plan
- [x] `go test ./views/view/ ./views/services/ ./views/secrets/ ./views/helpbar/` passes
- [x] `go test ./...` passes
- [x] `golangci-lint run ./...` clean
- [x] Pressing `x`/`w` in services view shows BE dialog with URL when actions not registered
- [x] Pressing `x` in secrets view shows BE dialog with updated text

Closes #237, closes #225

🤖 Generated with [Claude Code](https://claude.com/claude-code)