### PR TITLE
fix: revert context on failed switch

### DIFF
--- a/app/model.go
+++ b/app/model.go
@@ -41,6 +41,9 @@ type Model struct {
 	terminalWidth  int
 	terminalHeight int
 
+	// Previous context name, set on context switch for revert on failure
+	previousContext string
+
 	// Fullscreen mode — hides helpbar/stackbar, uses full terminal
 	fullscreen bool
 }

--- a/app/update.go
+++ b/app/update.go
@@ -49,9 +49,20 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, watchEventsCmd()
 	case snapshotLoadedMsg:
 		if msg.Err != nil {
-			m.showAppError(fmt.Sprintf("Error loading snapshot: %v", msg.Err), contextsview.ViewName)
+			if m.previousContext != "" {
+				_ = docker.UseContext(m.previousContext)
+				docker.ResetClient()
+				m.previousContext = ""
+				m.showAppError(
+					fmt.Sprintf("Error loading snapshot: %v\n\nReverted to previous context.", msg.Err),
+					contextsview.ViewName,
+				)
+			} else {
+				m.showAppError(fmt.Sprintf("Error loading snapshot: %v", msg.Err), contextsview.ViewName)
+			}
 			return m, nil
 		}
+		m.previousContext = ""
 		// Replace loading with stacks view
 		cmd := m.replaceView(stacksview.ViewName, nil)
 		return m, cmd
@@ -217,6 +228,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case contextsview.ContextChangedNotification:
 		// Context has changed - show loading view then navigate to stacks
+		m.previousContext = msg.PreviousContext
 		// Close cached Docker client so a fresh one is created for the new context
 		docker.ResetClient()
 		// Invalidate snapshot cache so stacks load fresh data for new context

--- a/docker/context.go
+++ b/docker/context.go
@@ -13,6 +13,8 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+
+	"github.com/docker/docker/api/types/swarm"
 )
 
 // ContextArchiveExts lists supported Docker context archive extensions.
@@ -173,6 +175,17 @@ func ValidateContext(contextName string) error {
 		// Switch back to original context
 		_ = UseContext(currentCtx)
 		return fmt.Errorf("failed to ping context %s: %w", contextName, err)
+	}
+
+	// Verify the node is part of a Swarm cluster
+	info, err := cli.Info(ctx)
+	if err != nil {
+		_ = UseContext(currentCtx)
+		return fmt.Errorf("failed to query info for context %s: %w", contextName, err)
+	}
+	if info.Swarm.LocalNodeState != swarm.LocalNodeStateActive {
+		_ = UseContext(currentCtx)
+		return fmt.Errorf("context %s is not part of a Docker Swarm cluster", contextName)
 	}
 
 	return nil

--- a/views/contexts/messages.go
+++ b/views/contexts/messages.go
@@ -72,7 +72,9 @@ type ContextUpdatedMsg struct {
 
 // ContextChangedNotification is sent to notify the app that the Docker context has changed
 // and should navigate to stacks view
-type ContextChangedNotification struct{}
+type ContextChangedNotification struct {
+	PreviousContext string
+}
 
 // loadContextsCmd loads all Docker contexts
 func (m *Model) loadContextsCmd() func() tea.Msg {

--- a/views/contexts/update.go
+++ b/views/contexts/update.go
@@ -107,11 +107,19 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 		}
 		m.SetError("")
 		m.SetSuccess("")
+		// Find the previous context before refreshing the list
+		var previousCtx string
+		for _, ctx := range m.List.Items {
+			if ctx.Current {
+				previousCtx = ctx.Name
+				break
+			}
+		}
 		// Refresh contexts list and then navigate to stacks view
 		m.SetLoading(true)
 		return tea.Batch(
 			m.loadContextsCmd(),
-			func() tea.Msg { return ContextChangedNotification{} },
+			func() tea.Msg { return ContextChangedNotification{PreviousContext: previousCtx} },
 		)
 
 	case ContextExportedMsg:


### PR DESCRIPTION
## Summary

- **Swarm membership validation**: `ValidateContext` now checks `Info.Swarm.LocalNodeState` after ping succeeds, rejecting non-Swarm contexts before the switch is committed to `~/.docker/config.json`
- **Safety-net revert**: If snapshot loading fails after a committed context switch, the app automatically reverts to the previous context via `docker context use` and shows "Reverted to previous context" in the error dialog
- **Previous context propagation**: `ContextChangedNotification` now carries the previous context name through to the app layer for revert tracking

## Test plan

- [x] `go build` compiles
- [x] `go test ./...` passes
- [x] `golangci-lint run ./...` clean
- [x] Switch to non-Swarm context → ValidateContext fails with "not part of a Docker Swarm cluster" → error dialog in contexts view → previous context still active
- [x] Switch to Swarm context that goes down mid-load → snapshot error → reverts to previous context → error dialog says "Reverted to previous context"
- [x] Normal context switch → stacks load → no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)