### PR TITLE
feat(docker): expose swarm cluster id in snapshot

### DIFF
--- a/docker/snapshot.go
+++ b/docker/snapshot.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/docker/docker/api/types/swarm"
+	"github.com/docker/docker/api/types/system"
 )
 
 type NodeEntry struct {
@@ -37,10 +38,11 @@ type StackEntry struct {
 
 // SwarmSnapshot contains the in-memory swarm state.
 type SwarmSnapshot struct {
-	Nodes    []swarm.Node
-	Services []swarm.Service
-	Tasks    []swarm.Task
-	Fetched  time.Time
+	Nodes     []swarm.Node
+	Services  []swarm.Service
+	Tasks     []swarm.Task
+	Fetched   time.Time
+	ClusterID string
 }
 
 var (
@@ -100,15 +102,32 @@ func RefreshSnapshot() (*SwarmSnapshot, error) {
 		return nil, fmt.Errorf("listing tasks: %w", err)
 	}
 
+	clusterID := ""
+	if info, err := c.Info(ctx); err != nil {
+		l().Warnf("snapshot: cli.Info failed (cluster id unavailable): %v", err)
+	} else {
+		clusterID = clusterIDFromInfo(info)
+	}
+
 	snap := &SwarmSnapshot{
-		Nodes:    nodes,
-		Services: services,
-		Tasks:    tasks,
-		Fetched:  time.Now(),
+		Nodes:     nodes,
+		Services:  services,
+		Tasks:     tasks,
+		Fetched:   time.Now(),
+		ClusterID: clusterID,
 	}
 
 	SetSnapshot(snap)
 	return snap, nil
+}
+
+// clusterIDFromInfo extracts the swarm cluster ID from a Docker Info result.
+// Returns empty string on non-swarm daemons (where info.Swarm.Cluster is nil).
+func clusterIDFromInfo(info system.Info) string {
+	if info.Swarm.Cluster == nil {
+		return ""
+	}
+	return info.Swarm.Cluster.ID
 }
 
 // RefreshSnapshotAsync triggers a background refresh if one is not already running.

--- a/docker/snapshot_test.go
+++ b/docker/snapshot_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types/swarm"
+	"github.com/docker/docker/api/types/system"
 	"github.com/stretchr/testify/require"
 )
 
@@ -177,4 +178,26 @@ func TestFindServiceByName_NotFound(t *testing.T) {
 	}
 	svc := snap.FindServiceByName("nonexistent")
 	require.Nil(t, svc)
+}
+
+func TestClusterIDFromInfo_Populated(t *testing.T) {
+	info := system.Info{
+		Swarm: swarm.Info{
+			Cluster: &swarm.ClusterInfo{ID: "abc123"},
+		},
+	}
+	require.Equal(t, "abc123", clusterIDFromInfo(info))
+}
+
+func TestClusterIDFromInfo_NilCluster(t *testing.T) {
+	// Non-swarm daemon: info.Swarm.Cluster is nil.
+	info := system.Info{Swarm: swarm.Info{Cluster: nil}}
+	require.Equal(t, "", clusterIDFromInfo(info))
+}
+
+func TestClusterIDFromInfo_EmptyID(t *testing.T) {
+	info := system.Info{
+		Swarm: swarm.Info{Cluster: &swarm.ClusterInfo{ID: ""}},
+	}
+	require.Equal(t, "", clusterIDFromInfo(info))
 }


### PR DESCRIPTION
## Summary

- Adds a `ClusterID` field to `SwarmSnapshot`, populated by an additional `cli.Info()` call inside `RefreshSnapshot`.
- Best-effort: on non-swarm daemons (`info.Swarm.Cluster == nil`) or on `Info()` error, the field is empty and the snapshot is still returned with the other lists.
- Generic extension point — no pro/license references in this change.

## Why

Required by the license-binding work tracked in [Eldara-Tech/swarmcli-be#124](https://github.com/Eldara-Tech/swarmcli-be/issues/124). The pro side will read `snap.ClusterID` to enforce per-swarm payload binding (see the implementation plan in that issue).

## Test plan

- [x] `go test ./...`
- [x] `go test -race -count=1 ./...`
- [x] `golangci-lint run ./...`
- [x] `go build -tags=integration ./...`
- [ ] Manual smoke: run against a real swarm, confirm `:nodes` view has no perceptible latency change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)