### PR TITLE
fix(networks): render inspect view as YAML via shared inspectview

### DIFF
--- a/docker/json_test.go
+++ b/docker/json_test.go
@@ -90,14 +90,3 @@ func TestNetworkJSON(t *testing.T) {
 	require.True(t, ok)
 	require.Len(t, services, 2)
 }
-
-func TestNetworkPrettyJSON(t *testing.T) {
-	nw := &NetworkWithUsage{
-		Network:  network.Summary{Name: "my-net"},
-		Services: []string{"web"},
-	}
-	raw, err := nw.PrettyJSON()
-	require.NoError(t, err)
-	require.Contains(t, string(raw), "\n")
-	require.Contains(t, string(raw), "  ")
-}

--- a/docker/network.go
+++ b/docker/network.go
@@ -4,10 +4,8 @@
 package docker
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
-	"fmt"
 
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/network"
@@ -115,19 +113,4 @@ func (nw *NetworkWithUsage) JSON() ([]byte, error) {
 	}
 
 	return json.Marshal(obj)
-}
-
-// PrettyJSON returns the JSON representation of the network,
-// but pretty-printed (indented) for human-readable viewing.
-func (nw *NetworkWithUsage) PrettyJSON() ([]byte, error) {
-	raw, err := nw.JSON()
-	if err != nil {
-		return nil, err
-	}
-
-	var pretty bytes.Buffer
-	if err := json.Indent(&pretty, raw, "", "  "); err != nil {
-		return nil, fmt.Errorf("pretty-print failed: %w", err)
-	}
-	return pretty.Bytes(), nil
 }

--- a/views/networks/actions.go
+++ b/views/networks/actions.go
@@ -5,10 +5,7 @@ package networksview
 
 import (
 	"fmt"
-	"swarmcli/docker"
 	"time"
-
-	"github.com/docker/docker/api/types/network"
 )
 
 type networkItem struct {
@@ -41,16 +38,3 @@ type usedByItem struct {
 func (i usedByItem) FilterValue() string { return i.StackName + " " + i.ServiceName }
 func (i usedByItem) Title() string       { return fmt.Sprintf("%-24s %-24s", i.StackName, i.ServiceName) }
 func (i usedByItem) Description() string { return "Service: " + i.ServiceName }
-
-type networkWithUsage struct {
-	Network  network.Summary
-	Services []string
-}
-
-func (nw *networkWithUsage) PrettyJSON() ([]byte, error) {
-	dockerNW := docker.NetworkWithUsage{
-		Network:  nw.Network,
-		Services: nw.Services,
-	}
-	return dockerNW.PrettyJSON()
-}

--- a/views/networks/actions_test.go
+++ b/views/networks/actions_test.go
@@ -6,7 +6,11 @@ package networksview
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
+
+	inspectview "swarmcli/views/inspect"
+	"swarmcli/views/view"
 
 	"github.com/docker/docker/api/types/network"
 	"github.com/stretchr/testify/require"
@@ -171,12 +175,16 @@ func TestInspectNetworkCmd_Success(t *testing.T) {
 	m := testModel(func(m *Model) { m.deps.Networks = mock })
 	cmd := m.inspectNetworkCmd("id-mynet")
 	msg := runCmd(cmd)
-	result, ok := msg.(NetworkInspectMsg)
+	nav, ok := msg.(view.NavigateToMsg)
 	require.True(t, ok)
-	require.Nil(t, result.Err)
-	require.NotNil(t, result.NetworkWithUsage)
-	require.Equal(t, "mynet", result.NetworkWithUsage.Network.Name)
-	require.Equal(t, []string{"svc1"}, result.NetworkWithUsage.Services)
+	require.Equal(t, inspectview.ViewName, nav.ViewName)
+	payload, ok := nav.Payload.(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "Network: mynet", payload["title"])
+	jsonStr, ok := payload["json"].(string)
+	require.True(t, ok)
+	require.Contains(t, jsonStr, `"Name":"mynet"`)
+	require.Contains(t, jsonStr, `"Services":["svc1"]`)
 }
 
 func TestInspectNetworkCmd_Error(t *testing.T) {
@@ -187,9 +195,15 @@ func TestInspectNetworkCmd_Error(t *testing.T) {
 	m := testModel(func(m *Model) { m.deps.Networks = mock })
 	cmd := m.inspectNetworkCmd("bad-id")
 	msg := runCmd(cmd)
-	result, ok := msg.(NetworkInspectMsg)
+	nav, ok := msg.(view.NavigateToMsg)
 	require.True(t, ok)
-	require.Error(t, result.Err)
+	require.Equal(t, inspectview.ViewName, nav.ViewName)
+	payload, ok := nav.Payload.(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, inspectview.FormatRaw, payload["format"])
+	jsonStr, ok := payload["json"].(string)
+	require.True(t, ok)
+	require.True(t, strings.Contains(jsonStr, "not found"))
 }
 
 func TestLoadUsedByCmd_ClientError(t *testing.T) {

--- a/views/networks/help.go
+++ b/views/networks/help.go
@@ -11,7 +11,7 @@ func GetNetworksHelpContent() []helpview.HelpCategory {
 		{
 			Title: "General",
 			Items: []helpview.HelpItem{
-				{Keys: "<i>", Description: "Inspect selected network (JSON)"},
+				{Keys: "<i>", Description: "Inspect selected network"},
 				{Keys: "<u>", Description: "Show services using the network"},
 				{Keys: "</>", Description: "Filter networks"},
 				{Keys: "<?>", Description: "Open this help"},

--- a/views/networks/messages.go
+++ b/views/networks/messages.go
@@ -8,6 +8,10 @@ import (
 	"fmt"
 	"time"
 
+	"swarmcli/docker"
+	inspectview "swarmcli/views/inspect"
+	"swarmcli/views/view"
+
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/api/types/swarm"
@@ -26,11 +30,6 @@ type SpinnerTickMsg time.Time
 type NetworksLoadedMsg struct {
 	Networks []networkItem
 	Err      error
-}
-
-type NetworkInspectMsg struct {
-	NetworkWithUsage *networkWithUsage
-	Err              error
 }
 
 type NetworkDeletedMsg struct {
@@ -100,9 +99,18 @@ func (m *Model) inspectNetworkCmd(networkID string) tea.Cmd {
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer cancel()
 
+		title := fmt.Sprintf("Network: %s", networkID)
+
 		net, err := networkOps.InspectNetwork(ctx, networkID)
 		if err != nil {
-			return NetworkInspectMsg{Err: fmt.Errorf("failed to inspect network: %w", err)}
+			return view.NavigateToMsg{
+				ViewName: inspectview.ViewName,
+				Payload: map[string]any{
+					"title":  title,
+					"json":   fmt.Sprintf("# Error inspecting network:\n# %v", err),
+					"format": inspectview.FormatRaw,
+				},
+			}
 		}
 
 		services, svcErr := networkOps.ListServicesUsingNetwork(ctx, networkID, net.Name)
@@ -129,9 +137,25 @@ func (m *Model) inspectNetworkCmd(networkID string) tea.Cmd {
 			Labels:     net.Labels,
 		}
 
-		return NetworkInspectMsg{
-			NetworkWithUsage: &networkWithUsage{Network: summary, Services: services},
-			Err:              nil,
+		nw := docker.NetworkWithUsage{Network: summary, Services: services}
+		content, jsonErr := nw.JSON()
+		if jsonErr != nil {
+			return view.NavigateToMsg{
+				ViewName: inspectview.ViewName,
+				Payload: map[string]any{
+					"title":  fmt.Sprintf("Network: %s", net.Name),
+					"json":   fmt.Sprintf("# Error marshalling network:\n# %v", jsonErr),
+					"format": inspectview.FormatRaw,
+				},
+			}
+		}
+
+		return view.NavigateToMsg{
+			ViewName: inspectview.ViewName,
+			Payload: map[string]any{
+				"title": fmt.Sprintf("Network: %s", net.Name),
+				"json":  string(content),
+			},
 		}
 	}
 }

--- a/views/networks/model.go
+++ b/views/networks/model.go
@@ -51,13 +51,6 @@ type Model struct {
 	networks          []networkItem
 	networkToDelete   *networkItem
 
-	// Inspect view
-	inspectViewActive bool
-	inspectViewport   viewport.Model
-	inspectContent    string
-	inspectSearchMode bool
-	inspectSearchTerm string
-
 	// Used By view
 	usedByViewActive  bool
 	usedByList        filterlist.FilterableList[usedByItem]
@@ -103,9 +96,6 @@ func New(width, height int) *Model {
 	vp := viewport.New(width, height)
 	vp.SetContent("")
 
-	inspectVp := viewport.New(width, height)
-	inspectVp.SetContent("")
-
 	nameInput := textinput.New()
 	nameInput.Placeholder = "my-network"
 	nameInput.Prompt = "Name: "
@@ -144,7 +134,6 @@ func New(width, height int) *Model {
 		visible:           true,
 		confirmDialog:     confirmdialog.New(0, 0),
 		loadingView:       loading.New(width, height, false, "Loading Docker networks..."),
-		inspectViewport:   inspectVp,
 		sortField:         SortByName,
 		sortAscending:     true,
 		createNameInput:   nameInput,
@@ -222,11 +211,8 @@ func (m *Model) CapturesInput() bool {
 }
 
 // IsSearching reports whether the networks view is in a sub-view that should
-// capture keys (inspect, usedBy, createDialog).
+// capture keys (usedBy, createDialog).
 func (m *Model) IsSearching() bool {
-	if m.inspectViewActive {
-		return true
-	}
 	if m.usedByViewActive {
 		return true
 	}
@@ -281,21 +267,6 @@ func (m *Model) ShortHelpItems() []helpbar.HelpEntry {
 		}
 	}
 
-	if m.inspectViewActive {
-		if m.inspectSearchMode {
-			return []helpbar.HelpEntry{
-				{Key: "Type", Desc: "Search"},
-				{Key: "Enter", Desc: "Apply"},
-				{Key: "Esc", Desc: "Cancel"},
-			}
-		}
-		return []helpbar.HelpEntry{
-			{Key: "/", Desc: "Search"},
-			{Key: "↑/↓/PgUp/PgDn", Desc: "Scroll"},
-			{Key: "Esc", Desc: "Back"},
-		}
-	}
-
 	return []helpbar.HelpEntry{
 		{Key: "↑/↓", Desc: "Navigate"},
 		{Key: "c", Desc: "Create"},
@@ -338,14 +309,6 @@ func (m *Model) SetSize(width, height int) {
 	if m.loadingView != nil {
 		m.loadingView.SetSize(width, height)
 	}
-
-	// Resize inspect viewport (content area inside the frame).
-	contentH := height - 4 // top+bottom borders + header + footer
-	if contentH < 1 {
-		contentH = 1
-	}
-	m.inspectViewport.Width = width
-	m.inspectViewport.Height = contentH
 
 	// Resize list viewports. Height is already adjusted by the app;
 	// do not subtract header/footer/help again.

--- a/views/networks/model_test.go
+++ b/views/networks/model_test.go
@@ -212,12 +212,6 @@ func TestIsSearching_Default(t *testing.T) {
 	require.False(t, m.IsSearching())
 }
 
-func TestIsSearching_InspectView(t *testing.T) {
-	m := testModel()
-	m.inspectViewActive = true
-	require.True(t, m.IsSearching())
-}
-
 func TestIsSearching_UsedByView(t *testing.T) {
 	m := testModel()
 	m.usedByViewActive = true
@@ -275,31 +269,6 @@ func TestShortHelpItems_UsedByView(t *testing.T) {
 	require.True(t, keys["Esc"])
 }
 
-func TestShortHelpItems_InspectView(t *testing.T) {
-	m := testModel()
-	m.inspectViewActive = true
-	items := m.ShortHelpItems()
-	keys := make(map[string]bool)
-	for _, item := range items {
-		keys[item.Key] = true
-	}
-	require.True(t, keys["/"])
-	require.True(t, keys["Esc"])
-}
-
-func TestShortHelpItems_InspectSearchMode(t *testing.T) {
-	m := testModel()
-	m.inspectViewActive = true
-	m.inspectSearchMode = true
-	items := m.ShortHelpItems()
-	keys := make(map[string]bool)
-	for _, item := range items {
-		keys[item.Key] = true
-	}
-	require.True(t, keys["Enter"])
-	require.True(t, keys["Esc"])
-}
-
 func TestSetSize(t *testing.T) {
 	m := testModel()
 	m.SetSize(120, 40)
@@ -339,16 +308,6 @@ func TestValidateGateway_Invalid(t *testing.T) {
 	require.Error(t, validateGateway("not-an-ip", false))
 	require.Error(t, validateGateway("fd00::1", false)) // ipv6 in ipv4 slot
 	require.Error(t, validateGateway("10.0.0.1", true)) // ipv4 in ipv6 slot
-}
-
-func TestHighlightMatches_NoTerm(t *testing.T) {
-	require.Equal(t, "hello world", highlightMatches("hello world", ""))
-}
-
-func TestHighlightMatches_WithTerm(t *testing.T) {
-	result := highlightMatches("hello world", "world")
-	require.Contains(t, result, "world")
-	// Styling may or may not render in test env; just verify the match text is present
 }
 
 func TestTruncateWithEllipsis(t *testing.T) {

--- a/views/networks/update.go
+++ b/views/networks/update.go
@@ -85,42 +85,6 @@ func validateGateway(addrStr string, wantIPv6 bool) error {
 	return nil
 }
 
-var inspectSearchHighlightStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("0")).Background(lipgloss.Color("11"))
-
-func highlightMatches(text, term string) string {
-	if term == "" {
-		return text
-	}
-	lowerText := strings.ToLower(text)
-	lowerTerm := strings.ToLower(term)
-
-	var b strings.Builder
-	offset := 0
-	for {
-		idx := strings.Index(lowerText[offset:], lowerTerm)
-		if idx == -1 {
-			b.WriteString(text[offset:])
-			break
-		}
-		b.WriteString(text[offset : offset+idx])
-		b.WriteString(inspectSearchHighlightStyle.Render(text[offset+idx : offset+idx+len(term)]))
-		offset += idx + len(term)
-	}
-	return b.String()
-}
-
-func (m *Model) updateInspectViewport() {
-	if m.inspectSearchTerm == "" {
-		m.inspectViewport.SetContent(m.inspectContent)
-		return
-	}
-	lines := strings.Split(m.inspectContent, "\n")
-	for i := range lines {
-		lines[i] = highlightMatches(lines[i], m.inspectSearchTerm)
-	}
-	m.inspectViewport.SetContent(strings.Join(lines, "\n"))
-}
-
 func truncateWithEllipsis(s string, maxWidth int) string {
 	if maxWidth <= 0 {
 		return ""
@@ -241,14 +205,6 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 		m.networksList.Viewport.Width = msg.Width
 		m.networksList.Viewport.Height = msg.Height
 		m.networksList.SetOuterSize(msg.Width, msg.Height)
-
-		// Inspect view uses its own viewport; keep it in sync with the window size.
-		inspectH := msg.Height - 4 // top+bottom borders + header + footer
-		if inspectH < 1 {
-			inspectH = 1
-		}
-		m.inspectViewport.Width = msg.Width
-		m.inspectViewport.Height = inspectH
 
 		if m.usedByViewActive {
 			m.usedByList.Viewport.Width = msg.Width
@@ -468,29 +424,6 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 		m.showToast(strings.Join(lines, "\n"))
 		return m.loadNetworksCmd()
 
-	case NetworkInspectMsg:
-		if msg.Err != nil {
-			m.errorDialogActive = true
-			m.err = msg.Err
-			return nil
-		}
-
-		// Format the inspection data
-		content, err := msg.NetworkWithUsage.PrettyJSON()
-		if err != nil {
-			m.errorDialogActive = true
-			m.err = err
-			return nil
-		}
-
-		m.inspectContent = string(content)
-		m.inspectSearchMode = false
-		m.inspectSearchTerm = ""
-		m.updateInspectViewport()
-		m.inspectViewport.GotoTop()
-		m.inspectViewActive = true
-		return nil
-
 	case UsedByLoadedMsg:
 		if msg.Err != nil {
 			m.errorDialogActive = true
@@ -546,10 +479,6 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 		if m.createDialogActive {
 			return m.handleCreateDialogKeys(msg)
 		}
-		// Handle inspect view
-		if m.inspectViewActive {
-			return m.handleInspectViewKeys(msg)
-		}
 
 		// Handle used-by view
 		if m.usedByViewActive {
@@ -583,50 +512,6 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 		return m.handleNormalKeys(msg)
 	}
 
-	return nil
-}
-
-func (m *Model) handleInspectViewKeys(msg tea.KeyMsg) tea.Cmd {
-	if m.inspectSearchMode {
-		switch msg.Type {
-		case tea.KeyRunes:
-			m.inspectSearchTerm += msg.String()
-			m.updateInspectViewport()
-		case tea.KeyBackspace:
-			if len(m.inspectSearchTerm) > 0 {
-				m.inspectSearchTerm = m.inspectSearchTerm[:len(m.inspectSearchTerm)-1]
-				m.updateInspectViewport()
-			}
-		case tea.KeyEnter:
-			m.inspectSearchMode = false
-			m.updateInspectViewport()
-		case tea.KeyEsc:
-			m.inspectSearchMode = false
-			m.inspectSearchTerm = ""
-			m.updateInspectViewport()
-		}
-		return nil
-	}
-
-	switch msg.String() {
-	case "esc":
-		m.inspectViewActive = false
-		m.inspectSearchMode = false
-		return nil
-	case "/", "shift+/":
-		m.inspectSearchMode = true
-		m.inspectSearchTerm = ""
-		m.updateInspectViewport()
-		return nil
-	case "up", "k":
-		m.inspectViewport.ScrollUp(1)
-	case "down", "j":
-		m.inspectViewport.ScrollDown(1)
-	case "pgup":
-		m.inspectViewport.ScrollUp(m.inspectViewport.Height)
-	case "pgdown":
-		m.inspectViewport.ScrollDown(m.inspectViewport.Height)
-	}
 	return nil
 }
 

--- a/views/networks/update_test.go
+++ b/views/networks/update_test.go
@@ -4,6 +4,7 @@
 package networksview
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -115,26 +116,6 @@ func TestUpdate_NetworkCreatedMsg_Error_NoDialog(t *testing.T) {
 	require.True(t, m.errorDialogActive)
 }
 
-func TestUpdate_NetworkInspectMsg_Success(t *testing.T) {
-	m := testModel()
-	m.networksList.Viewport.Width = 80
-	m.networksList.Viewport.Height = 20
-	nw := &networkWithUsage{
-		Network:  makeNetworkSummary("mynet", "id1"),
-		Services: []string{"svc1"},
-	}
-	m.Update(NetworkInspectMsg{NetworkWithUsage: nw})
-	require.True(t, m.inspectViewActive)
-	require.Contains(t, m.inspectContent, "mynet")
-}
-
-func TestUpdate_NetworkInspectMsg_Error(t *testing.T) {
-	m := testModel()
-	m.Update(NetworkInspectMsg{Err: fmt.Errorf("not found")})
-	require.True(t, m.errorDialogActive)
-	require.False(t, m.inspectViewActive)
-}
-
 func TestUpdate_UsedByLoadedMsg_Success(t *testing.T) {
 	m := testModel()
 	m.networksList.Viewport.Width = 80
@@ -210,11 +191,19 @@ func TestKey_CtrlU_OpensPruneConfirm(t *testing.T) {
 	require.Equal(t, "prune", m.pendingAction)
 }
 
-func TestKey_I_InspectsNetwork(t *testing.T) {
-	m := testModel()
+func TestKey_I_NavigatesToInspectView(t *testing.T) {
+	mock := noopNetworkOps()
+	mock.inspectNetworkFn = func(_ context.Context, networkID string) (network.Inspect, error) {
+		return network.Inspect{Name: "mynet", ID: networkID, Driver: "overlay", Scope: "swarm"}, nil
+	}
+	m := testModel(func(m *Model) { m.deps.Networks = mock })
 	loadNetworks(m, fakeNetworks("mynet"))
 	cmd := m.Update(key("i"))
 	require.NotNil(t, cmd)
+	msg := runCmd(cmd)
+	nav, ok := msg.(view.NavigateToMsg)
+	require.True(t, ok)
+	require.Equal(t, "inspect", nav.ViewName)
 }
 
 func TestKey_U_OpensUsedByView(t *testing.T) {
@@ -457,49 +446,6 @@ func TestCreateDialog_IPv6WithoutEnable(t *testing.T) {
 	require.Contains(t, m.createDialogError, "Enable IPv6")
 }
 
-// --- Inspect view key tests ---
-
-func TestInspectView_Esc_Closes(t *testing.T) {
-	m := testModel()
-	m.inspectViewActive = true
-	m.Update(key("esc"))
-	require.False(t, m.inspectViewActive)
-}
-
-func TestInspectView_Q_Disabled(t *testing.T) {
-	m := testModel()
-	m.inspectViewActive = true
-	m.Update(key("q"))
-	require.True(t, m.inspectViewActive) // q no longer closes inspect view
-}
-
-func TestInspectView_Slash_EntersSearch(t *testing.T) {
-	m := testModel()
-	m.inspectViewActive = true
-	m.Update(key("/"))
-	require.True(t, m.inspectSearchMode)
-}
-
-func TestInspectView_Search_Esc_CancelsSearch(t *testing.T) {
-	m := testModel()
-	m.inspectViewActive = true
-	m.inspectSearchMode = true
-	m.inspectSearchTerm = "test"
-	m.Update(key("esc"))
-	require.False(t, m.inspectSearchMode)
-	require.Empty(t, m.inspectSearchTerm)
-}
-
-func TestInspectView_Search_Enter_AppliesSearch(t *testing.T) {
-	m := testModel()
-	m.inspectViewActive = true
-	m.inspectSearchMode = true
-	m.inspectSearchTerm = "test"
-	m.Update(key("enter"))
-	require.False(t, m.inspectSearchMode)
-	require.Equal(t, "test", m.inspectSearchTerm) // term preserved
-}
-
 // --- Used-by view key tests ---
 
 func TestUsedByView_Esc_Returns(t *testing.T) {
@@ -526,15 +472,4 @@ func TestUsedByView_Enter_Navigates(t *testing.T) {
 	nav, ok := msg.(view.NavigateToMsg)
 	require.True(t, ok)
 	require.Equal(t, "services", nav.ViewName)
-}
-
-// --- helper for creating network.Summary ---
-
-func makeNetworkSummary(name, id string) network.Summary {
-	return network.Summary{
-		Name:   name,
-		ID:     id,
-		Driver: "overlay",
-		Scope:  "swarm",
-	}
 }

--- a/views/networks/view.go
+++ b/views/networks/view.go
@@ -19,18 +19,12 @@ func (m *Model) FrameTitle() string {
 	if m.usedByViewActive {
 		return fmt.Sprintf("Network '%s' - Used By (%d)", m.usedByNetworkName, len(m.usedByList.Filtered))
 	}
-	if m.inspectViewActive {
-		return "Inspect Network"
-	}
 	return fmt.Sprintf("Docker Networks (%d)", len(m.networksList.Filtered))
 }
 
 func (m *Model) FrameHeader() string {
 	if m.usedByViewActive {
 		return m.usedByList.RenderHeader()
-	}
-	if m.inspectViewActive {
-		return ui.FrameHeaderStyle.Render("Network Details (JSON)")
 	}
 	width := 80
 	if m.networksList.Viewport.Width > 0 {
@@ -45,22 +39,12 @@ func (m *Model) FrameFooter() string {
 	if m.usedByViewActive {
 		return m.usedByList.RenderFooter()
 	}
-	if m.inspectViewActive {
-		footerText := "↑/↓ Scroll | PgUp/PgDn Page | / Search | Esc Back"
-		if m.inspectSearchMode {
-			footerText = fmt.Sprintf("Search: %s  (Enter apply | Esc cancel)", m.inspectSearchTerm)
-		}
-		return ui.StatusBarStyle.Render(footerText)
-	}
 	return m.networksList.RenderFooter()
 }
 
 func (m *Model) FrameContent() string {
 	if m.usedByViewActive {
 		return m.buildUsedByContent()
-	}
-	if m.inspectViewActive {
-		return m.buildInspectContent()
 	}
 	return m.buildMainContent()
 }
@@ -80,30 +64,6 @@ func (m *Model) buildUsedByContent() string {
 		m.width, m.height, header, footer,
 	)
 	content := m.usedByList.VisibleContent(frame.DesiredContentLines)
-
-	if m.errorDialogActive {
-		errorDialog := errordialog.Render(fmt.Sprintf("%v", m.err))
-		content = ui.OverlayCentered(content, errorDialog, width, 0)
-	}
-	return content
-}
-
-func (m *Model) buildInspectContent() string {
-	width := m.networksList.Viewport.Width
-	if width <= 0 {
-		width = m.width
-	}
-	if width <= 0 {
-		width = 80
-	}
-
-	header := m.FrameHeader()
-	footer := m.FrameFooter()
-	frame := ui.ComputeFrameDimensions(
-		width, m.networksList.Viewport.Height,
-		m.width, m.height, header, footer,
-	)
-	content := ui.TrimOrPadContentToLines(m.inspectViewport.View(), frame.DesiredContentLines)
 
 	if m.errorDialogActive {
 		errorDialog := errordialog.Render(fmt.Sprintf("%v", m.err))
@@ -157,9 +117,6 @@ func (m *Model) buildMainContent() string {
 func (m *Model) View() string {
 	if m.usedByViewActive {
 		return m.renderUsedByView()
-	}
-	if m.inspectViewActive {
-		return m.renderInspectView()
 	}
 	return ui.RenderViewFrame(m.FrameTitle(), m.FrameHeader(), m.FrameContent(), m.FrameFooter(),
 		m.networksList.Viewport.Width, m.networksList.Viewport.Height, false)
@@ -408,45 +365,6 @@ func (m *Model) renderUsedByView() string {
 	}
 
 	title := fmt.Sprintf("Network '%s' - Used By (%d)", m.usedByNetworkName, len(m.usedByList.Filtered))
-	view := ui.RenderFramedBox(title, header, content, footer, frame.FrameWidth)
-
-	return view
-}
-
-func (m *Model) renderInspectView() string {
-	width := m.networksList.Viewport.Width
-	if width <= 0 {
-		width = m.width
-	}
-	if width <= 0 {
-		width = 80
-	}
-
-	header := ui.FrameHeaderStyle.Render("Network Details (JSON)")
-	footerText := "↑/↓ Scroll | PgUp/PgDn Page | / Search | Esc Back"
-	if m.inspectSearchMode {
-		footerText = fmt.Sprintf("Search: %s  (Enter apply | Esc cancel)", m.inspectSearchTerm)
-	}
-	footer := ui.StatusBarStyle.Render(footerText)
-
-	frame := ui.ComputeFrameDimensions(
-		width,
-		m.networksList.Viewport.Height,
-		m.width,
-		m.height,
-		header,
-		footer,
-	)
-
-	content := ui.TrimOrPadContentToLines(m.inspectViewport.View(), frame.DesiredContentLines)
-
-	// Apply overlays
-	if m.errorDialogActive {
-		errorDialog := errordialog.Render(fmt.Sprintf("%v", m.err))
-		content = ui.OverlayCentered(content, errorDialog, width, 0)
-	}
-
-	title := "Inspect Network"
 	view := ui.RenderFramedBox(title, header, content, footer, frame.FrameWidth)
 
 	return view

--- a/views/networks/view_test.go
+++ b/views/networks/view_test.go
@@ -91,17 +91,6 @@ func TestView_CreateDialog_Creating(t *testing.T) {
 	require.Contains(t, out, "Creating")
 }
 
-func TestView_InspectView(t *testing.T) {
-	m := testModel()
-	m.networksList.Viewport.Width = 80
-	m.networksList.Viewport.Height = 20
-	m.inspectViewActive = true
-	m.inspectContent = `{"name": "mynet"}`
-	m.updateInspectViewport()
-	out := m.View()
-	require.Contains(t, out, "Inspect Network")
-}
-
 func TestView_UsedByView(t *testing.T) {
 	m := testModel()
 	m.usedByViewActive = true


### PR DESCRIPTION
Fixes #356.

## Summary

- The network inspect view (`i` key) used a custom inline JSON viewer that just dumped `json.Indent` output — it was the only resource view doing this.
- Every other resource view in the project (services/nodes/secrets/configs/stacks/contexts) routes through the shared `inspectview` package, which parses JSON and renders a styled YAML-style document with `ctrl+f` search + `n/N` navigation, app-level `/` filter, and raw/yaml toggle.
- This PR reroutes the network `i` action through `inspectview` too, so users get a properly formatted document instead of raw JSON, with the same controls already used elsewhere in the TUI.
- Removes ~350 lines of duplicated inspect plumbing (state, viewport, search mode, render path) from `views/networks`.

Before:

```
{
  "Network": {
    "Name": "my-overlay-net",
    "Id": "abc123…",
    "Driver": "overlay",
    …
```

After (via shared `inspectview`):

```
Network: my-overlay-net  [YAML]

Network:
  Name: my-overlay-net
  Id: abc123…
  Scope: swarm
  Driver: overlay
  IPAM:
    Driver: default
    Config:
      [0]:
        Subnet: 10.0.0.0/24
Services:
  [0]: whoami
```

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./...` — all unit tests pass
- [x] `golangci-lint run ./... --build-tags=integration` — 0 issues
- [ ] Manual: open networks view, press `i` on a network → confirm YAML rendering, `ctrl+f` search, `/` filter, `r` raw toggle, `esc` back

🤖 Generated with [Claude Code](https://claude.com/claude-code)