### PR TITLE
fix: replace nested tea.Cmd returns with PollRetryMsg

### DIFF
--- a/views/configs/actions.go
+++ b/views/configs/actions.go
@@ -66,7 +66,7 @@ func (m *Model) checkConfigsCmd(lastHash uint64) tea.Cmd {
 		cfgs, err := configOps.ListConfigs(ctx)
 		if err != nil {
 			l().Errorf("checkConfigsCmd: ListConfigs failed: %v", err)
-			return tickCmd()
+			return PollRetryMsg{}
 		}
 
 		wrapped := make([]docker.ConfigWithDecodedData, len(cfgs))
@@ -93,7 +93,7 @@ func (m *Model) checkConfigsCmd(lastHash uint64) tea.Cmd {
 		if err != nil {
 			l().Errorf("checkConfigsCmd: Error computing hash: %v", err)
 			// Schedule next poll even on error
-			return tickCmd()
+			return PollRetryMsg{}
 		}
 
 		l().Infof("checkConfigsCmd: lastHash=%s, newHash=%s, configCount=%d",
@@ -106,8 +106,7 @@ func (m *Model) checkConfigsCmd(lastHash uint64) tea.Cmd {
 		}
 
 		l().Info("checkConfigsCmd: No changes detected, scheduling next poll")
-		// Schedule next poll in 5 seconds
-		return tickCmd()
+		return PollRetryMsg{}
 	}
 }
 

--- a/views/configs/actions_test.go
+++ b/views/configs/actions_test.go
@@ -185,7 +185,7 @@ func TestCreateConfigFromContentCmd_Error(t *testing.T) {
 	require.True(t, ok)
 }
 
-func TestCheckConfigsCmd_NoChange_ReturnsTick(t *testing.T) {
+func TestCheckConfigsCmd_NoChange_ReturnsPollRetry(t *testing.T) {
 	mock := noopConfigOps()
 	mock.listConfigsFn = func(_ context.Context) ([]swarm.Config, error) {
 		return nil, nil
@@ -195,6 +195,8 @@ func TestCheckConfigsCmd_NoChange_ReturnsTick(t *testing.T) {
 	msg := runCmd(cmd)
 	_, isLoaded := msg.(configsLoadedMsg)
 	require.False(t, isLoaded, "should not return configsLoadedMsg when no change")
+	_, isPollRetry := msg.(PollRetryMsg)
+	require.True(t, isPollRetry, "should return PollRetryMsg when no change")
 }
 
 func TestRotateConfigCmd_Success(t *testing.T) {

--- a/views/configs/messages.go
+++ b/views/configs/messages.go
@@ -71,6 +71,10 @@ type (
 
 type TickMsg time.Time
 
+// PollRetryMsg signals that polling found no changes; the Update handler
+// should schedule the next tick.
+type PollRetryMsg struct{}
+
 const PollInterval = 5 * time.Second
 
 type SpinnerTickMsg time.Time

--- a/views/configs/update.go
+++ b/views/configs/update.go
@@ -177,6 +177,9 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 		// Continue ticking even if not visible/ready
 		return tickCmd()
 
+	case PollRetryMsg:
+		return tickCmd()
+
 	case configRotatedMsg:
 		l().Infof("Config rotated: %s → %s", msg.Old.Config.Spec.Name, msg.New.Config.Spec.Name)
 		// After rotating a config, reload the config list so the "Used" state

--- a/views/networks/actions_test.go
+++ b/views/networks/actions_test.go
@@ -218,10 +218,11 @@ func TestCheckNetworksCmd_NoChange(t *testing.T) {
 	m := testModel(func(m *Model) { m.deps.Networks = mock })
 	cmd := m.checkNetworksCmd(0)
 	msg := runCmd(cmd)
-	// Empty list hashes to a specific value; with lastHash=0 and empty list, it should detect a change
-	// or return nil if hash matches. Since we pass 0 as lastHash, an empty list will likely differ.
-	if msg != nil {
-		_, isLoaded := msg.(NetworksLoadedMsg)
-		require.True(t, isLoaded)
+	require.NotNil(t, msg)
+	// Empty list with lastHash=0: hashes match, so we get PollRetryMsg (not NetworksLoadedMsg)
+	_, isLoaded := msg.(NetworksLoadedMsg)
+	if !isLoaded {
+		_, isPollRetry := msg.(PollRetryMsg)
+		require.True(t, isPollRetry, "should return PollRetryMsg when no change")
 	}
 }

--- a/views/networks/messages.go
+++ b/views/networks/messages.go
@@ -16,6 +16,11 @@ import (
 const PollInterval = 5 * time.Second
 
 type TickMsg time.Time
+
+// PollRetryMsg signals that polling found no changes; the Update handler
+// should schedule the next tick.
+type PollRetryMsg struct{}
+
 type SpinnerTickMsg time.Time
 
 type NetworksLoadedMsg struct {

--- a/views/networks/update.go
+++ b/views/networks/update.go
@@ -371,6 +371,9 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 		}
 		return tickCmd()
 
+	case PollRetryMsg:
+		return tickCmd()
+
 	case NetworkDeletedMsg:
 		if msg.Err != nil {
 			m.errorDialogActive = true
@@ -1277,7 +1280,7 @@ func (m *Model) checkNetworksCmd(lastHash uint64) tea.Cmd {
 		newHash, err := hash.Compute(stableNetworks)
 		if err != nil {
 			l().Errorf("Error computing hash: %v", err)
-			return nil
+			return PollRetryMsg{}
 		}
 
 		// Only reload if hash changed
@@ -1285,6 +1288,6 @@ func (m *Model) checkNetworksCmd(lastHash uint64) tea.Cmd {
 			l().Info("Networks changed, reloading")
 			return NetworksLoadedMsg{Networks: networks}
 		}
-		return nil
+		return PollRetryMsg{}
 	}
 }

--- a/views/nodes/messages.go
+++ b/views/nodes/messages.go
@@ -15,6 +15,10 @@ type Msg struct {
 // TickMsg triggers periodic node list check
 type TickMsg time.Time
 
+// PollRetryMsg signals that polling found no changes; the Update handler
+// should schedule the next tick.
+type PollRetryMsg struct{}
+
 // Poll interval for checking node changes
 const PollInterval = 5 * time.Second
 

--- a/views/nodes/model.go
+++ b/views/nodes/model.go
@@ -173,7 +173,7 @@ func (m *Model) checkNodesCmd(lastHash uint64) tea.Cmd {
 		newHash, err := hash.Compute(entries)
 		if err != nil {
 			l().Errorf("CheckNodesCmd: Compute hash failed: %v", err)
-			return tickCmd()
+			return PollRetryMsg{}
 		}
 
 		l().Infof("CheckNodesCmd: lastHash=%s, newHash=%s, nodeCount=%d",
@@ -188,7 +188,7 @@ func (m *Model) checkNodesCmd(lastHash uint64) tea.Cmd {
 		}
 
 		l().Info("CheckNodesCmd: No changes detected, scheduling next poll")
-		return tickCmd()
+		return PollRetryMsg{}
 	}
 }
 

--- a/views/nodes/update.go
+++ b/views/nodes/update.go
@@ -211,11 +211,14 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 
 	case TickMsg:
 		l().Infof("NodesView: Received TickMsg, visible=%v", m.Visible)
-		// Check for changes (this will return either a Msg or the next TickMsg)
+		// Check for changes (this will return either a Msg or PollRetryMsg)
 		if m.Visible {
 			return m.checkNodesCmd(m.lastSnapshot)
 		}
 		// Continue polling even if not visible
+		return tickCmd()
+
+	case PollRetryMsg:
 		return tickCmd()
 
 	case tea.WindowSizeMsg:

--- a/views/secrets/actions.go
+++ b/views/secrets/actions.go
@@ -68,7 +68,7 @@ func (m *Model) checkSecretsCmd(lastHash uint64) tea.Cmd {
 		secs, err := secretOps.ListSecrets(ctx)
 		if err != nil {
 			l().Errorf("checkSecretsCmd: ListSecrets failed: %v", err)
-			return tickCmd()
+			return PollRetryMsg{}
 		}
 
 		wrapped := make([]docker.SecretWithDecodedData, len(secs))
@@ -95,7 +95,7 @@ func (m *Model) checkSecretsCmd(lastHash uint64) tea.Cmd {
 		if err != nil {
 			l().Errorf("checkSecretsCmd: Error computing hash: %v", err)
 			// Schedule next poll even on error
-			return tickCmd()
+			return PollRetryMsg{}
 		}
 
 		l().Infof("checkSecretsCmd: lastHash=%s, newHash=%s, secretCount=%d",
@@ -108,8 +108,7 @@ func (m *Model) checkSecretsCmd(lastHash uint64) tea.Cmd {
 		}
 
 		l().Info("checkSecretsCmd: No changes detected, scheduling next poll")
-		// Schedule next poll in 5 seconds
-		return tickCmd()
+		return PollRetryMsg{}
 	}
 }
 

--- a/views/secrets/actions_test.go
+++ b/views/secrets/actions_test.go
@@ -138,7 +138,7 @@ func TestGetUsedByStacksCmd_ReturnsUsedByMsg(t *testing.T) {
 	require.Equal(t, "mystack", used.UsedBy[0].StackName)
 }
 
-func TestCheckSecretsCmd_NoChange_ReturnsTick(t *testing.T) {
+func TestCheckSecretsCmd_NoChange_ReturnsPollRetry(t *testing.T) {
 	mock := noopSecretOps()
 	mock.listSecretsFn = func(_ context.Context) ([]swarm.Secret, error) {
 		return nil, nil // empty = same as initial hash 0
@@ -147,7 +147,8 @@ func TestCheckSecretsCmd_NoChange_ReturnsTick(t *testing.T) {
 	// lastSnapshot=0 for empty, ListSecrets returns empty too → hashes match
 	cmd := m.checkSecretsCmd(0)
 	msg := runCmd(cmd)
-	// Should be a tick cmd (not secretsLoadedMsg)
 	_, isLoaded := msg.(secretsLoadedMsg)
 	require.False(t, isLoaded, "should not return secretsLoadedMsg when no change")
+	_, isPollRetry := msg.(PollRetryMsg)
+	require.True(t, isPollRetry, "should return PollRetryMsg when no change")
 }

--- a/views/secrets/messages.go
+++ b/views/secrets/messages.go
@@ -14,6 +14,10 @@ type errorMsg error
 
 type TickMsg time.Time
 
+// PollRetryMsg signals that polling found no changes; the Update handler
+// should schedule the next tick.
+type PollRetryMsg struct{}
+
 type SpinnerTickMsg time.Time
 
 // usedStatusUpdatedMsg carries a map of secret ID -> used boolean

--- a/views/secrets/update.go
+++ b/views/secrets/update.go
@@ -171,6 +171,9 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 		}
 		return tickCmd()
 
+	case PollRetryMsg:
+		return tickCmd()
+
 	case secretDeletedMsg:
 		l().Infof("Secret deleted successfully: %s", msg.Name)
 		return m.loadSecretsCmd()

--- a/views/services/messages.go
+++ b/views/services/messages.go
@@ -19,6 +19,10 @@ type Msg struct {
 
 type TickMsg time.Time
 
+// PollRetryMsg signals that polling found no changes; the Update handler
+// should schedule the next tick.
+type PollRetryMsg struct{}
+
 const PollInterval = 2 * time.Second
 
 // RestartErrorMsg is sent when a service restart fails

--- a/views/services/service.go
+++ b/views/services/service.go
@@ -6,7 +6,6 @@ package servicesview
 import (
 	"swarmcli/core/primitives/hash"
 	"swarmcli/docker"
-	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 )
@@ -71,7 +70,7 @@ func (m *Model) checkServicesCmd(lastHash uint64, filterType FilterType, nodeID,
 		newHash, err := hash.Compute(entries)
 		if err != nil {
 			l().Errorf("checkServicesCmd: Hash computation failed: %v", err)
-			return tickCmd()
+			return PollRetryMsg{}
 		}
 
 		l().Infof("checkServicesCmd: lastHash=%s, newHash=%s, serviceCount=%d",
@@ -90,10 +89,7 @@ func (m *Model) checkServicesCmd(lastHash uint64, filterType FilterType, nodeID,
 		}
 
 		l().Info("checkServicesCmd: No changes detected, scheduling next poll")
-		// Schedule next poll in 5 seconds
-		return tea.Tick(PollInterval, func(t time.Time) tea.Msg {
-			return TickMsg(t)
-		})()
+		return PollRetryMsg{}
 	}
 }
 

--- a/views/services/update.go
+++ b/views/services/update.go
@@ -92,6 +92,9 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 		// Continue polling even if not visible
 		return tickCmd()
 
+	case PollRetryMsg:
+		return tickCmd()
+
 	case TasksLoadedMsg:
 		// Store loaded tasks - view will automatically re-render
 		m.serviceTasks[msg.ServiceID] = msg.Tasks

--- a/views/stacks/messages.go
+++ b/views/stacks/messages.go
@@ -20,6 +20,10 @@ type RefreshErrorMsg struct {
 
 type TickMsg time.Time
 
+// PollRetryMsg signals that polling found no changes; the Update handler
+// should schedule the next tick.
+type PollRetryMsg struct{}
+
 const PollInterval = 5 * time.Second
 
 // StackTasksLoadedMsg is sent when tasks for a stack are loaded

--- a/views/stacks/model.go
+++ b/views/stacks/model.go
@@ -232,7 +232,7 @@ func (m *Model) checkStacksCmd(lastHash uint64, nodeID string) tea.Cmd {
 			s, err := snapOps.RefreshSnapshot()
 			if err != nil {
 				l().Errorf("checkStacksCmd: RefreshSnapshot failed: %v", err)
-				return tickCmd()
+				return PollRetryMsg{}
 			}
 			snap = s
 		}
@@ -242,7 +242,7 @@ func (m *Model) checkStacksCmd(lastHash uint64, nodeID string) tea.Cmd {
 		if err != nil {
 			l().Errorf("checkStacksCmd: Error computing hash: %v", err)
 			// Keep polling on error instead of returning nil which would stop the tick loop
-			return tickCmd()
+			return PollRetryMsg{}
 		}
 
 		l().Infof("checkStacksCmd: lastHash=%s, newHash=%s, stackCount=%d",
@@ -260,7 +260,7 @@ func (m *Model) checkStacksCmd(lastHash uint64, nodeID string) tea.Cmd {
 		}
 
 		l().Info("checkStacksCmd: No changes detected, scheduling next poll")
-		return tickCmd()
+		return PollRetryMsg{}
 	}
 }
 

--- a/views/stacks/update.go
+++ b/views/stacks/update.go
@@ -65,7 +65,7 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 
 	case TickMsg:
 		l().Infof("StacksView: Received TickMsg, visible=%v", m.Visible)
-		// Check for changes (this will return either a Msg or the next TickMsg)
+		// Check for changes (this will return either a Msg or PollRetryMsg)
 		if m.Visible {
 			return tea.Batch(
 				m.checkStacksCmd(m.lastSnapshot, m.nodeID),
@@ -73,6 +73,9 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 			)
 		}
 		// Continue polling even if not visible
+		return tickCmd()
+
+	case PollRetryMsg:
 		return tickCmd()
 
 	case RefreshErrorMsg:

--- a/views/tasks/messages.go
+++ b/views/tasks/messages.go
@@ -18,6 +18,10 @@ type TasksLoadedMsg struct {
 
 type TickMsg time.Time
 
+// PollRetryMsg signals that polling found no changes; the Update handler
+// should schedule the next tick.
+type PollRetryMsg struct{}
+
 const PollInterval = 2 * time.Second
 
 func LoadTasksCmd(stackName string) tea.Cmd {
@@ -47,13 +51,13 @@ func CheckTasksCmd(lastHash uint64, stackName string) tea.Cmd {
 		tasks, err := docker.GetTasksForStack(stackName)
 		if err != nil {
 			l().Errorf("CheckTasksCmd: Failed to get tasks: %v", err)
-			return tickCmd()
+			return PollRetryMsg{}
 		}
 
 		newHash, err := hash.Compute(tasks)
 		if err != nil {
 			l().Errorf("CheckTasksCmd: Hash computation failed: %v", err)
-			return tickCmd()
+			return PollRetryMsg{}
 		}
 
 		l().Infof("CheckTasksCmd: lastHash=%s, newHash=%s, taskCount=%d",
@@ -69,9 +73,6 @@ func CheckTasksCmd(lastHash uint64, stackName string) tea.Cmd {
 		}
 
 		l().Info("CheckTasksCmd: No changes detected, scheduling next poll")
-		// Schedule next poll
-		return tea.Tick(PollInterval, func(t time.Time) tea.Msg {
-			return TickMsg(t)
-		})()
+		return PollRetryMsg{}
 	}
 }

--- a/views/tasks/update.go
+++ b/views/tasks/update.go
@@ -38,11 +38,14 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 
 	case TickMsg:
 		l().Infof("TasksView: Received TickMsg, visible=%v", m.visible)
-		// Check for changes (this will return either a TasksLoadedMsg or the next TickMsg)
+		// Check for changes (this will return either a TasksLoadedMsg or PollRetryMsg)
 		if m.visible {
 			return CheckTasksCmd(m.lastSnapshot, m.stackName)
 		}
 		// Continue polling even if not visible
+		return tickCmd()
+
+	case PollRetryMsg:
 		return tickCmd()
 
 	case tea.WindowSizeMsg:


### PR DESCRIPTION
## Summary

- Every `Check*Cmd` polling function in 7 view packages (tasks, services, stacks, nodes, configs, secrets, networks) returned `tea.Cmd` where `tea.Msg` was expected, silently killing the tick loop
- Adds `PollRetryMsg` type to each package — returned on no-change/error paths, handled in `Update()` to schedule the next tick
- Removes synchronous `tea.Tick(...)()` hack that blocked goroutines unnecessarily

Fixes #123

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` — all unit tests pass (including updated tests for configs, secrets, networks)
- [x] `golangci-lint run ./... --build-tags=integration` — 0 issues
- [x] CI workflows pass
- [x] Manual: run with `SWARMCLI_ENV=dev LOG_LEVEL=debug` and verify tick loops continue on no-change polls

🤖 Generated with [Claude Code](https://claude.com/claude-code)