### PR TITLE
ui(confirmdialog): widen cap from 80 to 100 cols

### DIFF
--- a/views/confirmdialog/confirmdialog.go
+++ b/views/confirmdialog/confirmdialog.go
@@ -76,7 +76,10 @@ func (m *Model) View() string {
 	}
 
 	// Cap dialog width to a sensible maximum, then word-wrap.
-	maxWidth := 80
+	// 100 keeps long single-token content (URLs, paths) on one line on
+	// modern terminals; the m.Width-6 clamp below scales it down on
+	// narrow ones.
+	maxWidth := 100
 	if m.Width > 0 && m.Width-6 < maxWidth {
 		maxWidth = m.Width - 6
 	}


### PR DESCRIPTION
## Summary

- Bumps the `confirmdialog` width cap from 80 → 100 cols. Long single-token content (URLs, paths) used to wrap onto a second line on modern terminals; now stays intact when the terminal has the room.
- The `m.Width-6` clamp keeps narrow terminals scaling down as before.
- The `contentWidth = max(line lengths) + 4` floor at 50 logic is unchanged, so short confirm/info dialogs don't get stretched.

## Why

The bootstrap-missing hint introduced in https://github.com/Eldara-Tech/swarmcli-be/pull/113 ends with `Docs: https://github.com/Eldara-Tech/swarmcli-be-releases/blob/main/docs/bootstrap.md` — 86 chars, which wraps under the old 80-col cap. Reviewer feedback on that PR asked to keep the link on one line.

## Test plan

- [x] \`go test -race -count=1 ./views/confirmdialog/...\` (green)
- [x] \`go test -race -count=1 ./...\` (full suite green)
- [x] \`golangci-lint run ./views/confirmdialog/...\` (0 issues)
- [ ] Manual: open swarmcli-be with the PR-113 fix on a non-bootstrapped swarm, press \`x\` on a service, verify the docs URL is on one line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)