### PR TITLE
refactor: separate docker events from Bubble Tea TUI layer

### DIFF
--- a/app/model.go
+++ b/app/model.go
@@ -94,7 +94,7 @@ func (m *Model) Init() tea.Cmd {
 		loadSnapshotAsync(),
 		m.systemInfo.LoadStatus(),
 		m.systemInfo.Init(), // Initialize systeminfo's tick commands
-		docker.WatchEventsCmd(),
+		watchEventsCmd(),
 	)
 }
 

--- a/app/update.go
+++ b/app/update.go
@@ -28,7 +28,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	}
 
 	switch msg := msg.(type) {
-	case docker.EventMsg:
+	case docker.Event:
 		// On Docker events, trigger a background refresh and, if currently
 		// viewing stacks/nodes, trigger a reload so the UI updates quickly using cached data.
 		docker.TriggerRefreshIfNeeded()
@@ -36,16 +36,16 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		switch msg.Type {
 		case "node":
 			if nv, ok := m.currentView.(*nodesview.Model); ok {
-				return m, tea.Batch(nv.LoadNodesCmd(), docker.WatchEventsCmd())
+				return m, tea.Batch(nv.LoadNodesCmd(), watchEventsCmd())
 			}
 		case "service", "config", "network":
 			if sv, ok := m.currentView.(*stacksview.Model); ok {
 				// Use cached snapshot to update stacks quickly
-				return m, tea.Batch(sv.LoadStacksCmd(""), docker.WatchEventsCmd())
+				return m, tea.Batch(sv.LoadStacksCmd(""), watchEventsCmd())
 			}
 		}
 		// Re-issue watcher after handling
-		return m, docker.WatchEventsCmd()
+		return m, watchEventsCmd()
 	case snapshotLoadedMsg:
 		if msg.Err != nil {
 			// Replace with error message in the loading view
@@ -499,4 +499,11 @@ func (m *Model) goBack() tea.Cmd {
 
 	// Execute all lifecycle commands
 	return tea.Batch(exitCmd, enterCmd, resizeCmd)
+}
+
+// watchEventsCmd wraps docker.WatchEvent in a tea.Cmd for the Bubble Tea event loop.
+func watchEventsCmd() tea.Cmd {
+	return func() tea.Msg {
+		return docker.WatchEvent()
+	}
 }

--- a/docker/event_ops.go
+++ b/docker/event_ops.go
@@ -3,13 +3,11 @@
 
 package docker
 
-import tea "github.com/charmbracelet/bubbletea"
-
 // EventOps abstracts Docker event watching for testability and extensibility.
 type EventOps interface {
-	WatchEventsCmd() tea.Cmd
+	WatchEvent() Event
 }
 
 type defaultEventOps struct{}
 
-func (defaultEventOps) WatchEventsCmd() tea.Cmd { return WatchEventsCmd() }
+func (defaultEventOps) WatchEvent() Event { return WatchEvent() }

--- a/docker/events.go
+++ b/docker/events.go
@@ -7,51 +7,48 @@ import (
 	"context"
 	"time"
 
-	tea "github.com/charmbracelet/bubbletea"
 	"github.com/docker/docker/api/types/events"
 	"github.com/docker/docker/api/types/filters"
 )
 
-// EventMsg is emitted when a relevant Docker event occurs.
-type EventMsg struct {
+// Event represents a Docker event (or an error/timeout while watching).
+type Event struct {
 	Type   string
 	Action string
 	Err    error
 }
 
-// WatchEventsCmd listens for Docker events (service/config/network/node changes)
-// using the Docker SDK and returns a single EventMsg when an event is observed.
-// The command should be re-issued after handling to continue watching.
-func WatchEventsCmd() tea.Cmd {
-	return func() tea.Msg {
-		cli, err := GetClient()
-		if err != nil {
-			return EventMsg{Err: err}
-		}
-		ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
-		defer cancel()
+// WatchEvent listens for Docker events (service/config/network/node changes)
+// using the Docker SDK and returns a single Event when one is observed.
+// This is a blocking call; callers should wrap it in a goroutine or tea.Cmd.
+func WatchEvent() Event {
+	cli, err := GetClient()
+	if err != nil {
+		return Event{Err: err}
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
 
-		f := filters.NewArgs()
-		f.Add("type", "service")
-		f.Add("type", "config")
-		f.Add("type", "network")
-		f.Add("type", "node")
+	f := filters.NewArgs()
+	f.Add("type", "service")
+	f.Add("type", "config")
+	f.Add("type", "network")
+	f.Add("type", "node")
 
-		opts := events.ListOptions{Filters: f}
-		// The Docker SDK cleans up the event stream goroutine when ctx is cancelled.
-		msgs, errs := cli.Events(ctx, opts)
+	opts := events.ListOptions{Filters: f}
+	// The Docker SDK cleans up the event stream goroutine when ctx is cancelled.
+	msgs, errs := cli.Events(ctx, opts)
 
-		for {
-			select {
-			case ev := <-msgs:
-				return EventMsg{Type: string(ev.Type), Action: string(ev.Action)}
-			case e := <-errs:
-				if e != nil {
-					return EventMsg{Err: e}
-				}
-			case <-ctx.Done():
-				return EventMsg{Type: "timeout", Action: "timeout"}
+	for {
+		select {
+		case ev := <-msgs:
+			return Event{Type: string(ev.Type), Action: string(ev.Action)}
+		case e := <-errs:
+			if e != nil {
+				return Event{Err: e}
 			}
+		case <-ctx.Done():
+			return Event{Type: "timeout", Action: "timeout"}
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- Removed `bubbletea` dependency from the `docker/` package entirely
- Renamed `docker.EventMsg` → `docker.Event` and `docker.WatchEventsCmd() tea.Cmd` → `docker.WatchEvent() Event` (pure blocking function)
- Added `watchEventsCmd()` wrapper in `app/update.go` that wraps the pure call in a `tea.Cmd` closure — matching the pattern already used for every other docker operation

Closes #148

## Manual test: verify Docker events still refresh the UI

The event watcher drives live UI updates when Docker resources change. To verify:

1. **Start a Swarm** (`./test-setup/testenv.sh up && ./test-setup/testenv.sh deploy`)
2. **Run swarmcli** (`go run .`) — lands on the **Stacks** view
3. **In a separate terminal**, scale a service: `docker service scale <stack>_<service>=3`
4. **Observe the Stacks view** — the replica count should update automatically within a few seconds without pressing any key
5. **Navigate to the Nodes view**, then run `docker node update --label-add test=true <node-id>` — the nodes list should refresh automatically

If both views update reactively without manual refresh, the event watcher is working correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)