### PR TITLE
fix(systeminfo): prevent header version line wrap on long versions

### DIFF
--- a/views/systeminfo/systeminfo_test.go
+++ b/views/systeminfo/systeminfo_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"swarmcli/docker"
@@ -279,4 +280,30 @@ func TestUpdate_LatestVersionMsg(t *testing.T) {
 	require.Contains(t, m.content, "1.2.2")
 	require.Contains(t, m.content, "v1.3.3")
 	require.Contains(t, m.content, "⚡")
+}
+
+// Regression: long version+latest combinations must render in the fixed
+// systeminfo height without lipgloss wrapping the value onto a new line.
+// See https://github.com/Eldara-Tech/swarmcli-be/issues/93.
+func TestView_VersionLineDoesNotWrap_LongVersions(t *testing.T) {
+	cases := []struct {
+		name    string
+		version string
+		latest  string
+	}{
+		{"snapshot build", "1.4.6-next", "1.5.0"},
+		{"rc build", "v1.5.0-rc.1", "1.5.0"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := New(testDeps(), tc.version, "ce")
+			m.Update(LatestVersionMsg{latestVersion: tc.latest})
+
+			rendered := m.View()
+			lines := strings.Split(strings.TrimRight(rendered, "\n"), "\n")
+			require.Equal(t, Height, len(lines),
+				"systeminfo must render exactly %d lines (got %d) for version %q latest %q:\n%s",
+				Height, len(lines), tc.version, tc.latest, rendered)
+		})
+	}
 }

--- a/views/systeminfo/update.go
+++ b/views/systeminfo/update.go
@@ -129,7 +129,7 @@ func content(context, version, cpu, mem string, containers, services int) string
 	labelStyle := lipgloss.NewStyle().
 		Foreground(lipgloss.Color("214")).
 		Bold(true).
-		Width(15)
+		Width(12)
 
 	// Use lipgloss Width to handle styled text properly
 	return fmt.Sprintf(

--- a/views/systeminfo/view.go
+++ b/views/systeminfo/view.go
@@ -6,7 +6,7 @@ package systeminfoview
 import "swarmcli/ui"
 
 const Height = 6
-const Width = 35
+const Width = 40
 
 func (m *Model) View() string {
 	return ui.StatusStyle.Height(Height).


### PR DESCRIPTION
## Summary
- Snapshot/RC version strings combined with the `⚡v1.5.0` latest-version hint were overflowing the systeminfo header's value zone, and lipgloss wrapped the hint onto a new line — breaking the fixed 6-line header layout.
- Tightened the label style width 15 → 12 (longest label, `Containers:`, is 11 cells) and widened the box 35 → 40. Available value width: 17 → 25 cells.
- Helpbar absorbs the 5-cell shrink without regression (it already collapses below `minColWidth=20` and a typical viewport has ~130+ cells of slack here).

Refs Eldara-Tech/swarmcli-be#93 (BE checks-in BE-side: it doesn't call `app.SetEdition(\"be\")`; that fix lives in the BE repo).

## Test plan
- [x] `go test ./views/systeminfo/...` — added `TestView_VersionLineDoesNotWrap_LongVersions` covering snapshot (`1.4.6-next`) and RC (`v1.5.0-rc.1`) versions; both render in the fixed `Height=6` lines after the fix and would fail before.
- [x] `go test ./views/... ./app/...` — no regressions.
- [x] `golangci-lint run ./views/systeminfo/...` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)