### PR TITLE
fix: remove hot-path debug logs from render/streaming paths

### DIFF
--- a/views/logs/update.go
+++ b/views/logs/update.go
@@ -76,7 +76,6 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 			}
 			// When filters are active, skip incremental update; highlightContent will recompute
 		}
-		totalLines := len(m.lines)
 		shouldFollow := m.follow
 		m.mu.Unlock()
 
@@ -85,7 +84,6 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 			if shouldFollow {
 				m.viewport.SetContent(m.buildContent())
 				m.viewport.GotoBottom()
-				l().Debugf("[logsview] auto-scrolled to bottom (follow=true)")
 			} else {
 				// Save current offset before updating content
 				savedOffset := m.viewport.YOffset
@@ -110,10 +108,7 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 				}
 
 				m.viewport.YOffset = newOffset
-				l().Debugf("[logsview] NOT scrolling (follow=false), YOffset=%d->%d (dropped %d lines)", savedOffset, newOffset, linesDropped)
 			}
-			l().Debugf("[logsview] appended line; total=%d YOffset=%d Height=%d TotalLineCount=%d follow=%v",
-				totalLines, m.viewport.YOffset, m.viewport.Height, m.viewport.TotalLineCount(), shouldFollow)
 		}
 		return m.readOneLineCmd()
 

--- a/views/stacks/view.go
+++ b/views/stacks/view.go
@@ -30,9 +30,6 @@ func (m *Model) FrameContent() string {
 	)
 	content := m.List.VisibleContent(frame.DesiredContentLines)
 
-	l().Debugf("Rendering stacks view: createDialogActive=%v step=%s fileBrowserActive=%v",
-		m.createDialogActive, m.createDialogStep, m.fileBrowserActive)
-
 	width := frame.FrameWidth
 	if m.createDialogActive {
 		content = ui.OverlayCentered(content, m.renderCreateDialog(), width, 0)
@@ -56,9 +53,6 @@ func (m *Model) View() string {
 
 func (m *Model) renderCreateDialog() string {
 	var lines []string
-
-	l().Debugf("renderCreateDialog: step=%s content=%d bytes path=%s",
-		m.createDialogStep, len(m.createDialogContent), m.createStackPath)
 
 	switch m.createDialogStep {
 	case "source":


### PR DESCRIPTION
## Summary
- Remove 2 debug logs from `views/stacks/view.go` that fired on every `FrameContent()` / `renderCreateDialog()` render (~12x/sec)
- Remove 3 debug logs (+ 1 orphaned variable) from `views/logs/update.go` that fired on every streamed log line
- All meaningful debug logs (lifecycle events, error paths, user actions) are preserved

Ref: Eldara-Tech/swarmcli-be#45

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./views/stacks/ ./views/logs/` passes
- [x] `golangci-lint run ./views/stacks/ ./views/logs/` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)