### PR TITLE
fix: address review items 6 and test naming

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -44,13 +44,13 @@ func SetEdition(e string) {
 }
 
 func editionLabel(e string) string {
-	switch normalizeEdition(e) {
+	switch e {
 	case "ce":
 		return "Community Edition"
 	case "be":
 		return "Business Edition"
 	default:
-		return strings.ToUpper(strings.TrimSpace(e)) + " Edition"
+		return strings.ToUpper(e) + " Edition"
 	}
 }
 

--- a/views/systeminfo/systeminfo_test.go
+++ b/views/systeminfo/systeminfo_test.go
@@ -210,7 +210,7 @@ func TestCheckLatestVersion_NoMessageWhenNotNewer(t *testing.T) {
 	require.True(t, ok)
 }
 
-func TestCheckLatestVersion_FailureReturnsNilMsg(t *testing.T) {
+func TestCheckLatestVersion_FailureReturnsNoUpdate(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
 		_, _ = w.Write([]byte("boom"))


### PR DESCRIPTION
## Summary
- Remove redundant `normalizeEdition` call in `editionLabel` — input is already normalized by `SetEdition`, making the second normalization and the `strings.TrimSpace` in the default branch dead code (review item 6)
- Rename `TestCheckLatestVersion_FailureReturnsNilMsg` → `TestCheckLatestVersion_FailureReturnsNoUpdate` to match the actual assertion (`NoVersionUpdateMsg`, not nil)

## Test plan
- [x] `go build ./...`
- [x] `go test ./app/... ./views/systeminfo/... ./views/helpbar/...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)