### PR TITLE
fix: sanitize log lines and ANSI-aware truncation to prevent frame corruption

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,6 +127,8 @@ Every PR to `main` must pass the `check_labels.yml` workflow which requires one 
 
 Add all three labels when creating a PR: `gh pr edit <number> --add-label "A0-ui,B0-low-priority,C0-breaks-nothing"` (or use the REST API if `gh pr edit` fails due to classic projects deprecation).
 
+When a PR fixes a GitHub issue, copy the issue's labels to the PR and add any missing required group labels (A, B, C). Use `gh api repos/OWNER/REPO/issues/<pr-number>/labels -f "labels[]=LABEL"` to add labels via API.
+
 ## CI Workflows (.github/workflows/)
 
 - `ci.yml`: go fmt, golangci-lint, go build, Docker image build

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -415,12 +415,12 @@ func OverlayCentered(base, overlay string, width, height int) string {
 			newLine.WriteString(dialogLine)
 		} else {
 			// Overlay dialog in the middle using width-aware truncation
-			leftPart := truncateANSI(baseLine, startCol)
+			leftPart := TruncateANSI(baseLine, startCol)
 			rightStart := startCol + dialogWidth
 			rightPart := ""
 			if rightStart < baseWidth {
 				// Skip the overlay width and get the rest
-				rightPart = truncateANSIAfter(baseLine, rightStart)
+				rightPart = TruncateANSIAfter(baseLine, rightStart)
 			}
 
 			newLine.WriteString(leftPart)
@@ -434,8 +434,8 @@ func OverlayCentered(base, overlay string, width, height int) string {
 	return strings.Join(baseLines, "\n")
 }
 
-// truncateANSI truncates a string with ANSI codes to a specific visual width
-func truncateANSI(s string, width int) string {
+// TruncateANSI truncates a string with ANSI codes to a specific visual width.
+func TruncateANSI(s string, width int) string {
 	if width <= 0 {
 		return ""
 	}
@@ -467,8 +467,8 @@ func truncateANSI(s string, width int) string {
 	return result.String()
 }
 
-// truncateANSIAfter skips characters up to a width and returns the rest
-func truncateANSIAfter(s string, skipWidth int) string {
+// TruncateANSIAfter skips characters up to a visual width and returns the rest.
+func TruncateANSIAfter(s string, skipWidth int) string {
 	if skipWidth <= 0 {
 		return s
 	}

--- a/views/logs/logs_test.go
+++ b/views/logs/logs_test.go
@@ -604,6 +604,61 @@ func TestEsc_ClosesViewWhenNoFilter(t *testing.T) {
 	require.False(t, m.Visible)
 }
 
+func TestLineMsg_StripsCR(t *testing.T) {
+	m := testModel()
+	m.Visible = true
+	lines := make(chan string, 10)
+	errs := make(chan error, 1)
+	m.linesChan = lines
+	m.errChan = errs
+
+	m.Update(LineMsg{Line: "node1\x00downloading 50%\rprogress"})
+
+	m.mu.Lock()
+	require.Len(t, m.lines, 1)
+	require.Equal(t, "downloading 50%progress", m.lines[0])
+	require.NotContains(t, m.lines[0], "\r")
+	m.mu.Unlock()
+	close(lines)
+	close(errs)
+}
+
+func TestSetContent_StripsCR(t *testing.T) {
+	m := testModel()
+	m.SetContent("line1\r\nline2\r\nline3")
+	m.mu.Lock()
+	for _, line := range m.lines {
+		require.NotContains(t, line, "\r")
+	}
+	require.Len(t, m.lines, 3)
+	require.Equal(t, "line1", m.lines[0])
+	require.Equal(t, "line2", m.lines[1])
+	require.Equal(t, "line3", m.lines[2])
+	m.mu.Unlock()
+}
+
+func TestBuildContent_NoWrap_ANSIAware(t *testing.T) {
+	m := testModel()
+	m.viewport.Width = 20
+	m.setWrap(false)
+
+	// Line with ANSI color codes (like formatLogLineWithNode produces)
+	ansiLine := "\033[38;5;117mweb.task@node\033[0m | hello world message here"
+	m.mu.Lock()
+	m.lines = []string{ansiLine}
+	m.lineNodes = []string{"node1"}
+	m.mu.Unlock()
+
+	content := m.buildContent()
+
+	// Content should not contain broken ANSI sequences (partial escape without 'm')
+	// A broken sequence would look like \033[38;5; without the closing digit+m
+	require.NotContains(t, content, "\033[38;5;1>")
+	require.NotContains(t, content, "\033[38;5;11>")
+	// The truncated content should end with > indicator since the line is long
+	require.Contains(t, content, ">")
+}
+
 func TestShouldFallbackToRawFromStdCopy(t *testing.T) {
 	tests := []struct {
 		name string

--- a/views/logs/update.go
+++ b/views/logs/update.go
@@ -6,9 +6,11 @@ package logsview
 import (
 	"fmt"
 	"strings"
+	"swarmcli/ui"
 	"swarmcli/utils"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
 	"github.com/muesli/reflow/wordwrap"
 )
 
@@ -34,6 +36,9 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 		} else {
 			actualLine = msg.Line
 		}
+
+		// Strip carriage returns that break frame rendering (progress bars, CRLF)
+		actualLine = strings.ReplaceAll(actualLine, "\r", "")
 
 		// append line into bounded buffer (store both line and node)
 		m.mu.Lock()
@@ -254,6 +259,7 @@ func (m *Model) readOneLineCmd() tea.Cmd {
 
 func (m *Model) SetContent(content string) {
 	m.mu.Lock()
+	content = strings.ReplaceAll(content, "\r", "")
 	m.lines = strings.Split(content, "\n")
 	if m.MaxLines > 0 && len(m.lines) > m.MaxLines {
 		// keep only last MaxLines
@@ -352,21 +358,21 @@ func (m *Model) buildContent() string {
 		// Wrap the entire content to viewport width
 		full = wordwrap.String(full, m.viewport.Width)
 	} else if (!m.wrap || m.nodeSelectVisible) && m.viewport.Width > 0 {
-		// When wrap is off, apply horizontal scrolling
+		// When wrap is off, apply horizontal scrolling using ANSI-aware operations
+		// to avoid splitting escape sequences in colored log lines.
 		processedLines := make([]string, len(filteredLines))
 
 		for i, line := range filteredLines {
-			if len(line) <= m.horizontalOffset {
-				// Line is shorter than offset, show empty
+			lineWidth := lipgloss.Width(line)
+			if lineWidth <= m.horizontalOffset {
 				processedLines[i] = ""
 			} else {
-				// Apply horizontal offset
-				visiblePart := line[m.horizontalOffset:]
+				visiblePart := ui.TruncateANSIAfter(line, m.horizontalOffset)
+				visibleWidth := lipgloss.Width(visiblePart)
 
-				if len(visiblePart) > m.viewport.Width {
-					// Truncate and add > indicator
+				if visibleWidth > m.viewport.Width {
 					if m.viewport.Width > 1 {
-						processedLines[i] = visiblePart[:m.viewport.Width-1] + ">"
+						processedLines[i] = ui.TruncateANSI(visiblePart, m.viewport.Width-1) + ">"
 					} else {
 						processedLines[i] = ">"
 					}


### PR DESCRIPTION
## Summary
- Strip `\r` (carriage return) from Docker log lines before storing, preventing terminal cursor resets that overwrite the left frame border `│`
- Replace byte-based string slicing in the no-wrap horizontal scroll path with ANSI-aware `TruncateANSI`/`TruncateANSIAfter`, preventing split escape sequences from corrupting the frame

Fixes #256

## Test plan
- [x] `TestLineMsg_StripsCR` — `\r` stripped from received log lines
- [x] `TestSetContent_StripsCR` — `\r` stripped in SetContent
- [x] `TestBuildContent_NoWrap_ANSIAware` — ANSI lines truncated without breaking escape sequences
- [x] Full test suite passes (`go test ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)