### PR TITLE
fix(test-setup): valid HTTP from whoami services

### DIFF
--- a/test-setup/test-stack.yml
+++ b/test-setup/test-stack.yml
@@ -36,8 +36,7 @@ services:
         apk add --no-cache netcat-openbsd;
         echo "Starting whoami service...";
         while true; do
-          echo -e "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\n\r" \
-          "Service: whoami\nConfig:\n$$(cat /etc/whoami/config)\n\n" \
+          printf "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\n\r\nService: whoami\nConfig:\n%s\n\n" "$$(cat /etc/whoami/config)" \
           | nc -l -p 80 -q 1;
         done
       '
@@ -57,8 +56,7 @@ services:
         apk add --no-cache netcat-openbsd;
         echo "Starting whoami_single service...";
         while true; do
-          echo -e "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\n\r" \
-          "Service: whoami_single\nConfig:\n$$(cat /etc/whoami/config)\n\n" \
+          printf "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\n\r\nService: whoami_single\nConfig:\n%s\n\n" "$$(cat /etc/whoami/config)" \
           | nc -l -p 80 -q 1;
         done
       '


### PR DESCRIPTION
## Summary

The two demo whoami services in `test-setup/test-stack.yml` produce a malformed HTTP response. The two-arg `echo -e` form puts a single space between the headers terminator and the body, so the on-the-wire bytes are `\r\n\r ` instead of `\r\n\r\n`. Strict parsers (Go `net/http`) reject this as a malformed MIME header line; curl tolerates it, which is why it has gone undetected.

The BE port-forward integration test (Eldara-Tech/swarmcli-be#114, `TestForward_Whoami_RoundTrip`) is the first consumer that does real HTTP parsing on the response through the forward — it currently fails CI with:

```
malformed MIME header line: \r Service: whoami_single
```

The `\r` is what the strict parser is balking at. CI rendering swallows the carriage return, so the error visually splits across two lines.

### Reproduction

```sh
echo -e "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\n\r" \
"Service: whoami_single\nConfig:\nfoo\n\n" | od -c | sed -n '1,4p'
# 0000020  \n   C   o   n   t   e   n   t   -   T   y   p   e   :       t
# 0000040   e   x   t   /   p   l   a   i   n  \r  \n  \r       S   e   r
#                                                      ^^^^ space, not \n
```

### Fix

Switch each `echo -e <args>` to a single `printf` with the format placed in one string. `printf` is portable across busybox/coreutils, doesn't append its own trailing newline, and lets the CRLF placement match HTTP framing exactly.

## Test plan

- [x] `od -c` on the new `printf` output shows `\r\n\r\n` at the headers/body boundary
- [x] `http.ReadResponse` on the new bytes returns status=200 and a clean body (Go playground style check)
- [ ] OSS CI green
- [ ] Re-run BE PR 114 CI after this merges; `TestForward_Whoami_RoundTrip` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)