### PR TITLE
fix: don't quit app when dismissing error dialog without fallback view

### DIFF
--- a/app/update.go
+++ b/app/update.go
@@ -247,8 +247,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				cmd := m.replaceView(fallback, nil)
 				return m, cmd
 			}
-			cmd := m.goBack()
-			return m, cmd
+			return m, nil
 		}
 		cmd := m.delegateToCurrentView(msg)
 		return m, cmd

--- a/commands/command/bootstrap.go
+++ b/commands/command/bootstrap.go
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package command
+
+import (
+	"swarmcli/args"
+	"swarmcli/registry"
+	"swarmcli/views/view"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+type Bootstrap struct{}
+
+func (Bootstrap) Name() string { return "bootstrap" }
+func (Bootstrap) Description() string {
+	return view.BEHelpDesc("bootstrap", "Deploy swarmcli infrastructure (rbac-proxy + agent)")
+}
+
+func (Bootstrap) Execute(_ any, _ args.Args) tea.Cmd {
+	return func() tea.Msg {
+		return view.AppErrorMsg{
+			Error: view.BEUnavailableErr("Bootstrap").Error(),
+		}
+	}
+}
+
+func init() {
+	registry.Register(Bootstrap{})
+}


### PR DESCRIPTION
## Summary
- Dismissing an `AppErrorMsg` error dialog (e.g. from `:bootstrap`) with no `FallbackView` called `goBack()`, which returns `tea.Quit` at the root view — quitting the app
- Now it simply closes the dialog and stays on the current view

## Test plan
- [ ] `go build` succeeds
- [ ] `go test ./...` passes
- [ ] `golangci-lint run ./...` clean
- [ ] Manual: run `:bootstrap` → error dialog → press Enter → app stays open

🤖 Generated with [Claude Code](https://claude.com/claude-code)