### PR TITLE
Address review feedback on TTY log fallback

### DIFF
--- a/docker/service.go
+++ b/docker/service.go
@@ -529,6 +529,7 @@ func GetServiceLogs(ctx context.Context, serviceID string) (string, error) {
 
 	reader, err := client.ServiceLogs(ctx, serviceID, logOptions)
 	if err != nil {
+		// NOTE: This matches a Docker daemon error string. Update if Docker changes the message.
 		if strings.Contains(strings.ToLower(err.Error()), "tty service logs only supported with --raw") {
 			return getServiceLogsRawCLI(ctx, serviceID)
 		}
@@ -549,17 +550,26 @@ func GetServiceLogs(ctx context.Context, serviceID string) (string, error) {
 	return result, nil
 }
 
+// BuildRawLogArgs constructs the docker CLI arguments for "service logs --raw".
+// Extra flags (e.g. "--follow", "--details", "--tail", "100") are inserted before the serviceID.
+func BuildRawLogArgs(ctxName, serviceID string, extra ...string) []string {
+	args := make([]string, 0, 8+len(extra))
+	if strings.TrimSpace(ctxName) != "" {
+		args = append(args, "--context", ctxName)
+	}
+	args = append(args, "service", "logs", "--raw")
+	args = append(args, extra...)
+	args = append(args, serviceID)
+	return args
+}
+
 func getServiceLogsRawCLI(ctx context.Context, serviceID string) (string, error) {
 	ctxName, err := GetContextFromEnv()
 	if err != nil {
 		return "", fmt.Errorf("failed to determine docker context: %w", err)
 	}
 
-	args := make([]string, 0, 8)
-	if strings.TrimSpace(ctxName) != "" {
-		args = append(args, "--context", ctxName)
-	}
-	args = append(args, "service", "logs", "--raw", serviceID)
+	args := BuildRawLogArgs(ctxName, serviceID)
 
 	cmd := exec.CommandContext(ctx, "docker", args...)
 	var stdout, stderr bytes.Buffer

--- a/views/logs/logs_test.go
+++ b/views/logs/logs_test.go
@@ -1,6 +1,8 @@
 package logsview
 
 import (
+	"errors"
+	"io"
 	"testing"
 
 	"swarmcli/docker"
@@ -499,4 +501,27 @@ func TestSetContent_MaxLines(t *testing.T) {
 	require.Equal(t, "c", m.lines[0])
 	require.Equal(t, "d", m.lines[1])
 	m.mu.Unlock()
+}
+
+// --- shouldFallbackToRawFromStdCopy tests ---
+
+func TestShouldFallbackToRawFromStdCopy(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil error", nil, false},
+		{"tty error", errors.New("tty service logs only supported with --raw"), true},
+		{"tty error mixed case", errors.New("TTY Service Logs Only Supported With --raw"), true},
+		{"unrecognized header", errors.New("unrecognized input header"), true},
+		{"short write is not a fallback", io.ErrShortWrite, false},
+		{"context canceled", errors.New("context canceled"), false},
+		{"random error", errors.New("something went wrong"), false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, shouldFallbackToRawFromStdCopy(tc.err))
+		})
+	}
 }

--- a/views/logs/stream.go
+++ b/views/logs/stream.go
@@ -61,6 +61,7 @@ func (m *Model) startStreamingCmd(ctx context.Context, service docker.ServiceEnt
 			// call ServiceLogs (streams a multiplexed stream)
 			reader, err := cli.ServiceLogs(ctx, service.ServiceID, opts)
 			if err != nil {
+				// NOTE: This matches a Docker daemon error string. Update if Docker changes the message.
 				if strings.Contains(strings.ToLower(err.Error()), "tty service logs only supported with --raw") {
 					l().With("service", service.ServiceID).Warn("ServiceLogs requires --raw for tty service; falling back to docker CLI")
 					if cliErr := m.streamServiceLogsRawCLI(ctx, service, opts.Tail, lines); cliErr != nil {
@@ -147,18 +148,7 @@ func (m *Model) streamServiceLogsRawCLI(ctx context.Context, service docker.Serv
 		return fmt.Errorf("failed to determine docker context: %w", err)
 	}
 
-	args := make([]string, 0, 12)
-	if strings.TrimSpace(ctxName) != "" {
-		args = append(args, "--context", ctxName)
-	}
-	args = append(args,
-		"service", "logs",
-		"--raw",
-		"--follow",
-		"--details",
-		"--tail", tail,
-		service.ServiceID,
-	)
+	args := docker.BuildRawLogArgs(ctxName, service.ServiceID, "--follow", "--details", "--tail", tail)
 
 	cmd := exec.CommandContext(ctx, "docker", args...)
 	stdout, err := cmd.StdoutPipe()
@@ -174,6 +164,7 @@ func (m *Model) streamServiceLogsRawCLI(ctx context.Context, service docker.Serv
 	}
 
 	sc := bufio.NewScanner(stdout)
+	sc.Buffer(make([]byte, 0, 256*1024), 256*1024) // 256 KB to handle long TTY lines
 	for sc.Scan() {
 		line := sc.Text()
 		formattedLine, nodeName := m.formatLogLineWithNode(service.ServiceName, line)
@@ -203,6 +194,9 @@ func (m *Model) streamServiceLogsRawCLI(ctx context.Context, service docker.Serv
 	return nil
 }
 
+// shouldFallbackToRawFromStdCopy returns true when a stdcopy error indicates
+// the service uses TTY mode and needs raw log streaming instead.
+// NOTE: Error strings are coupled to Docker daemon messages — update if Docker changes them.
 func shouldFallbackToRawFromStdCopy(err error) bool {
 	if err == nil {
 		return false
@@ -212,9 +206,6 @@ func shouldFallbackToRawFromStdCopy(err error) bool {
 		return true
 	}
 	if strings.Contains(errText, "unrecognized input header") {
-		return true
-	}
-	if errors.Is(err, io.ErrShortWrite) {
 		return true
 	}
 	return false


### PR DESCRIPTION
## Summary
- Remove `io.ErrShortWrite` from `shouldFallbackToRawFromStdCopy` — too broad, not TTY-specific
- Add table-driven tests for `shouldFallbackToRawFromStdCopy` (7 cases)
- Extract shared `BuildRawLogArgs` helper to eliminate duplicated context+args logic between `docker/service.go` and `views/logs/stream.go`
- Add comments documenting fragile Docker error string coupling
- Increase `bufio.Scanner` buffer to 256 KB for long TTY lines

Addresses review feedback from #266.

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./views/logs/ ./docker/` passes (including new tests)
- [x] `golangci-lint run ./...` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)