### PR TITLE
ci(govulncheck): build with module toolchain; bump go1.26.3; harden wrapper

### DIFF
--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -24,7 +24,13 @@ jobs:
           cache: true
 
       - name: Install govulncheck
-        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+        # govulncheck statically type-checks targets with the go/types of the
+        # toolchain it was *built* with; a binary built with an older Go cannot
+        # analyze this module and silently scans nothing. Build it with the
+        # module's own toolchain (read from go.mod, stays in sync on bumps).
+        run: |
+          GOTOOLCHAIN=$(awk '/^toolchain /{print $2}' go.mod) \
+            go install golang.org/x/vuln/cmd/govulncheck@v1.3.0
 
       - name: Run govulncheck
         # GO-2026-4887 and GO-2026-4883 are Docker daemon-side vulnerabilities
@@ -39,7 +45,7 @@ jobs:
 
           SUPPRESSED = {"GO-2026-4887", "GO-2026-4883"}
 
-          # -format json always exits 0; vulnerability data is inside the JSON stream.
+          # -format json exits 0 and streams JSON; vulnerability data is in the stream.
           proc = subprocess.run(
               ["govulncheck", "-format", "json", "./..."],
               capture_output=True, text=True,
@@ -47,7 +53,7 @@ jobs:
 
           # Parse the pretty-printed JSON stream (one object per message)
           text, depth, start = proc.stdout, 0, None
-          symbol_vulns = set()
+          symbol_vulns, saw_config = set(), False
           for i, c in enumerate(text):
               if c == '{':
                   if depth == 0:
@@ -58,15 +64,32 @@ jobs:
                   if depth == 0 and start is not None:
                       try:
                           obj = json.loads(text[start:i+1])
+                          if 'config' in obj:
+                              saw_config = True
                           if obj.get('finding'):
                               f = obj['finding']
                               osv = f.get('osv', '')
-                              # Symbol-level finding: trace contains a frame with a function
+                              # Symbol-level finding: trace has a frame with a function
                               if osv and any('function' in fr for fr in f.get('trace', [])):
                                   symbol_vulns.add(osv)
                       except Exception:
                           pass
                       start = None
+
+          # Fail loudly if govulncheck errored instead of scanning. A silent
+          # exit-0 here previously masked broken runs (e.g. a govulncheck built
+          # with an older Go toolchain emitting "requires newer Go version" and
+          # exiting 0) as "no vulnerabilities found".
+          LOAD_ERR = ("loading packages", "requires newer Go version",
+                      "toolchain not available", "no go.mod file")
+          blob = proc.stderr + proc.stdout
+          if (proc.returncode != 0 or not saw_config
+                  or any(s in blob for s in LOAD_ERR)):
+              sys.stderr.write(proc.stderr)
+              print("govulncheck did not analyze any packages "
+                    "(exit %d, config=%s) -- see stderr above"
+                    % (proc.returncode, saw_config))
+              sys.exit(proc.returncode or 1)
 
           unexpected = symbol_vulns - SUPPRESSED
           if unexpected:

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module swarmcli
 
 go 1.26
 
-toolchain go1.26.2
+toolchain go1.26.3
 
 require (
 	github.com/briandowns/spinner v1.23.2


### PR DESCRIPTION
## Problem
`govulncheck` type-checks targets with the `go/types` of the toolchain it was **built** with. CI's `go install govulncheck@latest` built it with an older Go than the `go 1.26` directive, so it reported `requires newer Go version` and analyzed **nothing** — and the JSON wrapper silently exited 0 ("no vulnerabilities found"), masking it.

## Fix
- Install govulncheck with the module's own toolchain (`GOTOOLCHAIN` read from go.mod, self-syncing) and pin `@v1.3.0`.
- Bump `toolchain go1.26.2 → go1.26.3` — resolves genuine reachable stdlib vulns **GO-2026-4971** (net Dial/LookupPort panic) and **GO-2026-4918** (HTTP/2 transport infinite loop).
- Harden the wrapper to **fail loudly** when govulncheck cannot analyze (non-zero exit, missing `config` message, or load-error output) instead of false-greening.

## Verification
Ran the exact CI wrapper at go1.26.3: `govulncheck: suppressed 2 daemon false-positive(s): ['GO-2026-4883', 'GO-2026-4887']`, exit 0. Hardened wrapper tested against clean / real-vuln / broken / benign-toolchain-download cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)