### PR TITLE
fix: refresh expanded tasks from fresh snapshot

### DIFF
--- a/views/services/messages.go
+++ b/views/services/messages.go
@@ -54,3 +54,8 @@ type TasksLoadedMsg struct {
 	ServiceID string
 	Tasks     []docker.TaskEntry
 }
+
+// AllTasksLoadedMsg carries refreshed tasks for all expanded services at once.
+type AllTasksLoadedMsg struct {
+	Tasks map[string][]docker.TaskEntry
+}

--- a/views/services/model.go
+++ b/views/services/model.go
@@ -173,7 +173,7 @@ func (m *Model) ShortHelpItems() []helpbar.HelpEntry {
 }
 
 func (m *Model) OnEnter() tea.Cmd {
-	return nil
+	return tickCmd()
 }
 
 func (m *Model) OnExit() tea.Cmd {

--- a/views/services/model_test.go
+++ b/views/services/model_test.go
@@ -302,6 +302,21 @@ func TestTasksLoadedMsg_StoresTasks(t *testing.T) {
 	require.Len(t, m.serviceTasks["id-web"], 1)
 }
 
+func TestAllTasksLoadedMsg_StoresAllTasks(t *testing.T) {
+	m := testModel()
+	loadServices(m, fakeEntries("web", "api"))
+	m.expandedServices["id-web"] = true
+	m.expandedServices["id-api"] = true
+	m.Update(AllTasksLoadedMsg{
+		Tasks: map[string][]docker.TaskEntry{
+			"id-web": {{ID: "t1", Name: "web.1"}},
+			"id-api": {{ID: "t2", Name: "api.1"}, {ID: "t3", Name: "api.2"}},
+		},
+	})
+	require.Len(t, m.serviceTasks["id-web"], 1)
+	require.Len(t, m.serviceTasks["id-api"], 2)
+}
+
 // --- Key routing tests ---
 
 func TestKey_S_OpensScaleDialog(t *testing.T) {

--- a/views/services/model_test.go
+++ b/views/services/model_test.go
@@ -291,6 +291,16 @@ func TestTickMsg_NotVisible_SchedulesTick(t *testing.T) {
 	require.NotNil(t, cmd)
 }
 
+func TestOnEnter_RestartsTickLoop(t *testing.T) {
+	m := testModel()
+	m.Visible = true
+	loadServices(m, fakeEntries("web"))
+
+	// Simulate returning from another view (e.g. logs) via goBack → OnEnter.
+	cmd := m.OnEnter()
+	require.NotNil(t, cmd, "OnEnter must return a tick command to restart polling")
+}
+
 func TestTasksLoadedMsg_StoresTasks(t *testing.T) {
 	m := testModel()
 	loadServices(m, fakeEntries("web"))

--- a/views/services/service.go
+++ b/views/services/service.go
@@ -93,37 +93,43 @@ func (m *Model) checkServicesCmd(lastHash uint64, filterType FilterType, nodeID,
 	}
 }
 
-// refreshExpandedTasksCmd refreshes tasks for all expanded services
+// refreshExpandedTasksCmd refreshes tasks for all expanded services.
+// It ensures the snapshot is fresh before reading tasks so that expanded
+// task rows update on the fly instead of showing stale cached data.
 func (m *Model) refreshExpandedTasksCmd(expandedServices map[string]bool) tea.Cmd {
 	if len(expandedServices) == 0 {
 		return nil
 	}
 
+	snapshotOps := m.deps.Snapshot
 	taskOps := m.deps.Tasks
 
-	// Create a batch of commands to fetch tasks for each expanded service
-	var cmds []tea.Cmd
-	for serviceID, expanded := range expandedServices {
+	// Copy expanded service IDs to avoid closing over the mutable map.
+	var serviceIDs []string
+	for sid, expanded := range expandedServices {
 		if expanded {
-			// Capture serviceID in closure
-			sid := serviceID
-			cmds = append(cmds, func() tea.Msg {
-				tasks, err := taskOps.GetTasksForService(sid)
-				if err != nil {
-					l().Errorf("Failed to refresh tasks for service %s: %v", sid, err)
-					tasks = []docker.TaskEntry{}
-				}
-				return TasksLoadedMsg{
-					ServiceID: sid,
-					Tasks:     tasks,
-				}
-			})
+			serviceIDs = append(serviceIDs, sid)
 		}
 	}
-
-	if len(cmds) == 0 {
+	if len(serviceIDs) == 0 {
 		return nil
 	}
 
-	return tea.Batch(cmds...)
+	return func() tea.Msg {
+		// Ensure the snapshot is fresh before reading tasks.
+		if _, err := snapshotOps.GetOrRefreshSnapshot(); err != nil {
+			l().Errorf("refreshExpandedTasksCmd: GetOrRefreshSnapshot failed: %v", err)
+		}
+
+		result := make(map[string][]docker.TaskEntry, len(serviceIDs))
+		for _, sid := range serviceIDs {
+			tasks, err := taskOps.GetTasksForService(sid)
+			if err != nil {
+				l().Errorf("Failed to refresh tasks for service %s: %v", sid, err)
+				tasks = []docker.TaskEntry{}
+			}
+			result[sid] = tasks
+		}
+		return AllTasksLoadedMsg{Tasks: result}
+	}
 }

--- a/views/services/update.go
+++ b/views/services/update.go
@@ -102,6 +102,13 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 		m.setRenderItem()
 		return nil
 
+	case AllTasksLoadedMsg:
+		for sid, tasks := range msg.Tasks {
+			m.serviceTasks[sid] = tasks
+		}
+		m.setRenderItem()
+		return nil
+
 	case tea.WindowSizeMsg:
 		m.List.Viewport.Width = msg.Width
 		m.List.Viewport.Height = msg.Height


### PR DESCRIPTION
## Summary

Fixes #284 — tasks in the services view now refresh on the fly while expanded.

### Root cause

`refreshExpandedTasksCmd` and `checkServicesCmd` are dispatched concurrently from the `TickMsg` handler (every 2s). `checkServicesCmd` calls `TriggerRefreshIfNeeded()` which starts an **async** (non-blocking) background goroutine to refresh the snapshot. Meanwhile, `refreshExpandedTasksCmd` calls `GetTasksForService()` → `GetSnapshot()` which returns the **stale** cached snapshot — the background refresh hasn't completed yet. On the next tick, the snapshot TTL (3s) often hasn't expired, so no new refresh is triggered. The result: tasks are perpetually read from stale data.

Collapsing and re-expanding works because the manual toggle happens at a different point in the refresh cycle — typically after the background refresh has completed — so `GetSnapshot()` returns fresh data.

### Fix

Replace the `tea.Batch` of per-service closures with a single `tea.Cmd` that calls `GetOrRefreshSnapshot()` (blocking, synchronous) **before** fetching tasks. This guarantees the global snapshot cache is fresh when `GetTasksForService()` reads from it. The blocking call runs in a goroutine (`tea.Cmd`), so it does not freeze the UI. When the snapshot is already fresh (within 3s TTL), `GetOrRefreshSnapshot()` returns instantly from cache.

### Flow after fix

```
TickMsg (every 2s)
  → checkServicesCmd goroutine (unchanged, async)
  → refreshExpandedTasksCmd goroutine:
      1. GetOrRefreshSnapshot()   ← blocks ~0.5s if stale, instant if fresh
      2. GetTasksForService(sid)  ← reads FRESH snapshot
      3. returns AllTasksLoadedMsg
  → Update() stores fresh tasks in m.serviceTasks
  → View() re-renders with updated task rows
```

## Test plan

- [x] Unit tests pass (`go test ./views/services/...`)
- [x] Lint passes (`golangci-lint run ./...`)
- [x] Build passes
- [ ] Manual: expand a service with `p`, scale/restart it, verify tasks update without collapsing

🤖 Generated with [Claude Code](https://claude.com/claude-code)