### PR TITLE
feat(app,docker): add extension points for port-forward (BE)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,7 @@ tail -f ~/.local/state/swarmcli/app.log          # prod mode (JSON)
 main.go                    Entry point; version injection via ldflags, tea.NewProgram()
 app/
   app.go                   View factory registry, Init(), command autoload via _ "swarmcli/commands"
+  hooks.go                 PreUpdateHook registration; StartupOverlay; RegisterShutdownHook / RunShutdownHooks (BE port-forward manager registers CloseAll here)
   model.go                 Central state: Model struct (viewport, currentView, viewStack, commandInput, searchInput, systemInfo)
   update.go                Main message router: navigation, resize, events, key dispatch
 views/
@@ -68,7 +69,7 @@ docker/
   snapshot.go              In-memory cache (3s TTL, sync.RWMutex, atomic refresh flag)
   events.go                Docker event stream subscription
   service.go               Service ops: scale, restart, update
-  node.go, task.go         Entity queries
+  node.go, task.go         Entity queries (TaskEntry includes ContainerID, populated from task.Status.ContainerStatus.ContainerID with nil-guard)
   stack.go                 Stack queries
   secret.go, config.go     Secret/config CRUD
 registry/

--- a/app/hooks.go
+++ b/app/hooks.go
@@ -32,3 +32,22 @@ var startupOverlay StartupOverlay
 func SetStartupOverlay(o StartupOverlay) {
 	startupOverlay = o
 }
+
+var shutdownHooks []func()
+
+// RegisterShutdownHook adds a function to run when the program exits.
+// Must be called from init(). Hooks run synchronously in registration order
+// from RunShutdownHooks, which the entry point invokes after tea.Program.Run
+// returns. They also fire from a SIGINT/SIGTERM handler set up by callers
+// that need defensive cleanup on panic paths.
+func RegisterShutdownHook(fn func()) {
+	shutdownHooks = append(shutdownHooks, fn)
+}
+
+// RunShutdownHooks executes all registered shutdown hooks in order.
+// Safe to call multiple times; hooks themselves must be idempotent.
+func RunShutdownHooks() {
+	for _, h := range shutdownHooks {
+		h()
+	}
+}

--- a/docker/task.go
+++ b/docker/task.go
@@ -19,6 +19,7 @@ type TaskEntry struct {
 	ServiceName  string
 	Image        string
 	NodeName     string
+	ContainerID  string
 	DesiredState string
 	CurrentState string
 	Error        string
@@ -103,12 +104,17 @@ func GetTasksForStack(stackName string) ([]TaskEntry, error) {
 			if len(id) > 12 {
 				id = id[:12]
 			}
+			containerID := ""
+			if task.Status.ContainerStatus != nil {
+				containerID = task.Status.ContainerStatus.ContainerID
+			}
 			tasks = append(tasks, TaskEntry{
 				ID:           id,
 				Name:         fmt.Sprintf("%s.%d", svc.Spec.Name, task.Slot),
 				ServiceName:  svc.Spec.Name,
 				Image:        image,
 				NodeName:     nodeName,
+				ContainerID:  containerID,
 				DesiredState: string(task.DesiredState),
 				CurrentState: currentState,
 				Error:        errorMsg,
@@ -210,12 +216,17 @@ func GetTasksForService(serviceID string) ([]TaskEntry, error) {
 			if len(id) > 12 {
 				id = id[:12]
 			}
+			containerID := ""
+			if task.Status.ContainerStatus != nil {
+				containerID = task.Status.ContainerStatus.ContainerID
+			}
 			tasks = append(tasks, TaskEntry{
 				ID:           id,
 				Name:         fmt.Sprintf("%s.%d", serviceName, task.Slot),
 				ServiceName:  serviceName,
 				Image:        image,
 				NodeName:     nodeName,
+				ContainerID:  containerID,
 				DesiredState: string(task.DesiredState),
 				CurrentState: currentState,
 				Error:        errorMsg,


### PR DESCRIPTION
## Summary

Two purely additive changes to the OSS that the upcoming Pro **port-forward** feature (issue Eldara-Tech/swarmcli-be#13) needs as extension points. Mirrors the established pattern by which the OSS exposes generic hooks (no Pro-specific logic) for the BE to plug into.

- `docker.TaskEntry.ContainerID` — populated from `task.Status.ContainerStatus.ContainerID` with a nil-guard, in both `GetTasksForStack` and `GetTasksForService`. The BE port-forward replica picker needs the container ID to send to the agent without a second `TaskInspectWithRaw` round-trip.
- `app.RegisterShutdownHook(fn func())` / `app.RunShutdownHooks()` — package-level cleanup hooks. `swarmcli-be/main.go` will register `portforwards.Default().CloseAll` here so local TCP listeners and WebSocket connections drain synchronously after `tea.Program.Run` returns.

Phase 1 of 14 in [the port-forward implementation plan](https://github.com/Eldara-Tech/swarmcli-be/issues/13). No callsite in this repo reads either; the changes are ready for use by Pro once a CE release tag lands.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./docker/ ./app/ ./views/services/` passes
- [x] `golangci-lint run ./docker/... ./app/...` clean
- [x] CI green
- [ ] CE release tag cut after merge so `swarmcli-be` can bump `.swarmcli-ref`

🤖 Generated with [Claude Code](https://claude.com/claude-code)