### PR TITLE
ci(dependabot): group minor/patch updates into single PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,10 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    groups:
+      go-minor-patch:
+        patterns: ["*"]
+        update-types: [minor, patch]
     labels:
       - B0-low-priority
       - C0-breaks-nothing
@@ -14,6 +18,9 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    groups:
+      actions:
+        patterns: ["*"]
     labels:
       - B0-low-priority
       - C0-breaks-nothing
@@ -23,6 +30,9 @@ updates:
     directory: /
     schedule:
       interval: monthly
+    groups:
+      docker-images:
+        patterns: ["*"]
     labels:
       - B0-low-priority
       - C0-breaks-nothing


### PR DESCRIPTION
## Summary

Groups minor + patch dependabot updates into single PRs per ecosystem.

| Ecosystem | Group | Update types |
|---|---|---|
| `gomod` | `go-minor-patch` | minor, patch (majors stay individual) |
| `github-actions` | `actions` | all (action major versions are typically drop-in) |
| `docker` | `docker-images` | all (one base image, low blast radius) |

## Why
Currently every dep bump opens its own PR — multiplied by 4 repos this is ~60 dependabot PRs/month, each triggering a full CI run. Grouping minor/patch updates collapses this to roughly 1 PR per ecosystem per cycle (~12/mo total across the four repos), with proportional CI savings.

## Why this shape
- **Major Go bumps stay individual** — they're more likely to be breaking and the isolated PR makes review and revert easier.
- **Security advisories ride a separate dependabot channel** and ignore `groups:` config, so urgent CVE patches still arrive as standalone PRs immediately, not bundled with the next weekly group.
- **Action and Docker groups include everything** — major versions of pinned actions are usually drop-in (semantic compatibility), and we have very few base images.

## Trade-off accepted
Harder bisection on a regression in a grouped PR. Mitigated by reverting the whole group and letting dependabot reissue individually next cycle. Cheaper than absorbing 5× the per-PR CI runs.

## References
GitHub's grouped updates feature has been GA since mid-2023; this is the pattern recommended in their blog post and used by kubernetes, prometheus, and many large Go projects.