### PR TITLE
fix: wrap long error messages in confirm dialog

### DIFF
--- a/views/confirmdialog/confirmdialog.go
+++ b/views/confirmdialog/confirmdialog.go
@@ -9,6 +9,7 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+	"github.com/muesli/reflow/wordwrap"
 )
 
 type ResultMsg struct {
@@ -74,10 +75,30 @@ func (m *Model) View() string {
 		return ""
 	}
 
-	// Calculate content width based on message
-	contentWidth := lipgloss.Width(m.Message) + 4
+	// Cap dialog width to a sensible maximum, then word-wrap.
+	maxWidth := 80
+	if m.Width > 0 && m.Width-6 < maxWidth {
+		maxWidth = m.Width - 6
+	}
+	if maxWidth < 40 {
+		maxWidth = 40
+	}
+
+	wrappedMessage := wordwrap.String(m.Message, maxWidth-4)
+
+	// Content width = longest wrapped line + padding.
+	contentWidth := 0
+	for _, line := range strings.Split(wrappedMessage, "\n") {
+		if w := lipgloss.Width(line); w > contentWidth {
+			contentWidth = w
+		}
+	}
+	contentWidth += 4
 	if contentWidth < 50 {
 		contentWidth = 50
+	}
+	if contentWidth > maxWidth {
+		contentWidth = maxWidth
 	}
 
 	// Styled title — color varies by mode
@@ -122,7 +143,7 @@ func (m *Model) View() string {
 	} else {
 		lines = append(lines, titleStyle.Render(" Confirm Action "))
 	}
-	lines = append(lines, messageStyle.Render(m.Message))
+	lines = append(lines, messageStyle.Render(wrappedMessage))
 
 	// Add checkbox if label is provided
 	if m.CheckboxLabel != "" && !m.ErrorMode && !m.InfoMode {

--- a/views/confirmdialog/confirmdialog_test.go
+++ b/views/confirmdialog/confirmdialog_test.go
@@ -1,9 +1,11 @@
 package confirmdialog
 
 import (
+	"strings"
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
 	"github.com/stretchr/testify/require"
 )
 
@@ -182,4 +184,30 @@ func TestWithMessage(t *testing.T) {
 	ret := m.WithMessage("hi")
 	require.Equal(t, m, ret)
 	require.Equal(t, "hi", m.Message)
+}
+
+func TestView_LongMessage_Wraps(t *testing.T) {
+	m := New(80, 24)
+	m.ErrorMode = true
+	longMsg := "Bootstrap failed: error creating secret swarmcli-infra_proxy_cert: " +
+		"Error response from daemon: rpc error: code = AlreadyExists desc = secret swarmcli-infra_proxy_cert already exists"
+	m.Show(longMsg)
+	out := m.View()
+	// The dialog output should contain newlines from wrapping
+	// (the original message has no newlines, so any newlines in
+	// the rendered output come from wrapping).
+	require.Contains(t, out, "Bootstrap failed")
+	require.Contains(t, out, "already exists")
+	// Dialog should not be wider than the terminal (80 cols).
+	for _, line := range strings.Split(out, "\n") {
+		w := lipgloss.Width(line)
+		require.LessOrEqual(t, w, 82, "line too wide (visual width %d): %q", w, line)
+	}
+}
+
+func TestView_ShortMessage_NoWrapping(t *testing.T) {
+	m := New(80, 24)
+	m.Show("Short message")
+	out := m.View()
+	require.Contains(t, out, "Short message")
 }


### PR DESCRIPTION
## Summary
- Long error messages in the confirm dialog would overflow the terminal width
- Add word wrapping using `muesli/reflow/wordwrap` (already a dependency)
- Cap dialog width to `min(termWidth-6, 80)` characters

Requested in Eldara-Tech/swarmcli-be#25 review feedback.

## Test plan
- [x] `go build ./...` succeeds
- [x] `go test ./views/confirmdialog/...` passes
- [x] New tests for long message wrapping and visual width check

🤖 Generated with [Claude Code](https://claude.com/claude-code)