### PR TITLE
fix: forward `/` and `:` to active inputs

### DIFF
--- a/app/update.go
+++ b/app/update.go
@@ -126,6 +126,24 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				}
 			}
 
+			// If command input is already visible, forward ":" as text
+			if m.commandInput.Visible() {
+				cmd := m.commandInput.Update(msg)
+				return m, cmd
+			}
+			// If search input is actively being edited, forward ":" as text
+			if m.searchInput.Visible() && m.searchInput.Editing() {
+				cmd := m.searchInput.Update(msg)
+				return m, cmd
+			}
+			// If view has active internal search (ctrl+f), let it handle ":"
+			if searchView, ok := m.currentView.(interface{ IsSearching() bool }); ok {
+				if searchView.IsSearching() {
+					cmd := m.currentView.Update(msg)
+					return m, cmd
+				}
+			}
+
 			if m.searchInput.Visible() {
 				return m, nil
 			}
@@ -141,7 +159,6 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				resizeCmd := handleViewResize(m.currentView, m.viewport.Width, adjHeight, false)
 				return m, tea.Batch(cmd, resizeCmd)
 			}
-			// If already visible, consume it and do nothing
 			return m, nil
 		}
 
@@ -154,6 +171,16 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					cmd := m.currentView.Update(msg)
 					return m, cmd
 				}
+			}
+			// If command input is visible, forward "/" as text
+			if m.commandInput.Visible() {
+				cmd := m.commandInput.Update(msg)
+				return m, cmd
+			}
+			// If search input is actively being edited, forward "/" as text
+			if m.searchInput.Visible() && m.searchInput.Editing() {
+				cmd := m.searchInput.Update(msg)
+				return m, cmd
 			}
 			// If view doesn't implement Filterable, let it handle / itself
 			// (logs and inspect views have their own / search)
@@ -168,10 +195,6 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					cmd := m.currentView.Update(msg)
 					return m, cmd
 				}
-			}
-			// Don't open search if command input is visible
-			if m.commandInput.Visible() {
-				return m, nil
 			}
 			// If search box is passive (visible but not editing), resume editing
 			if m.searchInput.Visible() && !m.searchInput.Editing() {

--- a/app/update_test.go
+++ b/app/update_test.go
@@ -1,0 +1,163 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package app
+
+import (
+	"testing"
+
+	"swarmcli/views/commandinput"
+	"swarmcli/views/confirmdialog"
+	"swarmcli/views/helpbar"
+	"swarmcli/views/searchinput"
+	"swarmcli/views/view"
+	"swarmcli/views/viewstack"
+
+	"github.com/charmbracelet/bubbles/viewport"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/stretchr/testify/require"
+)
+
+// --- test helpers ---
+
+// stubView is a minimal view.View for testing key routing.
+type stubView struct{ name string }
+
+func (v *stubView) Update(tea.Msg) tea.Cmd              { return nil }
+func (v *stubView) View() string                        { return "" }
+func (v *stubView) Init() tea.Cmd                       { return nil }
+func (v *stubView) Name() string                        { return v.name }
+func (v *stubView) ShortHelpItems() []helpbar.HelpEntry { return nil }
+func (v *stubView) OnEnter() tea.Cmd                    { return nil }
+func (v *stubView) OnExit() tea.Cmd                     { return nil }
+func (v *stubView) HasErrors() bool                     { return false }
+func (v *stubView) FrameTitle() string                  { return "" }
+func (v *stubView) FrameHeader() string                 { return "" }
+func (v *stubView) FrameFooter() string                 { return "" }
+func (v *stubView) FrameContent() string                { return "" }
+
+// searchingStubView simulates a view with active internal search (ctrl+f).
+type searchingStubView struct {
+	stubView
+	received []tea.KeyMsg
+}
+
+func (v *searchingStubView) IsSearching() bool { return true }
+func (v *searchingStubView) Update(msg tea.Msg) tea.Cmd {
+	if k, ok := msg.(tea.KeyMsg); ok {
+		v.received = append(v.received, k)
+	}
+	return nil
+}
+
+func newTestAppModel(cv view.View) *Model {
+	return &Model{
+		viewport:       viewport.New(200, 50),
+		currentView:    cv,
+		viewStack:      viewstack.Stack{},
+		commandInput:   commandinput.New(),
+		searchInput:    searchinput.New(),
+		errorDialog:    confirmdialog.New(200, 50),
+		terminalWidth:  200,
+		terminalHeight: 50,
+	}
+}
+
+func runeKey(r rune) tea.KeyMsg {
+	return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}}
+}
+
+// findSubmitMsg extracts a commandinput.SubmitMsg from a tea.Cmd,
+// handling tea.Batch wrapping.
+func findSubmitMsg(cmd tea.Cmd) (commandinput.SubmitMsg, bool) {
+	if cmd == nil {
+		return commandinput.SubmitMsg{}, false
+	}
+	msg := cmd()
+	if sub, ok := msg.(commandinput.SubmitMsg); ok {
+		return sub, true
+	}
+	if batch, ok := msg.(tea.BatchMsg); ok {
+		for _, c := range batch {
+			if c == nil {
+				continue
+			}
+			if sub, ok := c().(commandinput.SubmitMsg); ok {
+				return sub, true
+			}
+		}
+	}
+	return commandinput.SubmitMsg{}, false
+}
+
+// --- Tests: "/" and ":" forwarded to search input while editing ---
+
+func TestSlashForwardedToSearchInput(t *testing.T) {
+	m := newTestAppModel(&stubView{name: "test"})
+	m.searchInput.Show()
+
+	m.Update(runeKey('a'))
+	m.Update(runeKey('/'))
+	m.Update(runeKey('b'))
+
+	require.True(t, m.searchInput.Editing())
+	require.Equal(t, "a/b", m.searchInput.Query())
+}
+
+func TestColonForwardedToSearchInput(t *testing.T) {
+	m := newTestAppModel(&stubView{name: "test"})
+	m.searchInput.Show()
+
+	m.Update(runeKey('a'))
+	m.Update(runeKey(':'))
+	m.Update(runeKey('b'))
+
+	require.True(t, m.searchInput.Editing())
+	require.Equal(t, "a:b", m.searchInput.Query())
+}
+
+// --- Tests: "/" and ":" forwarded to command input while visible ---
+
+func TestSlashForwardedToCommandInput(t *testing.T) {
+	m := newTestAppModel(&stubView{name: "test"})
+	m.commandInput.Show()
+
+	m.Update(runeKey('/'))
+
+	require.True(t, m.commandInput.Visible(), "commandInput should remain visible")
+	require.False(t, m.searchInput.Visible(), "searchInput should not have opened")
+
+	// Submit and verify "/" was captured as text
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	sub, ok := findSubmitMsg(cmd)
+	require.True(t, ok, "expected SubmitMsg")
+	require.Equal(t, "/", sub.Command)
+}
+
+func TestColonForwardedToCommandInput(t *testing.T) {
+	m := newTestAppModel(&stubView{name: "test"})
+	m.commandInput.Show()
+
+	m.Update(runeKey(':'))
+
+	require.True(t, m.commandInput.Visible(), "commandInput should remain visible")
+
+	// Submit and verify ":" was captured as text
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	sub, ok := findSubmitMsg(cmd)
+	require.True(t, ok, "expected SubmitMsg")
+	require.Equal(t, ":", sub.Command)
+}
+
+// --- Test: ":" forwarded to view during internal search (ctrl+f) ---
+
+func TestColonForwardedToViewDuringInternalSearch(t *testing.T) {
+	sv := &searchingStubView{stubView: stubView{name: "test"}}
+	m := newTestAppModel(sv)
+
+	m.Update(runeKey(':'))
+
+	require.False(t, m.commandInput.Visible(), "commandInput should not have opened")
+	require.Len(t, sv.received, 1, "view should have received the key")
+	require.Equal(t, ":", string(sv.received[0].Runes))
+}


### PR DESCRIPTION
## Summary
- Forward `/` and `:` as text to commandInput, searchInput, and view-internal search (ctrl+f) instead of swallowing them or triggering actions
- Fixes 5 related bugs in `app/update.go` where the `:` and `/` handlers ran before the input-forwarding logic
- Adds tests for all 5 cases

Fixes #300

## Test plan
- [ ] `go test ./app/... -run "TestSlash|TestColon"` — 5 new tests pass
- [x] `go test ./...` — full suite passes
- [ ] Manual: open search with `/`, type `/` and `:` — characters appear
- [ ] Manual: open command with `:`, type `:` and `/` — characters appear
- [ ] Manual: in logsview ctrl+f search, type `:` — character appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)