### PR TITLE
ci(goreleaser): do not move :latest on prereleases

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -189,3 +189,4 @@ docker_manifests:
     image_templates:
       - "eldaratech/swarmcli:{{ .Tag }}-amd64"
       - "eldaratech/swarmcli:{{ .Tag }}-arm64"
+    skip_push: "auto"


### PR DESCRIPTION
The `:latest` `docker_manifest` had no `skip_push` guard, so every tag — including RC prereleases — repointed `eldaratech/swarmcli:latest`. As a result `:latest` currently tracks `v1.7.0-rc2` (a prerelease), meaning a plain `docker pull eldaratech/swarmcli` gets an RC.

Adds `skip_push: "auto"` to the `:latest` manifest so it is only pushed for stable (non-prerelease) tags — mirroring the `docker/metadata-action` `latest=auto` behaviour the `swarmcli-agent` and `swarmcli-rbac-proxy` release workflows already rely on. The versioned `:{{ .Tag }}` manifest is unchanged and still publishes for RCs.

The live `:latest` tag will be repointed to the `v1.6.0` GA manifest separately (registry op).