### PR TITLE
fix(stacks): preserve healthcheck in stack inspect and edit (#379)

### DIFF
--- a/docker/stack_inspect.go
+++ b/docker/stack_inspect.go
@@ -28,17 +28,18 @@ type StackInspection struct {
 
 // ServiceSummary contains summary information about a service
 type ServiceSummary struct {
-	Name      string            `json:"name"`
-	ID        string            `json:"id"`
-	Image     string            `json:"image"`
-	Mode      string            `json:"mode"`
-	Replicas  string            `json:"replicas"`
-	Ports     []string          `json:"ports,omitempty"`
-	Secrets   []string          `json:"secrets,omitempty"`
-	Configs   []string          `json:"configs,omitempty"`
-	Labels    map[string]string `json:"labels,omitempty"`
-	CreatedAt time.Time         `json:"created_at"`
-	UpdatedAt time.Time         `json:"updated_at"`
+	Name        string            `json:"name"`
+	ID          string            `json:"id"`
+	Image       string            `json:"image"`
+	Mode        string            `json:"mode"`
+	Replicas    string            `json:"replicas"`
+	Ports       []string          `json:"ports,omitempty"`
+	Secrets     []string          `json:"secrets,omitempty"`
+	Configs     []string          `json:"configs,omitempty"`
+	Labels      map[string]string `json:"labels,omitempty"`
+	Healthcheck *Healthcheck      `json:"healthcheck,omitempty"`
+	CreatedAt   time.Time         `json:"created_at"`
+	UpdatedAt   time.Time         `json:"updated_at"`
 }
 
 // GetStackInspection returns detailed information about a stack in JSON format
@@ -136,8 +137,9 @@ func GetStackInspection(stackName string) (string, error) {
 			}
 		}
 
-		// Collect secrets, configs, and volumes
+		// Collect secrets, configs, volumes, and healthcheck
 		var svcSecrets, svcConfigs []string
+		var healthcheck *Healthcheck
 		if svc.Spec.TaskTemplate.ContainerSpec != nil {
 			for _, s := range svc.Spec.TaskTemplate.ContainerSpec.Secrets {
 				if s.SecretName != "" {
@@ -158,23 +160,30 @@ func GetStackInspection(stackName string) (string, error) {
 					volumesMap[m.Source] = true
 				}
 			}
+
+			if hc := svc.Spec.TaskTemplate.ContainerSpec.Healthcheck; hc != nil {
+				healthcheck = composeHealthcheck(hc.Test, int64(hc.Interval),
+					int64(hc.Timeout), int64(hc.StartPeriod), int64(hc.StartInterval),
+					hc.Retries, false /*no escape*/)
+			}
 		}
 		sort.Strings(svcSecrets)
 		sort.Strings(svcConfigs)
 
 		// Add service summary
 		desc.Services = append(desc.Services, ServiceSummary{
-			Name:      svc.Spec.Name,
-			ID:        svc.ID,
-			Image:     image,
-			Mode:      mode,
-			Replicas:  replicas,
-			Ports:     ports,
-			Secrets:   svcSecrets,
-			Configs:   svcConfigs,
-			Labels:    svc.Spec.Labels,
-			CreatedAt: svc.CreatedAt,
-			UpdatedAt: svc.UpdatedAt,
+			Name:        svc.Spec.Name,
+			ID:          svc.ID,
+			Image:       image,
+			Mode:        mode,
+			Replicas:    replicas,
+			Ports:       ports,
+			Secrets:     svcSecrets,
+			Configs:     svcConfigs,
+			Labels:      svc.Spec.Labels,
+			Healthcheck: healthcheck,
+			CreatedAt:   svc.CreatedAt,
+			UpdatedAt:   svc.UpdatedAt,
 		})
 	}
 

--- a/docker/stack_to_compose.go
+++ b/docker/stack_to_compose.go
@@ -11,6 +11,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	"gopkg.in/yaml.v3"
 )
@@ -40,7 +41,21 @@ type ComposeService struct {
 	Secrets     []map[string]any  `yaml:"secrets,omitempty"`
 	Configs     []map[string]any  `yaml:"configs,omitempty"`
 	Deploy      map[string]any    `yaml:"deploy,omitempty"`
+	Healthcheck *Healthcheck      `yaml:"healthcheck,omitempty"`
 	Extra       map[string]any    `yaml:",inline,omitempty"` // fallback
+}
+
+// Healthcheck is the compose-shaped view of a service healthcheck, used both
+// in reconstructed Compose YAML and in stack-inspect JSON. Durations are
+// rendered as compose duration strings (e.g. "30s").
+type Healthcheck struct {
+	Test          []string `json:"test,omitempty" yaml:"test,omitempty"`
+	Interval      string   `json:"interval,omitempty" yaml:"interval,omitempty"`
+	Timeout       string   `json:"timeout,omitempty" yaml:"timeout,omitempty"`
+	StartPeriod   string   `json:"start_period,omitempty" yaml:"start_period,omitempty"`
+	StartInterval string   `json:"start_interval,omitempty" yaml:"start_interval,omitempty"`
+	Retries       int      `json:"retries,omitempty" yaml:"retries,omitempty"`
+	Disable       bool     `json:"disable,omitempty" yaml:"disable,omitempty"`
 }
 
 // ServiceInspect represents Docker service inspect output (partial)
@@ -89,6 +104,20 @@ type ContainerSpec struct {
 	Mounts  []Mount           `json:"Mounts,omitempty"`
 	Secrets []SecretRef       `json:"Secrets,omitempty"`
 	Configs []ConfigRef       `json:"Configs,omitempty"`
+	// Healthcheck durations arrive as nanosecond integers over the
+	// `docker service inspect` CLI JSON.
+	Healthcheck *HealthConfigJSON `json:"Healthcheck,omitempty"`
+}
+
+// HealthConfigJSON captures the Healthcheck block of a `docker service inspect`
+// ContainerSpec. Durations are nanosecond integers.
+type HealthConfigJSON struct {
+	Test          []string `json:"Test,omitempty"`
+	Interval      int64    `json:"Interval,omitempty"`
+	Timeout       int64    `json:"Timeout,omitempty"`
+	StartPeriod   int64    `json:"StartPeriod,omitempty"`
+	StartInterval int64    `json:"StartInterval,omitempty"`
+	Retries       int      `json:"Retries,omitempty"`
 }
 
 // Mount represents a mount specification
@@ -367,6 +396,12 @@ func ReconstructStackCompose(stackName string) (string, error) {
 				}
 				cs.Configs = append(cs.Configs, ref)
 			}
+
+			// Healthcheck
+			if h := cspec.Healthcheck; h != nil {
+				cs.Healthcheck = composeHealthcheck(h.Test, h.Interval, h.Timeout,
+					h.StartPeriod, h.StartInterval, h.Retries, true /*escape*/)
+			}
 		}
 
 		// Ports
@@ -599,6 +634,47 @@ func filterLabels(labels map[string]string) map[string]string {
 // attempt variable interpolation on reconstructed command strings.
 func escapeComposeInterpolation(s string) string {
 	return strings.ReplaceAll(s, "$", "$$")
+}
+
+// composeHealthcheck builds the compose-shaped Healthcheck from a service's
+// healthcheck spec. Durations are raw nanoseconds (as Docker reports them) and
+// are rendered as compose duration strings (e.g. "30s"). Returns nil when the
+// spec carries nothing meaningful, i.e. the service inherits the image's
+// healthcheck. When escape is true, Test elements are escaped for Compose
+// variable interpolation (used in the reconstructed Compose YAML).
+func composeHealthcheck(test []string, intervalNs, timeoutNs, startPeriodNs,
+	startIntervalNs int64, retries int, escape bool) *Healthcheck {
+
+	disabled := len(test) == 1 && test[0] == "NONE"
+	if !disabled && len(test) == 0 && intervalNs == 0 && timeoutNs == 0 &&
+		startPeriodNs == 0 && startIntervalNs == 0 && retries == 0 {
+		return nil // inherit image healthcheck — nothing specified
+	}
+
+	hc := &Healthcheck{}
+	if disabled {
+		hc.Disable = true
+		return hc
+	}
+	if escape {
+		hc.Test = escapeComposeArgs(test)
+	} else {
+		hc.Test = test
+	}
+	if intervalNs > 0 {
+		hc.Interval = time.Duration(intervalNs).String()
+	}
+	if timeoutNs > 0 {
+		hc.Timeout = time.Duration(timeoutNs).String()
+	}
+	if startPeriodNs > 0 {
+		hc.StartPeriod = time.Duration(startPeriodNs).String()
+	}
+	if startIntervalNs > 0 {
+		hc.StartInterval = time.Duration(startIntervalNs).String()
+	}
+	hc.Retries = retries
+	return hc
 }
 
 // escapeComposeArgs applies escapeComposeInterpolation to each element.

--- a/docker/stack_to_compose_test.go
+++ b/docker/stack_to_compose_test.go
@@ -6,6 +6,7 @@ package docker
 import (
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
@@ -316,4 +317,65 @@ func TestEscapeComposeArgs(t *testing.T) {
 	require.Equal(t, []string{"sh", "-c", "echo $$HOME; date=$$(date)"}, got)
 	// original slice must not be modified
 	require.Equal(t, "echo $HOME; date=$(date)", in[2])
+}
+
+func TestComposeHealthcheck_FullSpec(t *testing.T) {
+	hc := composeHealthcheck(
+		[]string{"CMD", "curl", "-f", "http://localhost"},
+		90*int64(time.Second), 10*int64(time.Second),
+		40*int64(time.Second), 5*int64(time.Second), 3, false)
+	require.NotNil(t, hc)
+	require.Equal(t, []string{"CMD", "curl", "-f", "http://localhost"}, hc.Test)
+	require.Equal(t, "1m30s", hc.Interval)
+	require.Equal(t, "10s", hc.Timeout)
+	require.Equal(t, "40s", hc.StartPeriod)
+	require.Equal(t, "5s", hc.StartInterval)
+	require.Equal(t, 3, hc.Retries)
+	require.False(t, hc.Disable)
+}
+
+func TestComposeHealthcheck_Disabled(t *testing.T) {
+	hc := composeHealthcheck([]string{"NONE"}, 0, 0, 0, 0, 0, false)
+	require.NotNil(t, hc)
+	require.True(t, hc.Disable)
+	require.Empty(t, hc.Test)
+	require.Empty(t, hc.Interval)
+}
+
+func TestComposeHealthcheck_InheritReturnsNil(t *testing.T) {
+	require.Nil(t, composeHealthcheck(nil, 0, 0, 0, 0, 0, false))
+	require.Nil(t, composeHealthcheck([]string{}, 0, 0, 0, 0, 0, false))
+}
+
+func TestComposeHealthcheck_Escapes(t *testing.T) {
+	hc := composeHealthcheck(
+		[]string{"CMD-SHELL", "test $VAR = 1"}, int64(time.Second), 0, 0, 0, 0, true)
+	require.NotNil(t, hc)
+	require.Equal(t, []string{"CMD-SHELL", "test $$VAR = 1"}, hc.Test)
+}
+
+func TestComposeService_HealthcheckYAML(t *testing.T) {
+	cs := ComposeService{
+		Image: "nginx:latest",
+		Healthcheck: &Healthcheck{
+			Test:     []string{"CMD", "true"},
+			Interval: "30s",
+			Timeout:  "5s",
+			Retries:  3,
+		},
+	}
+	out, err := yaml.Marshal(&cs)
+	require.NoError(t, err)
+	yamlStr := string(out)
+	require.Contains(t, yamlStr, "healthcheck:")
+	require.Contains(t, yamlStr, "test:")
+	require.Contains(t, yamlStr, "interval: 30s")
+	require.Contains(t, yamlStr, "retries: 3")
+}
+
+func TestComposeService_HealthcheckOmittedWhenNil(t *testing.T) {
+	cs := ComposeService{Image: "nginx:latest"}
+	out, err := yaml.Marshal(&cs)
+	require.NoError(t, err)
+	require.NotContains(t, string(out), "healthcheck")
 }

--- a/integration-tests/docker/stack_inspect_test.go
+++ b/integration-tests/docker/stack_inspect_test.go
@@ -133,6 +133,22 @@ func TestInspectStack(t *testing.T) {
 				t.Errorf("Service %q: expected no configs, got %v", svc.Name, svc.Configs)
 			}
 		}
+
+		// Issue #379: whoami_single declares a healthcheck; other services do not.
+		if strings.HasSuffix(svc.Name, "whoami_single") {
+			if svc.Healthcheck == nil {
+				t.Errorf("Service %q: expected a healthcheck, got nil", svc.Name)
+			} else {
+				if svc.Healthcheck.Interval != "30s" {
+					t.Errorf("Service %q: healthcheck interval = %q, want \"30s\"", svc.Name, svc.Healthcheck.Interval)
+				}
+				if svc.Healthcheck.Retries != 3 {
+					t.Errorf("Service %q: healthcheck retries = %d, want 3", svc.Name, svc.Healthcheck.Retries)
+				}
+			}
+		} else if svc.Healthcheck != nil {
+			t.Errorf("Service %q: expected no healthcheck, got %+v", svc.Name, svc.Healthcheck)
+		}
 	}
 
 	t.Logf("Successfully inspected stack: %d services, %d tasks", inspection.ServiceCount, inspection.TaskCount)

--- a/integration-tests/docker/stack_to_compose_test.go
+++ b/integration-tests/docker/stack_to_compose_test.go
@@ -98,6 +98,29 @@ func TestReconstructStackCompose(t *testing.T) {
 		t.Errorf("Issue #363: 'default_net_probe' lost its networks: [default], got %#v", probe.Networks)
 	}
 
+	// Issue #379: whoami_single declares a healthcheck — it must round-trip
+	// through reconstruction rather than being silently dropped.
+	if !strings.Contains(yaml, "healthcheck:") {
+		t.Error("Issue #379: reconstructed YAML missing 'healthcheck:' section")
+	}
+	single, ok := composed.Services["whoami_single"]
+	if !ok {
+		t.Fatal("Issue #379: missing 'whoami_single' service in reconstructed YAML")
+	}
+	if single.Healthcheck == nil {
+		t.Error("Issue #379: 'whoami_single' lost its healthcheck during reconstruction")
+	} else {
+		if single.Healthcheck.Interval != "30s" {
+			t.Errorf("Issue #379: healthcheck interval = %q, want \"30s\"", single.Healthcheck.Interval)
+		}
+		if single.Healthcheck.Retries != 3 {
+			t.Errorf("Issue #379: healthcheck retries = %d, want 3", single.Healthcheck.Retries)
+		}
+		if len(single.Healthcheck.Test) == 0 {
+			t.Error("Issue #379: healthcheck test command is empty")
+		}
+	}
+
 	t.Logf("Successfully reconstructed stack YAML (%d bytes)", len(yaml))
 }
 

--- a/test-setup/test-stack.yml
+++ b/test-setup/test-stack.yml
@@ -53,6 +53,14 @@ services:
         target: /etc/whoami/config
     deploy:
       replicas: 1
+    # Issue #379 fixture: a service with a healthcheck. Both inspect and
+    # compose reconstruction must surface it.
+    healthcheck:
+      test: ["CMD", "true"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 5s
     command: >
       sh -c '
         apk add --no-cache netcat-openbsd;


### PR DESCRIPTION
## Summary

Fixes #379. A service's `healthcheck` was missing in both the stack **inspect** view and the stack **edit** flow.

The Docker API returns the healthcheck, but neither code path had a struct field to hold it:

- **Inspect** (`docker/stack_inspect.go`): `ServiceSummary` had no healthcheck field, so the JSON view omitted it.
- **Edit** (`docker/stack_to_compose.go`): the custom service-inspect `ContainerSpec` and `ComposeService` had no healthcheck field, so `ReconstructStackCompose` discarded it during the `service inspect` → struct → Compose YAML round-trip. This was **data-destroying** — editing and redeploying a stack silently removed the healthcheck.

## Changes

- New compose-shaped `Healthcheck` type (yaml + json tags) shared by both paths.
- `HealthConfigJSON` to capture the healthcheck from the `docker service inspect` JSON (nanosecond durations).
- `composeHealthcheck` converter: durations → compose strings (`"30s"`), `test: ["NONE"]` → `disable: true`, inherited/empty healthcheck → omitted, `$`→`$$` escaping on the reconstructed Compose path (mirrors `Command` handling).
- Wired into `ReconstructStackCompose` and `GetStackInspection`.
- Unit tests for the converter and marshaling; a healthcheck fixture on `whoami_single` in `test-setup/test-stack.yml`; integration assertions for both inspect and reconstruction.

## Verification

- `go build`, `go vet -tags=integration`, `go test ./docker/`, `golangci-lint run ./... --build-tags=integration`, gofmt — all clean locally.
- Integration suite (`testenv.sh integration`) runs in CI against DinD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)