### PR TITLE
chore: add go mod tidy CI check and dependabot auto-tidy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,11 @@ jobs:
       - name: Run go vet
         run: go vet ./...
 
+      - name: Check go mod tidy
+        run: |
+          go mod tidy
+          git diff --exit-code || (echo "Run go mod tidy locally" && exit 1)
+
   test:
     needs: [fmt, lint, vet]
     runs-on: ubuntu-latest

--- a/.github/workflows/dependabot-tidy.yml
+++ b/.github/workflows/dependabot-tidy.yml
@@ -1,0 +1,36 @@
+name: Dependabot go mod tidy
+
+on:
+  pull_request:
+    paths:
+      - 'go.mod'
+      - 'go.sum'
+
+permissions:
+  contents: write
+
+jobs:
+  tidy:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.head_ref }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
+        with:
+          go-version-file: go.mod
+
+      - name: Run go mod tidy
+        run: go mod tidy
+
+      - name: Push changes
+        run: |
+          git diff --quiet && exit 0
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add go.mod go.sum
+          git commit -m "chore: go mod tidy"
+          git push

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/muesli/termenv v0.16.0
 	github.com/stretchr/testify v1.11.1
 	go.uber.org/zap v1.27.1
+	golang.org/x/mod v0.34.0
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1
 	gopkg.in/yaml.v3 v3.0.1
 )
@@ -66,7 +67,6 @@ require (
 	go.opentelemetry.io/otel/metric v1.38.0 // indirect
 	go.opentelemetry.io/otel/trace v1.38.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
-	golang.org/x/mod v0.34.0 // indirect
 	golang.org/x/sys v0.38.0 // indirect
 	golang.org/x/term v0.1.0 // indirect
 	golang.org/x/text v0.31.0 // indirect


### PR DESCRIPTION
## Summary
- Add `go mod tidy` check to CI vet job to catch stale go.sum
- Add `dependabot-tidy.yml` workflow that auto-runs `go mod tidy` on dependabot PRs and pushes the fix

## Test plan
- [ ] Verify CI fails if go.sum is out of sync
- [ ] Verify dependabot PRs get auto-tidied

🤖 Generated with [Claude Code](https://claude.com/claude-code)