### PR TITLE
fix: release pipeline — changelog, label categories, goreleaser deprecation

### DIFF
--- a/.github/release_template.yml
+++ b/.github/release_template.yml
@@ -18,12 +18,12 @@ categories:
   - title: ' [Bug Fixes] '
     labels:
       - 'A2-bugfix'
-  - title: ' [Dependencies] '
-    labels:
-      - 'D0-dependency'
   - title: ' [Technical] '
     labels:
       - 'A3-technical'
+  - title: ' [Dependencies] '
+    labels:
+      - 'D0-dependency'
 change-template: '- $TITLE (#$NUMBER) @$AUTHOR '
 change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
 template: |

--- a/.github/workflows/check_labels.yml
+++ b/.github/workflows/check_labels.yml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         include:
           - test: A Label (change type)
-            enforced_labels: "A0-ui,A1-feature,A2-bugfix,A3-technical"
+            enforced_labels: "A0-ui,A1-feature,A2-bugfix,A3-technical,D0-dependency"
           - test: B Label (urgency)
             enforced_labels: "B0-low-priority,B2-high-priority"
           - test: C Label (breaking changes)

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -113,30 +113,7 @@ snapshot:
   version_template: "{{ incpatch .Version }}-next"
 
 changelog:
-  sort: asc
-  use: github
-  filters:
-    exclude:
-      - '^docs:'
-      - '^test:'
-      - '^ci:'
-      - '^chore:'
-      - 'merge conflict'
-      - Merge pull request
-      - Merge remote-tracking branch
-      - Merge branch
-  groups:
-    - title: Features
-      regexp: '^.*?feat(\([[:word:]]+\))??!?:.+$'
-      order: 0
-    - title: 'Bug fixes'
-      regexp: '^.*?fix(\([[:word:]]+\))??!?:.+$'
-      order: 1
-    - title: 'Performance improvements'
-      regexp: '^.*?perf(\([[:word:]]+\))??!?:.+$'
-      order: 2
-    - title: Others
-      order: 999
+  disable: true
 
 # Homebrew tap 
 brews:


### PR DESCRIPTION
Ports release-pipeline fixes from [swarmcli-rbac-proxy e666178](https://github.com/Eldara-Tech/swarmcli-rbac-proxy/commit/e666178ddf53db33c6b0d377f62ce0080cba3058).

- Disable goreleaser changelog generation so release-drafter's PR-based notes are preserved (goreleaser was overwriting them with an incomplete commit-based changelog due to GitHub API rate limiting).
- Add `D0-dependency` to group A in `check_labels` so dependency PRs don't need `A3-technical` (eliminates duplicate release note entries).
- Reorder release template: `[Technical]` above `[Dependencies]`.

Note: `archives.builds` (also dropped in the rbac-proxy commit) was already absent here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)