### PR TITLE
Fix 'c' key intercepting search input in stacks view

### DIFF
--- a/views/stacks/update.go
+++ b/views/stacks/update.go
@@ -272,6 +272,12 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 			return m.confirmDialog.Update(msg)
 		}
 
+		// --- if in search mode, handle all keys via FilterableList ---
+		if m.List.Mode == filterlist.ModeSearching {
+			m.List.HandleKey(msg)
+			return nil
+		}
+
 		// Handle keyboard shortcuts
 		if msg.String() == "c" {
 			m.createDialogActive = true
@@ -281,12 +287,6 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 			m.createFileInput.SetValue("")
 			m.createDialogContent = defaultStackTemplate
 			m.createDialogError = ""
-			return nil
-		}
-
-		// --- if in search mode, handle all keys via FilterableList ---
-		if m.List.Mode == filterlist.ModeSearching {
-			m.List.HandleKey(msg)
 			return nil
 		}
 


### PR DESCRIPTION
## Summary

- Fixes #259: pressing `c` while in `/` search mode on the stacks view opened the create stack dialog instead of appending to the search query
- Root cause: the `c` shortcut handler was checked **before** the search mode guard in `views/stacks/update.go`
- Fix: move the search mode guard above the `c` handler (swap two code blocks, no logic changes)

## Test plan

- [x] `go build` compiles cleanly
- [x] `go test ./views/stacks/...` passes
- [x] `go test ./...` passes (all packages)
- [x] `golangci-lint run ./...` — 0 issues
- [x] Manual: open stacks view → press `/` → type a query containing `c` → verify it filters instead of opening create dialog

🤖 Generated with [Claude Code](https://claude.com/claude-code)