### PR TITLE
fix(helpbar): bound header to its box so it can't scramble the screen

### DIFF
--- a/views/helpbar/helpbar.go
+++ b/views/helpbar/helpbar.go
@@ -16,11 +16,10 @@ type HelpEntry struct {
 }
 
 type Model struct {
-	globalHelp  []HelpEntry
-	viewHelp    []HelpEntry
-	width       int
-	height      int
-	minColWidth int
+	globalHelp []HelpEntry
+	viewHelp   []HelpEntry
+	width      int
+	height     int
 }
 
 // EditionLabel is rendered below the logo. Override in init() to customise.
@@ -30,8 +29,6 @@ func SetEditionLabel(label string) {
 	EditionLabel = label
 }
 
-const defaultMinColWidth = 20
-
 // KeyBack is the canonical key for "go back / close this view".
 const KeyBack = "esc"
 
@@ -40,10 +37,9 @@ const KeyQuit = "ctrl+q"
 
 func New(width, height int) *Model {
 	return &Model{
-		globalHelp:  []HelpEntry{{Key: KeyQuit, Desc: "quit"}, {Key: "?", Desc: "help"}},
-		width:       width,
-		height:      height,
-		minColWidth: defaultMinColWidth,
+		globalHelp: []HelpEntry{{Key: KeyQuit, Desc: "quit"}, {Key: "?", Desc: "help"}},
+		width:      width,
+		height:     height,
 	}
 }
 
@@ -67,10 +63,11 @@ func (m *Model) SetHeight(height int) *Model {
 	return m
 }
 
-func (m *Model) SetMinColWidth(width int) *Model {
-	m.minColWidth = width
-	return m
-}
+// Horizontal separators used when composing the header.
+const (
+	logoSpacer = "  "  // between the help block and the logo
+	colGap     = "   " // between help columns
+)
 
 func (m *Model) View(systemInfo string, hasError bool) string {
 	allHelp := append(m.globalHelp, m.viewHelp...)
@@ -78,67 +75,97 @@ func (m *Model) View(systemInfo string, hasError bool) string {
 		return systemInfo
 	}
 
-	// Reserve space for logo
-	logoWidth := 32 // Increased to give more room for the logo
 	infoWidth := lipgloss.Width(systemInfo)
-	availableWidth := m.width - infoWidth - logoWidth
-	if availableWidth < m.minColWidth {
-		// Not enough space to render help, just return systemInfo
-		return systemInfo
+
+	// Render every candidate help column at its natural width and build the
+	// logo once, so the packing below can budget against real widths.
+	cols, colWidths := renderColumns(allHelp)
+	logo := buildLogo(hasError)
+	logoWidth := lipgloss.Width(logo)
+
+	// Decide whether the logo fits, and how much room is left for help. The
+	// logo is right-aligned, so when it is shown it reserves spacer+logo and
+	// the help block fills the remaining gap.
+	showLogo := m.width-infoWidth >= len(logoSpacer)+logoWidth
+	helpFill := m.width - infoWidth
+	if showLogo {
+		helpFill -= len(logoSpacer) + logoWidth
 	}
 
-	// Fixed: 5 rows per column
-	rowsPerColumn := 5
-
-	// Calculate how many columns we need
-	numCols := (len(allHelp) + rowsPerColumn - 1) / rowsPerColumn
-
-	// Check if we have space for all columns
-	maxCols := availableWidth / m.minColWidth
-	if maxCols < 1 {
-		maxCols = 1
-	}
-	if numCols > maxCols {
-		numCols = maxCols
-	}
-
-	// Prepare columns filled top-to-bottom
-	columns := make([][]HelpEntry, numCols)
-
-	for i, entry := range allHelp {
-		col := i / rowsPerColumn
-		if col >= numCols {
-			// Skip items that don't fit
+	// Keep leading columns (left to right) while they fit within helpFill;
+	// drop the rest. This degrades gracefully as the terminal narrows.
+	kept, used := 0, 0
+	for i, w := range colWidths {
+		next := used + w
+		if i > 0 {
+			next += len(colGap)
+		}
+		if next > helpFill {
 			break
 		}
+		used, kept = next, i+1
+	}
+
+	parts := []string{systemInfo}
+	switch {
+	case kept > 0:
+		items := make([]string, 0, kept*2-1)
+		for i := 0; i < kept; i++ {
+			if i > 0 {
+				items = append(items, colGap)
+			}
+			items = append(items, cols[i])
+		}
+		helpBlock := lipgloss.JoinHorizontal(lipgloss.Top, items...)
+		if helpFill > 0 {
+			helpBlock = lipgloss.NewStyle().Width(helpFill).Align(lipgloss.Left).Render(helpBlock)
+		}
+		parts = append(parts, helpBlock)
+	case showLogo && helpFill > 0:
+		// No help columns fit; reserve the gap so the logo stays right-aligned.
+		parts = append(parts, lipgloss.NewStyle().Width(helpFill).Render(""))
+	}
+	if showLogo {
+		parts = append(parts, logoSpacer, logo)
+	}
+
+	out := lipgloss.JoinHorizontal(lipgloss.Top, parts...)
+
+	// Hard backstop: the app layout assumes the header is exactly m.height
+	// lines tall and no wider than m.width. Clamp so it can never overflow its
+	// box (and scramble the screen) even if the packing above is ever wrong.
+	return lipgloss.NewStyle().MaxWidth(m.width).MaxHeight(m.height).Render(out)
+}
+
+// renderColumns lays out the help entries into columns (filled top-to-bottom,
+// 5 rows per column) and returns each column's rendered block plus its width.
+func renderColumns(allHelp []HelpEntry) (blocks []string, widths []int) {
+	const rowsPerColumn = 5
+	numCols := (len(allHelp) + rowsPerColumn - 1) / rowsPerColumn
+
+	columns := make([][]HelpEntry, numCols)
+	for i, entry := range allHelp {
+		col := i / rowsPerColumn
 		columns[col] = append(columns[col], entry)
 	}
 
-	// Render columns with table formatting
-	keyStyle := lipgloss.NewStyle().
-		Foreground(lipgloss.Color("39")).
-		Bold(true)
-
+	keyStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("39")).Bold(true)
 	disabledKeyStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("240"))
 	disabledDescStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("240"))
 
-	var renderedCols []string
-	for colIdx, col := range columns {
-		// Find max key length in this column for alignment (visible length)
+	for _, col := range columns {
+		// Align descriptions on the widest key in this column.
 		maxKeyLen := 0
 		for _, entry := range col {
-			keyText := "<" + entry.Key + ">"
-			keyLen := lipgloss.Width(keyText)
-			if keyLen > maxKeyLen {
-				maxKeyLen = keyLen
+			if l := lipgloss.Width("<" + entry.Key + ">"); l > maxKeyLen {
+				maxKeyLen = l
 			}
 		}
 
 		var lines []string
 		for _, entry := range col {
 			keyText := "<" + entry.Key + ">"
-			visibleKeyLen := lipgloss.Width(keyText)
-			padding := maxKeyLen - visibleKeyLen
+			padding := maxKeyLen - lipgloss.Width(keyText)
 			var line string
 			if entry.Disabled {
 				line = disabledKeyStyle.Render(keyText) + strings.Repeat(" ", padding+2) + disabledDescStyle.Render(entry.Desc)
@@ -148,26 +175,16 @@ func (m *Model) View(systemInfo string, hasError bool) string {
 			lines = append(lines, line)
 		}
 
-		colContent := strings.Join(lines, "\n")
-
-		// Add spacing between columns (3 spaces)
-		if colIdx > 0 {
-			renderedCols = append(renderedCols, "   ")
-		}
-
-		colBlock := lipgloss.NewStyle().
-			Render(colContent)
-		renderedCols = append(renderedCols, colBlock)
+		block := strings.Join(lines, "\n")
+		blocks = append(blocks, block)
+		widths = append(widths, lipgloss.Width(block))
 	}
+	return blocks, widths
+}
 
-	helpBlock := lipgloss.JoinHorizontal(lipgloss.Top, renderedCols...)
-
-	helpAligned := lipgloss.NewStyle().
-		Width(availableWidth).
-		Align(lipgloss.Left).
-		Render(helpBlock)
-
-	// Add SWC logo on the right side
+// buildLogo renders the SWC logo with the edition label right-aligned on its
+// last line. The label is truncated if it would overflow the logo's width.
+func buildLogo(hasError bool) string {
 	logoTop := `  ___________      ___________
  /   _____/  \    /  \_   ___ \
  \_____  \\   \/\/   /    \  \/
@@ -180,18 +197,16 @@ func (m *Model) View(systemInfo string, hasError bool) string {
 	if hasError {
 		logoColor = lipgloss.Color("9") // red when errors exist
 	}
-	logoStyle := lipgloss.NewStyle().
-		Foreground(logoColor).
-		Bold(true)
+	logoStyle := lipgloss.NewStyle().Foreground(logoColor).Bold(true)
+	editionStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("75")).Bold(true)
 
-	editionStyle := lipgloss.NewStyle().
-		Foreground(lipgloss.Color("75")).
-		Bold(true)
-
-	// Right-align edition label on the last line
-	pad := len(logoBottom) - len(EditionLabel)
-	lastLine := logoStyle.Render(logoBottom[:pad]) + editionStyle.Render(EditionLabel)
-	swcLogo := logoStyle.Render(logoTop) + "\n" + lastLine
-
-	return lipgloss.JoinHorizontal(lipgloss.Top, systemInfo, helpAligned, "  ", swcLogo)
+	label := EditionLabel
+	if lipgloss.Width(label) >= len(logoBottom) {
+		// Keep the label inside the logo so the slice below cannot panic and
+		// the logo width stays fixed.
+		label = lipgloss.NewStyle().MaxWidth(len(logoBottom) - 1).Render(label)
+	}
+	pad := len(logoBottom) - lipgloss.Width(label)
+	lastLine := logoStyle.Render(logoBottom[:pad]) + editionStyle.Render(label)
+	return logoStyle.Render(logoTop) + "\n" + lastLine
 }

--- a/views/helpbar/helpbar_test.go
+++ b/views/helpbar/helpbar_test.go
@@ -4,8 +4,10 @@
 package helpbar
 
 import (
+	"strings"
 	"testing"
 
+	"github.com/charmbracelet/lipgloss"
 	"github.com/stretchr/testify/require"
 )
 
@@ -69,8 +71,60 @@ func TestSetters(t *testing.T) {
 	require.Equal(t, 100, m.width)
 	m.SetHeight(50)
 	require.Equal(t, 50, m.height)
-	m.SetMinColWidth(30)
-	require.Equal(t, 30, m.minColWidth)
+}
+
+// TestView_NeverOverflowsBox guards the invariant the app layout depends on:
+// the header is no wider than the width it was given and no taller than the
+// height it was given, at every terminal width. The previous implementation
+// rendered w+2 wide always, and 7-8 lines tall in the 112-124 band (word-wrap),
+// which pushed the body off-screen and scrambled the display.
+func TestView_NeverOverflowsBox(t *testing.T) {
+	const height = 6
+	// 40x6 system info stub, matching the real systeminfo view dimensions.
+	systemInfo := strings.TrimRight(strings.Repeat(strings.Repeat("x", 40)+"\n", height), "\n")
+	viewHelp := []HelpEntry{
+		{Key: "i", Desc: "Inspect"},
+		{Key: "ctrl+r", Desc: "Rollback service"},
+		{Key: "↑/↓", Desc: "Navigate"},
+		{Key: "ctrl+d", Desc: "Remove service"},
+		{Key: "p", Desc: "Show/hide tasks"},
+		{Key: "l", Desc: "View logs"},
+	}
+
+	for w := 60; w <= 200; w += 2 {
+		out := New(w, height).WithViewHelp(viewHelp).View(systemInfo, false)
+		require.LessOrEqualf(t, lipgloss.Width(out), w, "width overflow at vpWidth=%d", w)
+		require.LessOrEqualf(t, lipgloss.Height(out), height, "height overflow at vpWidth=%d", w)
+	}
+}
+
+// TestView_DegradesGracefully checks that the logo and help are shown when there
+// is room and dropped (without overflow) when there is not.
+func TestView_DegradesGracefully(t *testing.T) {
+	const height = 6
+	systemInfo := strings.TrimRight(strings.Repeat(strings.Repeat("x", 40)+"\n", height), "\n")
+	help := []HelpEntry{{Key: "i", Desc: "Inspect"}, {Key: "p", Desc: "Show/hide tasks"}}
+
+	wide := New(200, height).WithViewHelp(help).View(systemInfo, false)
+	require.Contains(t, wide, "_____", "logo should show when wide")
+	require.Contains(t, wide, "Inspect", "help should show when wide")
+
+	// Just enough for systemInfo only: logo and help both drop, no overflow.
+	narrow := New(44, height).WithViewHelp(help).View(systemInfo, false)
+	require.NotContains(t, narrow, "_____", "logo should drop when narrow")
+	require.LessOrEqual(t, lipgloss.Width(narrow), 44)
+}
+
+// TestView_OverlongEditionLabel ensures a label wider than the logo cannot panic.
+func TestView_OverlongEditionLabel(t *testing.T) {
+	orig := EditionLabel
+	defer SetEditionLabel(orig)
+	SetEditionLabel("An Absurdly Long Enterprise Ultimate Premium Edition Label")
+
+	require.NotPanics(t, func() {
+		out := New(200, 6).WithViewHelp([]HelpEntry{{Key: "i", Desc: "Inspect"}}).View("", false)
+		require.LessOrEqual(t, lipgloss.Width(out), 200)
+	})
 }
 
 func TestWithGlobalHelp(t *testing.T) {


### PR DESCRIPTION
## Summary
- The app layout assumes the header is exactly `systeminfoview.Height` (6) lines (`app/view.go:55`), but `helpbar.View()` word-wrapped the help columns at viewport widths ~112–124, rendering 7–8 lines. The overflow pushed the body + stack bar off the alt-screen, causing the scrambled logo and stale terminal-buffer bleed-through seen in the wild.
- Rewrote the width budgeting: render help columns at natural width, keep only those that fit, and degrade gracefully (drop columns right-to-left, then the logo) as the terminal narrows. Also fixes a latent bug where the header was always 2 cols wider than its given width (unaccounted spacer).
- Added a hard `MaxWidth/MaxHeight` backstop so the header can never overflow its box even if the packing math ever regresses. Guarded the edition-label slice against panics and removed the now-orphaned `minColWidth` field/setter.

## Test Plan
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] New `TestView_NeverOverflowsBox` sweeps widths 60→200 asserting `Height==6` and `Width≤w` (locks the previously-broken 112–124 band); plus graceful-degradation and over-long-label tests.
- [x] `swarmcli-be` builds against the changed API.
- [ ] Manual: drill into a stack's services and resize the terminal through the ~116–128 column band — logo stays intact, body never scrolls off-screen, no bleed-through.