### PR TITLE
feat(helpbar): add 'ctrl+q' shortcut for quitting in short help items

### DIFF
--- a/app/view.go
+++ b/app/view.go
@@ -28,6 +28,7 @@ func (m *Model) View() string {
 	globalHelp := []helpbar.HelpEntry{
 		{Key: "f", Desc: "Fullscreen"},
 		{Key: "?", Desc: "Help"},
+		{Key: "ctrl+q", Desc: "Quit"},
 	}
 	if m.currentView.Name() == view.NameHelp {
 		globalHelp = []helpbar.HelpEntry{}

--- a/views/stacks/model.go
+++ b/views/stacks/model.go
@@ -209,7 +209,6 @@ func (m *Model) ShortHelpItems() []helpbar.HelpEntry {
 		{Key: "↑/↓", Desc: "Navigate"},
 		{Key: "/", Desc: "Filter"},
 		{Key: "?", Desc: "Help"},
-		{Key: "ctrl+q", Desc: "Quit"},
 	}
 }
 

--- a/views/stacks/model.go
+++ b/views/stacks/model.go
@@ -209,6 +209,7 @@ func (m *Model) ShortHelpItems() []helpbar.HelpEntry {
 		{Key: "↑/↓", Desc: "Navigate"},
 		{Key: "/", Desc: "Filter"},
 		{Key: "?", Desc: "Help"},
+		{Key: "ctrl+q", Desc: "Quit"},
 	}
 }
 


### PR DESCRIPTION
Still getting used to the codebase and the CLI. Add missing short key to quit.

Using `ctrl+q` for `swarmcli` with VSCode Terminals results in conflict between a VSCode shortcut key. I think using `ctrl+c` or `q` could be better to aim for simplicity.