### PR TITLE
fix: add context timeouts to all Docker API calls and prevent polling goroutine pile-up

### DIFF
--- a/docker/context.go
+++ b/docker/context.go
@@ -150,7 +150,7 @@ func UseContext(contextName string) error {
 }
 
 // ValidateContext checks if a context switch would succeed by attempting to connect
-func ValidateContext(contextName string) error {
+func ValidateContext(ctx context.Context, contextName string) error {
 	// Save current context
 	currentCtx, err := GetCurrentContext()
 	if err != nil {
@@ -170,7 +170,6 @@ func ValidateContext(contextName string) error {
 		return fmt.Errorf("failed to connect to context %s: %w", contextName, err)
 	}
 	// Verify connection with ping
-	ctx := context.Background()
 	if _, err := cli.Ping(ctx); err != nil {
 		// Switch back to original context
 		_ = UseContext(currentCtx)

--- a/docker/context_lint_test.go
+++ b/docker/context_lint_test.go
@@ -1,0 +1,222 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package docker
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// allowedBareBackground lists files (relative to module root) and function names
+// where bare context.Background() is a known legitimate use.
+var allowedBareBackground = map[string]string{
+	"views/configs/model.go": "addConfig",
+	"views/secrets/model.go": "addSecret",
+	"commands/api/api.go":    "New",
+}
+
+func TestNoBareContextBackground(t *testing.T) {
+	root := moduleRoot(t)
+
+	dirs := []string{
+		filepath.Join(root, "views"),
+		filepath.Join(root, "docker"),
+	}
+
+	var violations []string
+
+	for _, dir := range dirs {
+		err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
+			if info.IsDir() {
+				if info.Name() == "integration-tests" {
+					return filepath.SkipDir
+				}
+				return nil
+			}
+			if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+				return nil
+			}
+
+			rel, _ := filepath.Rel(root, path)
+			vs := checkFile(t, path, rel)
+			violations = append(violations, vs...)
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("walking %s: %v", dir, err)
+		}
+	}
+
+	for _, v := range violations {
+		t.Errorf("%s", v)
+	}
+}
+
+// checkFile parses a single Go file and returns violations for bare context.Background() calls.
+func checkFile(t *testing.T, path, rel string) []string {
+	t.Helper()
+
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, path, nil, 0)
+	if err != nil {
+		t.Fatalf("parsing %s: %v", rel, err)
+	}
+
+	var violations []string
+	var stack []ast.Node
+
+	ast.Inspect(f, func(n ast.Node) bool {
+		if n == nil {
+			stack = stack[:len(stack)-1]
+			return false
+		}
+		defer func() { stack = append(stack, n) }()
+
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		if !isContextBackground(call) {
+			return true
+		}
+
+		// Check if the parent is a context.With* wrapping this call as first arg.
+		if parentWraps(stack, call) {
+			return true
+		}
+
+		// Check allow-list: match file and enclosing function.
+		pos := fset.Position(call.Pos())
+		if fn := enclosingFunc(stack); fn != "" {
+			if allowed, ok := allowedBareBackground[rel]; ok && allowed == fn {
+				return true
+			}
+		}
+
+		violations = append(violations,
+			"bare context.Background() at "+rel+":"+itoa(pos.Line)+
+				" — wrap with context.WithTimeout or add to allow-list")
+		return true
+	})
+
+	return violations
+}
+
+// isContextBackground returns true if call is context.Background().
+func isContextBackground(call *ast.CallExpr) bool {
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok {
+		return false
+	}
+	ident, ok := sel.X.(*ast.Ident)
+	if !ok {
+		return false
+	}
+	return ident.Name == "context" && sel.Sel.Name == "Background"
+}
+
+// parentWraps checks whether the immediate parent CallExpr is context.WithTimeout,
+// context.WithCancel, or context.WithDeadline with call as first argument.
+func parentWraps(stack []ast.Node, call *ast.CallExpr) bool {
+	if len(stack) == 0 {
+		return false
+	}
+	parent, ok := stack[len(stack)-1].(*ast.CallExpr)
+	if !ok {
+		return false
+	}
+	sel, ok := parent.Fun.(*ast.SelectorExpr)
+	if !ok {
+		return false
+	}
+	ident, ok := sel.X.(*ast.Ident)
+	if !ok {
+		return false
+	}
+	if ident.Name != "context" {
+		return false
+	}
+	switch sel.Sel.Name {
+	case "WithTimeout", "WithCancel", "WithDeadline":
+	default:
+		return false
+	}
+	if len(parent.Args) == 0 {
+		return false
+	}
+	return parent.Args[0] == call
+}
+
+// enclosingFunc returns the name of the innermost enclosing function, or "".
+func enclosingFunc(stack []ast.Node) string {
+	for i := len(stack) - 1; i >= 0; i-- {
+		switch fn := stack[i].(type) {
+		case *ast.FuncDecl:
+			return fn.Name.Name
+		case *ast.FuncLit:
+			// Check if the FuncLit is assigned in a variable declaration.
+			if i > 0 {
+				if assign, ok := stack[i-1].(*ast.AssignStmt); ok {
+					for _, lhs := range assign.Lhs {
+						if ident, ok := lhs.(*ast.Ident); ok {
+							return ident.Name
+						}
+					}
+				}
+			}
+			return ""
+		}
+	}
+	return ""
+}
+
+// moduleRoot finds the module root by walking up from the test file's directory.
+func moduleRoot(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatal("could not find module root (go.mod)")
+		}
+		dir = parent
+	}
+}
+
+// itoa is a minimal int-to-string to avoid importing strconv.
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var buf [20]byte
+	i := len(buf)
+	neg := n < 0
+	if neg {
+		n = -n
+	}
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	if neg {
+		i--
+		buf[i] = '-'
+	}
+	return string(buf[i:])
+}

--- a/docker/context_ops.go
+++ b/docker/context_ops.go
@@ -3,11 +3,13 @@
 
 package docker
 
+import "context"
+
 // ContextOps abstracts Docker context operations for testability and extensibility.
 type ContextOps interface {
 	ListContexts() ([]ContextInfo, error)
 	UseContext(contextName string) error
-	ValidateContext(contextName string) error
+	ValidateContext(ctx context.Context, contextName string) error
 	InspectContext(contextName string) (string, error)
 	ExportContext(contextName string) (string, error)
 	ExportContextWithForce(contextName string) (string, error)
@@ -29,8 +31,8 @@ func (defaultContextOps) ListContexts() ([]ContextInfo, error) {
 func (defaultContextOps) UseContext(contextName string) error {
 	return UseContext(contextName)
 }
-func (defaultContextOps) ValidateContext(contextName string) error {
-	return ValidateContext(contextName)
+func (defaultContextOps) ValidateContext(ctx context.Context, contextName string) error {
+	return ValidateContext(ctx, contextName)
 }
 func (defaultContextOps) InspectContext(contextName string) (string, error) {
 	return InspectContext(contextName)

--- a/docker/hostname.go
+++ b/docker/hostname.go
@@ -4,8 +4,10 @@
 package docker
 
 import (
+	"context"
 	"fmt"
 	"sync"
+	"time"
 )
 
 // Cache for nodeID → hostname lookups.
@@ -21,7 +23,9 @@ func ensureHostnameCache() error {
 	nodeCacheOnce.Do(func() {
 		nodeCacheMu.Lock()
 		defer nodeCacheMu.Unlock()
-		nodeCacheErr = refreshNodeCacheLocked()
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		nodeCacheErr = refreshNodeCacheLocked(ctx)
 	})
 	return nodeCacheErr
 }
@@ -35,7 +39,9 @@ func RefreshHostnameCache() error {
 	// Reset the Once so ensureHostnameCache() can run again if needed.
 	nodeCacheOnce = sync.Once{}
 
-	if err := refreshNodeCacheLocked(); err != nil {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if err := refreshNodeCacheLocked(ctx); err != nil {
 		nodeCacheErr = fmt.Errorf("manual hostname cache refresh failed: %w", err)
 		return nodeCacheErr
 	}
@@ -63,8 +69,8 @@ func GetNodeIDToHostnameMap() (map[string]string, error) {
 
 // refreshNodeCacheLocked updates the global cache map in-place.
 // Caller must hold nodeCacheMu write lock.
-func refreshNodeCacheLocked() error {
-	names, err := GetNodeIDToHostnameMapFromDocker()
+func refreshNodeCacheLocked(ctx context.Context) error {
+	names, err := GetNodeIDToHostnameMapFromDocker(ctx)
 	if err != nil {
 		return fmt.Errorf("refreshNodeCacheLocked: %w", err)
 	}

--- a/docker/node.go
+++ b/docker/node.go
@@ -10,13 +10,13 @@ import (
 	"github.com/docker/docker/api/types/swarm"
 )
 
-func GetNodeIDToHostnameMapFromDocker() (map[string]string, error) {
+func GetNodeIDToHostnameMapFromDocker(ctx context.Context) (map[string]string, error) {
 	c, err := GetClient()
 	if err != nil {
 		return nil, err
 	}
 
-	nodes, err := c.NodeList(context.Background(), swarm.NodeListOptions{})
+	nodes, err := c.NodeList(ctx, swarm.NodeListOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("listing nodes: %w", err)
 	}

--- a/docker/node_ops.go
+++ b/docker/node_ops.go
@@ -11,7 +11,7 @@ import (
 
 // NodeOps abstracts node operations for testability and extensibility.
 type NodeOps interface {
-	GetNodeIDToHostnameMapFromDocker() (map[string]string, error)
+	GetNodeIDToHostnameMapFromDocker(ctx context.Context) (map[string]string, error)
 	DemoteNode(ctx context.Context, nodeID string) error
 	PromoteNode(ctx context.Context, nodeID string) error
 	SetNodeAvailability(ctx context.Context, nodeID string, availability swarm.NodeAvailability) error
@@ -22,8 +22,8 @@ type NodeOps interface {
 
 type defaultNodeOps struct{}
 
-func (defaultNodeOps) GetNodeIDToHostnameMapFromDocker() (map[string]string, error) {
-	return GetNodeIDToHostnameMapFromDocker()
+func (defaultNodeOps) GetNodeIDToHostnameMapFromDocker(ctx context.Context) (map[string]string, error) {
+	return GetNodeIDToHostnameMapFromDocker(ctx)
 }
 func (defaultNodeOps) DemoteNode(ctx context.Context, nodeID string) error {
 	return DemoteNode(ctx, nodeID)

--- a/docker/service.go
+++ b/docker/service.go
@@ -97,13 +97,11 @@ func restartServiceCommon(ctx context.Context, c *client.Client, svc *swarm.Serv
 //
 
 // ScaleService updates the replica count of a service by ID.
-func ScaleService(serviceID string, replicas uint64) error {
+func ScaleService(ctx context.Context, serviceID string, replicas uint64) error {
 	c, err := GetClient()
 	if err != nil {
 		return fmt.Errorf("docker client: %w", err)
 	}
-
-	ctx := context.Background()
 
 	svc, _, err := c.ServiceInspectWithRaw(ctx, serviceID, swarm.ServiceInspectOptions{})
 	if err != nil {
@@ -113,13 +111,12 @@ func ScaleService(serviceID string, replicas uint64) error {
 }
 
 // ScaleServiceByName looks up a service by name and scales it.
-func ScaleServiceByName(serviceName string, replicas uint64) error {
+func ScaleServiceByName(ctx context.Context, serviceName string, replicas uint64) error {
 	c, err := GetClient()
 	if err != nil {
 		return fmt.Errorf("docker client: %w", err)
 	}
 
-	ctx := context.Background()
 	svc, err := findServiceByName(ctx, c, serviceName)
 	if err != nil {
 		return err
@@ -128,13 +125,12 @@ func ScaleServiceByName(serviceName string, replicas uint64) error {
 }
 
 // RestartService performs a rolling restart (like `docker service update --force`).
-func RestartService(serviceName string) error {
+func RestartService(ctx context.Context, serviceName string) error {
 	c, err := GetClient()
 	if err != nil {
 		return fmt.Errorf("docker client: %w", err)
 	}
 
-	ctx := context.Background()
 	svc, err := findServiceByName(ctx, c, serviceName)
 	if err != nil {
 		return err
@@ -143,13 +139,12 @@ func RestartService(serviceName string) error {
 }
 
 // RemoveService removes a service by name.
-func RemoveService(serviceName string) error {
+func RemoveService(ctx context.Context, serviceName string) error {
 	c, err := GetClient()
 	if err != nil {
 		return fmt.Errorf("docker client: %w", err)
 	}
 
-	ctx := context.Background()
 	svc, err := findServiceByName(ctx, c, serviceName)
 	if err != nil {
 		return err
@@ -164,13 +159,12 @@ func RemoveService(serviceName string) error {
 }
 
 // RollbackService rolls back a service to its previous configuration.
-func RollbackService(serviceName string) error {
+func RollbackService(ctx context.Context, serviceName string) error {
 	c, err := GetClient()
 	if err != nil {
 		return fmt.Errorf("docker client: %w", err)
 	}
 
-	ctx := context.Background()
 	svc, err := findServiceByName(ctx, c, serviceName)
 	if err != nil {
 		return err

--- a/docker/service_ops.go
+++ b/docker/service_ops.go
@@ -11,11 +11,11 @@ import (
 
 // ServiceOps abstracts service operations for testability and extensibility.
 type ServiceOps interface {
-	ScaleService(serviceID string, replicas uint64) error
-	ScaleServiceByName(serviceName string, replicas uint64) error
-	RestartService(serviceName string) error
-	RemoveService(serviceName string) error
-	RollbackService(serviceName string) error
+	ScaleService(ctx context.Context, serviceID string, replicas uint64) error
+	ScaleServiceByName(ctx context.Context, serviceName string, replicas uint64) error
+	RestartService(ctx context.Context, serviceName string) error
+	RemoveService(ctx context.Context, serviceName string) error
+	RollbackService(ctx context.Context, serviceName string) error
 	RestartServiceAndWait(ctx context.Context, serviceName string) error
 	RestartServiceWithProgress(ctx context.Context, serviceName string, progressCh chan<- ProgressUpdate) error
 	LoadNodeServices(nodeID string) []ServiceEntry
@@ -27,20 +27,20 @@ type ServiceOps interface {
 
 type defaultServiceOps struct{}
 
-func (defaultServiceOps) ScaleService(serviceID string, replicas uint64) error {
-	return ScaleService(serviceID, replicas)
+func (defaultServiceOps) ScaleService(ctx context.Context, serviceID string, replicas uint64) error {
+	return ScaleService(ctx, serviceID, replicas)
 }
-func (defaultServiceOps) ScaleServiceByName(serviceName string, replicas uint64) error {
-	return ScaleServiceByName(serviceName, replicas)
+func (defaultServiceOps) ScaleServiceByName(ctx context.Context, serviceName string, replicas uint64) error {
+	return ScaleServiceByName(ctx, serviceName, replicas)
 }
-func (defaultServiceOps) RestartService(serviceName string) error {
-	return RestartService(serviceName)
+func (defaultServiceOps) RestartService(ctx context.Context, serviceName string) error {
+	return RestartService(ctx, serviceName)
 }
-func (defaultServiceOps) RemoveService(serviceName string) error {
-	return RemoveService(serviceName)
+func (defaultServiceOps) RemoveService(ctx context.Context, serviceName string) error {
+	return RemoveService(ctx, serviceName)
 }
-func (defaultServiceOps) RollbackService(serviceName string) error {
-	return RollbackService(serviceName)
+func (defaultServiceOps) RollbackService(ctx context.Context, serviceName string) error {
+	return RollbackService(ctx, serviceName)
 }
 func (defaultServiceOps) RestartServiceAndWait(ctx context.Context, serviceName string) error {
 	return RestartServiceAndWait(ctx, serviceName)

--- a/docker/stack_deploy.go
+++ b/docker/stack_deploy.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"time"
 
 	"gopkg.in/yaml.v3"
 )
@@ -118,7 +119,8 @@ func extractNetworkNames(yamlContent string) []string {
 
 // cleanupNetworks attempts to remove networks that may have been created during a failed deployment
 func cleanupNetworks(stackName string, networkNames []string) {
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
 	for _, netName := range networkNames {
 		// Docker creates networks with the pattern: stackname_networkname
 		fullNetworkName := fmt.Sprintf("%s_%s", stackName, netName)

--- a/docker/stack_ops.go
+++ b/docker/stack_ops.go
@@ -3,10 +3,12 @@
 
 package docker
 
+import "context"
+
 // StackOps abstracts stack operations for testability and extensibility.
 type StackOps interface {
-	RemoveStack(stackName string) error
-	RemoveStackNetworks(stackName string) error
+	RemoveStack(ctx context.Context, stackName string) error
+	RemoveStackNetworks(ctx context.Context, stackName string) error
 	DeployStack(stackName string, yamlContent string) error
 	ValidateStackYAML(content string) error
 	InspectStack(stackName string) (string, error)
@@ -15,12 +17,12 @@ type StackOps interface {
 
 type defaultStackOps struct{}
 
-func (defaultStackOps) RemoveStack(stackName string) error {
-	return RemoveStack(stackName)
+func (defaultStackOps) RemoveStack(ctx context.Context, stackName string) error {
+	return RemoveStack(ctx, stackName)
 }
 
-func (defaultStackOps) RemoveStackNetworks(stackName string) error {
-	return RemoveStackNetworks(stackName)
+func (defaultStackOps) RemoveStackNetworks(ctx context.Context, stackName string) error {
+	return RemoveStackNetworks(ctx, stackName)
 }
 
 func (defaultStackOps) DeployStack(stackName string, yamlContent string) error {

--- a/docker/stack_remove.go
+++ b/docker/stack_remove.go
@@ -12,12 +12,11 @@ import (
 )
 
 // RemoveStack removes all services in a stack by stack name.
-func RemoveStack(stackName string) error {
+func RemoveStack(ctx context.Context, stackName string) error {
 	c, err := GetClient()
 	if err != nil {
 		return fmt.Errorf("docker client: %w", err)
 	}
-	ctx := context.Background()
 
 	// List all services in the stack
 	services, err := c.ServiceList(ctx, swarm.ServiceListOptions{})
@@ -51,12 +50,11 @@ func RemoveStack(stackName string) error {
 }
 
 // GetStackNetworks returns the names of networks associated with a stack
-func GetStackNetworks(stackName string) ([]string, error) {
+func GetStackNetworks(ctx context.Context, stackName string) ([]string, error) {
 	c, err := GetClient()
 	if err != nil {
 		return nil, fmt.Errorf("docker client: %w", err)
 	}
-	ctx := context.Background()
 
 	// List all networks
 	networks, err := c.NetworkList(ctx, network.ListOptions{})
@@ -78,8 +76,8 @@ func GetStackNetworks(stackName string) ([]string, error) {
 }
 
 // RemoveStackNetworks removes all networks associated with a stack
-func RemoveStackNetworks(stackName string) error {
-	networks, err := GetStackNetworks(stackName)
+func RemoveStackNetworks(ctx context.Context, stackName string) error {
+	networks, err := GetStackNetworks(ctx, stackName)
 	if err != nil {
 		return fmt.Errorf("getting stack networks: %w", err)
 	}
@@ -88,8 +86,6 @@ func RemoveStackNetworks(stackName string) error {
 		l().Infof("No networks found for stack %s", stackName)
 		return nil
 	}
-
-	ctx := context.Background()
 	var removedCount int
 	for _, netName := range networks {
 		if err := RemoveNetwork(ctx, netName); err != nil {

--- a/integration-tests/docker/service/restart_service_test.go
+++ b/integration-tests/docker/service/restart_service_test.go
@@ -6,6 +6,7 @@
 package service
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -48,7 +49,7 @@ func TestRestartWhoamiSingleService(t *testing.T) {
 
 	t.Logf("Restarting service %s (old task ID: %s)", serviceName, oldTaskID)
 	start := time.Now()
-	if err := docker.RestartService(serviceName); err != nil {
+	if err := docker.RestartService(context.Background(), serviceName); err != nil {
 		t.Fatalf("failed to restart service: %v", err)
 	}
 
@@ -115,7 +116,7 @@ func TestRestartWhoamiMultiService(t *testing.T) {
 
 	t.Logf("Restarting multi-replica service %s (%d replicas)", serviceName, replicas)
 	start := time.Now()
-	if err := docker.RestartService(serviceName); err != nil {
+	if err := docker.RestartService(context.Background(), serviceName); err != nil {
 		t.Fatalf("failed to restart service: %v", err)
 	}
 
@@ -158,7 +159,7 @@ func TestRestartWhoamiMultiService(t *testing.T) {
 func TestRestartService_NotFound_ReturnsError(t *testing.T) {
 	const serviceName = "nonexistent_demo_service"
 
-	err := docker.RestartService(serviceName)
+	err := docker.RestartService(context.Background(), serviceName)
 	if err == nil {
 		t.Fatalf("expected error when restarting nonexistent service %s, got nil", serviceName)
 	}

--- a/integration-tests/docker/service/scale_test.go
+++ b/integration-tests/docker/service/scale_test.go
@@ -6,6 +6,7 @@
 package service
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -37,7 +38,7 @@ func TestScaleWhoamiService(t *testing.T) {
 
 	scaleTarget := original - 1
 	t.Logf("Scaling service %s down from %d → %d replicas", serviceName, original, scaleTarget)
-	if err := docker.ScaleServiceByName(serviceName, scaleTarget); err != nil {
+	if err := docker.ScaleServiceByName(context.Background(), serviceName, scaleTarget); err != nil {
 		t.Fatalf("failed to scale down: %v", err)
 	}
 
@@ -65,7 +66,7 @@ func TestScaleWhoamiService(t *testing.T) {
 
 	// Restore
 	t.Logf("Restoring service %s back to %d replicas", serviceName, original)
-	if err := docker.ScaleServiceByName(serviceName, original); err != nil {
+	if err := docker.ScaleServiceByName(context.Background(), serviceName, original); err != nil {
 		t.Fatalf("failed to restore original count: %v", err)
 	}
 }
@@ -96,7 +97,7 @@ func TestScaleWhoamiSingleServiceTo0AndThenTo1(t *testing.T) {
 
 	// Scale down to 0
 	t.Logf("Scaling service %s down to 0 replicas", serviceName)
-	if err := docker.ScaleServiceByName(serviceName, 0); err != nil {
+	if err := docker.ScaleServiceByName(context.Background(), serviceName, 0); err != nil {
 		t.Fatalf("failed to scale down: %v", err)
 	}
 
@@ -124,7 +125,7 @@ func TestScaleWhoamiSingleServiceTo0AndThenTo1(t *testing.T) {
 
 	// Scale back up to 1
 	t.Logf("Scaling service %s back up to 1 replica", serviceName)
-	if err := docker.ScaleServiceByName(serviceName, 1); err != nil {
+	if err := docker.ScaleServiceByName(context.Background(), serviceName, 1); err != nil {
 		t.Fatalf("failed to scale up: %v", err)
 	}
 
@@ -157,13 +158,13 @@ func TestScaleServiceUnchanged(t *testing.T) {
 	const svcName = "demo_whoami_single"
 
 	// Get current replicas
-	err := docker.ScaleServiceByName(svcName, 1)
+	err := docker.ScaleServiceByName(context.Background(), svcName, 1)
 	if err != nil {
 		t.Fatalf("initial scale failed: %v", err)
 	}
 
 	// Scale to the same count again
-	err = docker.ScaleServiceByName(svcName, 1)
+	err = docker.ScaleServiceByName(context.Background(), svcName, 1)
 	if err != nil {
 		t.Fatalf("scaling to same count failed: %v", err)
 	}

--- a/views/configs/actions.go
+++ b/views/configs/actions.go
@@ -24,7 +24,8 @@ import (
 func (m *Model) loadConfigsCmd() tea.Cmd {
 	configOps := m.deps.Configs
 	return func() tea.Msg {
-		ctx := context.Background()
+		ctx, cancel := context.WithTimeout(context.Background(), pollTimeout)
+		defer cancel()
 		cfgs, err := configOps.ListConfigs(ctx)
 		if err != nil {
 			return errorMsg(fmt.Errorf("failed to list configs: %w", err))
@@ -44,7 +45,8 @@ func (m *Model) computeConfigUsedCmd(cfgs []docker.ConfigWithDecodedData) tea.Cm
 	configOps := m.deps.Configs
 	return func() tea.Msg {
 		usedMap := make(map[string]bool, len(cfgs))
-		ctx := context.Background()
+		ctx, cancel := context.WithTimeout(context.Background(), pollTimeout)
+		defer cancel()
 		for _, c := range cfgs {
 			usedMap[c.Config.ID] = false
 			svcs, err := configOps.ListServicesUsingConfigID(ctx, c.Config.ID)
@@ -60,9 +62,16 @@ func (m *Model) computeConfigUsedCmd(cfgs []docker.ConfigWithDecodedData) tea.Cm
 func (m *Model) checkConfigsCmd(lastHash uint64) tea.Cmd {
 	configOps := m.deps.Configs
 	return func() tea.Msg {
+		if !m.polling.CompareAndSwap(false, true) {
+			l().Info("checkConfigsCmd: skipped, previous poll still in flight")
+			return PollRetryMsg{}
+		}
+		defer m.polling.Store(false)
+
 		l().Info("checkConfigsCmd: Polling for config changes")
 
-		ctx := context.Background()
+		ctx, cancel := context.WithTimeout(context.Background(), pollTimeout)
+		defer cancel()
 		cfgs, err := configOps.ListConfigs(ctx)
 		if err != nil {
 			l().Errorf("checkConfigsCmd: ListConfigs failed: %v", err)
@@ -118,7 +127,8 @@ func (m *Model) rotateConfigCmd(oldCfg *docker.ConfigWithDecodedData, newCfg *do
 	configOps := m.deps.Configs
 	l().Debugln("Starting to rotate config", newCfg.Config.Spec.Name)
 	return func() tea.Msg {
-		ctx := context.Background()
+		ctx, cancel := context.WithTimeout(context.Background(), userActionTimeout)
+		defer cancel()
 
 		oldSwarmCfg := &swarm.Config{}
 		if oldCfg != nil {
@@ -142,7 +152,9 @@ func (m *Model) rotateConfigCmd(oldCfg *docker.ConfigWithDecodedData, newCfg *do
 func (m *Model) inspectConfigCmd(name string) tea.Cmd {
 	configOps := m.deps.Configs
 	return func() tea.Msg {
-		cfg, err := configOps.InspectConfig(context.Background(), name)
+		ctx, cancel := context.WithTimeout(context.Background(), userActionTimeout)
+		defer cancel()
+		cfg, err := configOps.InspectConfig(ctx, name)
 		jsonStr := ""
 		if err != nil {
 			jsonStr = fmt.Sprintf("Error inspecting config %q: %v", name, err)
@@ -170,7 +182,9 @@ func (m *Model) inspectConfigCmd(name string) tea.Cmd {
 func (m *Model) inspectRawConfigCmd(name string) tea.Cmd {
 	configOps := m.deps.Configs
 	return func() tea.Msg {
-		cfg, err := configOps.InspectConfig(context.Background(), name)
+		ctx, cancel := context.WithTimeout(context.Background(), userActionTimeout)
+		defer cancel()
+		cfg, err := configOps.InspectConfig(ctx, name)
 		if err != nil {
 			return view.NavigateToMsg{
 				ViewName: inspectview.ViewName,
@@ -198,7 +212,8 @@ func (m *Model) inspectRawConfigCmd(name string) tea.Cmd {
 func (m *Model) deleteConfigCmd(name string) tea.Cmd {
 	configOps := m.deps.Configs
 	return func() tea.Msg {
-		ctx := context.Background()
+		ctx, cancel := context.WithTimeout(context.Background(), userActionTimeout)
+		defer cancel()
 		err := configOps.DeleteConfig(ctx, name)
 		if err != nil {
 			return errorMsg(fmt.Errorf("failed to delete config %q: %w", name, err))
@@ -271,7 +286,8 @@ func (m *Model) createConfigFromFileCmd(name, filePath string, labels map[string
 		}
 
 		// Create the config
-		ctx := context.Background()
+		ctx, cancel := context.WithTimeout(context.Background(), userActionTimeout)
+		defer cancel()
 		newCfg, err := configOps.CreateConfig(ctx, name, data, labels)
 		if err != nil {
 			l().Errorf("Failed to create config %s: %v", name, err)
@@ -289,7 +305,8 @@ func (m *Model) createConfigFromContentCmd(name string, content []byte, labels m
 	return func() tea.Msg {
 		l().Infof("Creating config %s from inline content (labels=%v)", name, labels)
 
-		ctx := context.Background()
+		ctx, cancel := context.WithTimeout(context.Background(), userActionTimeout)
+		defer cancel()
 		newCfg, err := configOps.CreateConfig(ctx, name, content, labels)
 		if err != nil {
 			l().Errorf("Failed to create config %s: %v", name, err)
@@ -306,7 +323,8 @@ func (m *Model) getUsedByStacksCmd(configName string) tea.Cmd {
 	return func() tea.Msg {
 		l().Infof("Getting stacks/services that use config: %s", configName)
 
-		ctx := context.Background()
+		ctx, cancel := context.WithTimeout(context.Background(), userActionTimeout)
+		defer cancel()
 		// Get config ID for robust matching
 		cfg, err := configOps.InspectConfig(ctx, configName)
 		if err != nil {

--- a/views/configs/actions_test.go
+++ b/views/configs/actions_test.go
@@ -246,3 +246,43 @@ func TestRotateConfigCmd_NilNewConfig(t *testing.T) {
 	cmd := m.rotateConfigCmd(nil, nil)
 	require.Nil(t, cmd)
 }
+
+func TestCheckConfigsCmd_Timeout_ReturnsPollRetryMsg(t *testing.T) {
+	mock := noopConfigOps()
+	mock.listConfigsFn = func(_ context.Context) ([]swarm.Config, error) {
+		return nil, context.DeadlineExceeded
+	}
+	m := testModel(func(m *Model) { m.deps.Configs = mock })
+	cmd := m.checkConfigsCmd(0)
+	msg := runCmd(cmd)
+	_, ok := msg.(PollRetryMsg)
+	require.True(t, ok)
+}
+
+func TestLoadConfigsCmd_Timeout_ReturnsErrorMsg(t *testing.T) {
+	mock := noopConfigOps()
+	mock.listConfigsFn = func(_ context.Context) ([]swarm.Config, error) {
+		return nil, context.DeadlineExceeded
+	}
+	m := testModel(func(m *Model) { m.deps.Configs = mock })
+	cmd := m.loadConfigsCmd()
+	msg := runCmd(cmd)
+	_, ok := msg.(errorMsg)
+	require.True(t, ok)
+}
+
+func TestCheckConfigsCmd_InFlightGuard_SkipsDuplicate(t *testing.T) {
+	called := false
+	mock := noopConfigOps()
+	mock.listConfigsFn = func(_ context.Context) ([]swarm.Config, error) {
+		called = true
+		return nil, nil
+	}
+	m := testModel(func(m *Model) { m.deps.Configs = mock })
+	m.polling.Store(true)
+	cmd := m.checkConfigsCmd(0)
+	msg := runCmd(cmd)
+	_, ok := msg.(PollRetryMsg)
+	require.True(t, ok)
+	require.False(t, called, "listConfigsFn should not be called when polling is in flight")
+}

--- a/views/configs/editcmd.go
+++ b/views/configs/editcmd.go
@@ -93,7 +93,8 @@ func (m *Model) editConfigInEditorCmd(name string) tea.Cmd {
 	configOps := m.deps.Configs
 	l().Infoln("editConfigInEditorCmd: started")
 
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), userActionTimeout)
+	defer cancel()
 	cfg, err := configOps.InspectConfig(ctx, name)
 	if err != nil {
 		l().Infoln("InspectConfig error:", err)
@@ -116,7 +117,9 @@ func (m *Model) editConfigInEditorCmd(name string) tea.Cmd {
 			}
 
 			// Create a new Docker config version with the edited data
-			newCfg, err := configOps.CreateConfigVersion(ctx, cfg.Config, newData)
+			createCtx, createCancel := context.WithTimeout(context.Background(), userActionTimeout)
+			defer createCancel()
+			newCfg, err := configOps.CreateConfigVersion(createCtx, cfg.Config, newData)
 			if err != nil {
 				l().Infoln("CreateConfigVersion error:", err)
 				return editConfigErrorMsg{err}

--- a/views/configs/messages.go
+++ b/views/configs/messages.go
@@ -76,5 +76,7 @@ type TickMsg time.Time
 type PollRetryMsg struct{}
 
 const PollInterval = 5 * time.Second
+const pollTimeout = 4 * time.Second
+const userActionTimeout = 15 * time.Second
 
 type SpinnerTickMsg time.Time

--- a/views/configs/model.go
+++ b/views/configs/model.go
@@ -12,6 +12,7 @@ import (
 	"swarmcli/views/confirmdialog"
 	"swarmcli/views/helpbar"
 	loading "swarmcli/views/loading"
+	"sync/atomic"
 	"time"
 
 	"github.com/charmbracelet/bubbles/textinput"
@@ -37,7 +38,8 @@ type Model struct {
 	height        int
 	firstResize   bool   // tracks if we've received the first window size
 	lastSnapshot  uint64 // hash of last snapshot for change detection
-	visible       bool   // tracks if view is currently active
+	polling       atomic.Bool
+	visible       bool // tracks if view is currently active
 	sortField     SortField
 	sortAscending bool // true for ascending, false for descending
 

--- a/views/configs/update.go
+++ b/views/configs/update.go
@@ -168,7 +168,7 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 	case TickMsg:
 		l().Infof("ConfigsView: Received TickMsg, state=%v, visible=%v", m.state, m.visible)
 		// Only check for changes if view is visible, ready, and not showing dialogs
-		if m.visible && m.state == stateReady && !m.confirmDialog.Visible && !m.loadingView.Visible() {
+		if m.visible && m.state == stateReady && !m.confirmDialog.Visible && !m.loadingView.Visible() && !m.polling.Load() {
 			return tea.Batch(
 				m.checkConfigsCmd(m.lastSnapshot),
 				tickCmd(),
@@ -526,7 +526,8 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 			}
 			l().Infof("Clone key pressed for config: %s", cfgName)
 			// Inspect to get content
-			ctx := context.Background()
+			ctx, cancel := context.WithTimeout(context.Background(), userActionTimeout)
+			defer cancel()
 			cfg, err := m.deps.Configs.InspectConfig(ctx, cfgName)
 			if err != nil {
 				l().Errorf("Failed to inspect config for clone: %v", err)

--- a/views/configs/update_test.go
+++ b/views/configs/update_test.go
@@ -433,6 +433,21 @@ func TestParseLabels_Invalid(t *testing.T) {
 
 // --- Help content ---
 
+func TestTickMsg_WhenPollingInFlight_SkipsCheck(t *testing.T) {
+	m := testModel()
+	loadConfigs(m, fakeConfigs("c1"))
+	m.visible = true
+	m.polling.Store(true)
+	cmd := m.Update(TickMsg(time.Now()))
+	require.NotNil(t, cmd)
+	// With polling in flight the TickMsg handler should only return tickCmd,
+	// not batch(checkConfigsCmd, tickCmd). Executing the returned cmd should
+	// produce a TickMsg (from tickCmd), not a PollRetryMsg or configsLoadedMsg.
+	msg := runCmd(cmd)
+	_, isTickMsg := msg.(TickMsg)
+	require.True(t, isTickMsg, "expected TickMsg from tickCmd, got %T", msg)
+}
+
 func TestGetConfigsHelpContent(t *testing.T) {
 	cats := GetConfigsHelpContent()
 	require.True(t, len(cats) >= 3)

--- a/views/contexts/messages.go
+++ b/views/contexts/messages.go
@@ -4,6 +4,7 @@
 package contexts
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -13,9 +14,12 @@ import (
 	swarmlog "swarmcli/utils/log"
 	inspectview "swarmcli/views/inspect"
 	"swarmcli/views/view"
+	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 )
+
+const userActionTimeout = 15 * time.Second
 
 // isContextArchive checks if a filename is a context archive (supports multiple formats)
 func isContextArchive(filename string) bool {
@@ -112,9 +116,11 @@ func (m *Model) loadContextsCmd() func() tea.Msg {
 func (m *Model) switchContextCmd(contextName string) tea.Cmd {
 	contextOps := m.deps.Contexts
 	return func() tea.Msg {
+		ctx, cancel := context.WithTimeout(context.Background(), userActionTimeout)
+		defer cancel()
 		// ValidateContext will switch to the context, verify it's reachable,
 		// and switch back to the original if validation fails
-		err := contextOps.ValidateContext(contextName)
+		err := contextOps.ValidateContext(ctx, contextName)
 		return ContextSwitchedMsg{
 			ContextName: contextName,
 			Success:     err == nil,

--- a/views/contexts/model_test.go
+++ b/views/contexts/model_test.go
@@ -16,7 +16,7 @@ import (
 type mockContextOps struct {
 	listContextsFn               func() ([]docker.ContextInfo, error)
 	useContextFn                 func(contextName string) error
-	validateContextFn            func(contextName string) error
+	validateContextFn            func(ctx context.Context, contextName string) error
 	inspectContextFn             func(contextName string) (string, error)
 	exportContextFn              func(contextName string) (string, error)
 	exportContextWithForceFn     func(contextName string) (string, error)
@@ -36,8 +36,8 @@ func (m *mockContextOps) ListContexts() ([]docker.ContextInfo, error) {
 func (m *mockContextOps) UseContext(contextName string) error {
 	return m.useContextFn(contextName)
 }
-func (m *mockContextOps) ValidateContext(contextName string) error {
-	return m.validateContextFn(contextName)
+func (m *mockContextOps) ValidateContext(ctx context.Context, contextName string) error {
+	return m.validateContextFn(ctx, contextName)
 }
 func (m *mockContextOps) InspectContext(contextName string) (string, error) {
 	return m.inspectContextFn(contextName)
@@ -118,7 +118,7 @@ func noopContextOps() *mockContextOps {
 	return &mockContextOps{
 		listContextsFn:               func() ([]docker.ContextInfo, error) { return nil, nil },
 		useContextFn:                 func(_ string) error { return nil },
-		validateContextFn:            func(_ string) error { return nil },
+		validateContextFn:            func(_ context.Context, _ string) error { return nil },
 		inspectContextFn:             func(_ string) (string, error) { return "{}", nil },
 		exportContextFn:              func(_ string) (string, error) { return "/tmp/test.tar", nil },
 		exportContextWithForceFn:     func(_ string) (string, error) { return "/tmp/test.tar", nil },

--- a/views/contexts/update_test.go
+++ b/views/contexts/update_test.go
@@ -1,6 +1,7 @@
 package contexts
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -290,7 +291,7 @@ func TestUpdate_ConfirmDialog_EscCloses(t *testing.T) {
 func TestKey_Enter_SwitchContext(t *testing.T) {
 	var switched string
 	ops := noopContextOps()
-	ops.validateContextFn = func(name string) error {
+	ops.validateContextFn = func(_ context.Context, name string) error {
 		switched = name
 		return nil
 	}
@@ -809,7 +810,7 @@ func TestLoadContextsCmd(t *testing.T) {
 func TestSwitchContextCmd(t *testing.T) {
 	var validated string
 	ops := noopContextOps()
-	ops.validateContextFn = func(name string) error {
+	ops.validateContextFn = func(_ context.Context, name string) error {
 		validated = name
 		return nil
 	}

--- a/views/nodes/model_test.go
+++ b/views/nodes/model_test.go
@@ -37,7 +37,7 @@ func (m *mockSnapshotOps) GetOrRefreshSnapshot() (*docker.SwarmSnapshot, error) 
 }
 
 type mockNodeOps struct {
-	getNodeIDToHostnameMapFromDockerFn func() (map[string]string, error)
+	getNodeIDToHostnameMapFromDockerFn func(ctx context.Context) (map[string]string, error)
 	demoteNodeFn                       func(ctx context.Context, nodeID string) error
 	promoteNodeFn                      func(ctx context.Context, nodeID string) error
 	setNodeAvailabilityFn              func(ctx context.Context, nodeID string, availability swarm.NodeAvailability) error
@@ -46,8 +46,8 @@ type mockNodeOps struct {
 	removeNodeFn                       func(ctx context.Context, nodeID string, force bool) error
 }
 
-func (m *mockNodeOps) GetNodeIDToHostnameMapFromDocker() (map[string]string, error) {
-	return m.getNodeIDToHostnameMapFromDockerFn()
+func (m *mockNodeOps) GetNodeIDToHostnameMapFromDocker(ctx context.Context) (map[string]string, error) {
+	return m.getNodeIDToHostnameMapFromDockerFn(ctx)
 }
 func (m *mockNodeOps) DemoteNode(ctx context.Context, nodeID string) error {
 	return m.demoteNodeFn(ctx, nodeID)
@@ -133,7 +133,7 @@ func noopSnapshotOps() *mockSnapshotOps {
 
 func noopNodeOps() *mockNodeOps {
 	return &mockNodeOps{
-		getNodeIDToHostnameMapFromDockerFn: func() (map[string]string, error) { return nil, nil },
+		getNodeIDToHostnameMapFromDockerFn: func(_ context.Context) (map[string]string, error) { return nil, nil },
 		demoteNodeFn:                       func(_ context.Context, _ string) error { return nil },
 		promoteNodeFn:                      func(_ context.Context, _ string) error { return nil },
 		setNodeAvailabilityFn:              func(_ context.Context, _ string, _ swarm.NodeAvailability) error { return nil },

--- a/views/nodes/update.go
+++ b/views/nodes/update.go
@@ -16,10 +16,13 @@ import (
 	inspectview "swarmcli/views/inspect"
 	servicesview "swarmcli/views/services"
 	"swarmcli/views/view"
+	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/docker/docker/api/types/swarm"
 )
+
+const userActionTimeout = 15 * time.Second
 
 // getFreshNodeState retrieves the current node state with a forced refresh
 func (m *Model) getFreshNodeState(nodeID string) *docker.NodeEntry {
@@ -59,7 +62,9 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 				snapshotOps := m.deps.Snapshot
 				// Run demote, keeping dialog visible during operation
 				return func() tea.Msg {
-					if err := nodeOps.DemoteNode(context.Background(), node.ID); err != nil {
+					ctx, cancel := context.WithTimeout(context.Background(), userActionTimeout)
+					defer cancel()
+					if err := nodeOps.DemoteNode(ctx, node.ID); err != nil {
 						return DemoteErrorMsg{NodeID: node.ID, Error: err}
 					}
 					// Force refresh
@@ -74,7 +79,9 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 				snapshotOps := m.deps.Snapshot
 				// Run promote, keeping dialog visible during operation
 				return func() tea.Msg {
-					if err := nodeOps.PromoteNode(context.Background(), node.ID); err != nil {
+					ctx, cancel := context.WithTimeout(context.Background(), userActionTimeout)
+					defer cancel()
+					if err := nodeOps.PromoteNode(ctx, node.ID); err != nil {
 						return PromoteErrorMsg{NodeID: node.ID, Error: err}
 					}
 					// Force refresh
@@ -89,7 +96,9 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 				snapshotOps := m.deps.Snapshot
 				// Run remove with force=true, keeping dialog visible during operation
 				return func() tea.Msg {
-					if err := nodeOps.RemoveNode(context.Background(), node.ID, true); err != nil {
+					ctx, cancel := context.WithTimeout(context.Background(), userActionTimeout)
+					defer cancel()
+					if err := nodeOps.RemoveNode(ctx, node.ID, true); err != nil {
 						return RemoveErrorMsg{NodeID: node.ID, Error: err}
 					}
 					// Force refresh
@@ -303,7 +312,9 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 				node := m.List.Filtered[m.List.Cursor]
 				inspectOps := m.deps.Inspect
 				return func() tea.Msg {
-					inspectContent, err := inspectOps.Inspect(context.Background(), docker.InspectNode, node.ID)
+					ctx, cancel := context.WithTimeout(context.Background(), userActionTimeout)
+					defer cancel()
+					inspectContent, err := inspectOps.Inspect(ctx, docker.InspectNode, node.ID)
 					if err != nil {
 						inspectContent = "Error inspecting node: " + err.Error()
 					}
@@ -634,6 +645,8 @@ func (m *Model) handleAvailabilityDialogKey(msg tea.KeyMsg) tea.Cmd {
 		snapshotOps := m.deps.Snapshot
 		m.availabilityDialog = false
 		return func() tea.Msg {
+			ctx, cancel := context.WithTimeout(context.Background(), userActionTimeout)
+			defer cancel()
 			var avail swarm.NodeAvailability
 			switch availability {
 			case "active":
@@ -643,7 +656,7 @@ func (m *Model) handleAvailabilityDialogKey(msg tea.KeyMsg) tea.Cmd {
 			case "drain":
 				avail = swarm.NodeAvailabilityDrain
 			}
-			if err := nodeOps.SetNodeAvailability(context.Background(), nodeID, avail); err != nil {
+			if err := nodeOps.SetNodeAvailability(ctx, nodeID, avail); err != nil {
 				return SetAvailabilityErrorMsg{NodeID: nodeID, Error: err}
 			}
 			// Force refresh
@@ -701,7 +714,9 @@ func (m *Model) handleLabelInputDialogKey(msg tea.KeyMsg) tea.Cmd {
 		m.labelInputValue = ""
 
 		return func() tea.Msg {
-			if err := nodeOps.AddNodeLabel(context.Background(), nodeID, key, value); err != nil {
+			ctx, cancel := context.WithTimeout(context.Background(), userActionTimeout)
+			defer cancel()
+			if err := nodeOps.AddNodeLabel(ctx, nodeID, key, value); err != nil {
 				return AddLabelErrorMsg{NodeID: nodeID, Error: err}
 			}
 			// Force refresh
@@ -748,7 +763,9 @@ func (m *Model) handleLabelRemoveDialogKey(msg tea.KeyMsg) tea.Cmd {
 			m.labelRemoveDialog = false
 
 			return func() tea.Msg {
-				if err := nodeOps.RemoveNodeLabel(context.Background(), nodeID, key); err != nil {
+				ctx, cancel := context.WithTimeout(context.Background(), userActionTimeout)
+				defer cancel()
+				if err := nodeOps.RemoveNodeLabel(ctx, nodeID, key); err != nil {
 					return RemoveLabelErrorMsg{NodeID: nodeID, Error: err}
 				}
 				// Force refresh

--- a/views/nodes/update_test.go
+++ b/views/nodes/update_test.go
@@ -1,6 +1,7 @@
 package nodesview
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -448,6 +449,24 @@ func TestLabelRemoveDialog_Enter(t *testing.T) {
 }
 
 // --- LoadNodesCmd test ---
+
+func TestDemoteNode_Timeout_ReturnsError(t *testing.T) {
+	nodeMock := noopNodeOps()
+	nodeMock.demoteNodeFn = func(_ context.Context, _ string) error {
+		return context.DeadlineExceeded
+	}
+	m := testModel(func(m *Model) { m.deps.Nodes = nodeMock })
+	entries := fakeNodes("mgr")
+	entries[0].Manager = true
+	loadNodes(m, entries)
+	m.confirmDialog.Visible = true
+	m.confirmDialog.Message = "Demote node mgr"
+	cmd := m.Update(confirmdialog.ResultMsg{Confirmed: true})
+	require.NotNil(t, cmd)
+	msg := runCmd(cmd)
+	_, ok := msg.(DemoteErrorMsg)
+	require.True(t, ok, "expected DemoteErrorMsg, got %T", msg)
+}
 
 func TestLoadNodesCmd(t *testing.T) {
 	snap := &docker.SwarmSnapshot{

--- a/views/secrets/actions.go
+++ b/views/secrets/actions.go
@@ -26,7 +26,8 @@ import (
 func (m *Model) loadSecretsCmd() tea.Cmd {
 	secretOps := m.deps.Secrets
 	return func() tea.Msg {
-		ctx := context.Background()
+		ctx, cancel := context.WithTimeout(context.Background(), pollTimeout)
+		defer cancel()
 		secs, err := secretOps.ListSecrets(ctx)
 		if err != nil {
 			return errorMsg(fmt.Errorf("failed to list secrets: %w", err))
@@ -46,7 +47,8 @@ func (m *Model) computeSecretUsedCmd(secs []docker.SecretWithDecodedData) tea.Cm
 	secretOps := m.deps.Secrets
 	return func() tea.Msg {
 		usedMap := make(map[string]bool, len(secs))
-		ctx := context.Background()
+		ctx, cancel := context.WithTimeout(context.Background(), pollTimeout)
+		defer cancel()
 		for _, s := range secs {
 			usedMap[s.Secret.ID] = false
 			svcs, err := secretOps.ListServicesUsingSecretID(ctx, s.Secret.ID)
@@ -62,9 +64,16 @@ func (m *Model) computeSecretUsedCmd(secs []docker.SecretWithDecodedData) tea.Cm
 func (m *Model) checkSecretsCmd(lastHash uint64) tea.Cmd {
 	secretOps := m.deps.Secrets
 	return func() tea.Msg {
+		if !m.polling.CompareAndSwap(false, true) {
+			l().Info("checkSecretsCmd: skipped, previous poll still in flight")
+			return PollRetryMsg{}
+		}
+		defer m.polling.Store(false)
+
 		l().Info("checkSecretsCmd: Polling for secret changes")
 
-		ctx := context.Background()
+		ctx, cancel := context.WithTimeout(context.Background(), pollTimeout)
+		defer cancel()
 		secs, err := secretOps.ListSecrets(ctx)
 		if err != nil {
 			l().Errorf("checkSecretsCmd: ListSecrets failed: %v", err)
@@ -115,7 +124,9 @@ func (m *Model) checkSecretsCmd(lastHash uint64) tea.Cmd {
 func (m *Model) inspectSecretCmd(name string) tea.Cmd {
 	secretOps := m.deps.Secrets
 	return func() tea.Msg {
-		sec, err := secretOps.InspectSecret(context.Background(), name)
+		ctx, cancel := context.WithTimeout(context.Background(), userActionTimeout)
+		defer cancel()
+		sec, err := secretOps.InspectSecret(ctx, name)
 		jsonStr := ""
 		if err != nil {
 			jsonStr = fmt.Sprintf("Error inspecting secret %q: %v", name, err)
@@ -143,7 +154,8 @@ func (m *Model) inspectSecretCmd(name string) tea.Cmd {
 func (m *Model) deleteSecretCmd(name string) tea.Cmd {
 	secretOps := m.deps.Secrets
 	return func() tea.Msg {
-		ctx := context.Background()
+		ctx, cancel := context.WithTimeout(context.Background(), userActionTimeout)
+		defer cancel()
 		err := secretOps.DeleteSecret(ctx, name)
 		if err != nil {
 			return errorMsg(fmt.Errorf("failed to delete secret %q: %w", name, err))
@@ -227,7 +239,8 @@ func (m *Model) createSecretFromFileCmd(name, filePath string, labels map[string
 		}
 
 		// Create the secret
-		ctx := context.Background()
+		ctx, cancel := context.WithTimeout(context.Background(), userActionTimeout)
+		defer cancel()
 		newSec, err := secretOps.CreateSecret(ctx, name, data, labels)
 		if err != nil {
 			l().Errorf("Failed to create secret %s: %v", name, err)
@@ -261,7 +274,8 @@ func (m *Model) createSecretFromContentCmd(name string, content []byte, labels m
 		}
 
 		// Create the secret
-		ctx := context.Background()
+		ctx, cancel := context.WithTimeout(context.Background(), userActionTimeout)
+		defer cancel()
 		newSec, err := secretOps.CreateSecret(ctx, name, content, labels)
 		if err != nil {
 			l().Errorf("Failed to create secret %s: %v", name, err)
@@ -281,7 +295,8 @@ func (m *Model) getUsedByStacksCmd(secretName string) tea.Cmd {
 	return func() tea.Msg {
 		l().Infof("Getting stacks/services that use secret: %s", secretName)
 
-		ctx := context.Background()
+		ctx, cancel := context.WithTimeout(context.Background(), userActionTimeout)
+		defer cancel()
 		// Get secret ID for robust matching
 		sec, err := secretOps.InspectSecret(ctx, secretName)
 		if err != nil {

--- a/views/secrets/actions_test.go
+++ b/views/secrets/actions_test.go
@@ -153,6 +153,46 @@ func TestCheckSecretsCmd_NoChange_ReturnsPollRetry(t *testing.T) {
 	require.True(t, isPollRetry, "should return PollRetryMsg when no change")
 }
 
+func TestCheckSecretsCmd_Timeout_ReturnsPollRetryMsg(t *testing.T) {
+	mock := noopSecretOps()
+	mock.listSecretsFn = func(_ context.Context) ([]swarm.Secret, error) {
+		return nil, context.DeadlineExceeded
+	}
+	m := testModel(func(m *Model) { m.deps.Secrets = mock })
+	cmd := m.checkSecretsCmd(0)
+	msg := runCmd(cmd)
+	_, ok := msg.(PollRetryMsg)
+	require.True(t, ok)
+}
+
+func TestLoadSecretsCmd_Timeout_ReturnsErrorMsg(t *testing.T) {
+	mock := noopSecretOps()
+	mock.listSecretsFn = func(_ context.Context) ([]swarm.Secret, error) {
+		return nil, context.DeadlineExceeded
+	}
+	m := testModel(func(m *Model) { m.deps.Secrets = mock })
+	cmd := m.loadSecretsCmd()
+	msg := runCmd(cmd)
+	_, ok := msg.(errorMsg)
+	require.True(t, ok)
+}
+
+func TestCheckSecretsCmd_InFlightGuard_SkipsDuplicate(t *testing.T) {
+	called := false
+	mock := noopSecretOps()
+	mock.listSecretsFn = func(_ context.Context) ([]swarm.Secret, error) {
+		called = true
+		return nil, nil
+	}
+	m := testModel(func(m *Model) { m.deps.Secrets = mock })
+	m.polling.Store(true)
+	cmd := m.checkSecretsCmd(0)
+	msg := runCmd(cmd)
+	_, ok := msg.(PollRetryMsg)
+	require.True(t, ok)
+	require.False(t, called, "listSecretsFn should not be called when polling is in flight")
+}
+
 func TestCheckSecretsCmd_HashMatchesAfterLoad(t *testing.T) {
 	secrets := []swarm.Secret{
 		{ID: "id1", Meta: swarm.Meta{Version: swarm.Version{Index: 1}}, Spec: swarm.SecretSpec{Annotations: swarm.Annotations{Name: "alpha"}}},

--- a/views/secrets/model.go
+++ b/views/secrets/model.go
@@ -13,6 +13,7 @@ import (
 	"swarmcli/views/helpbar"
 	loading "swarmcli/views/loading"
 	view "swarmcli/views/view"
+	"sync/atomic"
 	"time"
 
 	"github.com/charmbracelet/bubbles/textinput"
@@ -38,7 +39,8 @@ type Model struct {
 	height        int
 	firstResize   bool   // tracks if we've received the first window size
 	lastSnapshot  uint64 // hash of last snapshot for change detection
-	visible       bool   // tracks if view is currently active
+	polling       atomic.Bool
+	visible       bool // tracks if view is currently active
 	sortField     SortField
 	sortAscending bool // true for ascending, false for descending
 
@@ -90,6 +92,8 @@ const (
 )
 
 const PollInterval = 5 * time.Second
+const pollTimeout = 4 * time.Second
+const userActionTimeout = 15 * time.Second
 
 func New(width, height int) *Model {
 	vp := viewport.New(width, height)

--- a/views/secrets/update.go
+++ b/views/secrets/update.go
@@ -163,7 +163,7 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 
 	case TickMsg:
 		l().Infof("SecretsView: Received TickMsg, state=%v, visible=%v", m.state, m.visible)
-		if m.visible && m.state == stateReady && !m.confirmDialog.Visible && !m.loadingView.Visible() {
+		if m.visible && m.state == stateReady && !m.confirmDialog.Visible && !m.loadingView.Visible() && !m.polling.Load() {
 			return tea.Batch(
 				m.checkSecretsCmd(m.lastSnapshot),
 				tickCmd(),

--- a/views/secrets/update_test.go
+++ b/views/secrets/update_test.go
@@ -527,6 +527,18 @@ func TestParseLabels_EmptyKey(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestTickMsg_WhenPollingInFlight_SkipsCheck(t *testing.T) {
+	m := testModel()
+	loadSecrets(m, fakeSecrets("s1"))
+	m.visible = true
+	m.polling.Store(true)
+	cmd := m.Update(TickMsg(time.Now()))
+	require.NotNil(t, cmd)
+	msg := runCmd(cmd)
+	_, isTickMsg := msg.(TickMsg)
+	require.True(t, isTickMsg, "expected TickMsg from tickCmd, got %T", msg)
+}
+
 // --- SpinnerTick ---
 
 func TestSpinnerTick_AdvancesSpinner(t *testing.T) {

--- a/views/services/messages.go
+++ b/views/services/messages.go
@@ -25,6 +25,8 @@ type PollRetryMsg struct{}
 
 const PollInterval = 2 * time.Second
 
+const userActionTimeout = 15 * time.Second
+
 // RestartErrorMsg is sent when a service restart fails
 type RestartErrorMsg struct {
 	ServiceName string

--- a/views/services/model_test.go
+++ b/views/services/model_test.go
@@ -19,28 +19,30 @@ import (
 // --- mocks ---
 
 type mockServiceOps struct {
-	scaleServiceFn      func(serviceID string, replicas uint64) error
-	restartServiceFn    func(serviceName string) error
-	removeServiceFn     func(serviceName string) error
-	rollbackServiceFn   func(serviceName string) error
+	scaleServiceFn      func(ctx context.Context, serviceID string, replicas uint64) error
+	restartServiceFn    func(ctx context.Context, serviceName string) error
+	removeServiceFn     func(ctx context.Context, serviceName string) error
+	rollbackServiceFn   func(ctx context.Context, serviceName string) error
 	loadNodeServicesFn  func(nodeID string) []docker.ServiceEntry
 	loadStackServicesFn func(stackName string) []docker.ServiceEntry
 	getServiceLogsFn    func(ctx context.Context, serviceID string) (string, error)
 	createServiceFn     func(ctx context.Context, spec swarm.ServiceSpec) (string, error)
 }
 
-func (m *mockServiceOps) ScaleService(serviceID string, replicas uint64) error {
-	return m.scaleServiceFn(serviceID, replicas)
+func (m *mockServiceOps) ScaleService(ctx context.Context, serviceID string, replicas uint64) error {
+	return m.scaleServiceFn(ctx, serviceID, replicas)
 }
-func (m *mockServiceOps) ScaleServiceByName(_ string, _ uint64) error { panic("not mocked") }
-func (m *mockServiceOps) RestartService(serviceName string) error {
-	return m.restartServiceFn(serviceName)
+func (m *mockServiceOps) ScaleServiceByName(_ context.Context, _ string, _ uint64) error {
+	panic("not mocked")
 }
-func (m *mockServiceOps) RemoveService(serviceName string) error {
-	return m.removeServiceFn(serviceName)
+func (m *mockServiceOps) RestartService(ctx context.Context, serviceName string) error {
+	return m.restartServiceFn(ctx, serviceName)
 }
-func (m *mockServiceOps) RollbackService(serviceName string) error {
-	return m.rollbackServiceFn(serviceName)
+func (m *mockServiceOps) RemoveService(ctx context.Context, serviceName string) error {
+	return m.removeServiceFn(ctx, serviceName)
+}
+func (m *mockServiceOps) RollbackService(ctx context.Context, serviceName string) error {
+	return m.rollbackServiceFn(ctx, serviceName)
 }
 func (m *mockServiceOps) RestartServiceAndWait(_ context.Context, _ string) error {
 	panic("not mocked")
@@ -155,10 +157,10 @@ func runCmd(cmd tea.Cmd) tea.Msg {
 
 func noopServiceOps() *mockServiceOps {
 	return &mockServiceOps{
-		scaleServiceFn:      func(_ string, _ uint64) error { return nil },
-		restartServiceFn:    func(_ string) error { return nil },
-		removeServiceFn:     func(_ string) error { return nil },
-		rollbackServiceFn:   func(_ string) error { return nil },
+		scaleServiceFn:      func(_ context.Context, _ string, _ uint64) error { return nil },
+		restartServiceFn:    func(_ context.Context, _ string) error { return nil },
+		removeServiceFn:     func(_ context.Context, _ string) error { return nil },
+		rollbackServiceFn:   func(_ context.Context, _ string) error { return nil },
 		loadNodeServicesFn:  func(_ string) []docker.ServiceEntry { return nil },
 		loadStackServicesFn: func(_ string) []docker.ServiceEntry { return nil },
 	}
@@ -431,10 +433,10 @@ func TestConfirmRestart_Success(t *testing.T) {
 	restarted := ""
 	m := testModel(func(m *Model) {
 		m.deps.Services = &mockServiceOps{
-			scaleServiceFn:      func(_ string, _ uint64) error { return nil },
-			restartServiceFn:    func(name string) error { restarted = name; return nil },
-			removeServiceFn:     func(_ string) error { return nil },
-			rollbackServiceFn:   func(_ string) error { return nil },
+			scaleServiceFn:      func(_ context.Context, _ string, _ uint64) error { return nil },
+			restartServiceFn:    func(_ context.Context, name string) error { restarted = name; return nil },
+			removeServiceFn:     func(_ context.Context, _ string) error { return nil },
+			rollbackServiceFn:   func(_ context.Context, _ string) error { return nil },
 			loadNodeServicesFn:  func(_ string) []docker.ServiceEntry { return nil },
 			loadStackServicesFn: func(_ string) []docker.ServiceEntry { return nil },
 		}
@@ -452,10 +454,10 @@ func TestConfirmRemove_Success(t *testing.T) {
 	removed := ""
 	m := testModel(func(m *Model) {
 		m.deps.Services = &mockServiceOps{
-			scaleServiceFn:      func(_ string, _ uint64) error { return nil },
-			restartServiceFn:    func(_ string) error { return nil },
-			removeServiceFn:     func(name string) error { removed = name; return nil },
-			rollbackServiceFn:   func(_ string) error { return nil },
+			scaleServiceFn:      func(_ context.Context, _ string, _ uint64) error { return nil },
+			restartServiceFn:    func(_ context.Context, _ string) error { return nil },
+			removeServiceFn:     func(_ context.Context, name string) error { removed = name; return nil },
+			rollbackServiceFn:   func(_ context.Context, _ string) error { return nil },
 			loadNodeServicesFn:  func(_ string) []docker.ServiceEntry { return nil },
 			loadStackServicesFn: func(_ string) []docker.ServiceEntry { return nil },
 		}
@@ -473,10 +475,10 @@ func TestConfirmRollback_Success(t *testing.T) {
 	rolledBack := ""
 	m := testModel(func(m *Model) {
 		m.deps.Services = &mockServiceOps{
-			scaleServiceFn:      func(_ string, _ uint64) error { return nil },
-			restartServiceFn:    func(_ string) error { return nil },
-			removeServiceFn:     func(_ string) error { return nil },
-			rollbackServiceFn:   func(name string) error { rolledBack = name; return nil },
+			scaleServiceFn:      func(_ context.Context, _ string, _ uint64) error { return nil },
+			restartServiceFn:    func(_ context.Context, _ string) error { return nil },
+			removeServiceFn:     func(_ context.Context, _ string) error { return nil },
+			rollbackServiceFn:   func(_ context.Context, name string) error { rolledBack = name; return nil },
 			loadNodeServicesFn:  func(_ string) []docker.ServiceEntry { return nil },
 			loadStackServicesFn: func(_ string) []docker.ServiceEntry { return nil },
 		}
@@ -516,14 +518,14 @@ func TestScaleDialogResult_Confirmed(t *testing.T) {
 	var scaledTo uint64
 	m := testModel(func(m *Model) {
 		m.deps.Services = &mockServiceOps{
-			scaleServiceFn: func(id string, replicas uint64) error {
+			scaleServiceFn: func(_ context.Context, id string, replicas uint64) error {
 				scaled = id
 				scaledTo = replicas
 				return nil
 			},
-			restartServiceFn:    func(_ string) error { return nil },
-			removeServiceFn:     func(_ string) error { return nil },
-			rollbackServiceFn:   func(_ string) error { return nil },
+			restartServiceFn:    func(_ context.Context, _ string) error { return nil },
+			removeServiceFn:     func(_ context.Context, _ string) error { return nil },
+			rollbackServiceFn:   func(_ context.Context, _ string) error { return nil },
 			loadNodeServicesFn:  func(_ string) []docker.ServiceEntry { return nil },
 			loadStackServicesFn: func(_ string) []docker.ServiceEntry { return nil },
 		}

--- a/views/services/update.go
+++ b/views/services/update.go
@@ -131,7 +131,9 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 			snapshotOps := m.deps.Snapshot
 			refreshCmd := m.refreshServicesCmd(m.nodeID, m.stackName, m.filterType)
 			return func() tea.Msg {
-				if err := serviceOps.ScaleService(entry.ServiceID, msg.Replicas); err != nil {
+				ctx, cancel := context.WithTimeout(context.Background(), userActionTimeout)
+				defer cancel()
+				if err := serviceOps.ScaleService(ctx, entry.ServiceID, msg.Replicas); err != nil {
 					l().Errorf("Failed to scale service %s: %v", entry.ServiceName, err)
 					return ScaleErrorMsg{
 						ServiceName: entry.ServiceName,
@@ -161,8 +163,10 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 			case "remove":
 				l().Debugln("Starting remove for", entry.ServiceName)
 				return func() tea.Msg {
+					ctx, cancel := context.WithTimeout(context.Background(), userActionTimeout)
+					defer cancel()
 					l().Infof("Executing remove for service: %s", entry.ServiceName)
-					if err := serviceOps.RemoveService(entry.ServiceName); err != nil {
+					if err := serviceOps.RemoveService(ctx, entry.ServiceName); err != nil {
 						l().Errorf("Failed to remove service %s: %v", entry.ServiceName, err)
 						return RemoveErrorMsg{
 							ServiceName: entry.ServiceName,
@@ -179,8 +183,10 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 			case "rollback":
 				l().Debugln("Starting rollback for", entry.ServiceName)
 				return func() tea.Msg {
+					ctx, cancel := context.WithTimeout(context.Background(), userActionTimeout)
+					defer cancel()
 					l().Infof("Executing rollback for service: %s", entry.ServiceName)
-					if err := serviceOps.RollbackService(entry.ServiceName); err != nil {
+					if err := serviceOps.RollbackService(ctx, entry.ServiceName); err != nil {
 						l().Errorf("Failed to rollback service %s: %v", entry.ServiceName, err)
 						return RollbackErrorMsg{
 							ServiceName: entry.ServiceName,
@@ -198,8 +204,10 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 				// Default to restart
 				l().Debugln("Starting restart for", entry.ServiceName)
 				return func() tea.Msg {
+					ctx, cancel := context.WithTimeout(context.Background(), userActionTimeout)
+					defer cancel()
 					l().Infof("Executing restart for service: %s", entry.ServiceName)
-					if err := serviceOps.RestartService(entry.ServiceName); err != nil {
+					if err := serviceOps.RestartService(ctx, entry.ServiceName); err != nil {
 						l().Errorf("Failed to restart service %s: %v", entry.ServiceName, err)
 						return RestartErrorMsg{
 							ServiceName: entry.ServiceName,
@@ -401,7 +409,9 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 				entry := m.List.Filtered[m.List.Cursor]
 				inspectOps := m.deps.Inspect
 				return func() tea.Msg {
-					content, err := inspectOps.Inspect(context.Background(), docker.InspectService, entry.ServiceID)
+					ctx, cancel := context.WithTimeout(context.Background(), userActionTimeout)
+					defer cancel()
+					content, err := inspectOps.Inspect(ctx, docker.InspectService, entry.ServiceID)
 					if err != nil {
 						content = fmt.Sprintf("Error inspecting service %q: %v", entry.ServiceName, err)
 					}

--- a/views/services/update_test.go
+++ b/views/services/update_test.go
@@ -1,0 +1,80 @@
+package servicesview
+
+import (
+	"context"
+	"testing"
+
+	"swarmcli/docker"
+	"swarmcli/views/confirmdialog"
+	"swarmcli/views/scaledialog"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestScaleService_Timeout_ReturnsScaleError(t *testing.T) {
+	m := testModel(func(m *Model) {
+		m.deps.Services = &mockServiceOps{
+			scaleServiceFn: func(_ context.Context, _ string, _ uint64) error {
+				return context.DeadlineExceeded
+			},
+			restartServiceFn:    func(_ context.Context, _ string) error { return nil },
+			removeServiceFn:     func(_ context.Context, _ string) error { return nil },
+			rollbackServiceFn:   func(_ context.Context, _ string) error { return nil },
+			loadNodeServicesFn:  func(_ string) []docker.ServiceEntry { return nil },
+			loadStackServicesFn: func(_ string) []docker.ServiceEntry { return nil },
+		}
+	})
+	loadServices(m, fakeEntries("web"))
+	m.scaleDialog.Visible = true
+	cmd := m.Update(scaledialog.ResultMsg{Confirmed: true, Replicas: 3})
+	require.NotNil(t, cmd)
+	msg := runCmd(cmd)
+	_, ok := msg.(ScaleErrorMsg)
+	require.True(t, ok, "expected ScaleErrorMsg, got %T", msg)
+}
+
+func TestRemoveService_Timeout_ReturnsRemoveError(t *testing.T) {
+	m := testModel(func(m *Model) {
+		m.deps.Services = &mockServiceOps{
+			scaleServiceFn:   func(_ context.Context, _ string, _ uint64) error { return nil },
+			restartServiceFn: func(_ context.Context, _ string) error { return nil },
+			removeServiceFn: func(_ context.Context, _ string) error {
+				return context.DeadlineExceeded
+			},
+			rollbackServiceFn:   func(_ context.Context, _ string) error { return nil },
+			loadNodeServicesFn:  func(_ string) []docker.ServiceEntry { return nil },
+			loadStackServicesFn: func(_ string) []docker.ServiceEntry { return nil },
+		}
+	})
+	loadServices(m, fakeEntries("web"))
+	m.pendingAction = "remove"
+	m.confirmDialog.Visible = true
+	cmd := m.Update(confirmdialog.ResultMsg{Confirmed: true})
+	require.NotNil(t, cmd)
+	msg := runCmd(cmd)
+	_, ok := msg.(RemoveErrorMsg)
+	require.True(t, ok, "expected RemoveErrorMsg, got %T", msg)
+}
+
+func TestRestartService_Timeout_ReturnsRestartError(t *testing.T) {
+	m := testModel(func(m *Model) {
+		m.deps.Services = &mockServiceOps{
+			scaleServiceFn: func(_ context.Context, _ string, _ uint64) error { return nil },
+			restartServiceFn: func(_ context.Context, _ string) error {
+				return context.DeadlineExceeded
+			},
+			removeServiceFn:     func(_ context.Context, _ string) error { return nil },
+			rollbackServiceFn:   func(_ context.Context, _ string) error { return nil },
+			loadNodeServicesFn:  func(_ string) []docker.ServiceEntry { return nil },
+			loadStackServicesFn: func(_ string) []docker.ServiceEntry { return nil },
+		}
+	})
+	loadServices(m, fakeEntries("web"))
+	m.pendingAction = "restart"
+	m.confirmDialog.Visible = true
+	cmd := m.Update(confirmdialog.ResultMsg{Confirmed: true})
+	require.NotNil(t, cmd)
+	msg := runCmd(cmd)
+	_, ok := msg.(RestartErrorMsg)
+	require.True(t, ok, "expected RestartErrorMsg, got %T", msg)
+}

--- a/views/stacks/model_test.go
+++ b/views/stacks/model_test.go
@@ -1,6 +1,7 @@
 package stacksview
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -14,19 +15,19 @@ import (
 // --- mocks ---
 
 type mockStackOps struct {
-	removeStackFn             func(stackName string) error
-	removeStackNetworksFn     func(stackName string) error
+	removeStackFn             func(ctx context.Context, stackName string) error
+	removeStackNetworksFn     func(ctx context.Context, stackName string) error
 	deployStackFn             func(stackName string, yamlContent string) error
 	validateStackYAMLFn       func(content string) error
 	inspectStackFn            func(stackName string) (string, error)
 	reconstructStackComposeFn func(stackName string) (string, error)
 }
 
-func (m *mockStackOps) RemoveStack(stackName string) error {
-	return m.removeStackFn(stackName)
+func (m *mockStackOps) RemoveStack(ctx context.Context, stackName string) error {
+	return m.removeStackFn(ctx, stackName)
 }
-func (m *mockStackOps) RemoveStackNetworks(stackName string) error {
-	return m.removeStackNetworksFn(stackName)
+func (m *mockStackOps) RemoveStackNetworks(ctx context.Context, stackName string) error {
+	return m.removeStackNetworksFn(ctx, stackName)
 }
 func (m *mockStackOps) DeployStack(stackName string, yamlContent string) error {
 	return m.deployStackFn(stackName, yamlContent)
@@ -129,8 +130,8 @@ func runCmd(cmd tea.Cmd) tea.Msg {
 
 func noopStackOps() *mockStackOps {
 	return &mockStackOps{
-		removeStackFn:             func(_ string) error { return nil },
-		removeStackNetworksFn:     func(_ string) error { return nil },
+		removeStackFn:             func(_ context.Context, _ string) error { return nil },
+		removeStackNetworksFn:     func(_ context.Context, _ string) error { return nil },
 		deployStackFn:             func(_ string, _ string) error { return nil },
 		validateStackYAMLFn:       func(_ string) error { return nil },
 		inspectStackFn:            func(_ string) (string, error) { return "", nil },

--- a/views/stacks/update.go
+++ b/views/stacks/update.go
@@ -4,6 +4,7 @@
 package stacksview
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -24,6 +25,8 @@ import (
 	"github.com/charmbracelet/lipgloss"
 	"github.com/docker/docker/api/types/swarm"
 )
+
+const userActionTimeout = 15 * time.Second
 
 // Update handles all messages for the stacks view.
 func (m *Model) Update(msg tea.Msg) tea.Cmd {
@@ -139,8 +142,10 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 				snapOps := m.deps.Snapshot
 				checkCmd := m.checkStacksCmd(m.lastSnapshot, m.nodeID)
 				return func() tea.Msg {
+					ctx, cancel := context.WithTimeout(context.Background(), userActionTimeout)
+					defer cancel()
 					l().Infof("Executing remove for stack: %s (remove networks: %v)", selected.Name, removeNetworks)
-					if err := stackOps.RemoveStack(selected.Name); err != nil {
+					if err := stackOps.RemoveStack(ctx, selected.Name); err != nil {
 						l().Errorf("Failed to remove stack %s: %v", selected.Name, err)
 						return RemoveErrorMsg{
 							StackName: selected.Name,
@@ -152,7 +157,7 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 					// Remove networks if checkbox was checked
 					if removeNetworks {
 						l().Infof("Removing networks for stack: %s", selected.Name)
-						if err := stackOps.RemoveStackNetworks(selected.Name); err != nil {
+						if err := stackOps.RemoveStackNetworks(ctx, selected.Name); err != nil {
 							l().Warnf("Failed to remove networks for stack %s: %v", selected.Name, err)
 							// Don't fail the whole operation if network removal fails
 						}

--- a/views/stacks/update_test.go
+++ b/views/stacks/update_test.go
@@ -1,6 +1,7 @@
 package stacksview
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -335,7 +336,7 @@ func TestSortKey_R_Error(t *testing.T) {
 func TestConfirmResult_Remove(t *testing.T) {
 	removed := ""
 	stackMock := noopStackOps()
-	stackMock.removeStackFn = func(name string) error {
+	stackMock.removeStackFn = func(_ context.Context, name string) error {
 		removed = name
 		return nil
 	}
@@ -352,8 +353,8 @@ func TestConfirmResult_Remove(t *testing.T) {
 func TestConfirmResult_RemoveWithNetworks(t *testing.T) {
 	removedNetworks := ""
 	stackMock := noopStackOps()
-	stackMock.removeStackFn = func(_ string) error { return nil }
-	stackMock.removeStackNetworksFn = func(name string) error {
+	stackMock.removeStackFn = func(_ context.Context, _ string) error { return nil }
+	stackMock.removeStackNetworksFn = func(_ context.Context, name string) error {
 		removedNetworks = name
 		return nil
 	}
@@ -588,6 +589,22 @@ func TestFileBrowser_Enter_Directory(t *testing.T) {
 	m.fileBrowserCursor = 0
 	cmd := m.Update(key("enter"))
 	require.NotNil(t, cmd)
+}
+
+func TestRemoveStack_Timeout_ReturnsRemoveError(t *testing.T) {
+	stackMock := noopStackOps()
+	stackMock.removeStackFn = func(_ context.Context, _ string) error {
+		return context.DeadlineExceeded
+	}
+	m := testModel(func(m *Model) { m.deps.Stacks = stackMock })
+	loadStacks(m, fakeStacks("target"))
+	m.pendingAction = "remove"
+	m.confirmDialog.Visible = true
+	cmd := m.Update(confirmdialog.ResultMsg{Confirmed: true})
+	require.NotNil(t, cmd)
+	msg := runCmd(cmd)
+	_, ok := msg.(RemoveErrorMsg)
+	require.True(t, ok, "expected RemoveErrorMsg, got %T", msg)
 }
 
 // --- Task navigation tests ---


### PR DESCRIPTION
## Summary

- Add `ctx context.Context` parameter to all Docker-layer functions that
  previously created their own `context.Background()` (ServiceOps, StackOps,
  NodeOps, ContextOps interfaces)
- Add context timeouts to all view-layer Docker API calls: 4s for background
  polling, 15s for user-initiated operations
- Add `atomic.Bool` in-flight guard to prevent overlapping `checkConfigsCmd` /
  `checkSecretsCmd` goroutines
- Add unit tests for timeout/unreachability handling and AST-based guardrail
  test to prevent regression

## Problem

When Docker becomes unreachable, the configs/secrets views freeze and become
unresponsive. All Docker API calls used `context.Background()` with no timeout,
so each call hung for the OS TCP timeout (30-60s). Meanwhile, the 5-second
polling tick kept spawning new goroutines — after 30 seconds, 6+ goroutines
were simultaneously blocked, each making N+1 API calls (1 list + N inspects).

**Why this was only observed on BE, not CE:** the bug exists in both editions
(same polling code), but the failure mode differs by connection type. CE users
typically connect via unix socket — when the daemon is down, the kernel returns
ECONNREFUSED instantly, so polls fail fast with no pile-up. BE requires TCP
connections (the shell feature derives a WebSocket URL from the Docker host and
rejects unix sockets), so all BE deployments use TCP contexts. When a TCP host
becomes unreachable there is no immediate rejection — the kernel enters TCP
retransmit and hangs for 30-60 seconds, which is what causes the goroutine
pile-up.

This is a codebase-wide fix — the networks view already followed the timeout
pattern correctly, but configs, secrets, nodes, services, stacks, and contexts
did not.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` (includes new timeout/unreachability unit tests)
- [x] `golangci-lint run ./...`
- [ ] `./test-setup/testenv.sh integration`
- [ ] Manual: connect to Swarm via TCP context, navigate to configs, kill
      Docker daemon — app should remain responsive (polls fail within 4s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)