### PR TITLE
fix: centralize and fix frame/list colors

### DIFF
--- a/ui/ui.go
+++ b/ui/ui.go
@@ -21,6 +21,14 @@ var (
 				Bold(true)
 
 	FrameBorderColor = lipgloss.Color("117")
+
+	ListItemStyle = lipgloss.NewStyle().
+			Foreground(lipgloss.Color("117"))
+
+	ListSelectedStyle = lipgloss.NewStyle().
+				Foreground(lipgloss.Color("230")).
+				Background(lipgloss.Color("63")).
+				Bold(true)
 )
 
 // RenderFramedBox draws a bordered frame with title, optional header, and content.

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -17,7 +17,7 @@ var (
 			Bold(true)
 
 	FrameHeaderStyle = lipgloss.NewStyle().
-				Foreground(lipgloss.Color("75")).
+				Foreground(lipgloss.Color("15")).
 				Bold(true)
 
 	FrameBorderColor = lipgloss.Color("117")

--- a/views/configs/update.go
+++ b/views/configs/update.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/charmbracelet/bubbles/viewport"
 	tea "github.com/charmbracelet/bubbletea"
-	"github.com/charmbracelet/lipgloss"
 )
 
 // parseLabels parses a comma-separated list of key=value pairs into a map
@@ -344,22 +343,14 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 					svcText = svcText[:colWidths[1]-1] + "…"
 				}
 
-				// Use bright white for content and reserve a leading space
-				itemStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("15"))
-				// Reserve one leading space for the first column so content aligns with headers
-				col0 := itemStyle.Render(fmt.Sprintf(" %-*s", colWidths[0]-1, stackText))
-				col1 := itemStyle.Render(fmt.Sprintf("%-*s", colWidths[1], svcText))
+				col0 := fmt.Sprintf(" %-*s", colWidths[0]-1, stackText)
+				col1 := fmt.Sprintf("%-*s", colWidths[1], svcText)
 				line := col0 + col1
 
 				if selected {
-					selBg := lipgloss.Color("63")
-					selStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("230")).Background(selBg).Bold(true)
-					// Keep leading space for first column when selected as well
-					col0 = selStyle.Render(fmt.Sprintf(" %-*s", colWidths[0]-1, stackText))
-					col1 = selStyle.Render(fmt.Sprintf("%-*s", colWidths[1], svcText))
-					return col0 + col1
+					return ui.ListSelectedStyle.Render(line)
 				}
-				return line
+				return ui.ListItemStyle.Render(line)
 			},
 		}
 		m.usedByList.SetOuterSize(w, h)
@@ -658,8 +649,7 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 }
 
 func (m *Model) setRenderItem() {
-	// Use bright white for content (color 15) for better contrast
-	itemStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("15"))
+	itemStyle := ui.ListItemStyle
 
 	m.configsList.RenderItem = func(cfg configItem, selected bool, _ int) string {
 		colWidths := m.configsList.ColWidths()
@@ -695,9 +685,7 @@ func (m *Model) setRenderItem() {
 
 		// Render all columns in one format string (no explicit separators, like secrets view)
 		if selected {
-			selBg := lipgloss.Color("63")
-			selStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("230")).Background(selBg).Bold(true)
-			return selStyle.Render(fmt.Sprintf(" %-*s%-*s%-*s%-*s%-*s%-*s",
+			return ui.ListSelectedStyle.Render(fmt.Sprintf(" %-*s%-*s%-*s%-*s%-*s%-*s",
 				colWidths[0]-1, nameText,
 				colWidths[1], idText,
 				colWidths[2], usedText,

--- a/views/contexts/view.go
+++ b/views/contexts/view.go
@@ -126,9 +126,9 @@ func (m *Model) FrameContent() string {
 			colWidths[4], errStr,
 		)
 		if selected {
-			return lipgloss.NewStyle().Background(lipgloss.Color("63")).Foreground(lipgloss.Color("230")).Render(line)
+			return ui.ListSelectedStyle.Render(line)
 		}
-		return line
+		return ui.ListItemStyle.Render(line)
 	}
 
 	var content string

--- a/views/networks/update.go
+++ b/views/networks/update.go
@@ -1153,14 +1153,12 @@ func (m *Model) applySorting() {
 }
 
 func (m *Model) setRenderItem() {
-	itemStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("15"))
+	itemStyle := ui.ListItemStyle
 
 	m.networksList.RenderItem = func(item networkItem, selected bool, colWidth int) string {
 		style := itemStyle
 		if selected {
-			style = lipgloss.NewStyle().
-				Foreground(lipgloss.Color("0")).
-				Background(lipgloss.Color("63"))
+			style = ui.ListSelectedStyle
 		}
 
 		colWidths := m.networksList.ColWidths()
@@ -1206,14 +1204,10 @@ func (m *Model) setRenderItem() {
 }
 
 func (m *Model) setUsedByRenderItem() {
-	itemStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("15"))
-
 	m.usedByList.RenderItem = func(item usedByItem, selected bool, colWidth int) string {
-		style := itemStyle
+		style := ui.ListItemStyle
 		if selected {
-			style = lipgloss.NewStyle().
-				Foreground(lipgloss.Color("0")).
-				Background(lipgloss.Color("63"))
+			style = ui.ListSelectedStyle
 		}
 
 		stackWidth := 30

--- a/views/nodes/update.go
+++ b/views/nodes/update.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"swarmcli/core/primitives/hash"
 	"swarmcli/docker"
+	"swarmcli/ui"
 	filterlist "swarmcli/ui/components/filterable/list"
 	"swarmcli/views/confirmdialog"
 	helpview "swarmcli/views/help"
@@ -18,7 +19,6 @@ import (
 	"swarmcli/views/view"
 
 	tea "github.com/charmbracelet/bubbletea"
-	"github.com/charmbracelet/lipgloss"
 	"github.com/docker/docker/api/types/swarm"
 )
 
@@ -534,7 +534,7 @@ func (m *Model) SetContent(msg Msg) {
 
 func (m *Model) setRenderItem() {
 	// Use bright white for content and reserve leading space in first column
-	itemStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("15"))
+	itemStyle := ui.ListItemStyle
 
 	m.List.RenderItem = func(n docker.NodeEntry, selected bool, _ int) string {
 		colWidths := m.List.ColWidths()
@@ -585,8 +585,7 @@ func (m *Model) setRenderItem() {
 		}
 		// Use the pre-calculated column widths instead of the single colWidth
 		if selected {
-			selBg := lipgloss.Color("63")
-			selStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("230")).Background(selBg).Bold(true)
+			selStyle := ui.ListSelectedStyle
 			// Preserve leading space for hostname when selected
 			return selStyle.Render(fmt.Sprintf(" %-*s%-*s%-*s%-*s%-*s%-*s%-*s%-*s%-*s%-*s",
 				colWidths[0]-1, idStr,

--- a/views/secrets/update.go
+++ b/views/secrets/update.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/charmbracelet/bubbles/viewport"
 	tea "github.com/charmbracelet/bubbletea"
-	"github.com/charmbracelet/lipgloss"
 )
 
 // parseLabels parses a comma-separated list of key=value pairs into a map
@@ -254,19 +253,14 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 					svcText = svcText[:colWidths[1]-1] + "…"
 				}
 
-				itemStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("15"))
-				col0 := itemStyle.Render(fmt.Sprintf(" %-*s", colWidths[0]-1, stackText))
-				col1 := itemStyle.Render(fmt.Sprintf("%-*s", colWidths[1], svcText))
+				col0 := fmt.Sprintf(" %-*s", colWidths[0]-1, stackText)
+				col1 := fmt.Sprintf("%-*s", colWidths[1], svcText)
 				line := col0 + col1
 
 				if selected {
-					selBg := lipgloss.Color("63")
-					selStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("230")).Background(selBg).Bold(true)
-					col0 = selStyle.Render(fmt.Sprintf(" %-*s", colWidths[0]-1, stackText))
-					col1 = selStyle.Render(fmt.Sprintf("%-*s", colWidths[1], svcText))
-					return col0 + col1
+					return ui.ListSelectedStyle.Render(line)
 				}
-				return line
+				return ui.ListItemStyle.Render(line)
 			},
 		}
 		m.usedByList.SetOuterSize(w, h)
@@ -537,7 +531,7 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 }
 
 func (m *Model) setRenderItem() {
-	itemStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("15"))
+	itemStyle := ui.ListItemStyle
 
 	m.secretsList.RenderItem = func(sec secretItem, selected bool, _ int) string {
 		colWidths := m.secretsList.ColWidths()
@@ -575,8 +569,7 @@ func (m *Model) setRenderItem() {
 
 		// Render all columns in one format string (no explicit separators, like nodes view)
 		if selected {
-			selBg := lipgloss.Color("63")
-			selStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("230")).Background(selBg).Bold(true)
+			selStyle := ui.ListSelectedStyle
 			return selStyle.Render(fmt.Sprintf(" %-*s%-*s%-*s%-*s%-*s%-*s",
 				colWidths[0]-1, nameText,
 				colWidths[1], idText,

--- a/views/services/update.go
+++ b/views/services/update.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"swarmcli/core/primitives/hash"
 	"swarmcli/docker"
+	"swarmcli/ui"
 	filterlist "swarmcli/ui/components/filterable/list"
 	"swarmcli/views/confirmdialog"
 	helpview "swarmcli/views/help"
@@ -898,7 +899,7 @@ func (m *Model) setRenderItem() {
 			errText = truncateWithEllipsis(m.serviceErrorText[e.ServiceID], colWidths[9])
 		}
 
-		itemStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("15"))
+		itemStyle := ui.ListItemStyle
 
 		// Build format string with all columns at once (like CONFIG view)
 		formatStr := fmt.Sprintf(" %%-%ds%%-%ds%%-%ds%%-%ds%%-%ds%%-%ds%%-%ds%%-%ds%%-%ds%%-%ds",
@@ -908,8 +909,7 @@ func (m *Model) setRenderItem() {
 		var lineStr string
 		if selected && m.selectedTaskIndex == -1 {
 			// Only highlight service row if no task is selected
-			selBg := lipgloss.Color("25") // Lighter blue
-			selBase := lipgloss.NewStyle().Foreground(lipgloss.Color("230")).Background(selBg).Bold(true)
+			selBase := ui.ListSelectedStyle
 			lineStr = selBase.Render(fmt.Sprintf(formatStr,
 				serviceName, stackName, replicasText, statusText, modeText, imageText, portsText, created, updated, errText))
 

--- a/views/stacks/update.go
+++ b/views/stacks/update.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"swarmcli/core/primitives/hash"
 	"swarmcli/docker"
+	"swarmcli/ui"
 	filterlist "swarmcli/ui/components/filterable/list"
 	"swarmcli/views/confirmdialog"
 	helpview "swarmcli/views/help"
@@ -1189,7 +1190,7 @@ func (m *Model) setRenderItem() {
 		}
 	}()
 	// Build RenderItem to match the header layout used by the view (4 columns: STACK, SERVICES, TASKS, ERROR)
-	itemStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("117"))
+	itemStyle := ui.ListItemStyle
 
 	m.List.RenderItem = func(s docker.StackEntry, selected bool, _ int) string {
 		colWidths := m.List.ColWidths()
@@ -1235,8 +1236,7 @@ func (m *Model) setRenderItem() {
 
 		// Render all columns in one format string using precision to truncate if needed
 		if selected {
-			selBg := lipgloss.Color("63")
-			selStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("230")).Background(selBg).Bold(true)
+			selStyle := ui.ListSelectedStyle
 			line := selStyle.Render(fmt.Sprintf(" %-*.*s%-*.*s%-*.*s%-*.*s",
 				colWidths[0]-1, colWidths[0]-1, name,
 				colWidths[1], colWidths[1], svcStr,

--- a/views/tasks/view.go
+++ b/views/tasks/view.go
@@ -124,7 +124,7 @@ func (m *Model) renderTasks() string {
 			colWidths[4], desiredState,
 			colWidths[5], status)
 
-		lines = append(lines, line)
+		lines = append(lines, ui.ListItemStyle.Render(line))
 	}
 
 	return strings.Join(lines, "\n")


### PR DESCRIPTION
## Summary
- Make frame header text white (was medium blue) so headers stand out from content
- Add centralized `ListItemStyle` (blue/117) and `ListSelectedStyle` (white-on-blue/bold) to `ui/ui.go`
- Update all 8 views (stacks, services, nodes, secrets, configs, networks, contexts, tasks) to use centralized styles instead of inline definitions
- Fix networks selected text color (was black, now white like all other views)
- Normalize services selected background (was 25, now 63 like all other views)
- Add blue item color to contexts and tasks views (were unstyled)
- Closes #249

## Test plan
- [x] Build passes (`go build`)
- [x] Unit tests pass (`go test ./...`)
- [x] Visual: frame headers render in white
- [x] Visual: list entries render in blue across all views
- [x] Visual: selected rows render as white-on-blue consistently

🤖 Generated with [Claude Code](https://claude.com/claude-code)