### PR TITLE
fix: populate Name in snapshot hash to prevent cursor jumping

### DIFF
--- a/views/configs/actions_test.go
+++ b/views/configs/actions_test.go
@@ -199,6 +199,31 @@ func TestCheckConfigsCmd_NoChange_ReturnsPollRetry(t *testing.T) {
 	require.True(t, isPollRetry, "should return PollRetryMsg when no change")
 }
 
+func TestCheckConfigsCmd_HashMatchesAfterLoad(t *testing.T) {
+	configs := []swarm.Config{
+		{ID: "id1", Meta: swarm.Meta{Version: swarm.Version{Index: 1}}, Spec: swarm.ConfigSpec{Annotations: swarm.Annotations{Name: "alpha"}}},
+		{ID: "id2", Meta: swarm.Meta{Version: swarm.Version{Index: 2}}, Spec: swarm.ConfigSpec{Annotations: swarm.Annotations{Name: "bravo"}}},
+	}
+	mock := noopConfigOps()
+	mock.listConfigsFn = func(_ context.Context) ([]swarm.Config, error) {
+		return configs, nil
+	}
+	m := testModel(func(m *Model) { m.deps.Configs = mock })
+
+	// Simulate initial load so m.lastSnapshot is set
+	wrapped := make([]docker.ConfigWithDecodedData, len(configs))
+	for i, c := range configs {
+		wrapped[i] = docker.ConfigWithDecodedData{Config: c}
+	}
+	m.Update(configsLoadedMsg(wrapped))
+
+	// Poll with the stored snapshot — same data must NOT trigger a reload
+	cmd := m.checkConfigsCmd(m.lastSnapshot)
+	msg := runCmd(cmd)
+	_, isLoaded := msg.(configsLoadedMsg)
+	require.False(t, isLoaded, "hash from configsLoadedMsg must match hash from checkConfigsCmd for identical data")
+}
+
 func TestRotateConfigCmd_Success(t *testing.T) {
 	rotated := false
 	mock := noopConfigOps()

--- a/views/configs/update.go
+++ b/views/configs/update.go
@@ -115,6 +115,7 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 			stableConfigs[i] = stableConfig{
 				ID:      c.Config.ID,
 				Version: c.Config.Version.Index,
+				Name:    c.Config.Spec.Name,
 			}
 		}
 		var err error

--- a/views/secrets/actions_test.go
+++ b/views/secrets/actions_test.go
@@ -152,3 +152,28 @@ func TestCheckSecretsCmd_NoChange_ReturnsPollRetry(t *testing.T) {
 	_, isPollRetry := msg.(PollRetryMsg)
 	require.True(t, isPollRetry, "should return PollRetryMsg when no change")
 }
+
+func TestCheckSecretsCmd_HashMatchesAfterLoad(t *testing.T) {
+	secrets := []swarm.Secret{
+		{ID: "id1", Meta: swarm.Meta{Version: swarm.Version{Index: 1}}, Spec: swarm.SecretSpec{Annotations: swarm.Annotations{Name: "alpha"}}},
+		{ID: "id2", Meta: swarm.Meta{Version: swarm.Version{Index: 2}}, Spec: swarm.SecretSpec{Annotations: swarm.Annotations{Name: "bravo"}}},
+	}
+	mock := noopSecretOps()
+	mock.listSecretsFn = func(_ context.Context) ([]swarm.Secret, error) {
+		return secrets, nil
+	}
+	m := testModel(func(m *Model) { m.deps.Secrets = mock })
+
+	// Simulate initial load so m.lastSnapshot is set
+	wrapped := make([]docker.SecretWithDecodedData, len(secrets))
+	for i, s := range secrets {
+		wrapped[i] = docker.SecretWithDecodedData{Secret: s}
+	}
+	m.Update(secretsLoadedMsg(wrapped))
+
+	// Poll with the stored snapshot — same data must NOT trigger a reload
+	cmd := m.checkSecretsCmd(m.lastSnapshot)
+	msg := runCmd(cmd)
+	_, isLoaded := msg.(secretsLoadedMsg)
+	require.False(t, isLoaded, "hash from secretsLoadedMsg must match hash from checkSecretsCmd for identical data")
+}

--- a/views/secrets/update.go
+++ b/views/secrets/update.go
@@ -116,6 +116,7 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 			stableSecrets[i] = stableSecret{
 				ID:      s.Secret.ID,
 				Version: s.Secret.Version.Index,
+				Name:    s.Secret.Spec.Name,
 			}
 		}
 		var err error


### PR DESCRIPTION
## Summary
- The `stableSecret`/`stableConfig` structs in `secretsLoadedMsg`/`configsLoadedMsg` handlers declared a `Name` field but never populated it, while `checkSecretsCmd`/`checkConfigsCmd` did populate it
- This hash mismatch caused every poll cycle to detect a false "change" and trigger a full reload, making the cursor jump back and forth after sorting
- Added regression tests that verify the hash from the load handler matches the hash from the poll checker for identical data

## Test plan
- [x] `go test ./views/secrets/... ./views/configs/...` passes
- [ ] Manual: open secrets view, sort by any column, confirm cursor stays stable (no jumping every few seconds)
- [ ] Check debug log for `checkSecretsCmd: No changes detected` instead of repeated `Change detected! Refreshing secret list`

🤖 Generated with [Claude Code](https://claude.com/claude-code)