### PR TITLE
fix: skip stack redeploy when editor content is unchanged

### DIFF
--- a/views/stacks/editcmd.go
+++ b/views/stacks/editcmd.go
@@ -79,7 +79,7 @@ func editWithTempFileCmd(baseName string, initialData []byte, onDone func([]byte
 func openEditorForStackCmd(initialData string) tea.Cmd {
 	return editWithTempFileCmd("stack", []byte(initialData),
 		func(newData []byte) tea.Msg {
-			return editorContentMsg{Content: string(newData)}
+			return editorContentMsg{Content: string(newData), OriginalContent: initialData}
 		},
 		func(err error) tea.Msg {
 			return stackCreateErrorMsg{err}

--- a/views/stacks/messages.go
+++ b/views/stacks/messages.go
@@ -41,7 +41,8 @@ type RemoveErrorMsg struct {
 
 // editorContentMsg is sent when editor returns content
 type editorContentMsg struct {
-	Content string
+	Content         string
+	OriginalContent string // populated in edit mode to detect no-change
 }
 
 // stackCreateErrorMsg is sent when stack creation has an error

--- a/views/stacks/update.go
+++ b/views/stacks/update.go
@@ -187,6 +187,12 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 			// Edit mode: redeploy the stack with updated YAML
 			stackName := m.editStackName
 			m.editStackName = "" // Clear edit mode
+
+			if msg.Content == msg.OriginalContent {
+				l().Infof("No changes to stack %s, skipping redeploy", stackName)
+				return nil
+			}
+
 			stackOps := m.deps.Stacks
 			snapOps := m.deps.Snapshot
 			checkCmd := m.checkStacksCmd(m.lastSnapshot, m.nodeID)

--- a/views/stacks/update_test.go
+++ b/views/stacks/update_test.go
@@ -158,11 +158,27 @@ func TestUpdate_EditorContentMsg_EditMode(t *testing.T) {
 	}
 	m := testModel(func(m *Model) { m.deps.Stacks = stackMock })
 	m.editStackName = "mystack"
-	cmd := m.Update(editorContentMsg{Content: "version: '3'"})
+	cmd := m.Update(editorContentMsg{Content: "version: '3'", OriginalContent: "version: '2'"})
 	require.Equal(t, "", m.editStackName) // cleared
 	require.NotNil(t, cmd)
 	runCmd(cmd)
 	require.Equal(t, "mystack", deployed)
+}
+
+func TestUpdate_EditorContentMsg_EditMode_NoChange(t *testing.T) {
+	deployed := false
+	stackMock := noopStackOps()
+	stackMock.deployStackFn = func(name string, content string) error {
+		deployed = true
+		return nil
+	}
+	m := testModel(func(m *Model) { m.deps.Stacks = stackMock })
+	m.editStackName = "mystack"
+	yaml := "version: '3'\nservices:\n  web:\n    image: nginx"
+	cmd := m.Update(editorContentMsg{Content: yaml, OriginalContent: yaml})
+	require.Equal(t, "", m.editStackName) // cleared
+	require.Nil(t, cmd)                   // no redeploy
+	require.False(t, deployed)
 }
 
 func TestUpdate_FilesLoadedMsg_Success(t *testing.T) {


### PR DESCRIPTION
## Summary
- Skip redeployment when the user exits the stack editor without making changes
- Carries original YAML through `editorContentMsg` and compares before deploying
- Follows the same pattern already used in the configs edit flow

Closes #316

## Test plan
- [x] New unit test `TestUpdate_EditorContentMsg_EditMode_NoChange` asserts no deploy when content is unchanged
- [x] Existing `TestUpdate_EditorContentMsg_EditMode` updated to verify deploy still happens on actual changes
- [ ] Manual: press `e` on a stack, exit editor without changes — stack should not redeploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)