### PR TITLE
feat(release): curated Upgrade Notes callout for breaking changes

### DIFF
--- a/.github/UPGRADE_NOTES.md
+++ b/.github/UPGRADE_NOTES.md
@@ -1,0 +1,9 @@
+<!--
+Upgrade Notes — curated breaking-change callout for the next release.
+
+Leave this file as-is (this comment only) when the release has no breaking
+changes. For a breaking release, replace the comment with migration prose in
+Markdown; the release workflow prepends it as a "## ⚠️ Upgrade Notes" section
+at the top of the GitHub release notes (see .github/workflows/release.yml).
+Clear it back to this comment once the GA is cut.
+-->

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,34 @@ jobs:
         with:
           fetch-depth: 0
 
+      # Curated breaking-change callout. The committed .github/UPGRADE_NOTES.md
+      # is a placeholder (HTML comment only); a maintainer fills it with
+      # migration prose for a breaking release and clears it back afterwards.
+      # When it has real content, prepend it as an "Upgrade Notes" section above
+      # the release-drafter changelog in the draft body. GoReleaser below
+      # publishes that draft verbatim (use_existing_draft + changelog.disable),
+      # so this must run before it.
+      - name: Prepend upgrade notes to release draft
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          NOTES=$(perl -0777 -pe 's/<!--.*?-->//gs' .github/UPGRADE_NOTES.md)
+          if [ -z "$(printf '%s' "$NOTES" | tr -d '[:space:]')" ]; then
+            echo "UPGRADE_NOTES.md has no content; nothing to prepend."
+            exit 0
+          fi
+          BODY=$(gh release view "$TAG" --json body --jq '.body // ""')
+          {
+            echo "## ⚠️ Upgrade Notes"
+            echo ""
+            printf '%s\n' "$NOTES" | sed -e 's/[[:space:]]*$//' -e '/./,$!d'
+            echo ""
+            printf '%s\n' "$BODY"
+          } > /tmp/release-body.md
+          gh release edit "$TAG" --notes-file /tmp/release-body.md
+          echo "Prepended upgrade notes to $TAG."
+
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,6 +131,8 @@ Add all three labels when creating a PR: `gh pr edit <number> --add-label "A0-ui
 
 When a PR fixes a GitHub issue, copy the issue's labels to the PR and add any missing required group labels (A, B, C). Use `gh api repos/OWNER/REPO/issues/<pr-number>/labels -f "labels[]=LABEL"` to add labels via API.
 
+**Versioning at release.** A `C1-breaking-change` PR merged since the last GA forces a **major** tag (`vX.0.0`). The release changelog is type-only (no dedicated "Breaking" section), so the label is the breaking-change gate — the pushed tag is authoritative, overriding release-drafter's `$RESOLVED_VERSION`. For a breaking release, fill `.github/UPGRADE_NOTES.md` before tagging.
+
 ## CI Workflows (.github/workflows/)
 
 - `ci.yml`: go fmt, golangci-lint, go build, Docker image build


### PR DESCRIPTION
## Context
Companion to the changelog dedupe (#371). With type-only categories, each PR is listed once but there's no dedicated breaking-change highlight. `version-resolver` can't help here — releases are cut from a manually-pushed tag that overrides `$RESOLVED_VERSION`.

## What
Add an opt-in **⚠️ Upgrade Notes** section prepended to the top of the release notes — the Kubernetes `Urgent Upgrade Notes` / Terraform `UPGRADE NOTES` model of a curated, human-written migration callout (which is what every gold-standard example actually ships, vs. bare auto-listed PR titles).

- `.github/UPGRADE_NOTES.md` ships as an HTML-comment placeholder, treated as **empty** → the step no-ops on normal releases.
- For a breaking release, a maintainer fills it with Markdown migration prose, then clears it back after GA.
- A new step in the `goreleaser` job prepends it to the release-drafter **draft** body before GoReleaser publishes it verbatim (`use_existing_draft` + `changelog.disable` preserve the body — verified against v1.7.0).

## Validation
`release.yml` YAML validated; the empty/filled branches of the prepend logic tested locally. Live exercise is the next tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)