### PR TITLE
fix: app-level error dialog, remove error handling from loadingView

### DIFF
--- a/app/model.go
+++ b/app/model.go
@@ -6,6 +6,7 @@ package app
 import (
 	"swarmcli/docker"
 	"swarmcli/views/commandinput"
+	"swarmcli/views/confirmdialog"
 	loadingview "swarmcli/views/loading"
 	"swarmcli/views/searchinput"
 	systeminfoview "swarmcli/views/systeminfo"
@@ -29,6 +30,12 @@ type Model struct {
 
 	commandInput *commandinput.Model
 	searchInput  *searchinput.Model
+
+	// App-level error dialog for loading/navigation errors.
+	// Per-view confirmdialog stays for operation errors (scale, restart, etc.).
+	errorDialog          *confirmdialog.Model
+	appErrorDialogActive bool
+	errorFallbackView    string // view to navigate to on dismiss; "" = goBack()
 
 	// Terminal dimensions
 	terminalWidth  int
@@ -80,6 +87,7 @@ func InitialModel() *Model {
 		viewStack:      viewstack.Stack{},
 		commandInput:   cmdBar(),
 		searchInput:    searchinput.New(),
+		errorDialog:    confirmdialog.New(terminalWidth, terminalHeight),
 		terminalWidth:  terminalWidth,
 		terminalHeight: terminalHeight,
 	}
@@ -153,4 +161,12 @@ func (m *Model) renderStackBar() string {
 func cmdBar() *commandinput.Model {
 	cmdBar := commandinput.New()
 	return cmdBar
+}
+
+func (m *Model) showAppError(errMsg string, fallbackView string) {
+	m.errorDialog.Visible = true
+	m.errorDialog.ErrorMode = true
+	m.errorDialog.Message = errMsg
+	m.appErrorDialogActive = true
+	m.errorFallbackView = fallbackView
 }

--- a/app/update.go
+++ b/app/update.go
@@ -9,6 +9,7 @@ import (
 	"swarmcli/commands/api"
 	"swarmcli/docker"
 	"swarmcli/views/commandinput"
+	"swarmcli/views/confirmdialog"
 	contextsview "swarmcli/views/contexts"
 	loadingview "swarmcli/views/loading"
 	nodesview "swarmcli/views/nodes"
@@ -48,9 +49,8 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, watchEventsCmd()
 	case snapshotLoadedMsg:
 		if msg.Err != nil {
-			// Replace with error message in the loading view
-			cmd := m.replaceView(loadingview.ViewName, fmt.Sprintf("Error loading snapshot: %v", msg.Err))
-			return m, cmd
+			m.showAppError(fmt.Sprintf("Error loading snapshot: %v", msg.Err), contextsview.ViewName)
+			return m, nil
 		}
 		// Replace loading with stacks view
 		cmd := m.replaceView(stacksview.ViewName, nil)
@@ -97,6 +97,12 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case tea.KeyMsg:
+		// If app-level error dialog is active, route all keys to handleKey
+		// which forwards them to the dialog exclusively.
+		if m.appErrorDialogActive {
+			return m.handleKey(msg)
+		}
+
 		if msg.String() == ":" {
 			// Check if current view has an active dialog - if so, don't intercept
 			if viewWithDialog, ok := m.currentView.(interface {
@@ -227,9 +233,24 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			loadSnapshotAndNavigateToStacksCmd(),
 		)
 
-	case loadingview.ErrorDismissedMsg:
-		// Navigate to contexts view from loading error screen
-		cmd := m.replaceView(contextsview.ViewName, nil)
+	case view.AppErrorMsg:
+		m.showAppError(msg.Error, msg.FallbackView)
+		return m, nil
+
+	case confirmdialog.ResultMsg:
+		if m.appErrorDialogActive {
+			m.appErrorDialogActive = false
+			m.errorDialog.Visible = false
+			fallback := m.errorFallbackView
+			m.errorFallbackView = ""
+			if fallback != "" {
+				cmd := m.replaceView(fallback, nil)
+				return m, cmd
+			}
+			cmd := m.goBack()
+			return m, cmd
+		}
+		cmd := m.delegateToCurrentView(msg)
 		return m, cmd
 
 	default:
@@ -321,6 +342,12 @@ func (m *Model) updateViewports(msg tea.Msg) tea.Cmd {
 }
 
 func (m *Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	// If app-level error dialog is active, forward keys to it exclusively
+	if m.appErrorDialogActive {
+		cmd := m.errorDialog.Update(msg)
+		return m, cmd
+	}
+
 	// If current view has an active dialog, forward keys to it first
 	if viewWithDialog, ok := m.currentView.(interface{ HasActiveDialog() bool }); ok {
 		if viewWithDialog.HasActiveDialog() {

--- a/app/view.go
+++ b/app/view.go
@@ -18,7 +18,8 @@ func (m *Model) View() string {
 		title := m.currentView.FrameTitle()
 		header := m.currentView.FrameHeader()
 		content := m.currentView.FrameContent()
-		return ui.RenderViewFrame(title, header, content, "", m.terminalWidth, m.terminalHeight, true)
+		out := ui.RenderViewFrame(title, header, content, "", m.terminalWidth, m.terminalHeight, true)
+		return m.overlayAppError(out)
 	}
 
 	systemInfo := m.systemInfo.View()
@@ -61,13 +62,14 @@ func (m *Model) View() string {
 		frameWidth := m.viewport.Width + 4
 		cmdFrame := ui.RenderFramedBoxHeight("", "", m.commandInput.View(), "", frameWidth, cmdFrameHeight)
 
-		return lipgloss.JoinVertical(
+		out := lipgloss.JoinVertical(
 			lipgloss.Left,
 			help,
 			cmdFrame,
 			framedView,
 			m.renderStackBar(),
 		)
+		return m.overlayAppError(out)
 	}
 
 	if m.searchInput.Visible() {
@@ -81,13 +83,14 @@ func (m *Model) View() string {
 		frameWidth := m.viewport.Width + 4
 		searchFrame := ui.RenderFramedBoxHeight("", "", m.searchInput.View(), "", frameWidth, searchFrameHeight)
 
-		return lipgloss.JoinVertical(
+		out := lipgloss.JoinVertical(
 			lipgloss.Left,
 			help,
 			searchFrame,
 			framedView,
 			m.renderStackBar(),
 		)
+		return m.overlayAppError(out)
 	}
 
 	if frameHeight < 1 {
@@ -95,10 +98,19 @@ func (m *Model) View() string {
 	}
 	framedView := ui.RenderViewFrame(title, header, content, footer, m.viewport.Width, frameHeight, false)
 
-	return lipgloss.JoinVertical(
+	out := lipgloss.JoinVertical(
 		lipgloss.Left,
 		help,
 		framedView,
 		m.renderStackBar(),
 	)
+	return m.overlayAppError(out)
+}
+
+// overlayAppError overlays the app-level error dialog on top of the rendered output.
+func (m *Model) overlayAppError(base string) string {
+	if !m.errorDialog.Visible {
+		return base
+	}
+	return ui.OverlayCentered(base, m.errorDialog.View(), m.terminalWidth, 0)
 }

--- a/views/loading/loading.go
+++ b/views/loading/loading.go
@@ -11,16 +11,12 @@ import (
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
-	"github.com/charmbracelet/lipgloss"
 )
 
 const ViewName = "loading"
 
 // SpinnerTickMsg for animating the spinner
 type SpinnerTickMsg time.Time
-
-// ErrorDismissedMsg is sent when user presses Enter on an error screen
-type ErrorDismissedMsg struct{}
 
 type Model struct {
 	width, height int
@@ -29,7 +25,6 @@ type Model struct {
 	message       string
 	spinner       int // frame counter for spinner animation
 	visible       bool
-	isError       bool
 }
 
 func New(width, height int, visible bool, payload any) *Model {
@@ -65,8 +60,7 @@ func New(width, height int, visible bool, payload any) *Model {
 		}
 	}
 
-	isError := strings.HasPrefix(message, "Error")
-	return &Model{width: width, height: height, title: title, header: header, message: message, spinner: 0, visible: visible, isError: isError}
+	return &Model{width: width, height: height, title: title, header: header, message: message, spinner: 0, visible: visible}
 }
 
 func (m *Model) Visible() bool        { return m.visible }
@@ -94,13 +88,6 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 		m.width = msg.Width + 4
 		m.height = msg.Height
 		return nil
-	case tea.KeyMsg:
-		if m.isError && msg.String() == "enter" {
-			// Emit generic error dismissed message
-			return func() tea.Msg {
-				return ErrorDismissedMsg{}
-			}
-		}
 	}
 	return nil
 }
@@ -110,17 +97,6 @@ func (m *Model) FrameHeader() string { return m.header }
 func (m *Model) FrameFooter() string { return "" }
 
 func (m *Model) FrameContent() string {
-	if m.isError {
-		// Return empty content with error dialog overlay
-		frameWidth := m.width
-		if frameWidth < 0 {
-			frameWidth = 80
-		}
-		frame := ui.ComputeFrameDimensions(frameWidth-4, m.height, frameWidth-4, m.height, "", "")
-		emptyContent := ui.TrimOrPadContentToLines("", frame.DesiredContentLines)
-		errorDialog := m.renderErrorDialog()
-		return ui.OverlayCentered(emptyContent, errorDialog, frameWidth, 0)
-	}
 	spinnerChar := ui.SpinnerCharAt(m.spinner)
 	return strings.TrimSpace(fmt.Sprintf("%s  %s", spinnerChar, m.message))
 }
@@ -130,12 +106,6 @@ func (m *Model) View() string {
 		return ""
 	}
 
-	if m.isError {
-		// Render error as a styled popup dialog (legacy path)
-		return m.renderErrorDialog()
-	}
-
-	// Normal loading view
 	spinnerChar := ui.SpinnerCharAt(m.spinner)
 	content := fmt.Sprintf("%s  %s", spinnerChar, m.message)
 	content = strings.TrimSpace(content)
@@ -149,52 +119,6 @@ func (m *Model) View() string {
 	}
 	box := ui.RenderFramedBoxHeight(m.title, m.header, content, "", frameWidth, frameHeight)
 	return box
-}
-
-// renderErrorDialog renders the error dialog with red styling
-func (m *Model) renderErrorDialog() string {
-	titleStyle := lipgloss.NewStyle().
-		Bold(true).
-		Foreground(lipgloss.Color("15")).
-		Background(lipgloss.Color("196")). // Red background for error
-		Padding(0, 1)
-
-	borderStyle := lipgloss.NewStyle().
-		Border(lipgloss.RoundedBorder()).
-		BorderForeground(lipgloss.Color("196")) // Red border
-
-	itemStyle := lipgloss.NewStyle().
-		Padding(0, 1)
-
-	helpStyle := lipgloss.NewStyle().
-		Foreground(lipgloss.Color("240")).
-		Padding(0, 1)
-
-	keyStyle := lipgloss.NewStyle().
-		Foreground(lipgloss.Color("63")).
-		Bold(true)
-
-	var lines []string
-	lines = append(lines, titleStyle.Render(" Error "))
-	lines = append(lines, itemStyle.Render(""))
-
-	// Wrap error message if too long
-	maxWidth := 70
-	wrappedLines := ui.WrapText(m.message, maxWidth)
-	for _, line := range wrappedLines {
-		lines = append(lines, itemStyle.Render(line))
-	}
-
-	lines = append(lines, itemStyle.Render(""))
-	helpText := fmt.Sprintf("%s %s %s",
-		helpStyle.Render("Press"),
-		keyStyle.Render("<Enter>"),
-		helpStyle.Render("to go to contexts view"))
-	lines = append(lines, helpText)
-
-	content := lipgloss.JoinVertical(lipgloss.Left, lines...)
-	dialog := borderStyle.Render(content)
-	return dialog
 }
 
 func (m *Model) ShortHelpItems() []helpbar.HelpEntry {

--- a/views/loading/loading_test.go
+++ b/views/loading/loading_test.go
@@ -40,11 +40,6 @@ func TestNew_NilPayload(t *testing.T) {
 	require.Equal(t, "Please wait...", m.message)
 }
 
-func TestNew_ErrorMessage_SetsErrorMode(t *testing.T) {
-	m := New(80, 24, true, "Error: connection refused")
-	require.True(t, m.isError)
-}
-
 func TestVisible(t *testing.T) {
 	m := New(80, 24, false, nil)
 	require.False(t, m.Visible())
@@ -72,21 +67,6 @@ func TestWindowSizeMsg(t *testing.T) {
 	require.Equal(t, 50, m.height)
 }
 
-func TestErrorMode_EnterDismisses(t *testing.T) {
-	m := New(80, 24, true, "Error: timeout")
-	cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
-	require.NotNil(t, cmd)
-	msg := cmd()
-	_, ok := msg.(ErrorDismissedMsg)
-	require.True(t, ok)
-}
-
-func TestNonError_EnterIgnored(t *testing.T) {
-	m := New(80, 24, true, "Loading...")
-	cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
-	require.Nil(t, cmd)
-}
-
 func TestView_NotVisible_Empty(t *testing.T) {
 	m := New(80, 24, false, nil)
 	require.Equal(t, "", m.View())
@@ -96,13 +76,6 @@ func TestView_Visible_ContainsMessage(t *testing.T) {
 	m := New(80, 24, true, "Loading secrets...")
 	out := m.View()
 	require.Contains(t, out, "Loading secrets...")
-}
-
-func TestView_ErrorMode_ContainsError(t *testing.T) {
-	m := New(80, 24, true, "Error: cannot connect")
-	out := m.View()
-	require.Contains(t, out, "Error")
-	require.Contains(t, out, "cannot connect")
 }
 
 func TestShortHelpItems(t *testing.T) {

--- a/views/tasks/update.go
+++ b/views/tasks/update.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"sort"
 	hash "swarmcli/core/primitives/hash"
-	"swarmcli/docker"
 	"swarmcli/ui"
 	helpview "swarmcli/views/help"
 	view "swarmcli/views/view"
@@ -20,9 +19,11 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 	case TasksLoadedMsg:
 		if msg.Error != nil {
 			l().Errorf("Error loading tasks: %v", msg.Error)
-			m.tasks = []docker.TaskEntry{}
-			m.viewport.SetContent(fmt.Sprintf("Error loading tasks: %v\n\nPress Esc or q to go back.", msg.Error))
-			return nil
+			return func() tea.Msg {
+				return view.AppErrorMsg{
+					Error: fmt.Sprintf("Error loading tasks: %v", msg.Error),
+				}
+			}
 		}
 		m.tasks = msg.Tasks
 		// Compute and store hash for change detection

--- a/views/view/navigation.go
+++ b/views/view/navigation.go
@@ -11,3 +11,11 @@ type NavigateToMsg struct {
 	// the view manager should push the new view onto the history stack.
 	Replace bool
 }
+
+// AppErrorMsg signals that a view (or the app layer) encountered a loading
+// error. The app shows a modal error dialog. On dismiss it navigates to
+// FallbackView (if non-empty) or calls goBack().
+type AppErrorMsg struct {
+	Error        string
+	FallbackView string
+}


### PR DESCRIPTION
## Summary

- **loadingView** stripped of all error handling — now a pure spinner. No more `strings.HasPrefix(message, "Error")` content sniffing or hardcoded "go to contexts view" navigation.
- **App-level error dialog** added to `app.Model`, reusing `confirmdialog` with `ErrorMode`. Any view can emit `view.AppErrorMsg` to trigger it; the app decides where to navigate on dismiss via `FallbackView`.
- **Tasks view** migrated from inline viewport error text to `AppErrorMsg` — dismiss goes back to the parent view.
- Snapshot load errors now show the app error dialog over the loading spinner, with contexts view as the fallback on dismiss (same UX, proper separation of concerns).

Closes #131, closes #52

## Test plan

- [x] `go build` / `go test ./...` / `golangci-lint` all pass
- [x] Start app with unreachable Docker host → error dialog appears over loading spinner → Enter navigates to contexts view
- [x] Switch to invalid context → loading spinner → error dialog → Enter → contexts view
- [x] Normal startup → loading spinner → stacks view (no regression)
- [ ] Navigate to tasks of a service that fails to load → error dialog → dismiss returns to previous view

🤖 Generated with [Claude Code](https://claude.com/claude-code)