### PR TITLE
docs: fix broken README TOC links (#339)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,11 @@
   </p>
 
   <p>
-    <a href="#-why-swarmcli">Why SwarmCLI?</a> •
-    <a href="#-quickstart">Quickstart</a> •
-    <a href="#-features">Features</a> •
-    <a href="#-installation">Installation</a> •
-    <a href="#-contributing">Contributing</a> •
+    <a href="#why-swarmcli">Why SwarmCLI?</a> •
+    <a href="#quickstart">Quickstart</a> •
+    <a href="#features">Features</a> •
+    <a href="#installation">Installation</a> •
+    <a href="CONTRIBUTING.md">Contributing</a> •
     <a href="https://swarmcli.io/">Homepage</a>
   </p>
 </div>


### PR DESCRIPTION
## Summary

- Drop the stray leading dash from the TOC anchors in `README.md` — `#-quickstart`, `#-features`, `#-installation`, `#-why-swarmcli` do not exist; GitHub generates `#quickstart`, `#features`, etc.
- Point the Contributing TOC entry at `CONTRIBUTING.md` since there is no `## Contributing` section (the guide is linked from the Project Hygiene section).

Fixes #339.

## Test plan

- [ ] Open the rendered README on the PR page and click every TOC link — each should jump to its target.