### PR TITLE
ci: add path filters to skip jobs on unrelated changes

### DIFF
--- a/.github/workflows/check_labels.yml
+++ b/.github/workflows/check_labels.yml
@@ -2,7 +2,7 @@ name: Check labels
 
 on:
   pull_request:
-    types: [opened, labeled, unlabeled, synchronize, ready_for_review]
+    types: [opened, labeled, unlabeled, ready_for_review]
 
 permissions: read-all
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,26 @@ name: SwarmCLI CI
 on:
   pull_request:
     branches: [main]
+    paths-ignore:
+      - '**.md'
+      - 'LICENSE'
+      - 'NOTICE'
+      - 'assets/**'
+      - '.devcontainer/**'
+      - '.idea/**'
+      - '.gitignore'
+      - '.github/release_template.yml'
   push:
     branches: [main]
+    paths-ignore:
+      - '**.md'
+      - 'LICENSE'
+      - 'NOTICE'
+      - 'assets/**'
+      - '.devcontainer/**'
+      - '.idea/**'
+      - '.gitignore'
+      - '.github/release_template.yml'
 
 permissions: read-all
 

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -3,8 +3,30 @@ name: Integration Tests
 on:
   push:
     branches: [main]
+    paths:
+      - '**.go'
+      - 'go.mod'
+      - 'go.sum'
+      - 'Dockerfile'
+      - 'Dockerfile.release'
+      - 'docker-compose.yaml'
+      - 'test-setup/**'
+      - 'integration-tests/**'
+      - 'scripts/**'
+      - '.github/workflows/integration-tests.yml'
   pull_request:
     branches: [main]
+    paths:
+      - '**.go'
+      - 'go.mod'
+      - 'go.sum'
+      - 'Dockerfile'
+      - 'Dockerfile.release'
+      - 'docker-compose.yaml'
+      - 'test-setup/**'
+      - 'integration-tests/**'
+      - 'scripts/**'
+      - '.github/workflows/integration-tests.yml'
 
 permissions: read-all
 

--- a/.github/workflows/licence.yml
+++ b/.github/workflows/licence.yml
@@ -3,8 +3,18 @@ name: License checks
 on:
   pull_request:
     branches: [main]
+    paths:
+      - '**.go'
+      - '**.sh'
+      - 'scripts/check-spdx.sh'
+      - '.github/workflows/licence.yml'
   push:
     branches: [main]
+    paths:
+      - '**.go'
+      - '**.sh'
+      - 'scripts/check-spdx.sh'
+      - '.github/workflows/licence.yml'
 
 permissions: read-all
 


### PR DESCRIPTION
## Summary

Cuts CI runtime on PRs that don't touch Go/build-relevant files.

### \`ci.yml\` — \`paths-ignore\`
Skip the whole workflow when all changed files are docs (\`**.md\`, \`LICENSE\`, \`NOTICE\`), branding (\`assets/**\`), dev-env-only (\`.devcontainer\`, \`.idea\`, \`.gitignore\`), or release-template-only. Mixed PRs (one \`.md\` + one \`.go\`) still trigger because paths-ignore requires *all* changed files to match.

### \`integration-tests.yml\` — positive \`paths\`
Only run when files that actually affect the integration pipeline change: Go sources/deps, \`Dockerfile(s)\`, \`test-setup/\`, \`scripts/\`, the workflow itself. A README typo no longer waits 5 minutes for DinD Swarm to spin up.

### \`licence.yml\` — positive \`paths\`
SPDX header check only inspects \`.go\` and \`.sh\` files. Trigger only on those (or the checker script / workflow itself).

### \`check_labels.yml\` — drop \`synchronize\`
The label set on a PR isn't affected by new commits, so re-running on every push is pure overhead. \`labeled\`/\`unlabeled\` cover label changes; \`ready_for_review\` covers draft → ready.

### Required-status-check note
GitHub treats jobs from a workflow that is never triggered (paths filter rejected) as auto-passed for the merge gate, so branch protection stays satisfied.

## Follow-up not done here
Per-job filters via \`dorny/paths-filter\` (e.g. skip \`lint\` when only \`Dockerfile\` changes). Marginal savings since most code-touching PRs change Go files anyway, and adds a third-party action dependency. Worth revisiting if PR mix shifts.

## Test plan
- [x] \`paths-ignore\` covers docs/assets/devcontainer/idea — verified file list against repo top-level.
- [x] \`integration-tests.yml\` positive list includes everything the testenv pipeline reads (Dockerfile*, test-setup/, scripts/, integration-tests/, Go sources & deps).
- [x] \`licence.yml\` positive list matches what \`scripts/check-spdx.sh\` actually scans (\`*.go\` and \`*.sh\`).
- [x] \`check_labels.yml\` still triggers on \`opened\`/\`labeled\`/\`unlabeled\`/\`ready_for_review\` — covers all label changes plus the draft→ready transition.
- [ ] After merge: open a docs-only PR (e.g. README typo) to verify \`SwarmCLI CI\` and \`Integration Tests\` stay skipped and the merge gate goes green.