### PR TITLE
feat: change context delete key from d to ctrl+d

### DIFF
--- a/views/contexts/model.go
+++ b/views/contexts/model.go
@@ -440,7 +440,7 @@ func (m *Model) ShortHelpItems() []helpbar.HelpEntry {
 		{Key: "x", Desc: "Export"},
 		{Key: "m", Desc: "Import"},
 		{Key: "c", Desc: "Create"},
-		{Key: "d", Desc: "Delete"},
+		{Key: "ctrl+d", Desc: "Delete"},
 		{Key: "/", Desc: "Filter"},
 		{Key: "?", Desc: "Help"},
 		{Key: "Esc", Desc: "Back"},

--- a/views/contexts/model_test.go
+++ b/views/contexts/model_test.go
@@ -99,6 +99,8 @@ func key(s string) tea.KeyMsg {
 		return tea.KeyMsg{Type: tea.KeyPgUp}
 	case "pgdown":
 		return tea.KeyMsg{Type: tea.KeyPgDown}
+	case "ctrl+d":
+		return tea.KeyMsg{Type: tea.KeyCtrlD}
 	case "backspace":
 		return tea.KeyMsg{Type: tea.KeyBackspace}
 	case " ":
@@ -356,7 +358,7 @@ func TestShortHelpItems(t *testing.T) {
 	require.True(t, keys["x"])
 	require.True(t, keys["m"])
 	require.True(t, keys["c"])
-	require.True(t, keys["d"])
+	require.True(t, keys["ctrl+d"])
 	require.True(t, keys["e"])
 	require.True(t, keys["?"])
 }

--- a/views/contexts/update.go
+++ b/views/contexts/update.go
@@ -826,7 +826,7 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 			m.SetSuccess("")
 			return textinput.Blink
 
-		case "d":
+		case "ctrl+d":
 			// Delete selected context
 			ctx, ok := m.GetSelectedContext()
 			if !ok {
@@ -863,7 +863,7 @@ func GetContextsHelpContent() []helpview.HelpCategory {
 				{Keys: "<e>", Description: "Edit context description"},
 				{Keys: "<x>", Description: "Export context"},
 				{Keys: "<m>", Description: "Import context from file"},
-				{Keys: "<d>", Description: "Delete context"},
+				{Keys: "<ctrl+d>", Description: "Delete context"},
 				{Keys: "</>", Description: "Filter"},
 			},
 		},

--- a/views/contexts/update_test.go
+++ b/views/contexts/update_test.go
@@ -397,7 +397,7 @@ func TestKey_Delete_CurrentContext_Error(t *testing.T) {
 	ctxs := fakeContexts("current")
 	ctxs[0].Current = true
 	loadContexts(m, ctxs)
-	m.Update(key("d"))
+	m.Update(key("ctrl+d"))
 	require.Contains(t, m.GetError(), "Cannot delete")
 	require.False(t, m.confirmDialog.Visible)
 }
@@ -409,7 +409,7 @@ func TestKey_Delete_NonCurrentContext(t *testing.T) {
 	ctxs[1].Current = false
 	loadContexts(m, ctxs)
 	m.MoveCursor(1)
-	m.Update(key("d"))
+	m.Update(key("ctrl+d"))
 	require.True(t, m.confirmDialog.Visible)
 	require.Equal(t, "other", m.pendingDeleteContext)
 	require.Equal(t, "delete", m.pendingAction)


### PR DESCRIPTION
## Summary

- Closes #336. Changes the delete-context keybinding in the contexts view from `d` to `ctrl+d`.
- Aligns contexts with the rest of the app — every other destructive action (services, secrets, stacks, networks, configs) already uses `ctrl+d`. Matches k9s convention.
- User-visible behavior change: existing users with muscle memory on `d` will need to relearn.

## Changes

- `views/contexts/update.go`: key dispatch + help entry now `ctrl+d` / `<ctrl+d>`.
- `views/contexts/model.go`: `ShortHelpItems` now reports `ctrl+d`.
- Tests updated; `key()` helper in `model_test.go` extended to emit `tea.KeyCtrlD`.

## Test plan

- [x] `go test ./views/contexts/...` passes
- [x] `go test ./...` passes
- [x] `go build .` succeeds
- [x] Manual: launch the TUI, open contexts view, confirm `d` no longer triggers delete and `ctrl+d` does
- [x] Manual: confirm helpbar and `?` help screen display `ctrl+d`