### PR TITLE
feat: migrate logs, inspect, help views to app-level search box

### DIFF
--- a/views/help/help_test.go
+++ b/views/help/help_test.go
@@ -145,3 +145,71 @@ func TestView_EmptyCategories_CommandList(t *testing.T) {
 	// Should render command list path (even if empty)
 	require.Contains(t, out, "Help")
 }
+
+// --- Filterable (app-level "/" filter) tests ---
+
+func TestApplySearchQuery_CommandMode(t *testing.T) {
+	cmds := []CommandInfo{
+		{Name: "stacks", Description: "List stacks"},
+		{Name: "help", Description: "Show help"},
+		{Name: "contexts", Description: "List contexts", Aliases: []string{"ctx"}},
+	}
+	m := New(120, 24, cmds)
+	m.ApplySearchQuery("stack")
+	require.Contains(t, m.content, ":stacks")
+	require.NotContains(t, m.content, ":help")
+	require.NotContains(t, m.content, ":contexts")
+}
+
+func TestClearSearchQuery_CommandMode(t *testing.T) {
+	cmds := []CommandInfo{
+		{Name: "stacks", Description: "List stacks"},
+		{Name: "help", Description: "Show help"},
+	}
+	m := New(120, 24, cmds)
+	m.ApplySearchQuery("stack")
+	m.ClearSearchQuery()
+	require.Contains(t, m.content, ":stacks")
+	require.Contains(t, m.content, ":help")
+}
+
+func TestApplySearchQuery_CommandMode_ByAlias(t *testing.T) {
+	cmds := []CommandInfo{
+		{Name: "contexts", Description: "List contexts", Aliases: []string{"ctx"}},
+		{Name: "help", Description: "Show help"},
+	}
+	m := New(120, 24, cmds)
+	m.ApplySearchQuery("ctx")
+	require.Contains(t, m.content, ":contexts")
+	require.NotContains(t, m.content, ":help")
+}
+
+func TestApplySearchQuery_CategorizedMode(t *testing.T) {
+	cats := []HelpCategory{
+		{Title: "Navigation", Items: []HelpItem{
+			{Keys: "<esc>", Description: "Go back"},
+			{Keys: "<q>", Description: "Quit"},
+		}},
+		{Title: "Actions", Items: []HelpItem{
+			{Keys: "<n>", Description: "New item"},
+		}},
+	}
+	m := NewDetailed(120, 40, cats)
+	m.ApplySearchQuery("quit")
+	out := m.View()
+	require.Contains(t, out, "Quit")
+	require.NotContains(t, out, "Go back")
+}
+
+func TestClearSearchQuery_CategorizedMode(t *testing.T) {
+	cats := []HelpCategory{
+		{Title: "Navigation", Items: []HelpItem{
+			{Keys: "<esc>", Description: "Go back"},
+		}},
+	}
+	m := NewDetailed(120, 40, cats)
+	m.ApplySearchQuery("nonexistent")
+	m.ClearSearchQuery()
+	out := m.View()
+	require.Contains(t, out, "Go back")
+}

--- a/views/help/model.go
+++ b/views/help/model.go
@@ -43,6 +43,8 @@ type Model struct {
 	categories []HelpCategory
 	width      int
 	height     int
+	// app-level "/" filter query
+	query string
 }
 
 type CommandInfo struct {
@@ -135,4 +137,77 @@ func (m *Model) OnExit() tea.Cmd {
 
 func (m *Model) HasErrors() bool {
 	return false
+}
+
+// ApplySearchQuery implements view.Filterable — filters commands/keybindings.
+func (m *Model) ApplySearchQuery(query string) {
+	m.query = query
+	if len(m.commands) > 0 {
+		m.rebuildCommandContent()
+	}
+	// Categorized content is rebuilt dynamically in buildCategorizedContent()
+}
+
+// ClearSearchQuery implements view.Filterable — clears the filter.
+func (m *Model) ClearSearchQuery() {
+	m.query = ""
+	if len(m.commands) > 0 {
+		m.rebuildCommandContent()
+	}
+}
+
+// rebuildCommandContent re-renders the command list with the current filter.
+func (m *Model) rebuildCommandContent() {
+	cmds := m.filteredCommands()
+
+	cmdW := 16
+	descW := 20
+	for _, c := range m.commands {
+		if w := len(c.Name) + 1; w > cmdW {
+			cmdW = w
+		}
+		if w := len(c.Description); w > descW {
+			descW = w
+		}
+	}
+
+	const gap = "   "
+	headerStyle := lipgloss.NewStyle().
+		Foreground(lipgloss.Color("33")).
+		Bold(true)
+
+	var b strings.Builder
+	if len(m.commands) > 0 {
+		header := fmt.Sprintf("%-*s%s%-*s%s%s", cmdW, "COMMAND", gap, descW, "DESCRIPTION", gap, "ALIASES")
+		fmt.Fprintln(&b, headerStyle.Render(header))
+	}
+	for _, c := range cmds {
+		fmt.Fprintf(&b, "%-*s%s%-*s%s%s\n", cmdW, ":"+c.Name, gap, descW, c.Description, gap, strings.Join(c.Aliases, ", "))
+	}
+
+	m.content = b.String()
+	m.Viewable.SetContent(m.content)
+}
+
+// filteredCommands returns commands matching the current query.
+func (m *Model) filteredCommands() []CommandInfo {
+	if m.query == "" {
+		return m.commands
+	}
+	lower := strings.ToLower(m.query)
+	var filtered []CommandInfo
+	for _, c := range m.commands {
+		if strings.Contains(strings.ToLower(c.Name), lower) ||
+			strings.Contains(strings.ToLower(c.Description), lower) {
+			filtered = append(filtered, c)
+			continue
+		}
+		for _, alias := range c.Aliases {
+			if strings.Contains(strings.ToLower(alias), lower) {
+				filtered = append(filtered, c)
+				break
+			}
+		}
+	}
+	return filtered
 }

--- a/views/help/view.go
+++ b/views/help/view.go
@@ -62,7 +62,27 @@ func (m *Model) buildCategorizedContent() string {
 	descStyle := lipgloss.NewStyle().
 		Foreground(lipgloss.Color("252"))
 
-	numCols := len(m.categories)
+	// Apply query filter to categories
+	categories := m.categories
+	if m.query != "" {
+		lower := strings.ToLower(m.query)
+		var filtered []HelpCategory
+		for _, cat := range categories {
+			var items []HelpItem
+			for _, item := range cat.Items {
+				if strings.Contains(strings.ToLower(item.Keys), lower) ||
+					strings.Contains(strings.ToLower(item.Description), lower) {
+					items = append(items, item)
+				}
+			}
+			if len(items) > 0 {
+				filtered = append(filtered, HelpCategory{Title: cat.Title, Items: items})
+			}
+		}
+		categories = filtered
+	}
+
+	numCols := len(categories)
 	if numCols == 0 {
 		numCols = 1
 	}
@@ -70,14 +90,14 @@ func (m *Model) buildCategorizedContent() string {
 	maxKeyWidth := 15
 
 	maxRows := 0
-	for _, cat := range m.categories {
+	for _, cat := range categories {
 		if len(cat.Items) > maxRows {
 			maxRows = len(cat.Items)
 		}
 	}
 
 	var headerParts []string
-	for _, cat := range m.categories {
+	for _, cat := range categories {
 		titleText := strings.ToUpper(cat.Title)
 		paddedTitle := fmt.Sprintf("%-*s", colWidth, titleText)
 		styledTitle := categoryStyle.Render(paddedTitle)
@@ -88,7 +108,7 @@ func (m *Model) buildCategorizedContent() string {
 	var contentLines []string
 	for row := 0; row < maxRows; row++ {
 		var rowParts []string
-		for _, cat := range m.categories {
+		for _, cat := range categories {
 			if row < len(cat.Items) {
 				item := cat.Items[row]
 				styledKey := keyStyle.Render(fmt.Sprintf("%-*s", maxKeyWidth, item.Keys))

--- a/views/inspect/handlekey.go
+++ b/views/inspect/handlekey.go
@@ -9,7 +9,15 @@ import (
 
 func handleNormalKey(m *Model, k tea.KeyMsg) tea.Cmd {
 	switch k.String() {
-	case "q", "esc":
+	case "q":
+		return nil
+	case "esc":
+		// If app-level filter is active, clear it instead of closing
+		if m.filterQuery != "" {
+			m.filterQuery = ""
+			m.updateViewport()
+			return nil
+		}
 		return nil
 	case "up", "k":
 		m.viewport.ScrollUp(1)
@@ -27,9 +35,22 @@ func handleNormalKey(m *Model, k tea.KeyMsg) tea.Cmd {
 		}
 		return nil
 
-	case "/", "shift+/":
+	case "ctrl+f":
 		m.searchMode = true
 		m.SearchTerm = ""
+		return nil
+
+	case "n":
+		if len(m.searchMatches) > 0 {
+			m.searchIndex = (m.searchIndex + 1) % len(m.searchMatches)
+			m.scrollToMatch()
+		}
+		return nil
+	case "N":
+		if len(m.searchMatches) > 0 {
+			m.searchIndex = (m.searchIndex - 1 + len(m.searchMatches)) % len(m.searchMatches)
+			m.scrollToMatch()
+		}
 		return nil
 	}
 	return nil
@@ -47,10 +68,18 @@ func handleSearchKey(m *Model, k tea.KeyMsg) tea.Cmd {
 		}
 	case tea.KeyEnter:
 		m.searchMode = false
-		m.updateViewport()
+		m.computeSearchMatches()
+		if len(m.searchMatches) > 0 {
+			m.searchIndex = 0
+			m.scrollToMatch()
+		} else {
+			m.updateViewport()
+		}
 	case tea.KeyEsc:
 		m.searchMode = false
 		m.SearchTerm = ""
+		m.searchMatches = nil
+		m.searchIndex = 0
 		m.updateViewport()
 	}
 	return nil

--- a/views/inspect/inspect_test.go
+++ b/views/inspect/inspect_test.go
@@ -1,6 +1,7 @@
 package inspectview
 
 import (
+	"strings"
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -25,6 +26,8 @@ func key(s string) tea.KeyMsg {
 		return tea.KeyMsg{Type: tea.KeyPgUp}
 	case "pgdown":
 		return tea.KeyMsg{Type: tea.KeyPgDown}
+	case "ctrl+f":
+		return tea.KeyMsg{Type: tea.KeyCtrlF}
 	}
 	if len(s) == 1 {
 		return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(s)}
@@ -108,7 +111,7 @@ func TestShortHelpItems_Normal(t *testing.T) {
 	for _, item := range items {
 		keys[item.Key] = true
 	}
-	require.True(t, keys["/"])
+	require.True(t, keys["ctrl+f"])
 	require.True(t, keys["r"])
 	require.True(t, keys["q"])
 }
@@ -165,10 +168,10 @@ func TestKey_R_ToggleFormat(t *testing.T) {
 	require.Equal(t, FormatYAML, m.Format)
 }
 
-func TestKey_Slash_EntersSearch(t *testing.T) {
+func TestKey_CtrlF_EntersSearch(t *testing.T) {
 	m := testModel()
 	m.ready = true
-	m.Update(key("/"))
+	m.Update(key("ctrl+f"))
 	require.True(t, m.searchMode)
 	require.Equal(t, "", m.SearchTerm)
 }
@@ -179,7 +182,7 @@ func TestSearch_TypeAndConfirm(t *testing.T) {
 	m := testModel()
 	m.SetContent(testJSON)
 	m.ready = true
-	m.Update(key("/"))
+	m.Update(key("ctrl+f"))
 	m.Update(key("n"))
 	m.Update(key("a"))
 	require.Equal(t, "na", m.SearchTerm)
@@ -191,7 +194,7 @@ func TestSearch_TypeAndConfirm(t *testing.T) {
 func TestSearch_EscCancels(t *testing.T) {
 	m := testModel()
 	m.ready = true
-	m.Update(key("/"))
+	m.Update(key("ctrl+f"))
 	m.Update(key("x"))
 	m.Update(key("esc"))
 	require.False(t, m.searchMode)
@@ -201,7 +204,7 @@ func TestSearch_EscCancels(t *testing.T) {
 func TestSearch_Backspace(t *testing.T) {
 	m := testModel()
 	m.ready = true
-	m.Update(key("/"))
+	m.Update(key("ctrl+f"))
 	m.Update(key("a"))
 	m.Update(key("b"))
 	require.Equal(t, "ab", m.SearchTerm)
@@ -245,4 +248,91 @@ func TestView_YAML(t *testing.T) {
 	m.viewport.Height = 24
 	out := m.viewport.View()
 	require.NotEmpty(t, out)
+}
+
+// --- Filterable (app-level "/" filter) tests ---
+
+func TestApplySearchQuery_FiltersLines(t *testing.T) {
+	m := testModel()
+	m.SetContent(testJSON)
+	m.ready = true
+	m.ApplySearchQuery("test")
+	// After filtering, only lines containing "test" should remain
+	visible := m.visiblePlainLines()
+	for _, line := range visible {
+		require.Contains(t, strings.ToLower(line), "test")
+	}
+}
+
+func TestClearSearchQuery_RestoresAll(t *testing.T) {
+	m := testModel()
+	m.SetContent(testJSON)
+	m.ready = true
+	allBefore := m.visiblePlainLines()
+	m.ApplySearchQuery("test")
+	m.ClearSearchQuery()
+	allAfter := m.visiblePlainLines()
+	require.Equal(t, len(allBefore), len(allAfter))
+}
+
+func TestHasActiveFilter_Default(t *testing.T) {
+	m := testModel()
+	require.False(t, m.HasActiveFilter())
+}
+
+func TestIsSearching_Default(t *testing.T) {
+	m := testModel()
+	require.False(t, m.IsSearching())
+}
+
+func TestIsSearching_SearchMode(t *testing.T) {
+	m := testModel()
+	m.searchMode = true
+	require.True(t, m.IsSearching())
+}
+
+func TestSearch_NNavigation(t *testing.T) {
+	m := testModel()
+	m.SetContent(`{"name":"test","count":42,"nested":{"name":"test2"}}`)
+	m.ready = true
+	m.viewport.Width = 80
+	m.viewport.Height = 24
+	// Enter search, type "name", confirm
+	m.Update(key("ctrl+f"))
+	m.Update(key("n"))
+	m.Update(key("a"))
+	m.Update(key("m"))
+	m.Update(key("e"))
+	m.Update(key("enter"))
+	require.False(t, m.searchMode)
+	require.Equal(t, "name", m.SearchTerm)
+	require.Greater(t, len(m.searchMatches), 0)
+
+	// Navigate with n
+	if len(m.searchMatches) > 1 {
+		m.Update(key("n"))
+		require.Equal(t, 1, m.searchIndex)
+		m.Update(key("N"))
+		require.Equal(t, 0, m.searchIndex)
+	}
+}
+
+func TestEsc_ClearsFilterBeforeGoBack(t *testing.T) {
+	m := testModel()
+	m.ready = true
+	m.filterQuery = "test"
+	m.Update(key("esc"))
+	// Filter should be cleared
+	require.Equal(t, "", m.filterQuery)
+	require.False(t, m.HasActiveFilter())
+}
+
+func TestApplySearchQuery_RawMode(t *testing.T) {
+	m := New(80, 24, FormatRaw)
+	m.SetContent("line one\nline two\nline three")
+	m.ready = true
+	m.ApplySearchQuery("two")
+	visible := m.visiblePlainLines()
+	require.Len(t, visible, 1)
+	require.Contains(t, visible[0], "two")
 }

--- a/views/inspect/model.go
+++ b/views/inspect/model.go
@@ -38,6 +38,11 @@ type Model struct {
 	Format     Format // "yml" or "raw"
 	RawContent string
 	ParseError string
+
+	// app-level "/" filter — hides non-matching lines
+	filterQuery   string
+	searchMatches []int
+	searchIndex   int
 }
 
 func New(width, height int, format Format) *Model {
@@ -72,6 +77,28 @@ func LoadInspectItem(title, jsonStr string) tea.Cmd {
 	return func() tea.Msg { return Msg{Title: title, Content: jsonStr} }
 }
 
+// ApplySearchQuery implements view.Filterable — sets the app-level "/" filter.
+func (m *Model) ApplySearchQuery(query string) {
+	m.filterQuery = query
+	m.updateViewport()
+}
+
+// ClearSearchQuery implements view.Filterable — clears the app-level "/" filter.
+func (m *Model) ClearSearchQuery() {
+	m.filterQuery = ""
+	m.updateViewport()
+}
+
+// IsSearching returns true when the ctrl+f search input is active.
+func (m *Model) IsSearching() bool {
+	return m.searchMode
+}
+
+// HasActiveFilter returns true when the app-level "/" filter is active.
+func (m *Model) HasActiveFilter() bool {
+	return m.filterQuery != ""
+}
+
 func (m *Model) ShortHelpItems() []helpbar.HelpEntry {
 	if m.searchMode {
 		return []helpbar.HelpEntry{
@@ -79,12 +106,18 @@ func (m *Model) ShortHelpItems() []helpbar.HelpEntry {
 			{Key: "esc", Desc: "Cancel"},
 		}
 	}
-	return []helpbar.HelpEntry{
-		{Key: "/", Desc: "Search"},
+	entries := []helpbar.HelpEntry{
+		{Key: "ctrl+f", Desc: "Search"},
 		{Key: "j/k", Desc: "Down/up"},
-		{Key: "r", Desc: "Toggle raw"},
-		{Key: "q", Desc: "Close"},
 	}
+	if m.SearchTerm != "" && len(m.searchMatches) > 0 {
+		entries = append(entries, helpbar.HelpEntry{Key: "n/N", Desc: "Next/prev"})
+	}
+	entries = append(entries,
+		helpbar.HelpEntry{Key: "r", Desc: "Toggle raw"},
+		helpbar.HelpEntry{Key: "q", Desc: "Close"},
+	)
+	return entries
 }
 
 func (m *Model) OnEnter() tea.Cmd {

--- a/views/inspect/update.go
+++ b/views/inspect/update.go
@@ -63,11 +63,31 @@ func (m *Model) SetContent(content string) {
 // updateViewport updates viewport content, preserving scroll if possible
 func (m *Model) updateViewport() {
 	if m.Format == "raw" {
-		// content is directly used, do nothing here
+		content := m.RawContent
+		if m.filterQuery != "" {
+			lower := strings.ToLower(m.filterQuery)
+			var filtered []string
+			for _, line := range strings.Split(content, "\n") {
+				if strings.Contains(strings.ToLower(line), lower) {
+					filtered = append(filtered, line)
+				}
+			}
+			content = strings.Join(filtered, "\n")
+		}
+		if m.SearchTerm != "" {
+			content = highlightInContent(content, m.SearchTerm)
+		}
+		m.viewport.SetContent(content)
 		return
 	}
 	content := m.renderYAML()
 	m.viewport.SetContent(content)
+}
+
+// renderedLine holds both the plain-text and styled versions of a YAML line.
+type renderedLine struct {
+	plainText string
+	styled    string
 }
 
 var keyStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("33"))                                             // blueish keys
@@ -78,40 +98,70 @@ func (m *Model) renderYAML() string {
 		return ""
 	}
 
-	var build func(n *Node, indent int) []string
-	build = func(n *Node, indent int) []string {
-		var lines []string
-		prefix := strings.Repeat("  ", indent)
+	// Pass 1: build all lines with plain text and styled versions
+	allLines := m.buildYAMLLines(m.Root, 0)
 
-		key := n.Key
-		value := n.ValueStr
-
-		// highlight search term in key
-		if m.SearchTerm != "" {
-			key = highlightMatches(key, m.SearchTerm, keyStyle)
-		} else {
-			key = keyStyle.Render(key)
+	// Pass 2: filter by filterQuery on plain text
+	var visible []renderedLine
+	if m.filterQuery != "" {
+		lower := strings.ToLower(m.filterQuery)
+		for _, rl := range allLines {
+			if strings.Contains(strings.ToLower(rl.plainText), lower) {
+				visible = append(visible, rl)
+			}
 		}
-
-		// highlight search term in value
-		if value != "" && m.SearchTerm != "" {
-			value = highlightMatches(value, m.SearchTerm, lipgloss.NewStyle()) // default value style
-		}
-
-		line := fmt.Sprintf("%s%s", prefix, key)
-		if value != "" {
-			line += fmt.Sprintf(": %s", value)
-		}
-		lines = append(lines, line)
-
-		// recursively render children
-		for _, c := range n.Children {
-			lines = append(lines, build(c, indent+1)...)
-		}
-		return lines
+	} else {
+		visible = allLines
 	}
 
-	return strings.Join(build(m.Root, 0), "\n")
+	// Pass 3: join styled lines
+	result := make([]string, len(visible))
+	for i, rl := range visible {
+		result[i] = rl.styled
+	}
+	return strings.Join(result, "\n")
+}
+
+// buildYAMLLines recursively builds renderedLine entries for the YAML tree.
+func (m *Model) buildYAMLLines(n *Node, indent int) []renderedLine {
+	var lines []renderedLine
+	prefix := strings.Repeat("  ", indent)
+
+	key := n.Key
+	value := n.ValueStr
+
+	// Build plain text version (no ANSI styles)
+	plainLine := prefix + key
+	if value != "" {
+		plainLine += ": " + value
+	}
+
+	// Build styled version
+	var styledKey string
+	if m.SearchTerm != "" {
+		styledKey = highlightMatches(key, m.SearchTerm, keyStyle)
+	} else {
+		styledKey = keyStyle.Render(key)
+	}
+
+	var styledValue string
+	if value != "" && m.SearchTerm != "" {
+		styledValue = highlightMatches(value, m.SearchTerm, lipgloss.NewStyle())
+	} else {
+		styledValue = value
+	}
+
+	styledLine := fmt.Sprintf("%s%s", prefix, styledKey)
+	if value != "" {
+		styledLine += fmt.Sprintf(": %s", styledValue)
+	}
+
+	lines = append(lines, renderedLine{plainText: plainLine, styled: styledLine})
+
+	for _, c := range n.Children {
+		lines = append(lines, m.buildYAMLLines(c, indent+1)...)
+	}
+	return lines
 }
 
 // highlightMatches highlights all occurrences of term in text with yellow background
@@ -132,4 +182,94 @@ func highlightMatches(text, term string, style lipgloss.Style) string {
 		offset += idx + len(term)
 	}
 	return result
+}
+
+// highlightInContent highlights search term in raw content string
+func highlightInContent(content, term string) string {
+	lowerContent := strings.ToLower(content)
+	lowerTerm := strings.ToLower(term)
+
+	result := ""
+	offset := 0
+	for {
+		idx := strings.Index(lowerContent[offset:], lowerTerm)
+		if idx == -1 {
+			result += content[offset:]
+			break
+		}
+		result += content[offset : offset+idx]
+		result += searchHighlightStyle.Render(content[offset+idx : offset+idx+len(term)])
+		offset += idx + len(term)
+	}
+	return result
+}
+
+// visiblePlainLines returns the plain-text lines visible after filtering.
+func (m *Model) visiblePlainLines() []string {
+	if m.Format == "raw" {
+		lines := strings.Split(m.RawContent, "\n")
+		if m.filterQuery == "" {
+			return lines
+		}
+		lower := strings.ToLower(m.filterQuery)
+		var filtered []string
+		for _, line := range lines {
+			if strings.Contains(strings.ToLower(line), lower) {
+				filtered = append(filtered, line)
+			}
+		}
+		return filtered
+	}
+
+	if m.Root == nil {
+		return nil
+	}
+
+	allLines := m.buildYAMLLines(m.Root, 0)
+	if m.filterQuery != "" {
+		lower := strings.ToLower(m.filterQuery)
+		var filtered []string
+		for _, rl := range allLines {
+			if strings.Contains(strings.ToLower(rl.plainText), lower) {
+				filtered = append(filtered, rl.plainText)
+			}
+		}
+		return filtered
+	}
+
+	result := make([]string, len(allLines))
+	for i, rl := range allLines {
+		result[i] = rl.plainText
+	}
+	return result
+}
+
+// computeSearchMatches finds all visible lines containing the search term.
+func (m *Model) computeSearchMatches() {
+	m.searchMatches = nil
+	m.searchIndex = 0
+	if m.SearchTerm == "" {
+		return
+	}
+	lower := strings.ToLower(m.SearchTerm)
+	for i, line := range m.visiblePlainLines() {
+		if strings.Contains(strings.ToLower(line), lower) {
+			m.searchMatches = append(m.searchMatches, i)
+		}
+	}
+}
+
+// scrollToMatch centers the viewport on the selected match
+func (m *Model) scrollToMatch() {
+	if len(m.searchMatches) == 0 {
+		return
+	}
+	idx := m.searchMatches[m.searchIndex]
+	offset := idx - m.viewport.Height/2
+	if offset < 0 {
+		offset = 0
+	}
+	m.updateViewport()
+	m.viewport.GotoTop()
+	m.viewport.SetYOffset(offset)
 }

--- a/views/inspect/view.go
+++ b/views/inspect/view.go
@@ -28,6 +28,10 @@ func (m *Model) FrameHeader() string {
 	header := fmt.Sprintf("Inspecting %s%s", formatIndicator, errorHint)
 	if m.searchMode {
 		header = fmt.Sprintf("%s — Search: %s", header, m.SearchTerm)
+	} else if m.SearchTerm != "" && len(m.searchMatches) > 0 {
+		matchCount := len(m.searchMatches)
+		currentMatch := m.searchIndex + 1
+		header = fmt.Sprintf("%s — Found %d matches (%d/%d) • 'n'/'N' to navigate", header, matchCount, currentMatch, matchCount)
 	}
 	return ui.FrameHeaderStyle.Render(header)
 }

--- a/views/logs/handlekey.go
+++ b/views/logs/handlekey.go
@@ -116,10 +116,18 @@ func HandleKey(m *Model, k tea.KeyMsg) tea.Cmd {
 		m.Visible = false
 		return nil
 	case "esc":
+		// If app-level filter is active, clear it instead of closing
+		if m.getFilterQuery() != "" {
+			m.mu.Lock()
+			m.filterQuery = ""
+			m.mu.Unlock()
+			m.highlightContent()
+			return nil
+		}
 		// Close the view
 		m.Visible = false
 		return nil
-	case "/":
+	case "ctrl+f":
 		m.mode = "search"
 		m.searchTerm = ""
 		m.searchIndex = 0

--- a/views/logs/logs_test.go
+++ b/views/logs/logs_test.go
@@ -55,6 +55,8 @@ func key(s string) tea.KeyMsg {
 		return tea.KeyMsg{Type: tea.KeyPgUp}
 	case "pgdown":
 		return tea.KeyMsg{Type: tea.KeyPgDown}
+	case "ctrl+f":
+		return tea.KeyMsg{Type: tea.KeyCtrlF}
 	}
 	if len(s) == 1 {
 		return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(s)}
@@ -130,7 +132,7 @@ func TestShortHelpItems_NormalMode(t *testing.T) {
 	for _, item := range items {
 		keys[item.Key] = true
 	}
-	require.True(t, keys["/"])
+	require.True(t, keys["ctrl+f"])
 	require.True(t, keys["s"])
 	require.True(t, keys["w"])
 	require.True(t, keys["o"])
@@ -260,10 +262,10 @@ func TestUpdate_WindowSizeMsg(t *testing.T) {
 
 // --- Key handling: normal mode ---
 
-func TestKey_Slash_EntersSearch(t *testing.T) {
+func TestKey_CtrlF_EntersSearch(t *testing.T) {
 	m := testModel()
 	m.Visible = true
-	m.Update(key("/"))
+	m.Update(key("ctrl+f"))
 	require.Equal(t, "search", m.mode)
 	require.Equal(t, "", m.searchTerm)
 }
@@ -309,7 +311,7 @@ func TestSearchMode_TypeAndConfirm(t *testing.T) {
 	m.mu.Lock()
 	m.lines = []string{"hello world", "foo bar"}
 	m.mu.Unlock()
-	m.Update(key("/"))
+	m.Update(key("ctrl+f"))
 	require.Equal(t, "search", m.mode)
 	m.Update(key("h"))
 	m.Update(key("e"))
@@ -322,7 +324,7 @@ func TestSearchMode_TypeAndConfirm(t *testing.T) {
 func TestSearchMode_EscCancels(t *testing.T) {
 	m := testModel()
 	m.Visible = true
-	m.Update(key("/"))
+	m.Update(key("ctrl+f"))
 	m.Update(key("t"))
 	m.Update(key("esc"))
 	require.Equal(t, "normal", m.mode)
@@ -331,7 +333,7 @@ func TestSearchMode_EscCancels(t *testing.T) {
 func TestSearchMode_Backspace(t *testing.T) {
 	m := testModel()
 	m.Visible = true
-	m.Update(key("/"))
+	m.Update(key("ctrl+f"))
 	m.Update(key("a"))
 	m.Update(key("b"))
 	require.Equal(t, "ab", m.searchTerm)
@@ -504,6 +506,103 @@ func TestSetContent_MaxLines(t *testing.T) {
 }
 
 // --- shouldFallbackToRawFromStdCopy tests ---
+
+// --- Filterable (app-level "/" filter) tests ---
+
+func TestApplySearchQuery(t *testing.T) {
+	m := testModel()
+	m.mu.Lock()
+	m.lines = []string{"hello world", "foo bar", "hello again"}
+	m.mu.Unlock()
+	m.ApplySearchQuery("hello")
+	require.Equal(t, "hello", m.getFilterQuery())
+	content := m.buildContent()
+	require.Contains(t, content, "hello world")
+	require.NotContains(t, content, "foo bar")
+	require.Contains(t, content, "hello again")
+}
+
+func TestClearSearchQuery(t *testing.T) {
+	m := testModel()
+	m.mu.Lock()
+	m.lines = []string{"hello world", "foo bar"}
+	m.mu.Unlock()
+	m.ApplySearchQuery("hello")
+	require.Equal(t, "hello", m.getFilterQuery())
+	m.ClearSearchQuery()
+	require.Equal(t, "", m.getFilterQuery())
+	content := m.buildContent()
+	require.Contains(t, content, "hello world")
+	require.Contains(t, content, "foo bar")
+}
+
+func TestHasActiveFilter_Default(t *testing.T) {
+	m := testModel()
+	require.False(t, m.HasActiveFilter())
+}
+
+func TestHasActiveFilter_WithQuery(t *testing.T) {
+	m := testModel()
+	m.ApplySearchQuery("test")
+	require.True(t, m.HasActiveFilter())
+}
+
+func TestHasActiveDialog(t *testing.T) {
+	m := testModel()
+	require.False(t, m.HasActiveDialog())
+	m.setNodeSelectVisible(true)
+	require.True(t, m.HasActiveDialog())
+}
+
+func TestBuildContent_WithFilterQuery(t *testing.T) {
+	m := testModel()
+	m.mu.Lock()
+	m.lines = []string{"error: something", "info: all good", "error: another"}
+	m.mu.Unlock()
+	m.mu.Lock()
+	m.filterQuery = "error"
+	m.mu.Unlock()
+	content := m.buildContent()
+	require.Contains(t, content, "error: something")
+	require.NotContains(t, content, "info: all good")
+	require.Contains(t, content, "error: another")
+}
+
+func TestFilterAndNodeFilter_Combined(t *testing.T) {
+	m := testModel()
+	m.mu.Lock()
+	m.lines = []string{"error on node1", "info on node1", "error on node2", "info on node2"}
+	m.lineNodes = []string{"node1", "node1", "node2", "node2"}
+	m.mu.Unlock()
+	m.setNodeFilter("node1")
+	m.mu.Lock()
+	m.filterQuery = "error"
+	m.mu.Unlock()
+	content := m.buildContent()
+	require.Contains(t, content, "error on node1")
+	require.NotContains(t, content, "info on node1")
+	require.NotContains(t, content, "error on node2")
+	require.NotContains(t, content, "info on node2")
+}
+
+func TestEsc_ClearsFilterBeforeClosing(t *testing.T) {
+	m := testModel()
+	m.Visible = true
+	m.mu.Lock()
+	m.filterQuery = "test"
+	m.mu.Unlock()
+	m.Update(key("esc"))
+	// Filter should be cleared but view stays visible
+	require.True(t, m.Visible)
+	require.Equal(t, "", m.getFilterQuery())
+}
+
+func TestEsc_ClosesViewWhenNoFilter(t *testing.T) {
+	m := testModel()
+	m.Visible = true
+	m.Update(key("esc"))
+	require.False(t, m.Visible)
+}
 
 func TestShouldFallbackToRawFromStdCopy(t *testing.T) {
 	tests := []struct {

--- a/views/logs/model.go
+++ b/views/logs/model.go
@@ -52,6 +52,8 @@ type Model struct {
 	horizontalOffset int
 	// node filter - if set, only show logs from this node
 	nodeFilter string
+	// app-level "/" filter — hides non-matching lines
+	filterQuery string
 	// node selection dialog
 	nodeSelectVisible bool
 	nodeSelectCursor  int
@@ -153,6 +155,46 @@ func (m *Model) IsSearching() bool {
 	return m.GetSearchMode()
 }
 
+// HasActiveDialog returns true when a modal dialog is open (node selection).
+func (m *Model) HasActiveDialog() bool {
+	return m.getNodeSelectVisible()
+}
+
+func (m *Model) getFilterQuery() string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.filterQuery
+}
+
+// ApplySearchQuery implements view.Filterable — sets the app-level "/" filter.
+func (m *Model) ApplySearchQuery(query string) {
+	m.mu.Lock()
+	m.filterQuery = query
+	m.mu.Unlock()
+	m.highlightContent()
+	if m.ready && m.getFollow() {
+		m.viewport.GotoBottom()
+	}
+}
+
+// ClearSearchQuery implements view.Filterable — clears the app-level "/" filter.
+func (m *Model) ClearSearchQuery() {
+	m.mu.Lock()
+	m.filterQuery = ""
+	m.mu.Unlock()
+	m.highlightContent()
+	if m.ready && m.getFollow() {
+		m.viewport.GotoBottom()
+	}
+}
+
+// HasActiveFilter returns true when the app-level "/" filter is active.
+func (m *Model) HasActiveFilter() bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.filterQuery != ""
+}
+
 // ShortHelpItems stays compatible with your helpbar interface.
 func (m *Model) ShortHelpItems() []helpbar.HelpEntry {
 	if m.mode == "search" {
@@ -164,7 +206,7 @@ func (m *Model) ShortHelpItems() []helpbar.HelpEntry {
 	}
 
 	entries := []helpbar.HelpEntry{
-		{Key: "/", Desc: "Search"},
+		{Key: "ctrl+f", Desc: "Search"},
 		{Key: "n/N", Desc: "Next/prev"},
 		{Key: "s", Desc: "Toggle AutoScroll"},
 		{Key: "w", Desc: "Toggle wrap"},

--- a/views/logs/update.go
+++ b/views/logs/update.go
@@ -59,8 +59,17 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 		}
 
 		// update searchMatches incrementally
-		if m.searchTerm != "" && strings.Contains(strings.ToLower(actualLine), strings.ToLower(m.searchTerm)) {
-			m.searchMatches = append(m.searchMatches, len(m.lines)-1)
+		if m.searchTerm != "" {
+			if linesDropped > 0 && m.searchMatches != nil {
+				// Lines dropped from top invalidate visible indices; recompute on next n/N
+				m.searchMatches = nil
+			} else if m.nodeFilter == "" && m.filterQuery == "" {
+				// Simple case: no filters, raw index equals visible index
+				if strings.Contains(strings.ToLower(actualLine), strings.ToLower(m.searchTerm)) {
+					m.searchMatches = append(m.searchMatches, len(m.lines)-1)
+				}
+			}
+			// When filters are active, skip incremental update; highlightContent will recompute
 		}
 		totalLines := len(m.lines)
 		shouldFollow := m.follow
@@ -273,10 +282,20 @@ func (m *Model) highlightContent() {
 		m.searchMatches = []int{}
 		lower := strings.ToLower(m.searchTerm)
 		m.mu.Lock()
+		visibleIdx := 0
 		for i, L := range m.lines {
-			if strings.Contains(strings.ToLower(L), lower) {
-				m.searchMatches = append(m.searchMatches, i)
+			// Skip lines hidden by node filter
+			if m.nodeFilter != "" && (i >= len(m.lineNodes) || m.lineNodes[i] != m.nodeFilter) {
+				continue
 			}
+			// Skip lines hidden by filterQuery
+			if m.filterQuery != "" && !strings.Contains(strings.ToLower(L), strings.ToLower(m.filterQuery)) {
+				continue
+			}
+			if strings.Contains(strings.ToLower(L), lower) {
+				m.searchMatches = append(m.searchMatches, visibleIdx)
+			}
+			visibleIdx++
 		}
 		m.mu.Unlock()
 		if len(m.searchMatches) > 0 {
@@ -310,6 +329,18 @@ func (m *Model) buildContent() string {
 	} else {
 		// No filter, use all lines
 		filteredLines = m.lines
+	}
+
+	// Apply text filter (app-level "/" search)
+	if m.filterQuery != "" {
+		lower := strings.ToLower(m.filterQuery)
+		var textFiltered []string
+		for _, line := range filteredLines {
+			if strings.Contains(strings.ToLower(line), lower) {
+				textFiltered = append(textFiltered, line)
+			}
+		}
+		filteredLines = textFiltered
 	}
 
 	// Join lines first

--- a/views/logs/view.go
+++ b/views/logs/view.go
@@ -40,7 +40,7 @@ func (m *Model) FrameHeader() string {
 	} else if m.searchTerm != "" && len(m.searchMatches) > 0 {
 		matchCount := len(m.searchMatches)
 		currentMatch := m.searchIndex + 1
-		header = fmt.Sprintf("Logs — Found %d matches (viewing %d/%d) • Press '/' to search, 'n'/'N' to navigate", matchCount, currentMatch, matchCount)
+		header = fmt.Sprintf("Logs — Found %d matches (viewing %d/%d) • Press 'ctrl+f' to search, 'n'/'N' to navigate", matchCount, currentMatch, matchCount)
 	}
 	return ui.FrameHeaderStyle.Render(header)
 }


### PR DESCRIPTION
## Summary

Closes #275

- Implement `Filterable` interface on **logs**, **inspect**, and **help** views so `/` opens the unified app-level search box (filter-only — hides non-matching lines)
- Move the existing highlight+navigate search to **Ctrl+F** for logs and inspect views
- Add **n/N** match navigation to the inspect view (previously only logs had this)
- Fix pre-existing bug where `highlightContent()` in logs used raw-line indices instead of visible-line indices (caused wrong match positions when node filter was active)

## Test plan

- [x] `go build ./...` compiles
- [x] `go test ./views/logs/ ./views/inspect/ ./views/help/` — all pass (19 new tests added)
- [x] `go test ./...` — full suite passes
- [x] `golangci-lint run ./...` — 0 issues
- [x] Manual: **Logs** — `/` opens app search box → type "error" → lines filter → `Ctrl+F` → highlights within filtered lines → `n`/`N` navigate → Esc cascade works
- [x] Manual: **Inspect** — `/` filter → `Ctrl+F` search → match count in header → `n`/`N` cycle → works in YAML and raw mode
- [x] Manual: **Help** — `/` opens search → type "scale" → only matching keybindings/commands shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)