### PR TITLE
fix(stacks): preserve networks + stop cosmetic mutations on stack edit (#363)

### DIFF
--- a/docker/stack_to_compose.go
+++ b/docker/stack_to_compose.go
@@ -205,7 +205,7 @@ func ReconstructStackCompose(stackName string) (string, error) {
 
 	// Initialize compose file structure
 	cf := ComposeFile{
-		Version:  "3.8",
+		Version:  "3.9",
 		Services: map[string]ComposeService{},
 		Networks: map[string]map[string]any{},
 		Volumes:  map[string]map[string]any{},
@@ -285,7 +285,7 @@ func ReconstructStackCompose(stackName string) (string, error) {
 
 		if si.Spec.TaskTemplate.ContainerSpec != nil {
 			cspec := si.Spec.TaskTemplate.ContainerSpec
-			cs.Image = cspec.Image
+			cs.Image = stripImageDigest(cspec.Image)
 
 			if cspec.Dir != "" {
 				cs.WorkingDir = cspec.Dir
@@ -375,15 +375,7 @@ func ReconstructStackCompose(stackName string) (string, error) {
 				if p.TargetPort == 0 {
 					continue
 				}
-				proto := p.Protocol
-				if proto == "" {
-					proto = "tcp"
-				}
-				if p.PublishedPort != 0 {
-					cs.Ports = append(cs.Ports, fmt.Sprintf("%d:%d/%s", p.PublishedPort, p.TargetPort, proto))
-				} else {
-					cs.Ports = append(cs.Ports, fmt.Sprintf("%d/%s", p.TargetPort, proto))
-				}
+				cs.Ports = append(cs.Ports, formatPort(p.PublishedPort, p.TargetPort, p.Protocol))
 			}
 		}
 
@@ -468,7 +460,7 @@ func ReconstructStackCompose(stackName string) (string, error) {
 			if si.Spec.TaskTemplate.RestartPolicy.Condition != "" {
 				rp["condition"] = si.Spec.TaskTemplate.RestartPolicy.Condition
 			}
-			if si.Spec.TaskTemplate.RestartPolicy.MaxAttempts != nil {
+			if si.Spec.TaskTemplate.RestartPolicy.MaxAttempts != nil && *si.Spec.TaskTemplate.RestartPolicy.MaxAttempts > 0 {
 				rp["max_attempts"] = int(*si.Spec.TaskTemplate.RestartPolicy.MaxAttempts)
 			}
 			if len(rp) > 0 {
@@ -487,32 +479,9 @@ func ReconstructStackCompose(stackName string) (string, error) {
 		cf.Services[key] = cs
 	}
 
-	// If the only declared network is "default" (implicit), suppress it
-	if len(cf.Networks) == 1 {
-		if _, ok := cf.Networks["default"]; ok {
-			cf.Networks = nil
-			for k, svc := range cf.Services {
-				if nets, ok := svc.Networks.([]string); ok && len(nets) == 1 && nets[0] == "default" {
-					svc.Networks = nil
-					cf.Services[k] = svc
-				}
-			}
-		}
-	}
-
-	// Remove empty top-level sections
-	if len(cf.Networks) == 0 {
-		cf.Networks = nil
-	}
-	if len(cf.Volumes) == 0 {
-		cf.Volumes = nil
-	}
-	if len(cf.Secrets) == 0 {
-		cf.Secrets = nil
-	}
-	if len(cf.Configs) == 0 {
-		cf.Configs = nil
-	}
+	// Remove empty top-level sections (does NOT suppress a "default"
+	// network — see issue #363)
+	pruneEmptySections(&cf)
 
 	// Marshal to YAML
 	y, err := yaml.Marshal(&cf)
@@ -639,6 +608,50 @@ func escapeComposeArgs(args []string) []string {
 		out[i] = escapeComposeInterpolation(a)
 	}
 	return out
+}
+
+// stripImageDigest removes a trailing "@sha256:<digest>" pin so the
+// reconstructed image is "repo:tag" rather than "repo:tag@sha256:...".
+// Docker resolves and pins the digest at deploy time; the original
+// Compose file only carried "repo:tag". See issue #363.
+func stripImageDigest(image string) string {
+	before, _, _ := strings.Cut(image, "@sha256:")
+	return before
+}
+
+// formatPort renders a Compose short-syntax port mapping. The "/proto"
+// suffix is omitted when proto is "tcp" (the Compose default) and kept
+// for udp/sctp. See issue #363.
+func formatPort(published, target uint32, proto string) string {
+	if proto == "" {
+		proto = "tcp"
+	}
+	base := fmt.Sprintf("%d", target)
+	if published != 0 {
+		base = fmt.Sprintf("%d:%d", published, target)
+	}
+	if proto == "tcp" {
+		return base
+	}
+	return base + "/" + proto
+}
+
+// pruneEmptySections nils out empty top-level map sections so they are
+// omitted from the marshaled Compose YAML (the structs use omitempty).
+// It does NOT suppress a "default" network — see issue #363.
+func pruneEmptySections(cf *ComposeFile) {
+	if len(cf.Networks) == 0 {
+		cf.Networks = nil
+	}
+	if len(cf.Volumes) == 0 {
+		cf.Volumes = nil
+	}
+	if len(cf.Secrets) == 0 {
+		cf.Secrets = nil
+	}
+	if len(cf.Configs) == 0 {
+		cf.Configs = nil
+	}
 }
 
 // stripStackPrefix removes the "<stack>_" prefix from a resource name

--- a/docker/stack_to_compose_test.go
+++ b/docker/stack_to_compose_test.go
@@ -4,6 +4,7 @@
 package docker
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -177,33 +178,85 @@ func TestComposeFile_VolumeManagedNotExternal(t *testing.T) {
 	require.NotContains(t, string(out), "external")
 }
 
-func TestComposeFile_DefaultNetworkOmitted(t *testing.T) {
+// Issue #363 regression: a stack declaring ONLY the "default" network with
+// a service referencing it must survive reconstruction unchanged. The old
+// suppression logic (removed) dropped both, causing "Edit Stack no network".
+func TestPruneEmptySections_KeepsSoleDefaultNetwork(t *testing.T) {
 	cf := ComposeFile{
-		Version: "3.8",
+		Version: "3.9",
 		Services: map[string]ComposeService{
 			"web": {Image: "nginx", Networks: []string{"default"}},
 		},
-		Networks: map[string]map[string]any{"default": {"external": true}},
+		Networks: map[string]map[string]any{"default": {"driver": "overlay"}},
 	}
 
-	// Simulate the suppression logic
-	if len(cf.Networks) == 1 {
-		if _, ok := cf.Networks["default"]; ok {
-			cf.Networks = nil
-			for k, svc := range cf.Services {
-				if nets, ok := svc.Networks.([]string); ok && len(nets) == 1 && nets[0] == "default" {
-					svc.Networks = nil
-					cf.Services[k] = svc
-				}
-			}
-		}
-	}
+	pruneEmptySections(&cf)
+
+	require.NotNil(t, cf.Networks)
+	require.Contains(t, cf.Networks, "default")
+	require.Equal(t, "overlay", cf.Networks["default"]["driver"])
 
 	out, err := yaml.Marshal(&cf)
 	require.NoError(t, err)
 	yamlStr := string(out)
-	require.NotContains(t, yamlStr, "networks:")
-	require.NotContains(t, yamlStr, "default")
+	require.Contains(t, yamlStr, "networks:")
+	require.Contains(t, yamlStr, "default:")
+	require.Contains(t, yamlStr, "driver: overlay")
+}
+
+func TestPruneEmptySections_NilsGenuinelyEmpty(t *testing.T) {
+	cf := ComposeFile{
+		Version:  "3.9",
+		Services: map[string]ComposeService{"web": {Image: "nginx"}},
+		Networks: map[string]map[string]any{},
+		Volumes:  map[string]map[string]any{},
+		Secrets:  map[string]map[string]any{},
+		Configs:  map[string]map[string]any{},
+	}
+
+	pruneEmptySections(&cf)
+
+	require.Nil(t, cf.Networks)
+	require.Nil(t, cf.Volumes)
+	require.Nil(t, cf.Secrets)
+	require.Nil(t, cf.Configs)
+}
+
+func TestStripImageDigest(t *testing.T) {
+	digest := strings.Repeat("a", 64)
+	tests := []struct{ name, in, want string }{
+		{"digest pinned", "nginx:1.25@sha256:" + digest, "nginx:1.25"},
+		{"no tag with digest", "nginx@sha256:" + digest, "nginx"},
+		{"registry port + digest", "reg:5000/app:v2@sha256:" + digest, "reg:5000/app:v2"},
+		{"plain tag", "alpine:latest", "alpine:latest"},
+		{"no tag no digest", "alpine", "alpine"},
+		{"empty", "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, stripImageDigest(tt.in))
+		})
+	}
+}
+
+func TestFormatPort(t *testing.T) {
+	tests := []struct {
+		name              string
+		published, target uint32
+		proto, want       string
+	}{
+		{"tcp default omitted", 8080, 80, "tcp", "8080:80"}, // issue #363 case
+		{"empty proto = tcp", 8080, 80, "", "8080:80"},
+		{"udp kept", 53, 53, "udp", "53:53/udp"},
+		{"sctp kept", 38412, 38412, "sctp", "38412:38412/sctp"},
+		{"target only tcp", 0, 80, "tcp", "80"},
+		{"target only udp", 0, 514, "udp", "514/udp"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, formatPort(tt.published, tt.target, tt.proto))
+		})
+	}
 }
 
 func TestComposeFile_NetworkManagedNotExternal(t *testing.T) {

--- a/integration-tests/docker/stack_to_compose_test.go
+++ b/integration-tests/docker/stack_to_compose_test.go
@@ -77,6 +77,27 @@ func TestReconstructStackCompose(t *testing.T) {
 		t.Error("Parsed YAML missing 'backend' network key")
 	}
 
+	// Issue #363 regression: a stack declaring ONLY the "default" network
+	// (with a service referencing it) must retain both the top-level
+	// networks: default key and the service-level networks: [default].
+	if _, ok := composed.Networks["default"]; !ok {
+		t.Error("Issue #363: reconstructed YAML dropped the 'default' network")
+	}
+	probe, ok := composed.Services["default_net_probe"]
+	if !ok {
+		t.Fatal("Issue #363: missing 'default_net_probe' service in reconstructed YAML")
+	}
+	probeNets, _ := probe.Networks.([]any) // yaml.Unmarshal yields []any
+	foundDefault := false
+	for _, n := range probeNets {
+		if s, _ := n.(string); s == "default" {
+			foundDefault = true
+		}
+	}
+	if !foundDefault {
+		t.Errorf("Issue #363: 'default_net_probe' lost its networks: [default], got %#v", probe.Networks)
+	}
+
 	t.Logf("Successfully reconstructed stack YAML (%d bytes)", len(yaml))
 }
 
@@ -167,6 +188,12 @@ func TestReconstructStackCompose_RoundTrip(t *testing.T) {
 	}
 
 	// 6. Compare: networks
+	// Issue #363: explicitly assert the default network survived the source
+	// reconstruction — the loop below would pass vacuously if "default" were
+	// dropped from BOTH src and rt.
+	if _, ok := srcCF.Networks["default"]; !ok {
+		t.Error("Issue #363: source reconstruction dropped the 'default' network")
+	}
 	for netName := range srcCF.Networks {
 		if _, ok := rtCF.Networks[netName]; !ok {
 			t.Errorf("Network %q present in source but missing from round-trip, got keys: %v",

--- a/test-setup/test-stack.yml
+++ b/test-setup/test-stack.yml
@@ -2,6 +2,8 @@ version: "3.9"
 
 networks:
   backend:
+  default:
+    driver: overlay
 
 volumes:
   whoami_data:
@@ -62,6 +64,18 @@ services:
       '
     ports:
       - "8082:80"
+  # Issue #363 regression fixture: a service using ONLY the explicitly
+  # declared "default" network. Reconstruction must retain both the
+  # top-level networks: default key and this service's networks: [default].
+  default_net_probe:
+    image: alpine:latest
+    networks:
+      - default
+    deploy:
+      replicas: 1
+    command: >
+      sh -c 'while true; do sleep 3600; done'
+
   log_ticker:
     image: alpine:latest
     deploy:


### PR DESCRIPTION
## Summary

Closes #363 ("Edit Stack no network"). Pressing `e` on a stack calls `ReconstructStackCompose()`, which rebuilds the compose YAML from `docker stack/service inspect` (Docker does not persist the original YAML). Five defects mutated the stack on edit:

| # | Mutation | Regression? | Fix |
|---|---|---|---|
| 1 | `networks:` + per-service `networks:` dropped when the sole network is `default` | **Yes** — commit `d2a4ea6` / PR #268, shipped **v1.3.3+** (current v1.5.1/main) | Removed the unconditional "suppress implicit default network" block; kept generic empty-section pruning |
| 2 | `version: 3.9 → 3.8` | No (since v1.0.0) | Bump hardcode to `"3.9"` |
| 3 | `nginx:latest → nginx:latest@sha256:…` | No | `stripImageDigest()` |
| 4 | `8080:80 → 8080:80/tcp` | No | `formatPort()` omits default `tcp` |
| 5 | spurious `max_attempts: 0` | No | only emit when `> 0` |

The issue reporter's stack declared **only** `networks: default: {driver: overlay}` with services on it, so defect #1 wiped both the top-level `networks:` and the per-service `networks:` → "no network".

## Root cause / regression

`git blame` → the suppression block was introduced by `d2a4ea6` ("Fix volume declarations… (#268)", 2026-03-09), whose message states *"…and suppress the implicit default network."* It could not distinguish an explicitly-declared `default` network from the implicit one. First released in **v1.3.3**.

## Decision note (`version:` field)

The original compose `version` is not recoverable from Docker inspect, and `docker stack deploy` ignores the value (advisory only). Chosen: bump the hardcode `"3.8" → "3.9"` (highest 3.x, matches the issue's input, smallest diff, no struct/test churn). Alternative considered: omit the field entirely (more honest but larger blast radius on existing `version:`-presence assertions).

## Tests

- Cleanup/port/image logic extracted into pure helpers (`pruneEmptySections`, `stripImageDigest`, `formatPort`) and unit-tested (table-driven, mirrors `TestStripStackPrefix`).
- Replaced `TestComposeFile_DefaultNetworkOmitted` (it re-implemented and asserted the buggy behavior) with `TestPruneEmptySections_KeepsSoleDefaultNetwork` / `_NilsGenuinelyEmpty`.
- Integration: added a `default_net_probe` service using only the explicitly-declared `default` overlay network to `test-setup/test-stack.yml`; added #363 assertions to `TestReconstructStackCompose` and a non-vacuous guard to `TestReconstructStackCompose_RoundTrip`.

Verification: `go test ./...` green; `golangci-lint run ./... --build-tags=integration` → 0 issues; `gofmt` clean. Full E2E (`./test-setup/testenv.sh integration`) runs in CI (`integration-tests.yml`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)