### PR TITLE
fix: help entries shift when dialog opens

### DIFF
--- a/app/view.go
+++ b/app/view.go
@@ -32,8 +32,8 @@ func (m *Model) View() string {
 	if m.currentView.Name() == view.NameHelp {
 		globalHelp = []helpbar.HelpEntry{}
 	}
-	// Suppress global keys when the view captures all input (e.g., shell).
-	if vc, ok := m.currentView.(interface{ CapturesInput() bool }); ok && vc.CapturesInput() {
+	// Suppress global keys when the view hides them (e.g., shell).
+	if vc, ok := m.currentView.(interface{ HidesGlobalHelp() bool }); ok && vc.HidesGlobalHelp() {
 		globalHelp = []helpbar.HelpEntry{}
 	}
 


### PR DESCRIPTION
## Summary
- Decouples help bar global-entry suppression from `CapturesInput()` by introducing a separate `HidesGlobalHelp()` duck-typed check
- `CapturesInput()` remains solely for input routing (forwarding keys to views with active dialogs)
- No OSS view implements `HidesGlobalHelp()`, so global help entries (`f`, `?`) now stay stable when any dialog opens
- Fixes the visual shift that occurred across all 8 views with dialogs: services, nodes, networks, configs, secrets, contexts, stacks, logs

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] `golangci-lint run ./...` — 0 issues
- [ ] Manual: open services view → press `x` (shell unavailable) → verify help bar entries don't shift
- [ ] Manual: open any confirm dialog (e.g. `ctrl+d` remove service) → verify help bar stays stable

Fixes #309

🤖 Generated with [Claude Code](https://claude.com/claude-code)