### PR TITLE
feat: save stack YAML to local file

### DIFF
--- a/ui/ui.go
+++ b/ui/ui.go
@@ -333,8 +333,10 @@ func RenderFileBrowserDialog(title, currentPath string, files []string, cursor i
 		item := files[i]
 		displayName := ""
 
-		// Handle parent directory
-		if item == ".." {
+		// Handle special entries and parent directory
+		if item == "[Save here]" {
+			displayName = "✓ [Save here]"
+		} else if item == ".." {
 			displayName = "📁 .."
 		} else if strings.HasSuffix(item, "/") {
 			// Directory

--- a/views/confirmdialog/confirmdialog.go
+++ b/views/confirmdialog/confirmdialog.go
@@ -21,7 +21,8 @@ type Model struct {
 	Message         string
 	Width           int
 	Height          int
-	ErrorMode       bool   // If true, shows "Close" instead of "Yes/No"
+	ErrorMode       bool   // If true, shows "Error" title and dismiss-only
+	InfoMode        bool   // If true, shows "Info" title and dismiss-only
 	CheckboxLabel   string // If non-empty, shows a checkbox with this label
 	CheckboxChecked bool   // State of the checkbox
 }
@@ -40,8 +41,8 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 			m.Visible = false
 			return func() tea.Msg { return ResultMsg{Confirmed: false, CheckboxChecked: m.CheckboxChecked} }
 		}
-		if m.ErrorMode {
-			// In error mode, any key closes the dialog
+		if m.ErrorMode || m.InfoMode {
+			// In error/info mode, any key closes the dialog
 			switch msg.String() {
 			case "enter", "esc", " ":
 				m.Visible = false
@@ -79,11 +80,15 @@ func (m *Model) View() string {
 		contentWidth = 50
 	}
 
-	// Styled title
+	// Styled title — color varies by mode
+	titleColor := lipgloss.Color("208") // Orange for warning/confirm
+	if m.InfoMode {
+		titleColor = lipgloss.Color("63") // Blue/purple for info
+	}
 	titleStyle := lipgloss.NewStyle().
 		Bold(true).
 		Foreground(lipgloss.Color("15")).
-		Background(lipgloss.Color("208")). // Orange for warning
+		Background(titleColor).
 		Padding(0, 1).
 		Width(contentWidth)
 
@@ -102,15 +107,17 @@ func (m *Model) View() string {
 		Foreground(lipgloss.Color("63")).
 		Bold(true)
 
-	// Border style
+	// Border style — matches title color
 	borderStyle := lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
-		BorderForeground(lipgloss.Color("208")).
+		BorderForeground(titleColor).
 		Width(contentWidth + 2)
 
 	// Build content
 	var lines []string
-	if m.ErrorMode {
+	if m.InfoMode {
+		lines = append(lines, titleStyle.Render(" Info "))
+	} else if m.ErrorMode {
 		lines = append(lines, titleStyle.Render(" Error "))
 	} else {
 		lines = append(lines, titleStyle.Render(" Confirm Action "))
@@ -118,7 +125,7 @@ func (m *Model) View() string {
 	lines = append(lines, messageStyle.Render(m.Message))
 
 	// Add checkbox if label is provided
-	if m.CheckboxLabel != "" && !m.ErrorMode {
+	if m.CheckboxLabel != "" && !m.ErrorMode && !m.InfoMode {
 		checkboxStyle := lipgloss.NewStyle().
 			Padding(0, 2).
 			Width(contentWidth)
@@ -134,7 +141,7 @@ func (m *Model) View() string {
 	}
 
 	var helpText string
-	if m.ErrorMode {
+	if m.ErrorMode || m.InfoMode {
 		helpText = fmt.Sprintf("%s Close", keyStyle.Render("<Enter/Esc>"))
 	} else {
 		if m.CheckboxLabel != "" {

--- a/views/stacks/messages.go
+++ b/views/stacks/messages.go
@@ -62,3 +62,13 @@ type filesLoadedMsg struct {
 	Files []string
 	Error error
 }
+
+// stackSavedMsg is sent when stack YAML is successfully saved to file
+type stackSavedMsg struct {
+	Path string
+}
+
+// stackSaveErrorMsg is sent when saving stack YAML fails
+type stackSaveErrorMsg struct {
+	Err error
+}

--- a/views/stacks/model.go
+++ b/views/stacks/model.go
@@ -92,6 +92,13 @@ type Model struct {
 
 	// Edit stack tracking
 	editStackName string // non-empty when editing a stack (vs creating new)
+
+	// Save stack dialog
+	saveDialogActive   bool
+	saveDialogError    string          // error message to display in save dialog
+	saveFileInput      textinput.Model // For typing file path
+	saveStackName      string          // name of stack being saved
+	fileBrowserContext string          // "create" or "save" — determines return target from file browser
 }
 
 func New(width, height int) *Model {
@@ -162,10 +169,19 @@ func New(width, height int) *Model {
 	fileInput.CharLimit = 512
 	fileInput.Width = 50
 
+	// Initialize save file path input
+	saveInput := textinput.New()
+	saveInput.Placeholder = "./my-stack.yml"
+	saveInput.Prompt = "Save to: "
+	saveInput.CharLimit = 512
+	saveInput.Width = 50
+
 	m.List = list
 	m.confirmDialog = confirmdialog.New(width, height)
 	m.createNameInput = nameInput
 	m.createFileInput = fileInput
+	m.saveFileInput = saveInput
+	m.fileBrowserContext = "create"
 	return m
 }
 
@@ -185,6 +201,7 @@ func (m *Model) ShortHelpItems() []helpbar.HelpEntry {
 	return []helpbar.HelpEntry{
 		{Key: "n", Desc: "New stack"},
 		{Key: "e", Desc: "Edit"},
+		{Key: "s", Desc: "Save YAML"},
 		{Key: "enter", Desc: "Services"},
 		{Key: "i", Desc: "Inspect"},
 		{Key: "p", Desc: "Tasks"},
@@ -292,7 +309,7 @@ func (m *Model) ClearSearchQuery() {
 
 // CapturesInput reports whether the view is currently capturing all keyboard input.
 func (m *Model) CapturesInput() bool {
-	return (m.confirmDialog != nil && m.confirmDialog.Visible) || m.createDialogActive || m.fileBrowserActive
+	return (m.confirmDialog != nil && m.confirmDialog.Visible) || m.createDialogActive || m.saveDialogActive || m.fileBrowserActive
 }
 
 // HasErrors returns true if any stack has errors

--- a/views/stacks/model_test.go
+++ b/views/stacks/model_test.go
@@ -234,6 +234,12 @@ func TestCapturesInput_FileBrowser(t *testing.T) {
 	require.True(t, m.CapturesInput())
 }
 
+func TestCapturesInput_SaveDialog(t *testing.T) {
+	m := testModel()
+	m.saveDialogActive = true
+	require.True(t, m.CapturesInput())
+}
+
 func TestHasActiveFilter_Default(t *testing.T) {
 	m := testModel()
 	require.False(t, m.HasActiveFilter())
@@ -258,13 +264,14 @@ func TestHasErrors_WithError(t *testing.T) {
 func TestShortHelpItems(t *testing.T) {
 	m := testModel()
 	items := m.ShortHelpItems()
-	require.True(t, len(items) >= 9)
+	require.True(t, len(items) >= 10)
 	keys := make(map[string]bool)
 	for _, item := range items {
 		keys[item.Key] = true
 	}
 	require.True(t, keys["n"])
 	require.True(t, keys["e"])
+	require.True(t, keys["s"])
 	require.True(t, keys["i"])
 	require.True(t, keys["ctrl+d"])
 	require.True(t, keys["?"])

--- a/views/stacks/update.go
+++ b/views/stacks/update.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime/debug"
+	"slices"
 	"sort"
 	"strings"
 	"swarmcli/core/primitives/hash"
@@ -27,6 +28,9 @@ import (
 )
 
 const userActionTimeout = 15 * time.Second
+
+// saveDirSentinel is a special file browser entry that selects the current directory.
+const saveDirSentinel = "[Save here]"
 
 // Update handles all messages for the stacks view.
 func (m *Model) Update(msg tea.Msg) tea.Cmd {
@@ -302,6 +306,14 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 		m.fileBrowserPath = msg.Path
 		m.fileBrowserFiles = msg.Files
 		m.fileBrowserCursor = 0
+		// In save context, inject "[Save here]" entry after ".."
+		if m.fileBrowserContext == "save" {
+			idx := 0
+			if len(m.fileBrowserFiles) > 0 && m.fileBrowserFiles[0] == ".." {
+				idx = 1
+			}
+			m.fileBrowserFiles = slices.Insert(m.fileBrowserFiles, idx, saveDirSentinel)
+		}
 		m.fileBrowserActive = true // Ensure browser stays active
 		return nil
 
@@ -1060,6 +1072,19 @@ func (m *Model) handleFileBrowserKey(msg tea.KeyMsg) tea.Cmd {
 		}
 
 		selected := m.fileBrowserFiles[m.fileBrowserCursor]
+
+		// Handle "[Save here]" sentinel — select current directory
+		if selected == saveDirSentinel {
+			baseName := filepath.Base(m.saveFileInput.Value())
+			if baseName == "" || baseName == "." {
+				baseName = m.saveStackName + ".yml"
+			}
+			m.saveFileInput.SetValue(filepath.Join(m.fileBrowserPath, baseName))
+			m.fileBrowserActive = false
+			m.saveDialogActive = true
+			m.saveFileInput.Focus()
+			return nil
+		}
 
 		// Handle parent directory
 		if selected == ".." {

--- a/views/stacks/update.go
+++ b/views/stacks/update.go
@@ -135,6 +135,7 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 	case confirmdialog.ResultMsg:
 		m.confirmDialog.Visible = false
 		m.confirmDialog.CheckboxLabel = "" // Clear checkbox for next use
+		m.confirmDialog.InfoMode = false
 
 		if m.pendingAction == "save-overwrite" {
 			if msg.Confirmed {
@@ -281,7 +282,7 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 		m.saveDialogError = ""
 		m.saveFileInput.Blur()
 		m.confirmDialog.Visible = true
-		m.confirmDialog.ErrorMode = true // dismiss-only dialog
+		m.confirmDialog.InfoMode = true
 		m.confirmDialog.Message = fmt.Sprintf("Stack YAML saved to:\n%s", msg.Path)
 		return nil
 

--- a/views/stacks/update.go
+++ b/views/stacks/update.go
@@ -132,6 +132,24 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 		m.confirmDialog.Visible = false
 		m.confirmDialog.CheckboxLabel = "" // Clear checkbox for next use
 
+		if m.pendingAction == "save-overwrite" {
+			if msg.Confirmed {
+				filePath := m.saveFileInput.Value()
+				if !filepath.IsAbs(filePath) {
+					if abs, err := filepath.Abs(filePath); err == nil {
+						filePath = abs
+					}
+				}
+				m.pendingAction = ""
+				return m.saveStackToFileCmd(m.saveStackName, filePath)
+			}
+			// Cancelled — return to save dialog
+			m.pendingAction = ""
+			m.saveDialogActive = true
+			m.saveFileInput.Focus()
+			return nil
+		}
+
 		if msg.Confirmed && m.List.Cursor < len(m.List.Filtered) {
 			selected := m.List.Filtered[m.List.Cursor]
 
@@ -253,12 +271,32 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 		m.fileBrowserActive = false
 		return nil
 
+	case stackSavedMsg:
+		m.saveDialogActive = false
+		m.saveDialogError = ""
+		m.saveFileInput.Blur()
+		m.confirmDialog.Visible = true
+		m.confirmDialog.ErrorMode = true // dismiss-only dialog
+		m.confirmDialog.Message = fmt.Sprintf("Stack YAML saved to:\n%s", msg.Path)
+		return nil
+
+	case stackSaveErrorMsg:
+		m.saveDialogActive = true
+		m.saveDialogError = msg.Err.Error()
+		m.saveFileInput.Focus()
+		return nil
+
 	case filesLoadedMsg:
 		if msg.Error != nil {
 			l().Errorf("Error loading files: %v", msg.Error)
 			m.fileBrowserActive = false
-			m.createDialogActive = true
-			m.createDialogError = fmt.Sprintf("Failed to load directory: %v", msg.Error)
+			if m.fileBrowserContext == "save" {
+				m.saveDialogActive = true
+				m.saveDialogError = fmt.Sprintf("Failed to load directory: %v", msg.Error)
+			} else {
+				m.createDialogActive = true
+				m.createDialogError = fmt.Sprintf("Failed to load directory: %v", msg.Error)
+			}
 			return nil
 		}
 		m.fileBrowserPath = msg.Path
@@ -268,6 +306,11 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 		return nil
 
 	case tea.KeyMsg:
+		// If save dialog is active, handle its keys
+		if m.saveDialogActive {
+			return m.handleSaveDialogKey(msg)
+		}
+
 		// If create dialog is active, handle its keys
 		if m.createDialogActive {
 			return m.handleCreateDialogKey(msg)
@@ -408,6 +451,19 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 				}
 				l().Infof("Reconstructed YAML for editing: %s (%d bytes)", stackName, len(yamlContent))
 				return openEditorForStackCmd(yamlContent)
+			}
+		}
+
+		// 's' saves stack YAML to a local file
+		if msg.String() == "s" {
+			if m.List.Cursor < len(m.List.Filtered) {
+				selected := m.List.Filtered[m.List.Cursor]
+				m.saveStackName = selected.Name
+				m.saveDialogActive = true
+				m.saveDialogError = ""
+				m.saveFileInput.SetValue(selected.Name + ".yml")
+				m.saveFileInput.Focus()
+				return nil
 			}
 		}
 
@@ -657,6 +713,7 @@ func (m *Model) handleCreateDialogKey(msg tea.KeyMsg) tea.Cmd {
 			if m.createInputFocus == 1 {
 				m.createDialogActive = false
 				m.fileBrowserActive = true
+				m.fileBrowserContext = "create"
 				homeDir, _ := os.UserHomeDir()
 				if homeDir == "" {
 					homeDir = "/"
@@ -863,12 +920,112 @@ func (m *Model) handleCreateDialogKey(msg tea.KeyMsg) tea.Cmd {
 	return nil
 }
 
+// handleSaveDialogKey handles key presses inside the save dialog
+func (m *Model) handleSaveDialogKey(msg tea.KeyMsg) tea.Cmd {
+	switch msg.String() {
+	case "esc":
+		m.saveDialogActive = false
+		m.saveDialogError = ""
+		m.saveFileInput.Blur()
+		return nil
+	case "f", "F":
+		// Open file browser for directory selection
+		m.saveDialogActive = false
+		m.fileBrowserActive = true
+		m.fileBrowserContext = "save"
+		startDir, _ := os.Getwd()
+		val := m.saveFileInput.Value()
+		if val != "" {
+			dir := filepath.Dir(val)
+			if filepath.IsAbs(dir) {
+				startDir = dir
+			} else if abs, err := filepath.Abs(dir); err == nil {
+				startDir = abs
+			}
+		}
+		return loadFilesCmd(startDir)
+	case "enter":
+		// If there's an error, clear it and stay
+		if m.saveDialogError != "" {
+			m.saveDialogError = ""
+			return nil
+		}
+		filePath := m.saveFileInput.Value()
+		if filePath == "" {
+			m.saveDialogError = "File path cannot be empty"
+			return nil
+		}
+		// Resolve to absolute path
+		if !filepath.IsAbs(filePath) {
+			if abs, err := filepath.Abs(filePath); err == nil {
+				filePath = abs
+			}
+		}
+		// Check if file exists — ask for overwrite confirmation
+		if _, err := os.Stat(filePath); err == nil {
+			m.saveDialogActive = false
+			m.saveFileInput.Blur()
+			m.pendingAction = "save-overwrite"
+			m.confirmDialog.Visible = true
+			m.confirmDialog.ErrorMode = false
+			m.confirmDialog.Message = fmt.Sprintf("File already exists:\n%s\n\nOverwrite?", filePath)
+			return nil
+		}
+		// File does not exist — proceed with save
+		m.saveDialogActive = false
+		m.saveFileInput.Blur()
+		return m.saveStackToFileCmd(m.saveStackName, filePath)
+	default:
+		var cmd tea.Cmd
+		m.saveFileInput, cmd = m.saveFileInput.Update(msg)
+		if m.saveDialogError != "" {
+			m.saveDialogError = ""
+		}
+		return cmd
+	}
+}
+
+// saveStackToFileCmd reconstructs and saves stack YAML to a file
+func (m *Model) saveStackToFileCmd(stackName, filePath string) tea.Cmd {
+	stackOps := m.deps.Stacks
+	return func() tea.Msg {
+		l().Infof("Reconstructing YAML for stack: %s", stackName)
+		yamlContent, err := stackOps.ReconstructStackCompose(stackName)
+		if err != nil {
+			l().Errorf("Failed to reconstruct YAML for stack %s: %v", stackName, err)
+			return stackSaveErrorMsg{Err: fmt.Errorf("failed to reconstruct stack YAML: %w", err)}
+		}
+		l().Infof("Writing %d bytes to %s", len(yamlContent), filePath)
+		dir := filepath.Dir(filePath)
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return stackSaveErrorMsg{Err: fmt.Errorf("failed to create directory: %w", err)}
+		}
+		if err := os.WriteFile(filePath, []byte(yamlContent), 0o644); err != nil {
+			l().Errorf("Failed to write file %s: %v", filePath, err)
+			return stackSaveErrorMsg{Err: fmt.Errorf("failed to write file: %w", err)}
+		}
+		l().Infof("Stack %s YAML saved to %s", stackName, filePath)
+		return stackSavedMsg{Path: filePath}
+	}
+}
+
 // handleFileBrowserKey handles key presses in file browser mode
 func (m *Model) handleFileBrowserKey(msg tea.KeyMsg) tea.Cmd {
 	switch msg.String() {
 	case "esc":
 		m.fileBrowserActive = false
-		m.createDialogActive = true
+		if m.fileBrowserContext == "save" {
+			// Update save path with the browsed directory
+			baseName := filepath.Base(m.saveFileInput.Value())
+			if baseName == "" || baseName == "." {
+				baseName = m.saveStackName + ".yml"
+			}
+			m.saveFileInput.SetValue(filepath.Join(m.fileBrowserPath, baseName))
+			m.saveDialogActive = true
+			m.saveFileInput.Focus()
+		} else {
+			m.createDialogActive = true
+		}
 		return nil
 
 	case "up":
@@ -917,6 +1074,20 @@ func (m *Model) handleFileBrowserKey(msg tea.KeyMsg) tea.Cmd {
 		if strings.HasSuffix(selected, "/") {
 			dirPath := strings.TrimSuffix(selected, "/")
 			return loadFilesCmd(dirPath)
+		}
+
+		// In save mode: selecting a file uses its parent directory as destination
+		if m.fileBrowserContext == "save" {
+			dir := filepath.Dir(selected)
+			baseName := filepath.Base(m.saveFileInput.Value())
+			if baseName == "" || baseName == "." {
+				baseName = m.saveStackName + ".yml"
+			}
+			m.saveFileInput.SetValue(filepath.Join(dir, baseName))
+			m.fileBrowserActive = false
+			m.saveDialogActive = true
+			m.saveFileInput.Focus()
+			return nil
 		}
 
 		// It's a file - read the content and load it into the editor
@@ -1377,6 +1548,7 @@ func GetStacksHelpContent() []helpview.HelpCategory {
 				{Keys: "<enter>", Description: "Show services for Stack"},
 				{Keys: "<i>", Description: "Inspect stack"},
 				{Keys: "<e>", Description: "Edit stack (opens editor)"},
+				{Keys: "<s>", Description: "Save stack YAML to file"},
 				{Keys: "<p>", Description: "Show tasks for Stack"},
 				{Keys: "<n>", Description: "Create new stack"},
 				{Keys: "<ctrl+d>", Description: "Delete stack"},

--- a/views/stacks/update.go
+++ b/views/stacks/update.go
@@ -150,6 +150,7 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 			// Cancelled — return to save dialog
 			m.pendingAction = ""
 			m.saveDialogActive = true
+			m.saveFileInput.CursorEnd()
 			m.saveFileInput.Focus()
 			return nil
 		}
@@ -287,6 +288,7 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 	case stackSaveErrorMsg:
 		m.saveDialogActive = true
 		m.saveDialogError = msg.Err.Error()
+		m.saveFileInput.CursorEnd()
 		m.saveFileInput.Focus()
 		return nil
 
@@ -474,6 +476,7 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 				m.saveDialogActive = true
 				m.saveDialogError = ""
 				m.saveFileInput.SetValue(selected.Name + ".yml")
+				m.saveFileInput.CursorEnd()
 				m.saveFileInput.Focus()
 				return nil
 			}
@@ -1033,6 +1036,7 @@ func (m *Model) handleFileBrowserKey(msg tea.KeyMsg) tea.Cmd {
 				baseName = m.saveStackName + ".yml"
 			}
 			m.saveFileInput.SetValue(filepath.Join(m.fileBrowserPath, baseName))
+			m.saveFileInput.CursorEnd()
 			m.saveDialogActive = true
 			m.saveFileInput.Focus()
 		} else {
@@ -1080,6 +1084,7 @@ func (m *Model) handleFileBrowserKey(msg tea.KeyMsg) tea.Cmd {
 				baseName = m.saveStackName + ".yml"
 			}
 			m.saveFileInput.SetValue(filepath.Join(m.fileBrowserPath, baseName))
+			m.saveFileInput.CursorEnd()
 			m.fileBrowserActive = false
 			m.saveDialogActive = true
 			m.saveFileInput.Focus()
@@ -1109,6 +1114,7 @@ func (m *Model) handleFileBrowserKey(msg tea.KeyMsg) tea.Cmd {
 				baseName = m.saveStackName + ".yml"
 			}
 			m.saveFileInput.SetValue(filepath.Join(dir, baseName))
+			m.saveFileInput.CursorEnd()
 			m.fileBrowserActive = false
 			m.saveDialogActive = true
 			m.saveFileInput.Focus()

--- a/views/stacks/update_test.go
+++ b/views/stacks/update_test.go
@@ -3,6 +3,7 @@ package stacksview
 import (
 	"context"
 	"fmt"
+	"os"
 	"testing"
 	"time"
 
@@ -651,4 +652,204 @@ func TestHorizontalScroll_Left(t *testing.T) {
 	m.errorScrollOffset = 10
 	m.Update(key("left"))
 	require.Equal(t, 5, m.errorScrollOffset)
+}
+
+// --- Save dialog tests ---
+
+func TestKey_S_OpensSaveDialog(t *testing.T) {
+	m := testModel()
+	loadStacks(m, fakeStacks("mystack"))
+	m.Update(key("s"))
+	require.True(t, m.saveDialogActive)
+	require.Equal(t, "mystack", m.saveStackName)
+	require.Equal(t, "mystack.yml", m.saveFileInput.Value())
+}
+
+func TestKey_S_NoStacks_NoDialog(t *testing.T) {
+	m := testModel()
+	m.Update(key("s"))
+	require.False(t, m.saveDialogActive)
+}
+
+func TestSaveDialog_Esc_Closes(t *testing.T) {
+	m := testModel()
+	m.saveDialogActive = true
+	m.saveStackName = "mystack"
+	m.saveDialogError = "some error"
+	m.Update(key("esc"))
+	require.False(t, m.saveDialogActive)
+	require.Equal(t, "", m.saveDialogError)
+}
+
+func TestSaveDialog_Enter_EmptyPath(t *testing.T) {
+	m := testModel()
+	m.saveDialogActive = true
+	m.saveStackName = "mystack"
+	m.saveFileInput.SetValue("")
+	m.Update(key("enter"))
+	require.Contains(t, m.saveDialogError, "File path cannot be empty")
+	require.True(t, m.saveDialogActive)
+}
+
+func TestSaveDialog_EnterWithError_ClearsError(t *testing.T) {
+	m := testModel()
+	m.saveDialogActive = true
+	m.saveDialogError = "previous error"
+	m.Update(key("enter"))
+	require.Equal(t, "", m.saveDialogError)
+	require.True(t, m.saveDialogActive)
+}
+
+func TestSaveDialog_F_OpensFileBrowser(t *testing.T) {
+	m := testModel()
+	m.saveDialogActive = true
+	m.saveStackName = "mystack"
+	m.saveFileInput.SetValue("mystack.yml")
+	cmd := m.Update(key("f"))
+	require.False(t, m.saveDialogActive)
+	require.True(t, m.fileBrowserActive)
+	require.Equal(t, "save", m.fileBrowserContext)
+	require.NotNil(t, cmd)
+}
+
+func TestStackSavedMsg_ShowsSuccess(t *testing.T) {
+	m := testModel()
+	m.saveDialogActive = true
+	m.Update(stackSavedMsg{Path: "/tmp/mystack.yml"})
+	require.False(t, m.saveDialogActive)
+	require.True(t, m.confirmDialog.Visible)
+	require.True(t, m.confirmDialog.ErrorMode)
+	require.Contains(t, m.confirmDialog.Message, "/tmp/mystack.yml")
+}
+
+func TestStackSaveErrorMsg_ReturnsToDialog(t *testing.T) {
+	m := testModel()
+	m.Update(stackSaveErrorMsg{Err: fmt.Errorf("permission denied")})
+	require.True(t, m.saveDialogActive)
+	require.Contains(t, m.saveDialogError, "permission denied")
+}
+
+func TestConfirmResult_SaveOverwrite_Confirmed(t *testing.T) {
+	reconstructed := false
+	stackMock := noopStackOps()
+	stackMock.reconstructStackComposeFn = func(_ string) (string, error) {
+		reconstructed = true
+		return "version: '3'", nil
+	}
+	m := testModel(func(m *Model) { m.deps.Stacks = stackMock })
+	loadStacks(m, fakeStacks("mystack"))
+	m.pendingAction = "save-overwrite"
+	m.confirmDialog.Visible = true
+	m.saveStackName = "mystack"
+	m.saveFileInput.SetValue("/tmp/mystack.yml")
+	cmd := m.Update(confirmdialog.ResultMsg{Confirmed: true})
+	require.False(t, m.confirmDialog.Visible)
+	require.Equal(t, "", m.pendingAction)
+	require.NotNil(t, cmd)
+	runCmd(cmd)
+	require.True(t, reconstructed)
+}
+
+func TestConfirmResult_SaveOverwrite_Cancelled(t *testing.T) {
+	m := testModel()
+	m.pendingAction = "save-overwrite"
+	m.confirmDialog.Visible = true
+	m.saveStackName = "mystack"
+	m.Update(confirmdialog.ResultMsg{Confirmed: false})
+	require.False(t, m.confirmDialog.Visible)
+	require.True(t, m.saveDialogActive)
+	require.Equal(t, "", m.pendingAction)
+}
+
+func TestFileBrowser_Esc_ReturnsSaveDialog(t *testing.T) {
+	m := testModel()
+	m.fileBrowserActive = true
+	m.fileBrowserContext = "save"
+	m.fileBrowserPath = "/tmp"
+	m.saveFileInput.SetValue("mystack.yml")
+	m.saveStackName = "mystack"
+	m.Update(key("esc"))
+	require.False(t, m.fileBrowserActive)
+	require.True(t, m.saveDialogActive)
+	require.Equal(t, "/tmp/mystack.yml", m.saveFileInput.Value())
+}
+
+func TestFileBrowser_Esc_ReturnsCreateDialog(t *testing.T) {
+	m := testModel()
+	m.fileBrowserActive = true
+	m.fileBrowserContext = "create"
+	m.Update(key("esc"))
+	require.False(t, m.fileBrowserActive)
+	require.True(t, m.createDialogActive)
+}
+
+func TestSaveStackToFileCmd_Success(t *testing.T) {
+	tmpDir := t.TempDir()
+	filePath := tmpDir + "/test-stack.yml"
+
+	stackMock := noopStackOps()
+	stackMock.reconstructStackComposeFn = func(_ string) (string, error) {
+		return "version: '3'\nservices:\n  web:\n    image: nginx\n", nil
+	}
+	m := testModel(func(m *Model) { m.deps.Stacks = stackMock })
+	cmd := m.saveStackToFileCmd("mystack", filePath)
+	msg := runCmd(cmd)
+	saved, ok := msg.(stackSavedMsg)
+	require.True(t, ok)
+	require.Equal(t, filePath, saved.Path)
+
+	// Verify file was written
+	data, err := os.ReadFile(filePath)
+	require.NoError(t, err)
+	require.Contains(t, string(data), "nginx")
+}
+
+func TestSaveStackToFileCmd_ReconstructError(t *testing.T) {
+	stackMock := noopStackOps()
+	stackMock.reconstructStackComposeFn = func(_ string) (string, error) {
+		return "", fmt.Errorf("stack not found")
+	}
+	m := testModel(func(m *Model) { m.deps.Stacks = stackMock })
+	cmd := m.saveStackToFileCmd("mystack", "/tmp/test.yml")
+	msg := runCmd(cmd)
+	errMsg, ok := msg.(stackSaveErrorMsg)
+	require.True(t, ok)
+	require.Contains(t, errMsg.Err.Error(), "stack not found")
+}
+
+func TestSaveStackToFileCmd_WriteError(t *testing.T) {
+	stackMock := noopStackOps()
+	stackMock.reconstructStackComposeFn = func(_ string) (string, error) {
+		return "version: '3'", nil
+	}
+	m := testModel(func(m *Model) { m.deps.Stacks = stackMock })
+	// Use an invalid path to trigger write error
+	cmd := m.saveStackToFileCmd("mystack", "/proc/0/nonexistent/test.yml")
+	msg := runCmd(cmd)
+	errMsg, ok := msg.(stackSaveErrorMsg)
+	require.True(t, ok)
+	require.Error(t, errMsg.Err)
+}
+
+func TestFilesLoadedMsg_Error_SaveContext(t *testing.T) {
+	m := testModel()
+	m.fileBrowserContext = "save"
+	m.Update(filesLoadedMsg{Path: "/nope", Error: fmt.Errorf("no access")})
+	require.False(t, m.fileBrowserActive)
+	require.True(t, m.saveDialogActive)
+	require.Contains(t, m.saveDialogError, "no access")
+}
+
+func TestFileBrowser_Enter_File_SaveContext(t *testing.T) {
+	m := testModel()
+	m.fileBrowserActive = true
+	m.fileBrowserContext = "save"
+	m.fileBrowserFiles = []string{"/tmp/existing-file.yml"}
+	m.fileBrowserCursor = 0
+	m.saveFileInput.SetValue("mystack.yml")
+	m.saveStackName = "mystack"
+	m.Update(key("enter"))
+	require.False(t, m.fileBrowserActive)
+	require.True(t, m.saveDialogActive)
+	require.Equal(t, "/tmp/mystack.yml", m.saveFileInput.Value())
 }

--- a/views/stacks/update_test.go
+++ b/views/stacks/update_test.go
@@ -840,6 +840,37 @@ func TestFilesLoadedMsg_Error_SaveContext(t *testing.T) {
 	require.Contains(t, m.saveDialogError, "no access")
 }
 
+func TestFileBrowser_Enter_SaveHere(t *testing.T) {
+	m := testModel()
+	m.fileBrowserActive = true
+	m.fileBrowserContext = "save"
+	m.fileBrowserPath = "/tmp/mydir"
+	m.fileBrowserFiles = []string{"..", saveDirSentinel, "/tmp/mydir/sub/"}
+	m.fileBrowserCursor = 1 // [Save here]
+	m.saveFileInput.SetValue("mystack.yml")
+	m.saveStackName = "mystack"
+	m.Update(key("enter"))
+	require.False(t, m.fileBrowserActive)
+	require.True(t, m.saveDialogActive)
+	require.Equal(t, "/tmp/mydir/mystack.yml", m.saveFileInput.Value())
+}
+
+func TestFilesLoadedMsg_SaveContext_InjectsSentinel(t *testing.T) {
+	m := testModel()
+	m.fileBrowserContext = "save"
+	m.Update(filesLoadedMsg{Path: "/tmp", Files: []string{"..", "/tmp/sub/", "/tmp/file.yml"}})
+	require.True(t, m.fileBrowserActive)
+	require.Equal(t, []string{"..", saveDirSentinel, "/tmp/sub/", "/tmp/file.yml"}, m.fileBrowserFiles)
+}
+
+func TestFilesLoadedMsg_CreateContext_NoSentinel(t *testing.T) {
+	m := testModel()
+	m.fileBrowserContext = "create"
+	m.Update(filesLoadedMsg{Path: "/tmp", Files: []string{"..", "/tmp/sub/"}})
+	require.True(t, m.fileBrowserActive)
+	require.Equal(t, []string{"..", "/tmp/sub/"}, m.fileBrowserFiles)
+}
+
 func TestFileBrowser_Enter_File_SaveContext(t *testing.T) {
 	m := testModel()
 	m.fileBrowserActive = true

--- a/views/stacks/update_test.go
+++ b/views/stacks/update_test.go
@@ -718,7 +718,8 @@ func TestStackSavedMsg_ShowsSuccess(t *testing.T) {
 	m.Update(stackSavedMsg{Path: "/tmp/mystack.yml"})
 	require.False(t, m.saveDialogActive)
 	require.True(t, m.confirmDialog.Visible)
-	require.True(t, m.confirmDialog.ErrorMode)
+	require.True(t, m.confirmDialog.InfoMode)
+	require.False(t, m.confirmDialog.ErrorMode)
 	require.Contains(t, m.confirmDialog.Message, "/tmp/mystack.yml")
 }
 

--- a/views/stacks/view.go
+++ b/views/stacks/view.go
@@ -33,8 +33,14 @@ func (m *Model) FrameContent() string {
 	width := frame.FrameWidth
 	if m.createDialogActive {
 		content = ui.OverlayCentered(content, m.renderCreateDialog(), width, 0)
+	} else if m.saveDialogActive {
+		content = ui.OverlayCentered(content, m.renderSaveDialog(), width, 0)
 	} else if m.fileBrowserActive {
-		fileBrowserDialog := ui.RenderFileBrowserDialog("Select Compose File", m.fileBrowserPath, m.fileBrowserFiles, m.fileBrowserCursor)
+		title := "Select Compose File"
+		if m.fileBrowserContext == "save" {
+			title = "Select Save Directory"
+		}
+		fileBrowserDialog := ui.RenderFileBrowserDialog(title, m.fileBrowserPath, m.fileBrowserFiles, m.fileBrowserCursor)
 		content = ui.OverlayCentered(content, fileBrowserDialog, width, 0)
 	} else if m.confirmDialog.Visible {
 		content = ui.OverlayCentered(content, m.confirmDialog.View(), width, 0)
@@ -193,6 +199,45 @@ func (m *Model) renderCreateDialog() string {
 		}
 		lines = append(lines, dialog.HelpStyle.Render(helpText))
 	}
+
+	content := lipgloss.JoinVertical(lipgloss.Left, lines...)
+	return dialog.BorderStyle.Render(content)
+}
+
+func (m *Model) renderSaveDialog() string {
+	var lines []string
+	lines = append(lines, dialog.TitleStyle.Render(fmt.Sprintf(" Save Stack: %s ", m.saveStackName)))
+	lines = append(lines, dialog.ItemStyle.Render(""))
+
+	if m.saveDialogError != "" {
+		errorStyle := lipgloss.NewStyle().
+			Foreground(lipgloss.Color("196")).
+			Padding(0, 1).
+			Width(70)
+		wrappedError := ui.WrapText("⚠ "+m.saveDialogError, 68)
+		for _, line := range wrappedError {
+			lines = append(lines, errorStyle.Render(line))
+		}
+		lines = append(lines, dialog.ItemStyle.Render(""))
+	}
+
+	fileLine := m.saveFileInput.View()
+	fileLine += "  " + dialog.KeyStyle.Render("[f: Browse]")
+	lines = append(lines, dialog.ItemStyle.Render(fileLine))
+	lines = append(lines, dialog.ItemStyle.Render(""))
+
+	var helpText string
+	if m.saveDialogError != "" {
+		helpText = fmt.Sprintf(" %s Fix error • %s Cancel",
+			dialog.KeyStyle.Render("<Enter>"),
+			dialog.KeyStyle.Render("<Esc>"))
+	} else {
+		helpText = fmt.Sprintf(" %s Save • %s Browse • %s Cancel",
+			dialog.KeyStyle.Render("<Enter>"),
+			dialog.KeyStyle.Render("<f>"),
+			dialog.KeyStyle.Render("<Esc>"))
+	}
+	lines = append(lines, dialog.HelpStyle.Render(helpText))
 
 	content := lipgloss.JoinVertical(lipgloss.Left, lines...)
 	return dialog.BorderStyle.Render(content)

--- a/views/stacks/view_test.go
+++ b/views/stacks/view_test.go
@@ -100,6 +100,19 @@ func TestView_ExpandedStackShowsTasks(t *testing.T) {
 	require.Contains(t, out, "node1")
 }
 
+func TestView_SaveDialog(t *testing.T) {
+	m := testModel()
+	loadStacks(m, fakeStacks("s1"))
+	m.setRenderItem()
+	m.List.Viewport.Width = 80
+	m.List.Viewport.Height = 20
+	m.saveDialogActive = true
+	m.saveStackName = "mystack"
+	m.saveFileInput.SetValue("mystack.yml")
+	out := m.View()
+	require.Contains(t, out, "Save Stack")
+}
+
 func TestView_ErrorColumnHeader(t *testing.T) {
 	m := testModel()
 	loadStacks(m, fakeStacks("s1"))


### PR DESCRIPTION
## Summary

- Adds `s` key binding in stacks view to save a stack's reconstructed compose YAML to a local file
- Save dialog with editable file path (pre-filled `<stackname>.yml`), file browser integration, overwrite confirmation
- Enables the save → delete → recreate workflow described in #320

Closes #320

## Test plan

- [x] Unit tests: 20 new tests covering key binding, dialog states, save/error flows, file browser context routing, file write verification
- [x] All 96 stacks view tests pass
- [x] Full test suite passes (`go test ./...`)
- [x] Lint clean (`golangci-lint run ./...`)
- [x] Manual: select a stack, press `s`, verify dialog appears with `<stackname>.yml`
- [x] Manual: press Enter to save, verify file is written with valid compose YAML
- [x] Manual: save again to same path, verify overwrite confirmation appears
- [x] Manual: press `f` to browse, navigate directories, verify path updates on return
- [x] Manual: press Esc to cancel at each stage

🤖 Generated with [Claude Code](https://claude.com/claude-code)