### PR TITLE
fix: show per-service secrets and configs in stack inspect

### DIFF
--- a/docker/stack_inspect.go
+++ b/docker/stack_inspect.go
@@ -34,6 +34,8 @@ type ServiceSummary struct {
 	Mode      string            `json:"mode"`
 	Replicas  string            `json:"replicas"`
 	Ports     []string          `json:"ports,omitempty"`
+	Secrets   []string          `json:"secrets,omitempty"`
+	Configs   []string          `json:"configs,omitempty"`
 	Labels    map[string]string `json:"labels,omitempty"`
 	CreatedAt time.Time         `json:"created_at"`
 	UpdatedAt time.Time         `json:"updated_at"`
@@ -135,16 +137,19 @@ func GetStackInspection(stackName string) (string, error) {
 		}
 
 		// Collect secrets, configs, and volumes
+		var svcSecrets, svcConfigs []string
 		if svc.Spec.TaskTemplate.ContainerSpec != nil {
 			for _, s := range svc.Spec.TaskTemplate.ContainerSpec.Secrets {
 				if s.SecretName != "" {
 					secretsMap[s.SecretName] = true
+					svcSecrets = append(svcSecrets, s.SecretName)
 				}
 			}
 
 			for _, c := range svc.Spec.TaskTemplate.ContainerSpec.Configs {
 				if c.ConfigName != "" {
 					configsMap[c.ConfigName] = true
+					svcConfigs = append(svcConfigs, c.ConfigName)
 				}
 			}
 
@@ -154,6 +159,8 @@ func GetStackInspection(stackName string) (string, error) {
 				}
 			}
 		}
+		sort.Strings(svcSecrets)
+		sort.Strings(svcConfigs)
 
 		// Add service summary
 		desc.Services = append(desc.Services, ServiceSummary{
@@ -163,6 +170,8 @@ func GetStackInspection(stackName string) (string, error) {
 			Mode:      mode,
 			Replicas:  replicas,
 			Ports:     ports,
+			Secrets:   svcSecrets,
+			Configs:   svcConfigs,
 			Labels:    svc.Spec.Labels,
 			CreatedAt: svc.CreatedAt,
 			UpdatedAt: svc.UpdatedAt,

--- a/docker/stack_inspect.go
+++ b/docker/stack_inspect.go
@@ -142,14 +142,14 @@ func GetStackInspection(stackName string) (string, error) {
 			for _, s := range svc.Spec.TaskTemplate.ContainerSpec.Secrets {
 				if s.SecretName != "" {
 					secretsMap[s.SecretName] = true
-					svcSecrets = append(svcSecrets, s.SecretName)
+					svcSecrets = append(svcSecrets, stripStackPrefix(stackName, s.SecretName))
 				}
 			}
 
 			for _, c := range svc.Spec.TaskTemplate.ContainerSpec.Configs {
 				if c.ConfigName != "" {
 					configsMap[c.ConfigName] = true
-					svcConfigs = append(svcConfigs, c.ConfigName)
+					svcConfigs = append(svcConfigs, stripStackPrefix(stackName, c.ConfigName))
 				}
 			}
 
@@ -202,12 +202,12 @@ func GetStackInspection(stackName string) (string, error) {
 	sort.Strings(desc.Volumes)
 
 	for sec := range secretsMap {
-		desc.Secrets = append(desc.Secrets, sec)
+		desc.Secrets = append(desc.Secrets, stripStackPrefix(stackName, sec))
 	}
 	sort.Strings(desc.Secrets)
 
 	for cfg := range configsMap {
-		desc.Configs = append(desc.Configs, cfg)
+		desc.Configs = append(desc.Configs, stripStackPrefix(stackName, cfg))
 	}
 	sort.Strings(desc.Configs)
 

--- a/integration-tests/docker/stack_inspect_test.go
+++ b/integration-tests/docker/stack_inspect_test.go
@@ -91,6 +91,50 @@ func TestInspectStack(t *testing.T) {
 		t.Errorf("Expected network 'backend' in networks, got %v", inspection.Networks)
 	}
 
+	// Verify secrets are present (top-level aggregated list)
+	foundSecret := false
+	for _, s := range inspection.Secrets {
+		if s == "whoami_secret" {
+			foundSecret = true
+		}
+	}
+	if !foundSecret {
+		t.Errorf("Expected secret 'whoami_secret' in secrets, got %v", inspection.Secrets)
+	}
+
+	// Verify configs are present (top-level aggregated list)
+	foundConfig := false
+	for _, c := range inspection.Configs {
+		if c == "whoami_config" {
+			foundConfig = true
+		}
+	}
+	if !foundConfig {
+		t.Errorf("Expected config 'whoami_config' in configs, got %v", inspection.Configs)
+	}
+
+	// Verify per-service secrets and configs
+	for _, svc := range inspection.Services {
+		switch {
+		case strings.HasSuffix(svc.Name, "whoami") && !strings.Contains(svc.Name, "single"):
+			// whoami service should have secrets and configs
+			if len(svc.Secrets) == 0 {
+				t.Errorf("Service %q: expected non-empty secrets", svc.Name)
+			}
+			if len(svc.Configs) == 0 {
+				t.Errorf("Service %q: expected non-empty configs", svc.Name)
+			}
+		case strings.HasSuffix(svc.Name, "log_ticker"):
+			// log_ticker has neither secrets nor configs
+			if len(svc.Secrets) != 0 {
+				t.Errorf("Service %q: expected no secrets, got %v", svc.Name, svc.Secrets)
+			}
+			if len(svc.Configs) != 0 {
+				t.Errorf("Service %q: expected no configs, got %v", svc.Name, svc.Configs)
+			}
+		}
+	}
+
 	t.Logf("Successfully inspected stack: %d services, %d tasks", inspection.ServiceCount, inspection.TaskCount)
 }
 

--- a/test-setup/secrets/whoami_secret.txt
+++ b/test-setup/secrets/whoami_secret.txt
@@ -1,0 +1,1 @@
+test-secret-value

--- a/test-setup/test-stack.yml
+++ b/test-setup/test-stack.yml
@@ -6,6 +6,10 @@ networks:
 volumes:
   whoami_data:
 
+secrets:
+  whoami_secret:
+    file: ./secrets/whoami_secret.txt
+
 configs:
   whoami_config:
     file: ./configs/whoami.conf
@@ -19,6 +23,9 @@ services:
       - backend
     volumes:
       - whoami_data:/data
+    secrets:
+      - source: whoami_secret
+        target: /run/secrets/whoami_secret
     configs:
       - source: whoami_config
         target: /etc/whoami/config


### PR DESCRIPTION
## Summary
- Add `Secrets` and `Configs` fields to `ServiceSummary` so the stack inspect view shows which secrets/configs each service references
- Add a test secret to the demo stack and extend integration test assertions for secrets and configs

Closes #317

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] `golangci-lint run ./... --build-tags=integration` — 0 issues
- [ ] `./test-setup/testenv.sh integration` — verify secrets/configs appear in inspect output

🤖 Generated with [Claude Code](https://claude.com/claude-code)