### PR TITLE
fix: handle pgup/pgdown in contexts view

### DIFF
--- a/views/contexts/update.go
+++ b/views/contexts/update.go
@@ -692,6 +692,14 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 			m.MoveCursor(1)
 			return nil
 
+		case "pgup":
+			m.MoveCursor(-m.List.Viewport.Height)
+			return nil
+
+		case "pgdown":
+			m.MoveCursor(m.List.Viewport.Height)
+			return nil
+
 		case "enter":
 			// Switch to selected context
 			ctx, ok := m.GetSelectedContext()

--- a/views/contexts/update_test.go
+++ b/views/contexts/update_test.go
@@ -468,6 +468,25 @@ func TestKey_UpDown(t *testing.T) {
 	require.Equal(t, 0, m.GetCursor())
 }
 
+func TestKey_PgUpPgDown(t *testing.T) {
+	m := testModel()
+	names := make([]string, 20)
+	for i := range names {
+		names[i] = fmt.Sprintf("ctx%d", i)
+	}
+	loadContexts(m, fakeContexts(names...))
+	m.List.Viewport.Height = 5
+	require.Equal(t, 0, m.GetCursor())
+	m.Update(key("pgdown"))
+	require.Equal(t, 5, m.GetCursor())
+	m.Update(key("pgdown"))
+	require.Equal(t, 10, m.GetCursor())
+	m.Update(key("pgup"))
+	require.Equal(t, 5, m.GetCursor())
+	m.Update(key("pgup"))
+	require.Equal(t, 0, m.GetCursor())
+}
+
 // --- Error dialog ---
 
 func TestKey_ErrorDialog_EnterClears(t *testing.T) {


### PR DESCRIPTION
## Summary

- `pgup`/`pgdown` were missing from the keyboard `switch` in `views/contexts/update.go`
- All other list views (`stacks`, `services`, `nodes`) handle these keys; contexts was the odd one out
- Added two cases that call `m.MoveCursor(±m.List.Viewport.Height)`, identical in shape to the existing `up`/`down` cases
- Added `TestKey_PgUpPgDown` unit test

Closes #329

## Test plan
- [ ] `go test ./views/contexts/...` passes (including `TestKey_PgUpPgDown`)
- [ ] Manual: open contexts view with >1 page of contexts, verify PgUp/PgDown scrolls

🤖 Generated with [Claude Code](https://claude.com/claude-code)