### PR TITLE
Fix volume declarations in stack compose reconstruction

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,4 +136,4 @@ Add all three labels when creating a PR: `gh pr edit <number> --add-label "A0-ui
 
 ## Go Version & Build
 
-Go 1.25. No Makefile — use `go build` directly. GoReleaser handles releases with `-trimpath -s -w` ldflags and version injection.
+Go 1.26. No Makefile — use `go build` directly. GoReleaser handles releases with `-trimpath -s -w` ldflags and version injection.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,10 +108,11 @@ The OSS repo must not contain pro implementation details — no pro-specific log
 
 - Tests in `integration-tests/` use `//go:build integration` tag
 - `test-setup/docker-compose.yml`: DinD multi-node Swarm (1 manager on tcp://localhost:22375, 2 workers)
-- `test-setup/test-stack.yml`: Demo services (whoami, whoami_single, etc.)
+- `test-setup/test-stack.yml`: Demo services (whoami, whoami_single, log_ticker) with volumes, networks, and configs
 - `test-setup/testenv.sh`: Orchestrator script
 - Tests use `gotestsum` as test runner (with `--format=testname` locally, `--format=github-actions` in CI)
 - Docker context name for tests: `swarmcli`
+- When adding new resource types (volumes, networks, secrets, configs), update `test-setup/test-stack.yml` and add integration test assertions to ensure inspect and compose reconstruction cover them
 
 ## Pull Requests
 

--- a/docker/inspect.go
+++ b/docker/inspect.go
@@ -43,6 +43,19 @@ func Inspect(ctx context.Context, t InspectType, id string) (string, error) {
 		if err != nil {
 			return "", fmt.Errorf("service inspect: %w", err)
 		}
+		// Resolve network IDs to names for readability
+		if netMap, _ := dockerNetworkIDToNameMap(); netMap != nil {
+			for i, n := range svc.Spec.Networks {
+				if name := netMap[n.Target]; name != "" {
+					svc.Spec.Networks[i].Target = name
+				}
+			}
+			for i, n := range svc.Spec.TaskTemplate.Networks {
+				if name := netMap[n.Target]; name != "" {
+					svc.Spec.TaskTemplate.Networks[i].Target = name
+				}
+			}
+		}
 		obj = svc
 
 	case InspectContainer:

--- a/docker/stack_inspect.go
+++ b/docker/stack_inspect.go
@@ -183,12 +183,12 @@ func GetStackInspection(stackName string) (string, error) {
 		if name == "" {
 			name = netID
 		}
-		desc.Networks = append(desc.Networks, name)
+		desc.Networks = append(desc.Networks, stripStackPrefix(stackName, name))
 	}
 	sort.Strings(desc.Networks)
 
 	for vol := range volumesMap {
-		desc.Volumes = append(desc.Volumes, vol)
+		desc.Volumes = append(desc.Volumes, stripStackPrefix(stackName, vol))
 	}
 	sort.Strings(desc.Volumes)
 

--- a/docker/stack_inspect.go
+++ b/docker/stack_inspect.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"sort"
 	"time"
+
+	"github.com/docker/docker/api/types/mount"
 )
 
 // StackInspection contains detailed information about a stack
@@ -15,6 +17,7 @@ type StackInspection struct {
 	Name         string           `json:"name"`
 	Services     []ServiceSummary `json:"services"`
 	Networks     []string         `json:"networks,omitempty"`
+	Volumes      []string         `json:"volumes,omitempty"`
 	Secrets      []string         `json:"secrets,omitempty"`
 	Configs      []string         `json:"configs,omitempty"`
 	ServiceCount int              `json:"service_count"`
@@ -48,8 +51,16 @@ func GetStackInspection(stackName string) (string, error) {
 		Services: []ServiceSummary{},
 	}
 
-	// Collect unique networks, secrets, and configs
+	// Build network ID to name mapping
+	netID2Name, err := dockerNetworkIDToNameMap()
+	if err != nil {
+		l().Warnf("Could not build network ID->name map: %v", err)
+		netID2Name = map[string]string{}
+	}
+
+	// Collect unique networks, volumes, secrets, and configs
 	networksMap := make(map[string]bool)
+	volumesMap := make(map[string]bool)
 	secretsMap := make(map[string]bool)
 	configsMap := make(map[string]bool)
 
@@ -111,14 +122,19 @@ func GetStackInspection(stackName string) (string, error) {
 			}
 		}
 
-		// Collect networks
+		// Collect networks (check both locations; some Docker versions use one or the other)
 		for _, net := range svc.Spec.TaskTemplate.Networks {
 			if net.Target != "" {
 				networksMap[net.Target] = true
 			}
 		}
+		for _, net := range svc.Spec.Networks {
+			if net.Target != "" {
+				networksMap[net.Target] = true
+			}
+		}
 
-		// Collect secrets
+		// Collect secrets, configs, and volumes
 		if svc.Spec.TaskTemplate.ContainerSpec != nil {
 			for _, s := range svc.Spec.TaskTemplate.ContainerSpec.Secrets {
 				if s.SecretName != "" {
@@ -126,10 +142,15 @@ func GetStackInspection(stackName string) (string, error) {
 				}
 			}
 
-			// Collect configs
 			for _, c := range svc.Spec.TaskTemplate.ContainerSpec.Configs {
 				if c.ConfigName != "" {
 					configsMap[c.ConfigName] = true
+				}
+			}
+
+			for _, m := range svc.Spec.TaskTemplate.ContainerSpec.Mounts {
+				if m.Type == mount.TypeVolume && m.Source != "" {
+					volumesMap[m.Source] = true
 				}
 			}
 		}
@@ -156,11 +177,20 @@ func GetStackInspection(stackName string) (string, error) {
 	desc.CreatedAt = earliestCreated
 	desc.UpdatedAt = latestUpdated
 
-	// Convert maps to sorted slices
-	for net := range networksMap {
-		desc.Networks = append(desc.Networks, net)
+	// Convert maps to sorted slices, resolving network IDs to names
+	for netID := range networksMap {
+		name := netID2Name[netID]
+		if name == "" {
+			name = netID
+		}
+		desc.Networks = append(desc.Networks, name)
 	}
 	sort.Strings(desc.Networks)
+
+	for vol := range volumesMap {
+		desc.Volumes = append(desc.Volumes, vol)
+	}
+	sort.Strings(desc.Volumes)
 
 	for sec := range secretsMap {
 		desc.Secrets = append(desc.Secrets, sec)

--- a/docker/stack_to_compose.go
+++ b/docker/stack_to_compose.go
@@ -223,14 +223,17 @@ func ReconstructStackCompose(stackName string) (string, error) {
 		}
 	}
 
-	declareVolume := func(volName string, m *Mount) {
+	declareVolume := func(volName string, m *Mount, external bool) {
 		if volName == "" {
 			return
 		}
 		if _, ok := cf.Volumes[volName]; ok {
 			return
 		}
-		vol := map[string]any{"external": true}
+		vol := map[string]any{}
+		if external {
+			vol["external"] = true
+		}
 		if m != nil && m.VolumeOptions != nil && m.VolumeOptions.DriverConfig != nil {
 			dc := m.VolumeOptions.DriverConfig
 			if dc.Name != "" {
@@ -270,7 +273,7 @@ func ReconstructStackCompose(stackName string) (string, error) {
 			continue
 		}
 
-		key := sanitizeServiceName(stackName, si.Spec.Name)
+		key := stripStackPrefix(stackName, si.Spec.Name)
 		cs := ComposeService{}
 
 		// ServiceSpec.Labels → deploy.labels in Compose
@@ -321,8 +324,10 @@ func ReconstructStackCompose(stackName string) (string, error) {
 					if src == "" {
 						continue // anonymous volume, cannot round-trip
 					}
-					declareVolume(src, &m)
-					cs.Volumes = append(cs.Volumes, fmt.Sprintf("%s:%s%s", src, m.Target, ro))
+					stripped := stripStackPrefix(stackName, src)
+					isExternal := stripped == src // no prefix removed → external
+					declareVolume(stripped, &m, isExternal)
+					cs.Volumes = append(cs.Volumes, fmt.Sprintf("%s:%s%s", stripped, m.Target, ro))
 				case "tmpfs":
 					if cs.Extra == nil {
 						cs.Extra = map[string]any{}
@@ -390,6 +395,7 @@ func ReconstructStackCompose(stackName string) (string, error) {
 			if nm == "" {
 				continue
 			}
+			nm = stripStackPrefix(stackName, nm)
 			netNames[nm] = struct{}{}
 			declareExternalNet(nm)
 		}
@@ -476,6 +482,19 @@ func ReconstructStackCompose(stackName string) (string, error) {
 		cf.Services[key] = cs
 	}
 
+	// If the only declared network is "default" (implicit), suppress it
+	if len(cf.Networks) == 1 {
+		if _, ok := cf.Networks["default"]; ok {
+			cf.Networks = nil
+			for k, svc := range cf.Services {
+				if nets, ok := svc.Networks.([]string); ok && len(nets) == 1 && nets[0] == "default" {
+					svc.Networks = nil
+					cf.Services[k] = svc
+				}
+			}
+		}
+	}
+
 	// Remove empty top-level sections
 	if len(cf.Networks) == 0 {
 		cf.Networks = nil
@@ -543,7 +562,7 @@ func inspectService(serviceName string) (*ServiceInspect, error) {
 
 // dockerNetworkIDToNameMap builds a map of network IDs to names
 func dockerNetworkIDToNameMap() (map[string]string, error) {
-	cmd := exec.Command("docker", "network", "ls", "--format", "{{.ID}}\t{{.Name}}")
+	cmd := exec.Command("docker", "network", "ls", "--no-trunc", "--format", "{{.ID}}\t{{.Name}}")
 	var out bytes.Buffer
 	var errb bytes.Buffer
 	cmd.Stdout = &out
@@ -602,8 +621,8 @@ func filterLabels(labels map[string]string) map[string]string {
 	return out
 }
 
-// sanitizeServiceName removes the stack prefix from service name
-func sanitizeServiceName(stack, full string) string {
+// stripStackPrefix removes the "<stack>_" prefix from a resource name
+func stripStackPrefix(stack, full string) string {
 	prefix := stack + "_"
 	if strings.HasPrefix(full, prefix) {
 		return strings.TrimPrefix(full, prefix)

--- a/docker/stack_to_compose.go
+++ b/docker/stack_to_compose.go
@@ -302,11 +302,11 @@ func ReconstructStackCompose(stackName string) (string, error) {
 				cs.Labels = cl
 			}
 
-			// Command / Args
+			// Command / Args — escape $ → $$ for Compose variable interpolation
 			if len(cspec.Args) > 0 {
-				cs.Command = cspec.Args
+				cs.Command = escapeComposeArgs(cspec.Args)
 			} else if len(cspec.Command) > 0 {
-				cs.Command = cspec.Command
+				cs.Command = escapeComposeArgs(cspec.Command)
 			}
 
 			// Mounts -> volumes
@@ -622,6 +622,21 @@ func filterLabels(labels map[string]string) map[string]string {
 	}
 	if len(out) == 0 {
 		return nil
+	}
+	return out
+}
+
+// escapeComposeInterpolation escapes $ as $$ so that Compose does not
+// attempt variable interpolation on reconstructed command strings.
+func escapeComposeInterpolation(s string) string {
+	return strings.ReplaceAll(s, "$", "$$")
+}
+
+// escapeComposeArgs applies escapeComposeInterpolation to each element.
+func escapeComposeArgs(args []string) []string {
+	out := make([]string, len(args))
+	for i, a := range args {
+		out[i] = escapeComposeInterpolation(a)
 	}
 	return out
 }

--- a/docker/stack_to_compose.go
+++ b/docker/stack_to_compose.go
@@ -223,13 +223,25 @@ func ReconstructStackCompose(stackName string) (string, error) {
 		}
 	}
 
-	declareVolume := func(volName string) {
+	declareVolume := func(volName string, m *Mount) {
 		if volName == "" {
 			return
 		}
-		if _, ok := cf.Volumes[volName]; !ok {
-			cf.Volumes[volName] = map[string]any{}
+		if _, ok := cf.Volumes[volName]; ok {
+			return
 		}
+		vol := map[string]any{"external": true}
+		if m != nil && m.VolumeOptions != nil && m.VolumeOptions.DriverConfig != nil {
+			dc := m.VolumeOptions.DriverConfig
+			if dc.Name != "" {
+				vol["driver"] = dc.Name
+				delete(vol, "external")
+			}
+			if len(dc.Options) > 0 {
+				vol["driver_opts"] = dc.Options
+			}
+		}
+		cf.Volumes[volName] = vol
 	}
 
 	declareSecretExternal := func(name string) {
@@ -307,9 +319,9 @@ func ReconstructStackCompose(stackName string) (string, error) {
 				case "volume":
 					src := m.Source
 					if src == "" {
-						src = fmt.Sprintf("%s_%s", stackName, strings.ReplaceAll(strings.TrimPrefix(m.Target, "/"), "/", "_"))
+						continue // anonymous volume, cannot round-trip
 					}
-					declareVolume(src)
+					declareVolume(src, &m)
 					cs.Volumes = append(cs.Volumes, fmt.Sprintf("%s:%s%s", src, m.Target, ro))
 				case "tmpfs":
 					if cs.Extra == nil {

--- a/docker/stack_to_compose.go
+++ b/docker/stack_to_compose.go
@@ -214,12 +214,16 @@ func ReconstructStackCompose(stackName string) (string, error) {
 	}
 
 	// Helper functions for declaring resources
-	declareExternalNet := func(netName string) {
+	declareNet := func(netName string, external bool) {
 		if netName == "" {
 			return
 		}
 		if _, ok := cf.Networks[netName]; !ok {
-			cf.Networks[netName] = map[string]any{"external": true}
+			props := map[string]any{}
+			if external {
+				props["external"] = true
+			}
+			cf.Networks[netName] = props
 		}
 	}
 
@@ -395,9 +399,10 @@ func ReconstructStackCompose(stackName string) (string, error) {
 			if nm == "" {
 				continue
 			}
-			nm = stripStackPrefix(stackName, nm)
-			netNames[nm] = struct{}{}
-			declareExternalNet(nm)
+			stripped := stripStackPrefix(stackName, nm)
+			isExternal := stripped == nm // no prefix removed → external
+			netNames[stripped] = struct{}{}
+			declareNet(stripped, isExternal)
 		}
 		if len(netNames) > 0 {
 			var nets []string

--- a/docker/stack_to_compose_test.go
+++ b/docker/stack_to_compose_test.go
@@ -238,3 +238,29 @@ func TestComposeFile_NetworkExternalTrue(t *testing.T) {
 	require.Contains(t, yamlStr, "shared_net:")
 	require.Contains(t, yamlStr, "external: true")
 }
+
+func TestEscapeComposeInterpolation(t *testing.T) {
+	tests := []struct {
+		name, input, want string
+	}{
+		{"no dollars", "echo hello", "echo hello"},
+		{"single dollar", "echo $HOME", "echo $$HOME"},
+		{"double dollar passthrough", "echo $$HOME", "echo $$$$HOME"},
+		{"subshell", "sh -c '$(date)'", "sh -c '$$(date)'"},
+		{"arithmetic", "i=$((i+1))", "i=$$((i+1))"},
+		{"empty", "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, escapeComposeInterpolation(tt.input))
+		})
+	}
+}
+
+func TestEscapeComposeArgs(t *testing.T) {
+	in := []string{"sh", "-c", "echo $HOME; date=$(date)"}
+	got := escapeComposeArgs(in)
+	require.Equal(t, []string{"sh", "-c", "echo $$HOME; date=$$(date)"}, got)
+	// original slice must not be modified
+	require.Equal(t, "echo $HOME; date=$(date)", in[2])
+}

--- a/docker/stack_to_compose_test.go
+++ b/docker/stack_to_compose_test.go
@@ -205,3 +205,36 @@ func TestComposeFile_DefaultNetworkOmitted(t *testing.T) {
 	require.NotContains(t, yamlStr, "networks:")
 	require.NotContains(t, yamlStr, "default")
 }
+
+func TestComposeFile_NetworkManagedNotExternal(t *testing.T) {
+	// Stack-managed networks (prefix was stripped) should not be external
+	cf := ComposeFile{
+		Version: "3.8",
+		Services: map[string]ComposeService{
+			"web": {Image: "nginx", Networks: []string{"mynet"}},
+		},
+		Networks: map[string]map[string]any{"mynet": {}},
+	}
+	out, err := yaml.Marshal(&cf)
+	require.NoError(t, err)
+	yamlStr := string(out)
+	require.Contains(t, yamlStr, "networks:")
+	require.Contains(t, yamlStr, "mynet:")
+	require.NotContains(t, yamlStr, "external")
+}
+
+func TestComposeFile_NetworkExternalTrue(t *testing.T) {
+	// External networks (no prefix stripped) should have external: true
+	cf := ComposeFile{
+		Version: "3.8",
+		Services: map[string]ComposeService{
+			"web": {Image: "nginx", Networks: []string{"shared_net"}},
+		},
+		Networks: map[string]map[string]any{"shared_net": {"external": true}},
+	}
+	out, err := yaml.Marshal(&cf)
+	require.NoError(t, err)
+	yamlStr := string(out)
+	require.Contains(t, yamlStr, "shared_net:")
+	require.Contains(t, yamlStr, "external: true")
+}

--- a/docker/stack_to_compose_test.go
+++ b/docker/stack_to_compose_test.go
@@ -147,3 +147,61 @@ func TestComposeService_BothLabelLevelsYAML(t *testing.T) {
 	require.True(t, ok, "deploy.labels should exist")
 	require.Equal(t, "dval", deployLabels["deploy.label"])
 }
+
+func TestStripStackPrefix(t *testing.T) {
+	tests := []struct {
+		stack, input, want string
+	}{
+		{"ubu", "ubu_ubuntu_example_data", "ubuntu_example_data"},
+		{"ubu", "external_volume", "external_volume"},
+		{"ubu", "ubu_default", "default"},
+		{"ubu", "ubu_", ""},
+		{"", "anything", "anything"},
+		{"ubu", "ubu", "ubu"}, // no underscore → no strip
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			require.Equal(t, tt.want, stripStackPrefix(tt.stack, tt.input))
+		})
+	}
+}
+
+func TestComposeFile_VolumeManagedNotExternal(t *testing.T) {
+	cf := ComposeFile{
+		Version:  "3.8",
+		Services: map[string]ComposeService{"web": {Image: "nginx", Volumes: []string{"mydata:/data"}}},
+		Volumes:  map[string]map[string]any{"mydata": {}},
+	}
+	out, err := yaml.Marshal(&cf)
+	require.NoError(t, err)
+	require.NotContains(t, string(out), "external")
+}
+
+func TestComposeFile_DefaultNetworkOmitted(t *testing.T) {
+	cf := ComposeFile{
+		Version: "3.8",
+		Services: map[string]ComposeService{
+			"web": {Image: "nginx", Networks: []string{"default"}},
+		},
+		Networks: map[string]map[string]any{"default": {"external": true}},
+	}
+
+	// Simulate the suppression logic
+	if len(cf.Networks) == 1 {
+		if _, ok := cf.Networks["default"]; ok {
+			cf.Networks = nil
+			for k, svc := range cf.Services {
+				if nets, ok := svc.Networks.([]string); ok && len(nets) == 1 && nets[0] == "default" {
+					svc.Networks = nil
+					cf.Services[k] = svc
+				}
+			}
+		}
+	}
+
+	out, err := yaml.Marshal(&cf)
+	require.NoError(t, err)
+	yamlStr := string(out)
+	require.NotContains(t, yamlStr, "networks:")
+	require.NotContains(t, yamlStr, "default")
+}

--- a/docker/stack_to_compose_test.go
+++ b/docker/stack_to_compose_test.go
@@ -44,6 +44,39 @@ func TestFilterLabels_NilInput(t *testing.T) {
 	require.Nil(t, filterLabels(nil))
 }
 
+func TestComposeFile_VolumesExternalTrue(t *testing.T) {
+	cf := ComposeFile{
+		Version:  "3.8",
+		Services: map[string]ComposeService{"web": {Image: "nginx"}},
+		Volumes: map[string]map[string]any{
+			"mydata": {"external": true},
+		},
+	}
+	out, err := yaml.Marshal(&cf)
+	require.NoError(t, err)
+	yamlStr := string(out)
+	require.Contains(t, yamlStr, "external: true")
+}
+
+func TestComposeFile_VolumeWithDriver(t *testing.T) {
+	cf := ComposeFile{
+		Version:  "3.8",
+		Services: map[string]ComposeService{"web": {Image: "nginx", Volumes: []string{"nfs_data:/data"}}},
+		Volumes: map[string]map[string]any{
+			"nfs_data": {
+				"driver":      "local",
+				"driver_opts": map[string]string{"type": "nfs", "device": ":/export"},
+			},
+		},
+	}
+	out, err := yaml.Marshal(&cf)
+	require.NoError(t, err)
+	yamlStr := string(out)
+	require.Contains(t, yamlStr, "driver: local")
+	require.Contains(t, yamlStr, "driver_opts:")
+	require.NotContains(t, yamlStr, "external")
+}
+
 func TestComposeService_DeployLabelsYAML(t *testing.T) {
 	cs := ComposeService{
 		Image: "nginx:latest",

--- a/integration-tests/docker/stack_inspect_test.go
+++ b/integration-tests/docker/stack_inspect_test.go
@@ -59,21 +59,21 @@ func TestInspectStack(t *testing.T) {
 		}
 	}
 
-	// Verify volumes are present (Docker prefixes with stack name: demo_whoami_data)
+	// Verify volumes are present (stack prefix stripped: whoami_data, not demo_whoami_data)
 	if len(inspection.Volumes) == 0 {
 		t.Error("Expected non-empty volumes")
 	}
 	foundVolume := false
 	for _, v := range inspection.Volumes {
-		if v == "demo_whoami_data" {
+		if v == "whoami_data" {
 			foundVolume = true
 		}
 	}
 	if !foundVolume {
-		t.Errorf("Expected volume 'demo_whoami_data' in volumes, got %v", inspection.Volumes)
+		t.Errorf("Expected volume 'whoami_data' in volumes, got %v", inspection.Volumes)
 	}
 
-	// Verify networks are present with names (not hex IDs) and include demo_backend
+	// Verify networks are present with names (not hex IDs), stack prefix stripped
 	if len(inspection.Networks) == 0 {
 		t.Error("Expected non-empty networks")
 	}
@@ -83,12 +83,12 @@ func TestInspectStack(t *testing.T) {
 		if len(n) == 64 && !strings.ContainsAny(n, "ghijklmnopqrstuvwxyz_-") {
 			t.Errorf("Network appears to be an unresolved ID: %s", n)
 		}
-		if n == "demo_backend" {
+		if n == "backend" {
 			foundNetwork = true
 		}
 	}
 	if !foundNetwork {
-		t.Errorf("Expected network 'demo_backend' in networks, got %v", inspection.Networks)
+		t.Errorf("Expected network 'backend' in networks, got %v", inspection.Networks)
 	}
 
 	t.Logf("Successfully inspected stack: %d services, %d tasks", inspection.ServiceCount, inspection.TaskCount)

--- a/integration-tests/docker/stack_inspect_test.go
+++ b/integration-tests/docker/stack_inspect_test.go
@@ -59,6 +59,38 @@ func TestInspectStack(t *testing.T) {
 		}
 	}
 
+	// Verify volumes are present (Docker prefixes with stack name: demo_whoami_data)
+	if len(inspection.Volumes) == 0 {
+		t.Error("Expected non-empty volumes")
+	}
+	foundVolume := false
+	for _, v := range inspection.Volumes {
+		if v == "demo_whoami_data" {
+			foundVolume = true
+		}
+	}
+	if !foundVolume {
+		t.Errorf("Expected volume 'demo_whoami_data' in volumes, got %v", inspection.Volumes)
+	}
+
+	// Verify networks are present with names (not hex IDs) and include demo_backend
+	if len(inspection.Networks) == 0 {
+		t.Error("Expected non-empty networks")
+	}
+	foundNetwork := false
+	for _, n := range inspection.Networks {
+		// Network names should not be hex IDs (64-char hex strings)
+		if len(n) == 64 && !strings.ContainsAny(n, "ghijklmnopqrstuvwxyz_-") {
+			t.Errorf("Network appears to be an unresolved ID: %s", n)
+		}
+		if n == "demo_backend" {
+			foundNetwork = true
+		}
+	}
+	if !foundNetwork {
+		t.Errorf("Expected network 'demo_backend' in networks, got %v", inspection.Networks)
+	}
+
 	t.Logf("Successfully inspected stack: %d services, %d tasks", inspection.ServiceCount, inspection.TaskCount)
 }
 

--- a/integration-tests/docker/stack_to_compose_test.go
+++ b/integration-tests/docker/stack_to_compose_test.go
@@ -10,9 +10,8 @@ import (
 	"strings"
 	"swarmcli/docker"
 	"testing"
-	"time"
 
-	"gopkg.in/yaml.v3"
+	yamlPkg "gopkg.in/yaml.v3"
 )
 
 func TestReconstructStackCompose(t *testing.T) {
@@ -60,88 +59,97 @@ func TestReconstructStackCompose(t *testing.T) {
 		t.Error("Reconstructed YAML missing network 'backend' (should be stripped of 'demo_' prefix)")
 	}
 
-	// Stack-managed networks should NOT be marked external
-	if strings.Contains(yaml, "external: true") {
-		t.Error("Stack-managed network 'backend' should not be marked as external")
+	// Parse YAML and verify backend network is not marked external
+	var composed docker.ComposeFile
+	if err := yamlPkg.Unmarshal([]byte(yaml), &composed); err != nil {
+		t.Fatalf("Failed to parse reconstructed YAML: %v", err)
+	}
+	if netProps, ok := composed.Networks["backend"]; ok {
+		if _, hasExternal := netProps["external"]; hasExternal {
+			t.Error("Stack-managed network 'backend' should not be marked as external")
+		}
+	} else {
+		t.Error("Parsed YAML missing 'backend' network key")
 	}
 
 	t.Logf("Successfully reconstructed stack YAML (%d bytes)", len(yaml))
 }
 
 func TestReconstructStackCompose_RoundTrip(t *testing.T) {
+	// Round-trip: reconstruct → parse → verify volumes/networks survive structurally.
+	// Full deploy round-trip is blocked by $$ escaping in commands (separate issue).
 	stackName := "demo"
 
-	// Step 1: Reconstruct YAML from the running stack
-	yamlBefore, err := docker.ReconstructStackCompose(stackName)
+	yamlStr, err := docker.ReconstructStackCompose(stackName)
 	if err != nil {
-		t.Fatalf("Failed to reconstruct stack compose (before): %v", err)
+		t.Fatalf("Failed to reconstruct stack compose: %v", err)
 	}
 
-	// Step 2: Redeploy from reconstructed YAML
-	if err := docker.DeployStack(stackName, yamlBefore); err != nil {
-		t.Fatalf("Failed to redeploy stack from reconstructed YAML: %v", err)
+	var cf docker.ComposeFile
+	if err := yamlPkg.Unmarshal([]byte(yamlStr), &cf); err != nil {
+		t.Fatalf("Failed to parse reconstructed YAML: %v", err)
 	}
 
-	// Step 3: Wait for services to converge
-	deadline := time.Now().Add(60 * time.Second)
-	for time.Now().Before(deadline) {
-		_, err := docker.GetOrRefreshSnapshot()
-		if err == nil {
-			break
-		}
-		time.Sleep(2 * time.Second)
-	}
-	// Extra settle time for service convergence
-	time.Sleep(5 * time.Second)
-
-	// Step 4: Reconstruct again
-	yamlAfter, err := docker.ReconstructStackCompose(stackName)
-	if err != nil {
-		t.Fatalf("Failed to reconstruct stack compose (after): %v", err)
+	// Verify top-level volumes survived reconstruction
+	if _, ok := cf.Volumes["whoami_data"]; !ok {
+		t.Errorf("Volume 'whoami_data' missing from reconstructed compose, got keys: %v", mapKeys(cf.Volumes))
 	}
 
-	// Step 5: Parse both as ComposeFile structs and compare
-	var before, after docker.ComposeFile
-	if err := yaml.Unmarshal([]byte(yamlBefore), &before); err != nil {
-		t.Fatalf("Failed to parse yamlBefore: %v", err)
-	}
-	if err := yaml.Unmarshal([]byte(yamlAfter), &after); err != nil {
-		t.Fatalf("Failed to parse yamlAfter: %v", err)
+	// Verify top-level networks survived reconstruction
+	if _, ok := cf.Networks["backend"]; !ok {
+		t.Errorf("Network 'backend' missing from reconstructed compose, got keys: %v", mapKeys(cf.Networks))
 	}
 
-	// Assert top-level volume keys are identical
-	if len(before.Volumes) != len(after.Volumes) {
-		t.Errorf("Volume count changed: before=%d, after=%d", len(before.Volumes), len(after.Volumes))
-	}
-	for k := range before.Volumes {
-		if _, ok := after.Volumes[k]; !ok {
-			t.Errorf("Volume %q lost after round-trip", k)
+	// Verify backend is not external
+	if props, ok := cf.Networks["backend"]; ok {
+		if _, hasExternal := props["external"]; hasExternal {
+			t.Error("Stack-managed network 'backend' should not be marked as external after reconstruction")
 		}
 	}
 
-	// Assert top-level network keys are identical
-	if len(before.Networks) != len(after.Networks) {
-		t.Errorf("Network count changed: before=%d, after=%d", len(before.Networks), len(after.Networks))
-	}
-	for k := range before.Networks {
-		if _, ok := after.Networks[k]; !ok {
-			t.Errorf("Network %q lost after round-trip", k)
+	// Verify service-level volume mount
+	if svc, ok := cf.Services["whoami"]; ok {
+		found := false
+		for _, v := range svc.Volumes {
+			if strings.Contains(v, "whoami_data:") {
+				found = true
+			}
 		}
+		if !found {
+			t.Errorf("Service 'whoami' missing volume mount for 'whoami_data', got: %v", svc.Volumes)
+		}
+	} else {
+		t.Error("Service 'whoami' missing from reconstructed compose")
 	}
 
-	// Assert service-level volume mounts survived
-	for svcName, svcBefore := range before.Services {
-		svcAfter, ok := after.Services[svcName]
+	// Verify service-level network attachment
+	if svc, ok := cf.Services["whoami"]; ok {
+		nets, ok := svc.Networks.([]any)
 		if !ok {
-			t.Errorf("Service %q lost after round-trip", svcName)
-			continue
-		}
-		if len(svcBefore.Volumes) != len(svcAfter.Volumes) {
-			t.Errorf("Service %q volume mounts changed: before=%v, after=%v", svcName, svcBefore.Volumes, svcAfter.Volumes)
+			t.Errorf("Service 'whoami' networks not a list, got %T", svc.Networks)
+		} else {
+			found := false
+			for _, n := range nets {
+				if n == "backend" {
+					found = true
+				}
+			}
+			if !found {
+				t.Errorf("Service 'whoami' missing network 'backend', got: %v", nets)
+			}
 		}
 	}
 
-	t.Logf("Round-trip test passed: %d volumes, %d networks preserved", len(after.Volumes), len(after.Networks))
+	t.Logf("Round-trip structural test passed: volumes=%v, networks=%v",
+		mapKeys(cf.Volumes), mapKeys(cf.Networks))
+}
+
+func mapKeys[V any](m map[string]V) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	return keys
 }
 
 func TestReconstructStackCompose_NonExistentStack(t *testing.T) {

--- a/integration-tests/docker/stack_to_compose_test.go
+++ b/integration-tests/docker/stack_to_compose_test.go
@@ -7,9 +7,14 @@
 package docker_test
 
 import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
 	"strings"
 	"swarmcli/docker"
 	"testing"
+	"time"
 
 	yamlPkg "gopkg.in/yaml.v3"
 )
@@ -76,72 +81,149 @@ func TestReconstructStackCompose(t *testing.T) {
 }
 
 func TestReconstructStackCompose_RoundTrip(t *testing.T) {
-	// Round-trip: reconstruct → parse → verify volumes/networks survive structurally.
-	// Full deploy round-trip is blocked by $$ escaping in commands (separate issue).
-	stackName := "demo"
+	// Full round-trip: reconstruct demo → deploy as demo_rt → reconstruct demo_rt → compare.
+	const srcStack = "demo"
+	const rtStack = "demo_rt"
 
-	yamlStr, err := docker.ReconstructStackCompose(stackName)
+	// 1. Reconstruct the original stack
+	yamlStr, err := docker.ReconstructStackCompose(srcStack)
 	if err != nil {
-		t.Fatalf("Failed to reconstruct stack compose: %v", err)
+		t.Fatalf("Failed to reconstruct source stack: %v", err)
 	}
+	t.Logf("Reconstructed YAML:\n%s", yamlStr)
 
-	var cf docker.ComposeFile
-	if err := yamlPkg.Unmarshal([]byte(yamlStr), &cf); err != nil {
+	var srcCF docker.ComposeFile
+	if err := yamlPkg.Unmarshal([]byte(yamlStr), &srcCF); err != nil {
 		t.Fatalf("Failed to parse reconstructed YAML: %v", err)
 	}
 
-	// Verify top-level volumes survived reconstruction
-	if _, ok := cf.Volumes["whoami_data"]; !ok {
-		t.Errorf("Volume 'whoami_data' missing from reconstructed compose, got keys: %v", mapKeys(cf.Volumes))
+	// 2. Write to temp file and deploy as a new stack
+	tmpFile, err := os.CreateTemp("", "compose-rt-*.yml")
+	if err != nil {
+		t.Fatalf("Failed to create temp file: %v", err)
+	}
+	defer os.Remove(tmpFile.Name())
+	if _, err := tmpFile.WriteString(yamlStr); err != nil {
+		t.Fatalf("Failed to write compose file: %v", err)
+	}
+	tmpFile.Close()
+
+	// Deploy round-trip stack
+	deployCmd := exec.Command("docker", "stack", "deploy", "-c", tmpFile.Name(), rtStack)
+	var deployErr bytes.Buffer
+	deployCmd.Stderr = &deployErr
+	if out, err := deployCmd.Output(); err != nil {
+		t.Fatalf("Failed to deploy round-trip stack: %v\nstderr: %s\nstdout: %s", err, deployErr.String(), string(out))
 	}
 
-	// Verify top-level networks survived reconstruction
-	if _, ok := cf.Networks["backend"]; !ok {
-		t.Errorf("Network 'backend' missing from reconstructed compose, got keys: %v", mapKeys(cf.Networks))
-	}
-
-	// Verify backend is not external
-	if props, ok := cf.Networks["backend"]; ok {
-		if _, hasExternal := props["external"]; hasExternal {
-			t.Error("Stack-managed network 'backend' should not be marked as external after reconstruction")
-		}
-	}
-
-	// Verify service-level volume mount
-	if svc, ok := cf.Services["whoami"]; ok {
-		found := false
-		for _, v := range svc.Volumes {
-			if strings.Contains(v, "whoami_data:") {
-				found = true
+	// Cleanup: remove the round-trip stack when done
+	t.Cleanup(func() {
+		rmCmd := exec.Command("docker", "stack", "rm", rtStack)
+		_ = rmCmd.Run()
+		// Wait for removal to complete
+		for range 30 {
+			check := exec.Command("docker", "stack", "services", rtStack, "--format", "{{.Name}}")
+			if out, _ := check.Output(); len(bytes.TrimSpace(out)) == 0 {
+				break
 			}
+			time.Sleep(time.Second)
 		}
-		if !found {
-			t.Errorf("Service 'whoami' missing volume mount for 'whoami_data', got: %v", svc.Volumes)
-		}
-	} else {
-		t.Error("Service 'whoami' missing from reconstructed compose")
+	})
+
+	// 3. Wait for convergence
+	if err := waitForStackConvergence(rtStack, len(srcCF.Services), 60*time.Second); err != nil {
+		t.Fatalf("Round-trip stack failed to converge: %v", err)
 	}
 
-	// Verify service-level network attachment
-	if svc, ok := cf.Services["whoami"]; ok {
-		nets, ok := svc.Networks.([]any)
+	// 4. Reconstruct the round-trip stack
+	rtYAML, err := docker.ReconstructStackCompose(rtStack)
+	if err != nil {
+		t.Fatalf("Failed to reconstruct round-trip stack: %v", err)
+	}
+
+	var rtCF docker.ComposeFile
+	if err := yamlPkg.Unmarshal([]byte(rtYAML), &rtCF); err != nil {
+		t.Fatalf("Failed to parse round-trip YAML: %v", err)
+	}
+
+	// 5. Compare: volumes
+	for volName := range srcCF.Volumes {
+		if _, ok := rtCF.Volumes[volName]; !ok {
+			t.Errorf("Volume %q present in source but missing from round-trip, got keys: %v",
+				volName, mapKeys(rtCF.Volumes))
+		}
+	}
+
+	// 6. Compare: networks
+	for netName := range srcCF.Networks {
+		if _, ok := rtCF.Networks[netName]; !ok {
+			t.Errorf("Network %q present in source but missing from round-trip, got keys: %v",
+				netName, mapKeys(rtCF.Networks))
+		}
+	}
+
+	// 7. Compare: service volume mounts
+	for svcName, srcSvc := range srcCF.Services {
+		rtSvc, ok := rtCF.Services[svcName]
 		if !ok {
-			t.Errorf("Service 'whoami' networks not a list, got %T", svc.Networks)
-		} else {
+			t.Errorf("Service %q present in source but missing from round-trip", svcName)
+			continue
+		}
+		for _, srcVol := range srcSvc.Volumes {
 			found := false
-			for _, n := range nets {
-				if n == "backend" {
+			for _, rtVol := range rtSvc.Volumes {
+				if rtVol == srcVol {
 					found = true
+					break
 				}
 			}
 			if !found {
-				t.Errorf("Service 'whoami' missing network 'backend', got: %v", nets)
+				t.Errorf("Service %q: volume mount %q missing from round-trip, got: %v",
+					svcName, srcVol, rtSvc.Volumes)
 			}
 		}
 	}
 
-	t.Logf("Round-trip structural test passed: volumes=%v, networks=%v",
-		mapKeys(cf.Volumes), mapKeys(cf.Networks))
+	t.Logf("Round-trip deploy test passed: volumes=%v, networks=%v",
+		mapKeys(rtCF.Volumes), mapKeys(rtCF.Networks))
+}
+
+// waitForStackConvergence waits until all services in the stack have running tasks.
+func waitForStackConvergence(stack string, expectedServices int, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		cmd := exec.Command("docker", "stack", "services", stack, "--format", "{{.Name}} {{.Replicas}}")
+		out, err := cmd.Output()
+		if err != nil {
+			time.Sleep(2 * time.Second)
+			continue
+		}
+		lines := strings.Split(strings.TrimSpace(string(out)), "\n")
+		if len(lines) < expectedServices {
+			time.Sleep(2 * time.Second)
+			continue
+		}
+		allReady := true
+		for _, line := range lines {
+			// Format: "stack_svc 2/2" — check N/M where N==M
+			parts := strings.Fields(line)
+			if len(parts) < 2 {
+				allReady = false
+				break
+			}
+			replicas := parts[len(parts)-1]
+			slash := strings.Index(replicas, "/")
+			if slash < 0 || replicas[:slash] != replicas[slash+1:] {
+				allReady = false
+				break
+			}
+		}
+		if allReady {
+			return nil
+		}
+		time.Sleep(2 * time.Second)
+	}
+	return fmt.Errorf("stack %q did not converge within %v", stack, timeout)
 }
 
 func mapKeys[V any](m map[string]V) []string {

--- a/integration-tests/docker/stack_to_compose_test.go
+++ b/integration-tests/docker/stack_to_compose_test.go
@@ -97,16 +97,28 @@ func TestReconstructStackCompose_RoundTrip(t *testing.T) {
 		t.Fatalf("Failed to parse reconstructed YAML: %v", err)
 	}
 
-	// 2. Write to temp file and deploy as a new stack
+	// 2. Strip published ports to avoid conflicts with the running demo stack
+	for k, svc := range srcCF.Services {
+		svc.Ports = nil
+		srcCF.Services[k] = svc
+	}
+	deployYAML, err := yamlPkg.Marshal(&srcCF)
+	if err != nil {
+		t.Fatalf("Failed to marshal deploy YAML: %v", err)
+	}
+
+	// Write to temp file and deploy as a new stack
 	tmpFile, err := os.CreateTemp("", "compose-rt-*.yml")
 	if err != nil {
 		t.Fatalf("Failed to create temp file: %v", err)
 	}
-	defer os.Remove(tmpFile.Name())
-	if _, err := tmpFile.WriteString(yamlStr); err != nil {
+	defer func() { _ = os.Remove(tmpFile.Name()) }()
+	if _, err := tmpFile.Write(deployYAML); err != nil {
 		t.Fatalf("Failed to write compose file: %v", err)
 	}
-	tmpFile.Close()
+	if err := tmpFile.Close(); err != nil {
+		t.Fatalf("Failed to close compose file: %v", err)
+	}
 
 	// Deploy round-trip stack
 	deployCmd := exec.Command("docker", "stack", "deploy", "-c", tmpFile.Name(), rtStack)

--- a/integration-tests/docker/stack_to_compose_test.go
+++ b/integration-tests/docker/stack_to_compose_test.go
@@ -10,6 +10,9 @@ import (
 	"strings"
 	"swarmcli/docker"
 	"testing"
+	"time"
+
+	"gopkg.in/yaml.v3"
 )
 
 func TestReconstructStackCompose(t *testing.T) {
@@ -41,7 +44,104 @@ func TestReconstructStackCompose(t *testing.T) {
 		t.Error("Reconstructed YAML missing expected service 'whoami'")
 	}
 
+	// Verify volumes section
+	if !strings.Contains(yaml, "volumes:") {
+		t.Error("Reconstructed YAML missing volumes section")
+	}
+	if !strings.Contains(yaml, "whoami_data:") {
+		t.Error("Reconstructed YAML missing volume 'whoami_data' (should be stripped of 'demo_' prefix)")
+	}
+
+	// Verify networks section
+	if !strings.Contains(yaml, "networks:") {
+		t.Error("Reconstructed YAML missing networks section")
+	}
+	if !strings.Contains(yaml, "backend:") {
+		t.Error("Reconstructed YAML missing network 'backend' (should be stripped of 'demo_' prefix)")
+	}
+
+	// Stack-managed networks should NOT be marked external
+	if strings.Contains(yaml, "external: true") {
+		t.Error("Stack-managed network 'backend' should not be marked as external")
+	}
+
 	t.Logf("Successfully reconstructed stack YAML (%d bytes)", len(yaml))
+}
+
+func TestReconstructStackCompose_RoundTrip(t *testing.T) {
+	stackName := "demo"
+
+	// Step 1: Reconstruct YAML from the running stack
+	yamlBefore, err := docker.ReconstructStackCompose(stackName)
+	if err != nil {
+		t.Fatalf("Failed to reconstruct stack compose (before): %v", err)
+	}
+
+	// Step 2: Redeploy from reconstructed YAML
+	if err := docker.DeployStack(stackName, yamlBefore); err != nil {
+		t.Fatalf("Failed to redeploy stack from reconstructed YAML: %v", err)
+	}
+
+	// Step 3: Wait for services to converge
+	deadline := time.Now().Add(60 * time.Second)
+	for time.Now().Before(deadline) {
+		_, err := docker.GetOrRefreshSnapshot()
+		if err == nil {
+			break
+		}
+		time.Sleep(2 * time.Second)
+	}
+	// Extra settle time for service convergence
+	time.Sleep(5 * time.Second)
+
+	// Step 4: Reconstruct again
+	yamlAfter, err := docker.ReconstructStackCompose(stackName)
+	if err != nil {
+		t.Fatalf("Failed to reconstruct stack compose (after): %v", err)
+	}
+
+	// Step 5: Parse both as ComposeFile structs and compare
+	var before, after docker.ComposeFile
+	if err := yaml.Unmarshal([]byte(yamlBefore), &before); err != nil {
+		t.Fatalf("Failed to parse yamlBefore: %v", err)
+	}
+	if err := yaml.Unmarshal([]byte(yamlAfter), &after); err != nil {
+		t.Fatalf("Failed to parse yamlAfter: %v", err)
+	}
+
+	// Assert top-level volume keys are identical
+	if len(before.Volumes) != len(after.Volumes) {
+		t.Errorf("Volume count changed: before=%d, after=%d", len(before.Volumes), len(after.Volumes))
+	}
+	for k := range before.Volumes {
+		if _, ok := after.Volumes[k]; !ok {
+			t.Errorf("Volume %q lost after round-trip", k)
+		}
+	}
+
+	// Assert top-level network keys are identical
+	if len(before.Networks) != len(after.Networks) {
+		t.Errorf("Network count changed: before=%d, after=%d", len(before.Networks), len(after.Networks))
+	}
+	for k := range before.Networks {
+		if _, ok := after.Networks[k]; !ok {
+			t.Errorf("Network %q lost after round-trip", k)
+		}
+	}
+
+	// Assert service-level volume mounts survived
+	for svcName, svcBefore := range before.Services {
+		svcAfter, ok := after.Services[svcName]
+		if !ok {
+			t.Errorf("Service %q lost after round-trip", svcName)
+			continue
+		}
+		if len(svcBefore.Volumes) != len(svcAfter.Volumes) {
+			t.Errorf("Service %q volume mounts changed: before=%v, after=%v", svcName, svcBefore.Volumes, svcAfter.Volumes)
+		}
+	}
+
+	t.Logf("Round-trip test passed: %d volumes, %d networks preserved", len(after.Volumes), len(after.Networks))
 }
 
 func TestReconstructStackCompose_NonExistentStack(t *testing.T) {

--- a/test-setup/test-stack.yml
+++ b/test-setup/test-stack.yml
@@ -1,5 +1,11 @@
 version: "3.9"
 
+networks:
+  backend:
+
+volumes:
+  whoami_data:
+
 configs:
   whoami_config:
     file: ./configs/whoami.conf
@@ -9,6 +15,10 @@ configs:
 services:
   whoami:
     image: alpine:latest
+    networks:
+      - backend
+    volumes:
+      - whoami_data:/data
     configs:
       - source: whoami_config
         target: /etc/whoami/config


### PR DESCRIPTION
## Summary

Fixes bugs in `ReconstructStackCompose()` (`docker/stack_to_compose.go`) that caused volume/network corruption and deploy failures when editing and redeploying a stack:

- **Volumes missing `external: true`**: `declareVolume()` wrote `{}` instead of `{"external": true}` for external volumes, causing `docker stack deploy` to create new stack-prefixed local volumes instead of reusing existing named volumes
- **Synthetic name for empty Source**: Anonymous volumes (empty `Source`) got fabricated names that orphaned the original volume — now skipped since they can't round-trip
- **Volume driver/options lost**: `VolumeOptions.DriverConfig` (driver name, driver options) was never serialized to compose format — now preserved in the volume declaration
- **Stack prefix not stripped**: Volume and network names kept the `<stack>_` prefix (e.g. `demo_whoami_data` instead of `whoami_data`), causing duplication on redeploy. Added `stripStackPrefix()` and applied it to volumes, networks, and service names
- **Stack-managed networks marked external**: Networks created by the stack were incorrectly marked `external: true` — now only truly external networks get that flag
- **`$` in commands breaks deploy**: Docker resolves `$$` → `$` at runtime, so reconstructed commands contain literal `$` which causes `docker stack deploy` to fail on variable interpolation. Added `escapeComposeInterpolation()` to escape `$` → `$$` in command strings
- **Network ID resolution**: `docker network ls` was not using `--no-trunc`, causing ID mismatches in the network name map
- **Implicit default network suppressed**: When `default` is the only network, it's now omitted from the output since Compose adds it implicitly

Closes #261

## Test plan

- [x] Unit tests for `stripStackPrefix`, volume external/managed, network external/managed, default network suppression, `escapeComposeInterpolation`, `escapeComposeArgs`
- [x] Integration test: reconstruct `demo` stack and verify volumes/networks are correct
- [x] Integration test: full deploy round-trip — reconstruct → deploy as new stack → wait for convergence → reconstruct again → compare volumes, networks, and mounts
- [x] `golangci-lint run ./... --build-tags=integration` clean
- [x] All CI checks green

🤖 Generated with [Claude Code](https://claude.com/claude-code)