### PR TITLE
ci(goreleaser): migrate to dockers_v2 + homebrew_casks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,12 @@ jobs:
           go-version-file: go.mod
           cache: true
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Login to Docker Hub
         uses: docker/login-action@v4
         with:
@@ -49,7 +55,9 @@ jobs:
         uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 # v7.2.2
         with:
           distribution: goreleaser
-          version: '~> v2'
+          # >= v2.12: dockers_v2 (replaces dockers/docker_manifests).
+          # homebrew_casks needs >= v2.10.
+          version: '~> v2.12'
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -115,24 +115,34 @@ snapshot:
 changelog:
   disable: true
 
-# Homebrew tap 
-brews:
+# Homebrew tap (cask)
+homebrew_casks:
   - name: swarmcli
     ids:
       - default
+    binaries:
+      - swarmcli
     repository:
       owner: Eldara-Tech
       name: homebrew-tap
       token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
-    directory: Formula
+    directory: Casks
     homepage: "https://swarmcli.io"
     description: "Docker Swarm TUI management tool"
-    license: "Apache-2.0"
     commit_author:
       name: Eldara Tech
       email: hello@eldara.io
-    install: |
-      bin.install "swarmcli"
+    conflicts:
+      - cask: swarmcli-be
+    # GoReleaser binaries are not Apple-notarized; strip the Gatekeeper
+    # quarantine xattr on install so the CLI runs without a security prompt.
+    hooks:
+      post:
+        install: |
+          if OS.mac?
+            system_command "/usr/bin/xattr",
+                           args: ["-dr", "com.apple.quarantine", "#{staged_path}/swarmcli"]
+          end
 
 # Scoop bucket for Windows
 scoops:
@@ -152,41 +162,21 @@ scoops:
     post_install:
       - "Write-Host 'swarmcli installed successfully!' -ForegroundColor Green"
 
-# Docker images
-dockers:
-  - image_templates:
-      - "eldaratech/swarmcli:{{ .Tag }}-amd64"
+# Docker images (multi-arch; replaces the deprecated dockers + docker_manifests)
+dockers_v2:
+  - id: swarmcli
+    images:
+      - "eldaratech/swarmcli"
     dockerfile: Dockerfile.release
-    use: buildx
-    build_flag_templates:
-      - "--platform=linux/amd64"
-      - "--load"
-      - "--label=org.opencontainers.image.created={{.Date}}"
-      - "--label=org.opencontainers.image.title={{.ProjectName}}"
-      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
-      - "--label=org.opencontainers.image.version={{.Version}}"
-    goos: linux
-    goarch: amd64
-  - image_templates:
-      - "eldaratech/swarmcli:{{ .Tag }}-arm64"
-    dockerfile: Dockerfile.release
-    use: buildx
-    build_flag_templates:
-      - "--platform=linux/arm64"
-      - "--label=org.opencontainers.image.created={{.Date}}"
-      - "--label=org.opencontainers.image.title={{.ProjectName}}"
-      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
-      - "--label=org.opencontainers.image.version={{.Version}}"
-    goos: linux
-    goarch: arm64
-
-docker_manifests:
-  - name_template: "eldaratech/swarmcli:{{ .Tag }}"
-    image_templates:
-      - "eldaratech/swarmcli:{{ .Tag }}-amd64"
-      - "eldaratech/swarmcli:{{ .Tag }}-arm64"
-  - name_template: "eldaratech/swarmcli:latest"
-    image_templates:
-      - "eldaratech/swarmcli:{{ .Tag }}-amd64"
-      - "eldaratech/swarmcli:{{ .Tag }}-arm64"
-    skip_push: "auto"
+    platforms:
+      - linux/amd64
+      - linux/arm64
+    tags:
+      - "{{ .Tag }}"
+      # Only move :latest for stable releases — never on -rc/-beta tags.
+      - '{{ if not .Prerelease }}latest{{ end }}'
+    labels:
+      org.opencontainers.image.created: "{{ .Date }}"
+      org.opencontainers.image.title: "{{ .ProjectName }}"
+      org.opencontainers.image.revision: "{{ .FullCommit }}"
+      org.opencontainers.image.version: "{{ .Version }}"

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,6 +1,9 @@
 FROM docker
 
-COPY swarmcli /swarmcli
+# dockers_v2 runs a single multi-platform buildx build and stages each
+# platform's binary under its $TARGETPLATFORM (e.g. linux/amd64/swarmcli).
+ARG TARGETPLATFORM
+COPY ${TARGETPLATFORM}/swarmcli /swarmcli
 
 ENV TERM=xterm-256color
 ENTRYPOINT ["/swarmcli"]


### PR DESCRIPTION
## What

Mirrors Eldara-Tech/swarmcli-be#157 on the OSS repo so its releases stop emitting the GoReleaser deprecation notices (`dockers`/`docker_manifests` → `dockers_v2`, `brews` → `homebrew_casks`; removed in GoReleaser v3).

## Changes

- **`dockers_v2`**: one multi-arch (`linux/amd64,arm64`) entry replaces the two per-arch `dockers` blocks + `docker_manifests`. `Dockerfile.release` now uses `ARG TARGETPLATFORM` + `COPY ${TARGETPLATFORM}/swarmcli`.
- **`:latest` guarded** to stable releases only (`{{ if not .Prerelease }}`) — an `-rc` tag no longer moves `:latest`.
- **`homebrew_casks`** replaces `brews`, with a macOS-guarded `postflight` quarantine strip (GoReleaser binaries are not Apple-notarized). `conflicts_with` is the symmetric `cask: swarmcli-be`. The formula-only `license: Apache-2.0` field is dropped — Homebrew casks have no license stanza (the in-repo LICENSE is unaffected).
- Pin `goreleaser-action` to `~> v2.12`.

## Behavioral changes (C1)

- Homebrew is now a **cask** and **macOS-only**; Linux users use the binary/docker/scoop.
- `:latest` is no longer pushed from prerelease tags.

## Verification

- `goreleaser check` — clean, zero deprecations.
- `goreleaser release --snapshot --clean --skip=publish,docker` — binaries build; cask renders with correct `binary "swarmcli"`, `conflicts_with cask: ["swarmcli-be"]`, and the quarantine `postflight`.
- Multi-arch image build (the `${TARGETPLATFORM}` COPY) is validated by the next `-rc` release run.

## Required follow-up

`tap_migrations.json` + stale `Formula/*.rb` removal in `Eldara-Tech/homebrew-tap` so existing `brew install` users transition to the cask (covers both `swarmcli` and `swarmcli-be`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)