### PR TITLE
chore: add goheader linter for dev-time SPDX header enforcement

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,6 +3,7 @@ version: "2"
 linters:
   default: none
   enable:
+    - goheader
     - errcheck
     - govet
     - staticcheck
@@ -13,6 +14,10 @@ linters:
     - revive
     - bodyclose
   settings:
+    goheader:
+      template: |-
+        SPDX-License-Identifier: Apache-2.0
+        Copyright © 2026 Eldara Tech
     gocritic:
       enabled-tags:
         - diagnostic

--- a/args/args_test.go
+++ b/args/args_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package args
 
 import (

--- a/commands/api/parse_test.go
+++ b/commands/api/parse_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package api //nolint:revive // standard short package name
 
 import (

--- a/core/primitives/hash/hash_test.go
+++ b/core/primitives/hash/hash_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package hash //nolint:revive // matches stdlib name intentionally
 
 import (

--- a/docker/json_test.go
+++ b/docker/json_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package docker
 
 import (

--- a/docker/service_helpers_test.go
+++ b/docker/service_helpers_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package docker
 
 import (

--- a/docker/service_test.go
+++ b/docker/service_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package docker
 
 import (

--- a/docker/snapshot_test.go
+++ b/docker/snapshot_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package docker
 
 import (

--- a/docker/task_test.go
+++ b/docker/task_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package docker
 
 import (

--- a/docker/utils_test.go
+++ b/docker/utils_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package docker
 
 import (

--- a/docker/version_naming_test.go
+++ b/docker/version_naming_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package docker
 
 import (

--- a/integration-tests/docker/network/network_test.go
+++ b/integration-tests/docker/network/network_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 //go:build integration
 
 package network

--- a/integration-tests/docker/node/node_test.go
+++ b/integration-tests/docker/node/node_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 //go:build integration
 
 package node

--- a/integration-tests/docker/secret/helper.go
+++ b/integration-tests/docker/secret/helper.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 //go:build integration
 
 package secret

--- a/integration-tests/docker/secret/secret_lifecycle_test.go
+++ b/integration-tests/docker/secret/secret_lifecycle_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 //go:build integration
 
 package secret

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package registry
 
 import (

--- a/scripts/check-spdx.sh
+++ b/scripts/check-spdx.sh
@@ -1,21 +1,22 @@
 #!/usr/bin/env sh
+# SPDX-License-Identifier: Apache-2.0
+# Copyright © 2026 Eldara Tech
 set -eu
 
-fail=0
-
-check_file () {
-  f="$1"
-  if ! head -n 20 "$f" | grep -q "SPDX-License-Identifier: Apache-2.0"; then
-    echo "Missing SPDX header: $f"
-    fail=1
-  fi
-}
+tmpfile=$(mktemp)
+trap 'rm -f "$tmpfile"' EXIT
 
 find . -type f \( -name '*.go' -o -name '*.sh' \) \
   -not -path './vendor/*' \
   -not -path './.git/*' \
-  | while read -r f; do
-      check_file "$f"
-    done
+  > "$tmpfile"
+
+fail=0
+while IFS= read -r f; do
+  if ! head -n 20 "$f" | grep -q "SPDX-License-Identifier: Apache-2.0"; then
+    echo "Missing SPDX header: $f"
+    fail=1
+  fi
+done < "$tmpfile"
 
 exit "$fail"

--- a/ui/columns_test.go
+++ b/ui/columns_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package ui
 
 import (

--- a/ui/components/sorting/sort_test.go
+++ b/ui/components/sorting/sort_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package sorting
 
 import (

--- a/ui/framecalc_test.go
+++ b/ui/framecalc_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package ui
 
 import (

--- a/utils/log/logger_test.go
+++ b/utils/log/logger_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package swarmlog
 
 import (

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package utils //nolint:revive // standard utility package name
 
 import (

--- a/views/commandinput/commandinput_test.go
+++ b/views/commandinput/commandinput_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package commandinput
 
 import (

--- a/views/configs/actions_test.go
+++ b/views/configs/actions_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package configsview
 
 import (

--- a/views/configs/model_test.go
+++ b/views/configs/model_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package configsview
 
 import (

--- a/views/configs/update_test.go
+++ b/views/configs/update_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package configsview
 
 import (

--- a/views/configs/view_test.go
+++ b/views/configs/view_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package configsview
 
 import (

--- a/views/confirmdialog/confirmdialog_test.go
+++ b/views/confirmdialog/confirmdialog_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package confirmdialog
 
 import (

--- a/views/contexts/model_test.go
+++ b/views/contexts/model_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package contexts
 
 import (

--- a/views/contexts/update_test.go
+++ b/views/contexts/update_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package contexts
 
 import (

--- a/views/contexts/view_test.go
+++ b/views/contexts/view_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package contexts
 
 import (

--- a/views/help/help_test.go
+++ b/views/help/help_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package helpview
 
 import (

--- a/views/helpbar/helpbar_test.go
+++ b/views/helpbar/helpbar_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package helpbar
 
 import (

--- a/views/inspect/inspect_test.go
+++ b/views/inspect/inspect_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package inspectview
 
 import (

--- a/views/loading/loading_test.go
+++ b/views/loading/loading_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package loadingview
 
 import (

--- a/views/logs/logs_test.go
+++ b/views/logs/logs_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package logsview
 
 import (

--- a/views/networks/actions_test.go
+++ b/views/networks/actions_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package networksview
 
 import (

--- a/views/networks/model_test.go
+++ b/views/networks/model_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package networksview
 
 import (

--- a/views/networks/update_test.go
+++ b/views/networks/update_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package networksview
 
 import (

--- a/views/networks/view_test.go
+++ b/views/networks/view_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package networksview
 
 import (

--- a/views/nodes/model_test.go
+++ b/views/nodes/model_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package nodesview
 
 import (

--- a/views/nodes/update_test.go
+++ b/views/nodes/update_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package nodesview
 
 import (

--- a/views/nodes/view_test.go
+++ b/views/nodes/view_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package nodesview
 
 import (

--- a/views/scaledialog/scaledialog_test.go
+++ b/views/scaledialog/scaledialog_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package scaledialog
 
 import (

--- a/views/secrets/actions_test.go
+++ b/views/secrets/actions_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package secretsview
 
 import (

--- a/views/secrets/model_test.go
+++ b/views/secrets/model_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package secretsview
 
 import (

--- a/views/secrets/update_test.go
+++ b/views/secrets/update_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package secretsview
 
 import (

--- a/views/secrets/view_test.go
+++ b/views/secrets/view_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package secretsview
 
 import (

--- a/views/services/model_test.go
+++ b/views/services/model_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package servicesview
 
 import (

--- a/views/services/update_test.go
+++ b/views/services/update_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package servicesview
 
 import (

--- a/views/stacks/model_test.go
+++ b/views/stacks/model_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package stacksview
 
 import (

--- a/views/stacks/update_test.go
+++ b/views/stacks/update_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package stacksview
 
 import (

--- a/views/stacks/view_test.go
+++ b/views/stacks/view_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package stacksview
 
 import (

--- a/views/systeminfo/systeminfo_test.go
+++ b/views/systeminfo/systeminfo_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package systeminfoview
 
 import (

--- a/views/tasks/tasks_test.go
+++ b/views/tasks/tasks_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package tasksview
 
 import (

--- a/views/viewstack/viewstack_test.go
+++ b/views/viewstack/viewstack_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
 package viewstack
 
 import (


### PR DESCRIPTION
## Summary

- Add \`goheader\` linter to \`.golangci.yml\` — \`golangci-lint run\` now catches missing SPDX headers locally, complementing the CI \`check-spdx.sh\` check
- Add \`SPDX-License-Identifier: Apache-2.0\` + \`Copyright © 2026 Eldara Tech\` headers to 54 \`.go\` files that were added to \`main\` after the original SPDX pass and slipped through undetected
- Fix \`scripts/check-spdx.sh\`: had a POSIX pipe-subshell bug where \`fail=1\` inside \`while read | pipe\` ran in a subshell, so \`exit \"\$fail\"\` always exited 0 — rewrote to feed \`find\` output via a temp file so \`fail\` propagates correctly

## Test plan

- [ ] \`./scripts/check-spdx.sh\` exits 0
- [ ] \`golangci-lint run ./...\` passes with goheader enabled
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.ai/claude-code)