### PR TITLE
chore(deps): drop A3-technical from dependabot labels

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,6 @@ updates:
     schedule:
       interval: weekly
     labels:
-      - A3-technical
       - B0-low-priority
       - C0-breaks-nothing
       - D0-dependency
@@ -16,7 +15,6 @@ updates:
     schedule:
       interval: weekly
     labels:
-      - A3-technical
       - B0-low-priority
       - C0-breaks-nothing
       - D0-dependency
@@ -26,7 +24,6 @@ updates:
     schedule:
       interval: monthly
     labels:
-      - A3-technical
       - B0-low-priority
       - C0-breaks-nothing
       - D0-dependency


### PR DESCRIPTION
## Summary

Drops `A3-technical` from all three dependabot ecosystems (`gomod`, `github-actions`, `docker`). PRs will continue to pass `check_labels.yml` because `D0-dependency` is already in the A-group enforcement list. After merge, dependabot PRs will appear only under **Dependencies** in release notes — not duplicated under **Technical**.

Companion PRs:
- Eldara-Tech/swarmcli-rbac-proxy#95 (originating PR; dupe entries first surfaced in rbac-proxy v1.1.0 notes)
- Eldara-Tech/swarmcli-be#84
- Eldara-Tech/swarmcli-agent#39

## Test plan

- [x] One file changed; three identical 4-line label blocks lose `- A3-technical`.
- [ ] Next dependabot PR after merge has `[B0-low-priority, C0-breaks-nothing, D0-dependency]` and check_labels passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)