### PR TITLE
chore(release): dedupe changelog (type-only categories)

### DIFF
--- a/.github/release_template.yml
+++ b/.github/release_template.yml
@@ -2,13 +2,12 @@ name-template: 'v$RESOLVED_VERSION'
 tag-template: 'v$RESOLVED_VERSION'
 exclude-labels:
   - 'E0-silent'
+# Categories key off the mutually-exclusive A-type (and D0) labels only.
+# B (urgency) and C (breaking) are orthogonal axes: release-drafter places
+# a PR in *every* matching category (by design, no per-category exclude),
+# so keeping B2/C1 categories duplicated those PRs into their type section.
+# Breaking-ness is conveyed by the version/RC itself.
 categories:
-  - title: ' ‼️ High Priority Release '
-    labels:
-      - 'B2-high-priority'
-  - title: '⚡ Breaking API Changes'
-    labels:
-      - 'C1-breaking-change'
   - title: '[UI]'
     labels:
       - 'A0-ui'


### PR DESCRIPTION
## Problem

The release changelog lists high-priority and breaking PRs **twice** — once under "‼️ High Priority Release" / "⚡ Breaking API Changes" and again under their type section ([Feature]/[Bug Fixes]/...).

## Root cause

release-drafter (v7.3.0 `categorize-pull-requests.ts`) pushes a PR into **every** category whose labels intersect the PR's labels — intentional, with an inline source comment saying so. There is **no per-category `exclude-labels`, no first-match, no precedence** (upstream issue #811); global `exclude-labels` removes a PR from the whole changelog. The only dedupe mechanism is mutually-exclusive label data driving categories.

The `A` (type) / `B` (urgency) / `C` (breaking) label groups are **orthogonal** and `check_labels` requires one of each per PR, so any `B2`/`C1` PR matched its highlight category *and* its `A`-type category → duplicated.

## Fix

Drop the `B2-high-priority` and `C1-breaking-change` categories; categorize off the mutually-exclusive `A`-type (+ `D0`) labels only (group A is `{A0,A1,A2,A3,D0}`, exactly one per PR → perfect partition). Each PR appears exactly once. Section titles unchanged. No code/tooling change; breaking-ness is conveyed by the version/RC.

Trade-off (accepted): no dedicated "Breaking" section — a breaking PR appears once under its type. A self-populating Breaking section would require the mono-label/autolabeler pattern (out of scope).

## Validation

Changelog path is tag-triggered only (not CI-validatable). YAML validated locally; categories = [UI]/[Feature]/[Bug Fixes]/[Technical]/[Dependencies]. First live exercise is the next tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)