### PR TITLE
Extract BELandingURL constant (swarmcli-be#144)

### DIFF
--- a/views/view/edition.go
+++ b/views/view/edition.go
@@ -16,9 +16,14 @@ func BEHelpDesc(actionName, desc string) string {
 	return desc + " (BE)"
 }
 
+// BELandingURL is the public Business Edition landing page (trial info,
+// feature overview). Exported so the BE module references the same
+// string instead of re-hardcoding it.
+const BELandingURL = "https://swarmcli.io/be"
+
 // BEUnavailableFormat is the format string used by BEUnavailableErr.
 // Contains one %s verb for the feature name. Override in init() to customise.
-var BEUnavailableFormat = "%s is a Business Edition feature.\nFor more information, visit: https://swarmcli.io/be"
+var BEUnavailableFormat = "%s is a Business Edition feature.\nFor more information, visit: " + BELandingURL
 
 // BEUnavailableFormatFn, if set, returns the error message for a feature.
 // Takes precedence over BEUnavailableFormat. Override in init() to customise.


### PR DESCRIPTION
## What

Introduces an exported `view.BELandingURL` constant
(`https://swarmcli.io/be`) and builds `BEUnavailableFormat` from it,
instead of hardcoding the Business Edition landing-page URL.

## Why

Part of Eldara-Tech/swarmcli-be#144 (review all swarmcli.io link sites
after the license URL move). The BE landing URL was hardcoded in
several places across both repos. Per the consensus in that issue,
sites 3–5 keep pointing at the BE landing page — so the value is
**unchanged**; this change only removes the duplication so the BE
module can reference one source of truth.

## Scope

- OSS-only, no behavior change. `BEUnavailableErr("…")` produces a
  byte-identical message; existing tests asserting `https://swarmcli.io/be`
  (edition_test.go, secrets/update_test.go, services/model_test.go)
  pass unchanged.
- **Must merge before** the companion swarmcli-be PR, which references
  the new export (pro CI builds against remote OSS).

## Verification

- `go build ./...`, `go test ./...` — green
- `golangci-lint run ./views/view/...` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)