### PR TITLE
chore: add D0-dependency label and fix release drafter

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,7 @@ updates:
       - A3-technical
       - B0-low-priority
       - C0-breaks-nothing
+      - D0-dependency
 
   - package-ecosystem: github-actions
     directory: /
@@ -18,6 +19,7 @@ updates:
       - A3-technical
       - B0-low-priority
       - C0-breaks-nothing
+      - D0-dependency
 
   - package-ecosystem: docker
     directory: /
@@ -27,3 +29,4 @@ updates:
       - A3-technical
       - B0-low-priority
       - C0-breaks-nothing
+      - D0-dependency

--- a/.github/release_template.yml
+++ b/.github/release_template.yml
@@ -9,17 +9,20 @@ categories:
   - title: '⚡ Breaking API Changes'
     labels:
       - 'C1-breaking-change'
-  - title: ' [Bug Fixes] '
-    label:
-      - 'A2-bugfix'
   - title: '[UI]'
     labels:
       - 'A0-ui'
   - title: ' [Feature] '
-    label:
+    labels:
       - 'A1-feature'
+  - title: ' [Bug Fixes] '
+    labels:
+      - 'A2-bugfix'
+  - title: ' [Dependencies] '
+    labels:
+      - 'D0-dependency'
   - title: ' [Technical] '
-    label:
+    labels:
       - 'A3-technical'
 change-template: '- $TITLE (#$NUMBER) @$AUTHOR '
 change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.


### PR DESCRIPTION
## Summary
- Add `D0-dependency` label to all dependabot ecosystem entries for distinct categorization of dependency updates
- Fix `label:` → `labels:` bug in release_template.yml (Bug Fixes, Feature, Technical categories were silently ignored by release-drafter)
- Add `[Dependencies]` section to release drafter template
- Reorder release categories: UI → Feature → Bug Fixes → Dependencies → Technical

## Test plan
- [ ] Verify dependabot PRs get the D0-dependency label applied
- [ ] Verify release drafter categorizes dependency PRs under `[Dependencies]` section
- [ ] Create `D0-dependency` label on repo: `gh label create D0-dependency --color 0075ca --description "Dependency update"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)