### PR TITLE
feat(docker): add GetLocalNodeID accessor for the connected swarm node

### DIFF
--- a/docker/node.go
+++ b/docker/node.go
@@ -10,6 +10,21 @@ import (
 	"github.com/docker/docker/api/types/swarm"
 )
 
+// GetLocalNodeID returns the swarm node ID of the daemon the active Docker
+// client is connected to, or "" if it is not an active swarm node.
+func GetLocalNodeID(ctx context.Context) (string, error) {
+	c, err := GetClient()
+	if err != nil {
+		return "", err
+	}
+
+	info, err := c.Info(ctx)
+	if err != nil {
+		return "", fmt.Errorf("query docker info: %w", err)
+	}
+	return info.Swarm.NodeID, nil
+}
+
 func GetNodeIDToHostnameMapFromDocker(ctx context.Context) (map[string]string, error) {
 	c, err := GetClient()
 	if err != nil {


### PR DESCRIPTION
## What

Adds `docker.GetLocalNodeID(ctx)` — returns the swarm node ID of the daemon the active Docker client is connected to (`cli.Info(ctx).Swarm.NodeID`), or `""` if it is not an active swarm node.

## Why

A small, generic extension point next to the existing node helpers in `docker/node.go`. It lets a caller learn which node it is talking to — e.g. to pin a short-lived workload to the same daemon it will read results from, so it doesn't depend on cross-node behaviour.

## Notes

No behaviour change. Additive accessor only; mirrors the `cli.Info` usage already in `docker/context.go`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)