### PR TITLE
fix(release): force goreleaser to use pushed tag (RC→GA promotion)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,3 +55,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
           SCOOP_BUCKET_GITHUB_TOKEN: ${{ secrets.SCOOP_BUCKET_TOKEN }}
+          # Force goreleaser to use the pushed tag rather than `git describe`,
+          # which is non-deterministic when two tags point at the same commit
+          # (e.g. promoting v1.1.0-rc1 to v1.1.0). Without this, the RC→GA
+          # promotion fails because goreleaser tries to re-publish the RC.
+          GORELEASER_CURRENT_TAG: ${{ github.ref_name }}


### PR DESCRIPTION
## Summary

Adds `GORELEASER_CURRENT_TAG: ${{ github.ref_name }}` to the goreleaser step in `.github/workflows/release.yml` so the binary release, Homebrew formula, and Scoop manifest all match the tag that triggered the workflow rather than whatever `git describe` happens to return.

## Why (proactive — same defect just broke rbac-proxy)

The identical goreleaser-action invocation just caused the rbac-proxy v1.1.0 release to fail (https://github.com/Eldara-Tech/swarmcli-rbac-proxy/actions/runs/24924235770). When two tags point at the same commit — the canonical shape of an RC→GA promotion (e.g. `v1.1.0` placed on the commit that already carries `v1.1.0-rc1`) — goreleaser's `git describe` may resolve to the older tag and try to re-publish the RC. The PATCH fails with `tag_name already_exists`.

This repo would hit the same failure on the next RC→GA promotion. Sister fixes:
- https://github.com/Eldara-Tech/swarmcli-rbac-proxy/pull/<rbac-proxy-PR>
- https://github.com/Eldara-Tech/swarmcli-be/pull/<swarmcli-be-PR>

## Test plan

- [x] One-line addition to goreleaser env block; YAML valid
- [ ] Verified end-to-end on the next release tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)