### PR TITLE
fix: skip version check for dev builds

### DIFF
--- a/views/systeminfo/model.go
+++ b/views/systeminfo/model.go
@@ -112,6 +112,11 @@ func (m *Model) CheckLatestVersion() tea.Cmd {
 		return nil
 	}
 
+	if currentVersion == "dev" {
+		l().Infow("startup version check skipped for dev build")
+		return nil
+	}
+
 	return func() tea.Msg {
 		latestVersion, err := fetchLatestVersion(m.versionCheckURL, currentVersion, currentEdition)
 		if err != nil {

--- a/views/systeminfo/systeminfo_test.go
+++ b/views/systeminfo/systeminfo_test.go
@@ -223,19 +223,9 @@ func TestCheckLatestVersion_FailureReturnsNoUpdate(t *testing.T) {
 	require.True(t, ok)
 }
 
-func TestCheckLatestVersion_DevBuildShowsLatest(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(`{"latestVersion":"1.3.3","message":"upgrade"}`))
-	}))
-	defer server.Close()
-
+func TestCheckLatestVersion_DevBuildSkipsCheck(t *testing.T) {
 	m := New(testDeps(), "dev", "ce")
-	m.versionCheckURL = server.URL
-	msg := m.CheckLatestVersion()()
-	latestMsg, ok := msg.(LatestVersionMsg)
-	require.True(t, ok)
-	require.Equal(t, "1.3.3", latestMsg.latestVersion)
+	require.Nil(t, m.CheckLatestVersion())
 }
 
 func TestCheckLatestVersion_UsesOverriddenEdition(t *testing.T) {


### PR DESCRIPTION
## Summary
- Skip the remote version check entirely when the current version is `"dev"` (unbuilt/local binary), avoiding unnecessary API calls during development.

Closes #198

## Test plan
- [x] `TestCheckLatestVersion_DevBuildSkipsCheck` asserts `nil` return (no command issued)
- [x] All existing version-check tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)