### PR TITLE
refactor: aggregate systeminfo messages via marker interface

### DIFF
--- a/app/update.go
+++ b/app/update.go
@@ -206,25 +206,8 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tickMsg:
 		return m.handleTick(msg)
 
-	case systeminfoview.Msg:
-		var cmd tea.Cmd
-		cmd = m.systemInfo.Update(msg)
-		return m, cmd
-
-	case systeminfoview.SlowStatusMsg:
-		var cmd tea.Cmd
-		cmd = m.systemInfo.Update(msg)
-		return m, cmd
-
-	case systeminfoview.TickMsg:
-		var cmd tea.Cmd
-		cmd = m.systemInfo.Update(msg)
-		return m, cmd
-
-	case systeminfoview.SpinnerTickMsg:
-		var cmd tea.Cmd
-		cmd = m.systemInfo.Update(msg)
-		return m, cmd
+	case systeminfoview.SystemInfoMsg:
+		return m, m.systemInfo.Update(msg)
 
 	case contextsview.ContextChangedNotification:
 		// Context has changed - show loading view then navigate to stacks

--- a/views/systeminfo/messages.go
+++ b/views/systeminfo/messages.go
@@ -5,6 +5,17 @@ package systeminfoview
 
 import "time"
 
+// SystemInfoMsg is implemented by all messages owned by the systeminfo component.
+// The app-level router uses this to forward messages without listing each type.
+type SystemInfoMsg interface {
+	systemInfoMsg()
+}
+
+func (Msg) systemInfoMsg()            {}
+func (SlowStatusMsg) systemInfoMsg()  {}
+func (TickMsg) systemInfoMsg()        {}
+func (SpinnerTickMsg) systemInfoMsg() {}
+
 type Msg struct {
 	context     string
 	cpu         string


### PR DESCRIPTION
## Summary
- Introduces a `SystemInfoMsg` marker interface in the systeminfo package, implemented by all four message types (`Msg`, `SlowStatusMsg`, `TickMsg`, `SpinnerTickMsg`)
- Collapses four identical case branches in `app/update.go` into a single interface match
- New systeminfo message types now route automatically without touching the app-level router

Closes #114

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./...` passes (including `views/systeminfo`)
- [x] Manual smoke test: system header updates CPU/MEM with spinners and trend arrows as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)