### PR TITLE
feat: change app exit key from q to Ctrl+Q

### DIFF
--- a/app/update.go
+++ b/app/update.go
@@ -519,17 +519,10 @@ func (m *Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, cmd
 	}
 
-	// Global quit handler
-	if msg.Type == tea.KeyCtrlC || msg.String() == "q" {
-		// Allow views in search mode to consume the key (so typing 'q' in a search query doesn't exit)
-		if searchView, ok := m.currentView.(interface{ IsSearching() bool }); ok {
-			if searchView.IsSearching() {
-				cmd := m.currentView.Update(msg)
-				return m, cmd
-			}
-		}
-		cmd := m.goBack()
-		return m, cmd
+	// Global quit handler: Ctrl+Q (primary) and Ctrl+C (standard terminal fallback)
+	if msg.String() == "ctrl+q" || msg.Type == tea.KeyCtrlC {
+		exitCmd := m.currentView.OnExit()
+		return m, tea.Batch(exitCmd, tea.Quit)
 	}
 
 	cmd := m.currentView.Update(msg)

--- a/commands/command/quit.go
+++ b/commands/command/quit.go
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package command
+
+import (
+	"swarmcli/args"
+	"swarmcli/registry"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+type Quit struct{}
+
+func (Quit) Name() string        { return "quit" }
+func (Quit) Description() string { return "Exit SwarmCLI" }
+
+func (Quit) Execute(_ any, _ args.Args) tea.Cmd {
+	return tea.Quit
+}
+
+var quitCmd = Quit{}
+
+func init() {
+	registry.Register(quitCmd)
+	registry.Register(aliasCommand{name: "q", target: quitCmd})
+}

--- a/commands/command/quit_test.go
+++ b/commands/command/quit_test.go
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package command
+
+import (
+	"testing"
+
+	"swarmcli/args"
+	"swarmcli/registry"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestQuit_Name(t *testing.T) {
+	require.Equal(t, "quit", quitCmd.Name())
+}
+
+func TestQuit_Description(t *testing.T) {
+	require.NotEmpty(t, quitCmd.Description())
+}
+
+func TestQuit_Execute(t *testing.T) {
+	cmd := quitCmd.Execute(nil, args.Args{})
+	require.NotNil(t, cmd)
+}
+
+func TestQuit_RegisteredAliasQ(t *testing.T) {
+	cmd, ok := registry.Get("q")
+	require.True(t, ok)
+	a, ok := cmd.(registry.Aliaser)
+	require.True(t, ok)
+	require.Equal(t, "quit", a.AliasOf())
+}

--- a/views/configs/model.go
+++ b/views/configs/model.go
@@ -227,7 +227,7 @@ func (m *Model) ShortHelpItems() []helpbar.HelpEntry {
 		{Key: "e", Desc: "Edit & Rotate"},
 		{Key: "ctrl+d", Desc: "Delete"},
 		{Key: "?", Desc: "Help"},
-		{Key: "esc/q", Desc: "Back"},
+		{Key: "esc", Desc: "Back"},
 	}
 }
 

--- a/views/help/help_test.go
+++ b/views/help/help_test.go
@@ -44,7 +44,7 @@ func TestShortHelpItems(t *testing.T) {
 	m := New(80, 24, nil)
 	items := m.ShortHelpItems()
 	require.Len(t, items, 1)
-	require.Equal(t, "q", items[0].Key)
+	require.Equal(t, "esc", items[0].Key)
 	require.Equal(t, "Close", items[0].Desc)
 }
 
@@ -120,7 +120,7 @@ func TestView_Categorized(t *testing.T) {
 	cats := []HelpCategory{
 		{Title: "Navigation", Items: []HelpItem{
 			{Keys: "<esc>", Description: "Go back"},
-			{Keys: "<q>", Description: "Quit"},
+			{Keys: "<ctrl+q>", Description: "Quit"},
 		}},
 		{Title: "Actions", Items: []HelpItem{
 			{Keys: "<n>", Description: "New item"},
@@ -188,7 +188,7 @@ func TestApplySearchQuery_CategorizedMode(t *testing.T) {
 	cats := []HelpCategory{
 		{Title: "Navigation", Items: []HelpItem{
 			{Keys: "<esc>", Description: "Go back"},
-			{Keys: "<q>", Description: "Quit"},
+			{Keys: "<ctrl+q>", Description: "Quit"},
 		}},
 		{Title: "Actions", Items: []HelpItem{
 			{Keys: "<n>", Description: "New item"},

--- a/views/help/model.go
+++ b/views/help/model.go
@@ -123,7 +123,7 @@ func (m *Model) Name() string {
 
 func (m *Model) ShortHelpItems() []helpbar.HelpEntry {
 	return []helpbar.HelpEntry{
-		{Key: "q", Desc: "Close"},
+		{Key: "esc", Desc: "Close"},
 	}
 }
 

--- a/views/helpbar/helpbar.go
+++ b/views/helpbar/helpbar.go
@@ -34,7 +34,7 @@ const defaultMinColWidth = 20
 
 func New(width, height int) *Model {
 	return &Model{
-		globalHelp:  []HelpEntry{{Key: "q", Desc: "quit"}, {Key: "?", Desc: "help"}},
+		globalHelp:  []HelpEntry{{Key: "ctrl+q", Desc: "quit"}, {Key: "?", Desc: "help"}},
 		width:       width,
 		height:      height,
 		minColWidth: defaultMinColWidth,

--- a/views/helpbar/helpbar.go
+++ b/views/helpbar/helpbar.go
@@ -32,9 +32,15 @@ func SetEditionLabel(label string) {
 
 const defaultMinColWidth = 20
 
+// KeyBack is the canonical key for "go back / close this view".
+const KeyBack = "esc"
+
+// KeyQuit is the canonical key for "quit the application".
+const KeyQuit = "ctrl+q"
+
 func New(width, height int) *Model {
 	return &Model{
-		globalHelp:  []HelpEntry{{Key: "ctrl+q", Desc: "quit"}, {Key: "?", Desc: "help"}},
+		globalHelp:  []HelpEntry{{Key: KeyQuit, Desc: "quit"}, {Key: "?", Desc: "help"}},
 		width:       width,
 		height:      height,
 		minColWidth: defaultMinColWidth,

--- a/views/helpbar/helpbar_test.go
+++ b/views/helpbar/helpbar_test.go
@@ -9,7 +9,7 @@ import (
 func TestNew_DefaultGlobalHelp(t *testing.T) {
 	m := New(200, 40)
 	require.Len(t, m.globalHelp, 2)
-	require.Equal(t, "q", m.globalHelp[0].Key)
+	require.Equal(t, "ctrl+q", m.globalHelp[0].Key)
 	require.Equal(t, "?", m.globalHelp[1].Key)
 }
 
@@ -20,7 +20,7 @@ func TestView_WithEntries(t *testing.T) {
 		{Key: "d", Desc: "Delete"},
 	})
 	out := m.View("", false)
-	require.Contains(t, out, "q")
+	require.Contains(t, out, "ctrl+q")
 	require.Contains(t, out, "help")
 	require.Contains(t, out, "n")
 	require.Contains(t, out, "New")

--- a/views/inspect/handlekey.go
+++ b/views/inspect/handlekey.go
@@ -9,8 +9,6 @@ import (
 
 func handleNormalKey(m *Model, k tea.KeyMsg) tea.Cmd {
 	switch k.String() {
-	case "q":
-		return nil
 	case "esc":
 		// If app-level filter is active, clear it instead of closing
 		if m.filterQuery != "" {

--- a/views/inspect/inspect_test.go
+++ b/views/inspect/inspect_test.go
@@ -113,7 +113,7 @@ func TestShortHelpItems_Normal(t *testing.T) {
 	}
 	require.True(t, keys["ctrl+f"])
 	require.True(t, keys["r"])
-	require.True(t, keys["q"])
+	require.True(t, keys["esc"])
 }
 
 func TestShortHelpItems_SearchMode(t *testing.T) {

--- a/views/inspect/model.go
+++ b/views/inspect/model.go
@@ -115,7 +115,7 @@ func (m *Model) ShortHelpItems() []helpbar.HelpEntry {
 	}
 	entries = append(entries,
 		helpbar.HelpEntry{Key: "r", Desc: "Toggle raw"},
-		helpbar.HelpEntry{Key: "q", Desc: "Close"},
+		helpbar.HelpEntry{Key: "esc", Desc: "Close"},
 	)
 	return entries
 }

--- a/views/loading/loading.go
+++ b/views/loading/loading.go
@@ -123,7 +123,7 @@ func (m *Model) View() string {
 
 func (m *Model) ShortHelpItems() []helpbar.HelpEntry {
 	return []helpbar.HelpEntry{
-		{Key: "q", Desc: "Quit"},
+		{Key: "ctrl+q", Desc: "Quit"},
 	}
 }
 

--- a/views/loading/loading_test.go
+++ b/views/loading/loading_test.go
@@ -82,7 +82,7 @@ func TestShortHelpItems(t *testing.T) {
 	m := New(80, 24, true, nil)
 	items := m.ShortHelpItems()
 	require.Len(t, items, 1)
-	require.Equal(t, "q", items[0].Key)
+	require.Equal(t, "ctrl+q", items[0].Key)
 }
 
 func TestInit_ReturnsCmd(t *testing.T) {

--- a/views/logs/handlekey.go
+++ b/views/logs/handlekey.go
@@ -112,9 +112,6 @@ func HandleKey(m *Model, k tea.KeyMsg) tea.Cmd {
 
 	// Normal mode key handling
 	switch k.String() {
-	case "q":
-		m.Visible = false
-		return nil
 	case "esc":
 		// If app-level filter is active, clear it instead of closing
 		if m.getFilterQuery() != "" {

--- a/views/logs/logs_test.go
+++ b/views/logs/logs_test.go
@@ -136,7 +136,7 @@ func TestShortHelpItems_NormalMode(t *testing.T) {
 	require.True(t, keys["s"])
 	require.True(t, keys["w"])
 	require.True(t, keys["o"])
-	require.True(t, keys["q"])
+	require.True(t, keys["esc"])
 }
 
 func TestShortHelpItems_SearchMode(t *testing.T) {
@@ -289,11 +289,11 @@ func TestKey_W_TogglesWrap(t *testing.T) {
 	require.NotNil(t, cmd) // WrapToggledMsg
 }
 
-func TestKey_Q_ClosesView(t *testing.T) {
+func TestKey_Q_Disabled(t *testing.T) {
 	m := testModel()
 	m.Visible = true
 	m.Update(key("q"))
-	require.False(t, m.Visible)
+	require.True(t, m.Visible) // q no longer closes view
 }
 
 func TestKey_Esc_ClosesView(t *testing.T) {

--- a/views/logs/model.go
+++ b/views/logs/model.go
@@ -218,7 +218,7 @@ func (m *Model) ShortHelpItems() []helpbar.HelpEntry {
 		entries = append(entries, helpbar.HelpEntry{Key: "←/→", Desc: "Scroll"})
 	}
 
-	entries = append(entries, helpbar.HelpEntry{Key: "q", Desc: "Close"})
+	entries = append(entries, helpbar.HelpEntry{Key: "esc", Desc: "Close"})
 	return entries
 }
 

--- a/views/networks/model.go
+++ b/views/networks/model.go
@@ -305,7 +305,7 @@ func (m *Model) ShortHelpItems() []helpbar.HelpEntry {
 		{Key: "ctrl+u", Desc: "Prune Unused"},
 		{Key: "/", Desc: "Filter"},
 		{Key: "?", Desc: "Help"},
-		{Key: "esc/q", Desc: "Back"},
+		{Key: "esc", Desc: "Back"},
 	}
 }
 

--- a/views/networks/update.go
+++ b/views/networks/update.go
@@ -609,7 +609,7 @@ func (m *Model) handleInspectViewKeys(msg tea.KeyMsg) tea.Cmd {
 	}
 
 	switch msg.String() {
-	case "esc", "q":
+	case "esc":
 		m.inspectViewActive = false
 		m.inspectSearchMode = false
 		return nil
@@ -632,7 +632,7 @@ func (m *Model) handleInspectViewKeys(msg tea.KeyMsg) tea.Cmd {
 
 func (m *Model) handleUsedByViewKeys(msg tea.KeyMsg) tea.Cmd {
 	switch msg.String() {
-	case "esc", "q":
+	case "esc":
 		m.usedByViewActive = false
 		return nil
 	case "up", "k":
@@ -899,7 +899,7 @@ func (m *Model) handleNormalKeys(msg tea.KeyMsg) tea.Cmd {
 	}
 
 	switch msg.String() {
-	case "esc", "q":
+	case "esc":
 		// Networks is a root view, no back navigation
 		return nil
 	case "?":

--- a/views/networks/update_test.go
+++ b/views/networks/update_test.go
@@ -463,11 +463,11 @@ func TestInspectView_Esc_Closes(t *testing.T) {
 	require.False(t, m.inspectViewActive)
 }
 
-func TestInspectView_Q_Closes(t *testing.T) {
+func TestInspectView_Q_Disabled(t *testing.T) {
 	m := testModel()
 	m.inspectViewActive = true
 	m.Update(key("q"))
-	require.False(t, m.inspectViewActive)
+	require.True(t, m.inspectViewActive) // q no longer closes inspect view
 }
 
 func TestInspectView_Slash_EntersSearch(t *testing.T) {

--- a/views/nodes/model.go
+++ b/views/nodes/model.go
@@ -131,7 +131,7 @@ func (m *Model) ShortHelpItems() []helpbar.HelpEntry {
 		{Key: "↑/↓", Desc: "Navigate"},
 		{Key: "/", Desc: "Filter"},
 		{Key: "?", Desc: "Help"},
-		{Key: "q", Desc: "Close"},
+		{Key: "esc", Desc: "Back"},
 	}
 }
 

--- a/views/nodes/update.go
+++ b/views/nodes/update.go
@@ -504,8 +504,6 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 				m.confirmDialog.ErrorMode = false
 				m.confirmDialog.Message = fmt.Sprintf("Remove node %q from swarm?\nWarning: This action cannot be undone.", node.Hostname)
 			}
-		case "q":
-			m.Visible = false
 		}
 
 		return nil
@@ -665,7 +663,7 @@ func (m *Model) handleAvailabilityDialogKey(msg tea.KeyMsg) tea.Cmd {
 			}
 			return SetAvailabilitySuccessMsg{}
 		}
-	case "esc", "q":
+	case "esc":
 		m.availabilityDialog = false
 	}
 	return nil
@@ -775,7 +773,7 @@ func (m *Model) handleLabelRemoveDialogKey(msg tea.KeyMsg) tea.Cmd {
 				return RemoveLabelSuccessMsg{}
 			}
 		}
-	case "esc", "q":
+	case "esc":
 		m.labelRemoveDialog = false
 	}
 	return nil
@@ -816,7 +814,7 @@ func GetNodesHelpContent() []helpview.HelpCategory {
 				{Keys: "<↑/↓>", Description: "Navigate"},
 				{Keys: "<pgup>", Description: "Page up"},
 				{Keys: "<pgdown>", Description: "Page down"},
-				{Keys: "<q>", Description: "Back to stacks"},
+				{Keys: "<esc>", Description: "Back"},
 			},
 		},
 	}

--- a/views/nodes/update_test.go
+++ b/views/nodes/update_test.go
@@ -251,11 +251,11 @@ func TestKey_CtrlR_NoLabels_ShowsError(t *testing.T) {
 	require.Contains(t, m.confirmDialog.Message, "no labels")
 }
 
-func TestKey_Q_HidesView(t *testing.T) {
+func TestKey_Q_Disabled(t *testing.T) {
 	m := testModel()
 	loadNodes(m, fakeNodes("n1"))
 	m.Update(key("q"))
-	require.False(t, m.Visible)
+	require.True(t, m.Visible) // q is disabled, does nothing
 }
 
 // --- Sort key tests ---

--- a/views/secrets/model.go
+++ b/views/secrets/model.go
@@ -240,7 +240,7 @@ func (m *Model) ShortHelpItems() []helpbar.HelpEntry {
 		{Key: "u", Desc: "Used By"},
 		{Key: "ctrl+d", Desc: "Delete"},
 		{Key: "?", Desc: "Help"},
-		{Key: "esc/q", Desc: "Back"},
+		{Key: "esc", Desc: "Back"},
 	}
 }
 

--- a/views/services/model.go
+++ b/views/services/model.go
@@ -168,7 +168,7 @@ func (m *Model) ShortHelpItems() []helpbar.HelpEntry {
 		{Key: "w", Desc: view.BEHelpDesc("port-forward", "Port Forward"), Disabled: !view.HasAction("port-forward")},
 		{Key: "/", Desc: "Filter"},
 		{Key: "?", Desc: "Help"},
-		{Key: "q", Desc: "Close"},
+		{Key: "esc", Desc: "Back"},
 	}
 }
 

--- a/views/services/model_test.go
+++ b/views/services/model_test.go
@@ -416,15 +416,11 @@ func TestKey_Help_NavigatesToHelp(t *testing.T) {
 	require.Equal(t, view.NameHelp, nav.ViewName)
 }
 
-func TestKey_Q_NavigatesToStacks(t *testing.T) {
+func TestKey_Q_Disabled(t *testing.T) {
 	m := testModel()
 	loadServices(m, fakeEntries("web"))
 	cmd := m.Update(key("q"))
-	require.NotNil(t, cmd)
-	msg := runCmd(cmd)
-	nav, ok := msg.(view.NavigateToMsg)
-	require.True(t, ok)
-	require.Equal(t, view.NameStacks, nav.ViewName)
+	require.Nil(t, cmd) // q is disabled, does nothing
 }
 
 // --- Confirm dialog result tests ---

--- a/views/services/update.go
+++ b/views/services/update.go
@@ -491,11 +491,6 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 				return nil
 			}
 			return action(entry.ServiceName)
-		case "q":
-			m.Visible = false
-			// Go back to stacks view
-			return func() tea.Msg { return view.NavigateToMsg{ViewName: view.NameStacks, Payload: nil} }
-
 		case "esc":
 			// ESC should also go back to stacks view
 			m.Visible = false
@@ -1042,7 +1037,7 @@ func GetServicesHelpContent() []helpview.HelpCategory {
 				{Keys: "<↑/↓>", Description: "Navigate"},
 				{Keys: "<pgup>", Description: "Page up"},
 				{Keys: "<pgdown>", Description: "Page down"},
-				{Keys: "<q>", Description: "Back to stacks"},
+				{Keys: "<esc>", Description: "Back"},
 			},
 		},
 	}

--- a/views/stacks/model.go
+++ b/views/stacks/model.go
@@ -209,7 +209,6 @@ func (m *Model) ShortHelpItems() []helpbar.HelpEntry {
 		{Key: "↑/↓", Desc: "Navigate"},
 		{Key: "/", Desc: "Filter"},
 		{Key: "?", Desc: "Help"},
-		{Key: "q", Desc: "Close"},
 	}
 }
 

--- a/views/stacks/update.go
+++ b/views/stacks/update.go
@@ -1602,7 +1602,7 @@ func GetStacksHelpContent() []helpview.HelpCategory {
 				{Keys: "<↑/↓>", Description: "Navigate"},
 				{Keys: "<pgup>", Description: "Page up"},
 				{Keys: "<pgdown>", Description: "Page down"},
-				{Keys: "<q>", Description: "Quit"},
+				{Keys: "<ctrl+q>", Description: "Quit"},
 			},
 		},
 	}


### PR DESCRIPTION
## Summary

- Disable bare `q` as quit/back key to prevent accidental exits from root view
- `Ctrl+Q` is the primary quit key (shown in helpbar), `Ctrl+C` remains as standard terminal fallback
- `Esc` is now the sole go-back key across all views
- Add `:q` / `:quit` commands for k9s parity
- Update all help text, helpbar entries, per-view key handlers, and tests

Closes #325

## Test plan

- [x] `q` does nothing on any view (root and nested)
- [x] `Ctrl+Q` exits from root (stacks) view
- [x] `Ctrl+Q` exits from nested view (e.g. services → logs)
- [x] `Ctrl+C` exits from any view
- [x] `Esc` goes back from nested views, does nothing at root
- [x] `:q` and `:quit` commands exit the app
- [x] Typing `q` in search/filter input works normally
- [x] Helpbar shows `<ctrl+q> quit` globally
- [x] Per-view helpbar shows `<esc> back/close`
- [x] `?` help pages show updated keys
- [x] `go test ./...` passes
- [x] `golangci-lint run ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)