### PR TITLE
fix: place service labels under deploy.labels in stack YAML

### DIFF
--- a/docker/stack_to_compose.go
+++ b/docker/stack_to_compose.go
@@ -261,11 +261,8 @@ func ReconstructStackCompose(stackName string) (string, error) {
 		key := sanitizeServiceName(stackName, si.Spec.Name)
 		cs := ComposeService{}
 
-		// Collect labels from service and container specs
-		labels := make(map[string]string)
-		for k, v := range si.Spec.Labels {
-			labels[k] = v
-		}
+		// ServiceSpec.Labels → deploy.labels in Compose
+		deployLabels := filterLabels(si.Spec.Labels)
 
 		if si.Spec.TaskTemplate.ContainerSpec != nil {
 			cspec := si.Spec.TaskTemplate.ContainerSpec
@@ -281,9 +278,9 @@ func ReconstructStackCompose(stackName string) (string, error) {
 				cs.Environment = env
 			}
 
-			// Merge container labels
-			for k, v := range cspec.Labels {
-				labels[k] = v
+			// ContainerSpec.Labels → service-level labels in Compose
+			if cl := filterLabels(cspec.Labels); len(cl) > 0 {
+				cs.Labels = cl
 			}
 
 			// Command / Args
@@ -349,10 +346,6 @@ func ReconstructStackCompose(stackName string) (string, error) {
 				}
 				cs.Configs = append(cs.Configs, ref)
 			}
-		}
-
-		if len(labels) > 0 {
-			cs.Labels = labels
 		}
 
 		// Ports
@@ -458,6 +451,10 @@ func ReconstructStackCompose(stackName string) (string, error) {
 			if len(rp) > 0 {
 				deploy["restart_policy"] = rp
 			}
+		}
+
+		if len(deployLabels) > 0 {
+			deploy["labels"] = deployLabels
 		}
 
 		if len(deploy) > 0 {
@@ -576,6 +573,21 @@ func parseKeyValEnv(env []string) map[string]string {
 		return nil
 	}
 	return m
+}
+
+// filterLabels returns a copy of labels with Docker-internal keys removed.
+// Returns nil if no user labels remain.
+func filterLabels(labels map[string]string) map[string]string {
+	out := make(map[string]string)
+	for k, v := range labels {
+		if !strings.HasPrefix(k, "com.docker.stack.") {
+			out[k] = v
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
 }
 
 // sanitizeServiceName removes the stack prefix from service name

--- a/docker/stack_to_compose_test.go
+++ b/docker/stack_to_compose_test.go
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package docker
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func TestFilterLabels_RemovesDockerStackKeys(t *testing.T) {
+	input := map[string]string{
+		"com.docker.stack.namespace": "mystack",
+		"com.docker.stack.image":     "nginx:latest",
+		"app":                        "web",
+	}
+	got := filterLabels(input)
+	require.Equal(t, map[string]string{"app": "web"}, got)
+}
+
+func TestFilterLabels_KeepsUserLabels(t *testing.T) {
+	input := map[string]string{
+		"app":     "web",
+		"version": "1.0",
+	}
+	got := filterLabels(input)
+	require.Equal(t, map[string]string{"app": "web", "version": "1.0"}, got)
+}
+
+func TestFilterLabels_ReturnsNilWhenAllFiltered(t *testing.T) {
+	input := map[string]string{
+		"com.docker.stack.namespace": "mystack",
+	}
+	require.Nil(t, filterLabels(input))
+}
+
+func TestFilterLabels_ReturnsNilForEmptyMap(t *testing.T) {
+	require.Nil(t, filterLabels(map[string]string{}))
+}
+
+func TestFilterLabels_NilInput(t *testing.T) {
+	require.Nil(t, filterLabels(nil))
+}
+
+func TestComposeService_DeployLabelsYAML(t *testing.T) {
+	cs := ComposeService{
+		Image: "nginx:latest",
+		Deploy: map[string]any{
+			"replicas": 3,
+			"labels": map[string]string{
+				"com.example.role": "frontend",
+			},
+		},
+	}
+
+	out, err := yaml.Marshal(cs)
+	require.NoError(t, err)
+	yamlStr := string(out)
+
+	require.Contains(t, yamlStr, "deploy:")
+	require.Contains(t, yamlStr, "labels:")
+	require.Contains(t, yamlStr, "com.example.role: frontend")
+}
+
+func TestComposeService_ServiceLevelLabelsYAML(t *testing.T) {
+	cs := ComposeService{
+		Image: "nginx:latest",
+		Labels: map[string]string{
+			"container.label": "value",
+		},
+	}
+
+	out, err := yaml.Marshal(cs)
+	require.NoError(t, err)
+	yamlStr := string(out)
+
+	require.Contains(t, yamlStr, "labels:")
+	require.Contains(t, yamlStr, "container.label: value")
+	require.NotContains(t, yamlStr, "deploy:")
+}
+
+func TestComposeService_BothLabelLevelsYAML(t *testing.T) {
+	cs := ComposeService{
+		Image: "nginx:latest",
+		Labels: map[string]string{
+			"container.label": "cval",
+		},
+		Deploy: map[string]any{
+			"replicas": 2,
+			"labels": map[string]string{
+				"deploy.label": "dval",
+			},
+		},
+	}
+
+	out, err := yaml.Marshal(cs)
+	require.NoError(t, err)
+
+	// Unmarshal back to verify structure
+	var parsed map[string]any
+	require.NoError(t, yaml.Unmarshal(out, &parsed))
+
+	// Service-level labels
+	svcLabels, ok := parsed["labels"].(map[string]any)
+	require.True(t, ok, "service-level labels should exist")
+	require.Equal(t, "cval", svcLabels["container.label"])
+
+	// Deploy labels
+	deploy, ok := parsed["deploy"].(map[string]any)
+	require.True(t, ok, "deploy section should exist")
+	deployLabels, ok := deploy["labels"].(map[string]any)
+	require.True(t, ok, "deploy.labels should exist")
+	require.Equal(t, "dval", deployLabels["deploy.label"])
+}


### PR DESCRIPTION
## Summary
- Service labels (`ServiceSpec.Labels`) are now correctly placed under `deploy.labels` instead of at the service level in reconstructed stack YAML
- Container labels (`ContainerSpec.Labels`) remain at the service level where they belong
- Docker-internal labels (`com.docker.stack.*`) are filtered from both locations

Closes #248

## Test plan
- [x] Unit tests for `filterLabels` helper (5 cases: Docker keys removed, user keys kept, all-filtered returns nil, empty map, nil input)
- [x] YAML structure tests verifying deploy labels, service labels, and both together produce correct output
- [x] Full test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)