### PR TITLE
ci: restore synchronize trigger on check_labels

### DIFF
--- a/.github/workflows/check_labels.yml
+++ b/.github/workflows/check_labels.yml
@@ -2,7 +2,12 @@ name: Check labels
 
 on:
   pull_request:
-    types: [opened, labeled, unlabeled, ready_for_review]
+    # synchronize is required so that this workflow re-publishes its check
+    # status on every new HEAD commit (including merges from main). Branch
+    # protection evaluates required checks per commit SHA — without
+    # synchronize, the check goes stale on push and blocks the merge gate
+    # even though the labels themselves haven't changed.
+    types: [opened, labeled, unlabeled, synchronize, ready_for_review]
 
 permissions: read-all
 


### PR DESCRIPTION
#349 dropped `synchronize` from check_labels.yml on the reasoning that "labels don't change on new commits" — semantically true, but breaks branch-protection mechanics. Required checks are evaluated per commit SHA: a successful run on the original HEAD doesn't carry forward when new commits land (whether by user push or by merging main into the PR branch). Without synchronize, the workflow never re-publishes a status on the new HEAD, leaving required checks stuck on "Expected — Waiting".

Observed on Eldara-Tech/swarmcli#350 after a merge-from-main: SwarmCLI CI / Integration Tests / License checks all re-ran on the merge SHA, but Check labels stayed on the prior SHA. Re-add synchronize.

Cost vs original justification: each synchronize fires 3 matrix jobs (~3 billed minutes). Worth it — the alternative is manually rerunning the workflow on every PR that gets synced with main.