### PR TITLE
docs: add Business Edition section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,10 +60,31 @@ swarmcli
 - **Real-time Observability**: Live monitoring of Services, Tasks, Nodes, and Containers.
 - **Stack Awareness**: Navigate your cluster hierarchically (Stacks > Services > Tasks).
 - **Instant Logs**: No more `docker service logs -f`. Just press `l` on any service.
-- **Secrets & Configs**: Manage, rotate, and — with Pro — **reveal** secrets for debugging.
+- **Secrets & Configs**: Manage, rotate, and — with [Business Edition](#business-edition) — **reveal** secrets for debugging.
 - **Management Actions**: Scale, restart, remove, and update services with single keystrokes.
 - **Zero Config**: Works out-of-the-box with your local Docker engine or remote via SSH/Contexts.
 - **Lightweight**: Built with Go. Single static binary (< 20MB). Zero dependencies.
+
+## Business Edition
+
+The Community Edition is the full open-source TUI. **Business Edition** is a
+commercial superset that adds:
+
+- `:bootstrap` — one-command deploy of an mTLS-fronted RBAC proxy and
+  per-node agent stack onto your existing Swarm.
+- Per-user RBAC, identity by client certificate, role-gated mutation and
+  exec.
+- Interactive shell into a running service task.
+- Reveal-secret for debugging.
+
+Installs via `brew install Eldara-Tech/tap/swarmcli-be`,
+`scoop install swarmcli-be`, or `docker pull eldaratech/swarmcli-be`. The
+binary on disk is named `swarmcli` (BE is a strict superset of CE — same
+binary name, expanded feature set), so existing scripts and aliases
+continue to work.
+
+Documentation, install channels, and license sign-up are at the BE release
+repo: [Eldara-Tech/swarmcli-be-releases](https://github.com/Eldara-Tech/swarmcli-be-releases).
 
 ## Installation
 


### PR DESCRIPTION
## Summary

Adds a short Business Edition section to the README pointing at the BE release repo, and updates the existing "with Pro" reveal-secret reference to use the canonical "Business Edition" wording.

Scope is intentionally minimal: the section is a single-screen pitch + install snippet + link to the BE docs home. Full BE documentation lives in `Eldara-Tech/swarmcli-be-releases/docs` (PR Eldara-Tech/swarmcli-be-releases#4) — this README does not duplicate it.

## Test plan

- [ ] Render the README on GitHub — confirm the new "Business Edition" section appears between "Features" and "Installation" and the `[Business Edition](#business-edition)` anchor in the Features bullet jumps correctly.
- [ ] Confirm the link to `Eldara-Tech/swarmcli-be-releases` resolves (will be public once that repo gets its first BE release).
- [ ] Verify the label gate passes (this PR is `A3-technical`, `B0-low-priority`, `C0-breaks-nothing`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)