### PR TITLE
feat: add RegisterTopLevel for dynamic root view registration

### DIFF
--- a/views/view/constants.go
+++ b/views/view/constants.go
@@ -25,5 +25,9 @@ var topLevelViews = map[string]bool{
 	NameLoading: true, NameHelp: true,
 }
 
+// RegisterTopLevel marks a view name as top-level. Called from init() by
+// extension modules to register additional root views.
+func RegisterTopLevel(name string) { topLevelViews[name] = true }
+
 // IsTopLevel reports whether a view name is a top-level (root) view.
 func IsTopLevel(name string) bool { return topLevelViews[name] }


### PR DESCRIPTION
## Summary
- Add `view.RegisterTopLevel(name)` so extension modules can register additional top-level (breadcrumb root) views from `init()` without modifying the hardcoded `topLevelViews` map.

## Test plan
- [x] `go test ./views/view/` passes
- [ ] Used by BE repo to register the license view as top-level

🤖 Generated with [Claude Code](https://claude.com/claude-code)