### PR TITLE
feat(logs): hide stopped-container logs by default (#388)

### DIFF
--- a/views/logs/handlekey.go
+++ b/views/logs/handlekey.go
@@ -236,6 +236,14 @@ func HandleKey(m *Model, k tea.KeyMsg) tea.Cmd {
 			l().Infof("[logsview] 'o' key pressed: showing node selection dialog with %d nodes", len(nodes))
 		}
 		return nil
+	case "t":
+		// Toggle showing logs from stopped (non-running) tasks
+		old := m.getHideStopped()
+		m.setHideStopped(!old)
+		l().Infof("[logsview] 't' key pressed: hideStopped %v -> %v", old, !old)
+		return func() tea.Msg {
+			return HideStoppedToggledMsg{}
+		}
 	}
 
 	return nil

--- a/views/logs/logs_test.go
+++ b/views/logs/logs_test.go
@@ -11,6 +11,7 @@ import (
 	"swarmcli/docker"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/docker/docker/api/types/swarm"
 	"github.com/stretchr/testify/require"
 )
 
@@ -30,9 +31,9 @@ func testModel() *Model {
 	return m
 }
 
-type mockSnapshotOps struct{}
+type mockSnapshotOps struct{ snap *docker.SwarmSnapshot }
 
-func (m *mockSnapshotOps) GetSnapshot() *docker.SwarmSnapshot              { return nil }
+func (m *mockSnapshotOps) GetSnapshot() *docker.SwarmSnapshot              { return m.snap }
 func (m *mockSnapshotOps) SetSnapshot(_ *docker.SwarmSnapshot)             {}
 func (m *mockSnapshotOps) InvalidateSnapshot()                             {}
 func (m *mockSnapshotOps) RefreshSnapshot() (*docker.SwarmSnapshot, error) { return nil, nil }
@@ -139,6 +140,7 @@ func TestShortHelpItems_NormalMode(t *testing.T) {
 	require.True(t, keys["s"])
 	require.True(t, keys["w"])
 	require.True(t, keys["o"])
+	require.True(t, keys["t"])
 	require.True(t, keys["esc"])
 }
 
@@ -187,12 +189,13 @@ func TestUpdate_LineMsg(t *testing.T) {
 	m.errChan = errs
 
 	// Add a line
-	m.Update(LineMsg{Line: "node1\x00hello world"})
+	m.Update(LineMsg{Line: "node1\x00task-1\x00hello world"})
 
 	m.mu.Lock()
 	require.Len(t, m.lines, 1)
 	require.Equal(t, "hello world", m.lines[0])
 	require.Equal(t, "node1", m.lineNodes[0])
+	require.Equal(t, "task-1", m.lineTasks[0])
 	m.mu.Unlock()
 	close(lines)
 	close(errs)
@@ -212,6 +215,8 @@ func TestUpdate_LineMsg_Trimming(t *testing.T) {
 	}
 	m.mu.Lock()
 	require.Len(t, m.lines, 3)
+	require.Len(t, m.lineTasks, 3) // parallel slice trimmed in lock-step
+	require.Len(t, m.lineNodes, 3)
 	m.mu.Unlock()
 	close(lines)
 	close(errs)
@@ -440,6 +445,7 @@ func TestView_Normal(t *testing.T) {
 	require.Contains(t, out, "Service: web")
 	require.Contains(t, out, "AutoScroll: on")
 	require.Contains(t, out, "wrap: on")
+	require.Contains(t, out, "Stopped: hidden")
 }
 
 func TestView_SearchMode(t *testing.T) {
@@ -615,7 +621,7 @@ func TestLineMsg_StripsCR(t *testing.T) {
 	m.linesChan = lines
 	m.errChan = errs
 
-	m.Update(LineMsg{Line: "node1\x00downloading 50%\rprogress"})
+	m.Update(LineMsg{Line: "node1\x00task-1\x00downloading 50%\rprogress"})
 
 	m.mu.Lock()
 	require.Len(t, m.lines, 1)
@@ -681,4 +687,124 @@ func TestShouldFallbackToRawFromStdCopy(t *testing.T) {
 			require.Equal(t, tc.want, shouldFallbackToRawFromStdCopy(tc.err))
 		})
 	}
+}
+
+// --- hide-stopped (issue #388) tests ---
+
+// hideStoppedModel returns a model whose snapshot has one running and one
+// stopped task for the model's service (svc-123).
+func hideStoppedModel() *Model {
+	m := testModel()
+	m.deps.Snapshot = &mockSnapshotOps{snap: &docker.SwarmSnapshot{
+		Tasks: []swarm.Task{
+			{ID: "task-run", ServiceID: "svc-123", DesiredState: swarm.TaskStateRunning},
+			{ID: "task-stop", ServiceID: "svc-123", DesiredState: swarm.TaskStateShutdown},
+		},
+	}}
+	return m
+}
+
+func TestHideStopped_Default(t *testing.T) {
+	m := testModel()
+	require.True(t, m.getHideStopped())
+}
+
+func TestHideStoppedToggle(t *testing.T) {
+	m := testModel()
+	m.setHideStopped(false)
+	require.False(t, m.getHideStopped())
+	m.setHideStopped(true)
+	require.True(t, m.getHideStopped())
+}
+
+func TestKey_T_TogglesHideStopped(t *testing.T) {
+	m := testModel()
+	m.Visible = true
+	require.True(t, m.getHideStopped())
+	cmd := m.Update(key("t"))
+	require.False(t, m.getHideStopped())
+	require.NotNil(t, cmd) // HideStoppedToggledMsg
+	m.Update(key("t"))
+	require.True(t, m.getHideStopped())
+}
+
+func TestBuildContent_HidesStoppedTasks(t *testing.T) {
+	m := hideStoppedModel()
+	m.mu.Lock()
+	m.lines = []string{"running line", "stopped line", "system line"}
+	m.lineTasks = []string{"task-run", "task-stop", ""}
+	m.lineNodes = []string{"n", "n", ""}
+	m.mu.Unlock()
+	content := m.buildContent()
+	require.Contains(t, content, "running line")
+	require.NotContains(t, content, "stopped line")
+	require.Contains(t, content, "system line") // empty task ID => always visible
+}
+
+func TestBuildContent_ShowAllWhenHideStoppedOff(t *testing.T) {
+	m := hideStoppedModel()
+	m.setHideStopped(false)
+	m.mu.Lock()
+	m.lines = []string{"running line", "stopped line", "system line"}
+	m.lineTasks = []string{"task-run", "task-stop", ""}
+	m.lineNodes = []string{"n", "n", ""}
+	m.mu.Unlock()
+	content := m.buildContent()
+	require.Contains(t, content, "running line")
+	require.Contains(t, content, "stopped line")
+	require.Contains(t, content, "system line")
+}
+
+func TestBuildContent_NilSnapshotFailOpen(t *testing.T) {
+	m := testModel() // default mock => nil snapshot
+	require.True(t, m.getHideStopped())
+	m.mu.Lock()
+	m.lines = []string{"a", "b"}
+	m.lineTasks = []string{"task-run", "task-stop"}
+	m.lineNodes = []string{"", ""}
+	m.mu.Unlock()
+	content := m.buildContent()
+	require.Contains(t, content, "a")
+	require.Contains(t, content, "b") // nil snapshot => show all
+}
+
+func TestBuildContent_EmptyTaskIDAlwaysVisible(t *testing.T) {
+	m := hideStoppedModel()
+	m.mu.Lock()
+	m.lines = []string{"no task line"}
+	m.lineTasks = []string{""}
+	m.lineNodes = []string{""}
+	m.mu.Unlock()
+	content := m.buildContent()
+	require.Contains(t, content, "no task line")
+}
+
+func TestHighlightContent_SyncWithHideStopped(t *testing.T) {
+	m := hideStoppedModel()
+	m.mu.Lock()
+	m.lines = []string{"match running", "match stopped", "match again"}
+	m.lineTasks = []string{"task-run", "task-stop", "task-run"}
+	m.lineNodes = []string{"n", "n", "n"}
+	m.mu.Unlock()
+	m.searchTerm = "match"
+	m.highlightContent()
+	// The stopped line is hidden, so only two visible matches remain and their
+	// visible indices are contiguous (0,1) — aligned with buildContent's output.
+	require.Equal(t, []int{0, 1}, m.searchMatches)
+}
+
+func TestSetContent_ResetsTaskSlice(t *testing.T) {
+	m := testModel()
+	m.mu.Lock()
+	m.lineTasks = []string{"old"}
+	m.lineNodes = []string{"old"}
+	m.mu.Unlock()
+	m.SetContent("a\nb\nc")
+	m.mu.Lock()
+	require.Len(t, m.lineTasks, 3)
+	require.Len(t, m.lineNodes, 3)
+	for _, id := range m.lineTasks {
+		require.Equal(t, "", id)
+	}
+	m.mu.Unlock()
 }

--- a/views/logs/messages.go
+++ b/views/logs/messages.go
@@ -22,3 +22,5 @@ type StreamDoneMsg struct{}
 type WrapToggledMsg struct{}
 
 type NodeFilterToggledMsg struct{}
+
+type HideStoppedToggledMsg struct{}

--- a/views/logs/model.go
+++ b/views/logs/model.go
@@ -6,6 +6,7 @@ package logsview
 import (
 	"context"
 	"sort"
+	"strings"
 	"swarmcli/docker"
 	"swarmcli/views/helpbar"
 	"sync"
@@ -26,6 +27,7 @@ type Model struct {
 	searchMatches []int
 	lines         []string // bounded: only last MaxLines kept
 	lineNodes     []string // node name for each line (parallel to lines)
+	lineTasks     []string // full task ID for each line (parallel to lines), "" if unparseable
 	MaxLines      int
 	ready         bool
 
@@ -54,6 +56,8 @@ type Model struct {
 	nodeFilter string
 	// app-level "/" filter — hides non-matching lines
 	filterQuery string
+	// when true, hide log lines from tasks that are no longer running
+	hideStopped bool
 	// node selection dialog
 	nodeSelectVisible bool
 	nodeSelectCursor  int
@@ -71,6 +75,7 @@ func New(width, height int, maxLines int, service docker.ServiceEntry) *Model {
 		mode:              "normal",
 		lines:             make([]string, 0, 1024),
 		lineNodes:         make([]string, 0, 1024),
+		lineTasks:         make([]string, 0, 1024),
 		MaxLines:          maxLines,
 		StreamCtx:         ctx,
 		StreamCancel:      cancel,
@@ -80,7 +85,8 @@ func New(width, height int, maxLines int, service docker.ServiceEntry) *Model {
 		follow:            true, // auto-follow by default
 		wrap:              true, // wrap lines by default
 		horizontalOffset:  0,
-		nodeFilter:        "", // empty = show all nodes
+		nodeFilter:        "",   // empty = show all nodes
+		hideStopped:       true, // hide stopped-task logs by default
 		nodeSelectVisible: false,
 		nodeSelectCursor:  0,
 		nodeSelectNodes:   []string{},
@@ -141,6 +147,18 @@ func (m *Model) getWrap() bool {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	return m.wrap
+}
+
+func (m *Model) getHideStopped() bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.hideStopped
+}
+
+func (m *Model) setHideStopped(v bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.hideStopped = v
 }
 
 // GetSearchMode is exported for app to check search mode status
@@ -211,6 +229,7 @@ func (m *Model) ShortHelpItems() []helpbar.HelpEntry {
 		{Key: "s", Desc: "Toggle AutoScroll"},
 		{Key: "w", Desc: "Toggle wrap"},
 		{Key: "o", Desc: "Filter node"},
+		{Key: "t", Desc: "Show/hide stopped"},
 	}
 
 	// Show left/right help only when wrap is off
@@ -233,6 +252,49 @@ func (m *Model) OnExit() tea.Cmd {
 
 func (m *Model) HasErrors() bool {
 	return false
+}
+
+// runningTaskIDs returns the set of full task IDs for this service whose desired
+// state is running. Returns nil when no snapshot is available (callers treat nil
+// as "show all" — fail open). Does not take m.mu; callers already hold it.
+func (m *Model) runningTaskIDs() map[string]bool {
+	snap := m.deps.Snapshot.GetSnapshot()
+	if snap == nil {
+		return nil
+	}
+	running := make(map[string]bool)
+	for _, task := range snap.Tasks {
+		if task.ServiceID == m.ServiceEntry.ServiceID && task.DesiredState == swarm.TaskStateRunning {
+			running[task.ID] = true
+		}
+	}
+	return running
+}
+
+// lineVisible reports whether the line at index i passes all active filters
+// (node filter, "/" text filter, hide-stopped). Callers must hold m.mu and pass
+// the precomputed running-task set (nil = don't apply the hide-stopped filter).
+func (m *Model) lineVisible(i int, running map[string]bool) bool {
+	// node filter
+	if m.nodeFilter != "" && (i >= len(m.lineNodes) || m.lineNodes[i] != m.nodeFilter) {
+		return false
+	}
+	// app-level "/" text filter
+	if m.filterQuery != "" && !strings.Contains(strings.ToLower(m.lines[i]), strings.ToLower(m.filterQuery)) {
+		return false
+	}
+	// hide-stopped filter
+	if m.hideStopped && running != nil {
+		taskID := ""
+		if i < len(m.lineTasks) {
+			taskID = m.lineTasks[i]
+		}
+		// empty task ID => always visible (can't determine task state)
+		if taskID != "" && !running[taskID] {
+			return false
+		}
+	}
+	return true
 }
 
 // extractUniqueNodes returns a sorted list of nodes where the service has running tasks

--- a/views/logs/stream.go
+++ b/views/logs/stream.go
@@ -97,11 +97,11 @@ func (m *Model) startStreamingCmd(ctx context.Context, service docker.ServiceEnt
 				for sc.Scan() {
 					line := sc.Text()
 					// Format the log line with node information
-					formattedLine, nodeName := m.formatLogLineWithNode(service.ServiceName, line)
-					// Store both the formatted line and node name (separated by a special marker)
-					// Format: "NODENAME\x00formatted_line" where \x00 is a null byte separator
+					formattedLine, nodeName, taskID := m.formatLogLineWithNode(service.ServiceName, line)
+					// Store the formatted line, node name and task ID (separated by a special marker)
+					// Format: "NODENAME\x00TASKID\x00formatted_line" where \x00 is a null byte separator
 					select {
-					case lines <- nodeName + "\x00" + formattedLine:
+					case lines <- nodeName + "\x00" + taskID + "\x00" + formattedLine:
 					case <-ctx.Done():
 						return
 					}
@@ -167,9 +167,9 @@ func (m *Model) streamServiceLogsRawCLI(ctx context.Context, service docker.Serv
 	sc.Buffer(make([]byte, 0, 256*1024), 256*1024) // 256 KB to handle long TTY lines
 	for sc.Scan() {
 		line := sc.Text()
-		formattedLine, nodeName := m.formatLogLineWithNode(service.ServiceName, line)
+		formattedLine, nodeName, taskID := m.formatLogLineWithNode(service.ServiceName, line)
 		select {
-		case lines <- nodeName + "\x00" + formattedLine:
+		case lines <- nodeName + "\x00" + taskID + "\x00" + formattedLine:
 		case <-ctx.Done():
 			_ = cmd.Wait()
 			return nil
@@ -229,18 +229,18 @@ func (m *Model) StopStreamingCmd() tea.Cmd {
 
 // formatLogLineWithNode parses the Docker log details and formats the line with node information
 // Input format: "com.docker.swarm.node.id=xxx,com.docker.swarm.task.id=yyy actual log message"
-// Output format: formatted line and node name for filtering
-// Returns: ("service_name.task_id@node_name | actual log message", "node_name")
-func (m *Model) formatLogLineWithNode(serviceName string, line string) (string, string) {
+// Output format: formatted line, node name and full task ID for filtering
+// Returns: ("service_name.task_id@node_name | actual log message", "node_name", "task_id")
+func (m *Model) formatLogLineWithNode(serviceName string, line string) (string, string, string) {
 	// Check if line has Docker details prefix
 	if !strings.Contains(line, "com.docker.swarm.") {
-		return line, ""
+		return line, "", ""
 	}
 
 	// Split on first space to separate details from message
 	parts := strings.SplitN(line, " ", 2)
 	if len(parts) != 2 {
-		return line, ""
+		return line, "", ""
 	}
 
 	details := parts[0]
@@ -283,7 +283,7 @@ func (m *Model) formatLogLineWithNode(serviceName string, line string) (string, 
 	// ANSI escape: \033[38;5;117m for foreground color 117, \033[0m to reset
 	prefix := fmt.Sprintf("\033[38;5;117m%s.%s@%s\033[0m", serviceName, taskIDShort, nodeName)
 
-	return fmt.Sprintf("%s | %s", prefix, message), nodeName
+	return fmt.Sprintf("%s | %s", prefix, message), nodeName, taskID
 }
 
 // getNodeHostname retrieves the hostname for a node ID from the snapshot

--- a/views/logs/update.go
+++ b/views/logs/update.go
@@ -27,12 +27,13 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 		return m.readOneLineCmd()
 
 	case LineMsg:
-		// Parse node name from the line (format: "nodename\x00actual_line")
-		parts := strings.SplitN(msg.Line, "\x00", 2)
-		var nodeName, actualLine string
-		if len(parts) == 2 {
+		// Parse node name and task ID (format: "nodename\x00taskid\x00actual_line")
+		parts := strings.SplitN(msg.Line, "\x00", 3)
+		var nodeName, taskID, actualLine string
+		if len(parts) == 3 {
 			nodeName = parts[0]
-			actualLine = parts[1]
+			taskID = parts[1]
+			actualLine = parts[2]
 		} else {
 			actualLine = msg.Line
 		}
@@ -40,11 +41,12 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 		// Strip carriage returns that break frame rendering (progress bars, CRLF)
 		actualLine = strings.ReplaceAll(actualLine, "\r", "")
 
-		// append line into bounded buffer (store both line and node)
+		// append line into bounded buffer (store line, node and task)
 		m.mu.Lock()
 		// store line as-is (no newline); rendering will join with '\n'
 		m.lines = append(m.lines, actualLine)
 		m.lineNodes = append(m.lineNodes, nodeName)
+		m.lineTasks = append(m.lineTasks, taskID)
 
 		// track how many lines we're dropping from the top
 		linesDropped := 0
@@ -61,6 +63,10 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 			newNodeBuf := make([]string, 0, m.MaxLines)
 			newNodeBuf = append(newNodeBuf, m.lineNodes[start:]...)
 			m.lineNodes = newNodeBuf
+
+			newTaskBuf := make([]string, 0, m.MaxLines)
+			newTaskBuf = append(newTaskBuf, m.lineTasks[start:]...)
+			m.lineTasks = newTaskBuf
 		}
 
 		// update searchMatches incrementally
@@ -68,7 +74,7 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 			if linesDropped > 0 && m.searchMatches != nil {
 				// Lines dropped from top invalidate visible indices; recompute on next n/N
 				m.searchMatches = nil
-			} else if m.nodeFilter == "" && m.filterQuery == "" {
+			} else if m.nodeFilter == "" && m.filterQuery == "" && !m.hideStopped {
 				// Simple case: no filters, raw index equals visible index
 				if strings.Contains(strings.ToLower(actualLine), strings.ToLower(m.searchTerm)) {
 					m.searchMatches = append(m.searchMatches, len(m.lines)-1)
@@ -116,6 +122,8 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 		// append an error line and stop
 		m.mu.Lock()
 		m.lines = append(m.lines, fmt.Sprintf("Error: %v", msg.Err))
+		m.lineNodes = append(m.lineNodes, "")
+		m.lineTasks = append(m.lineTasks, "")
 		m.mu.Unlock()
 		l().Errorf("[logsview] stream error: %v", msg.Err)
 		if m.ready {
@@ -126,6 +134,8 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 	case StreamDoneMsg:
 		m.mu.Lock()
 		m.lines = append(m.lines, "--- stream closed ---")
+		m.lineNodes = append(m.lineNodes, "")
+		m.lineTasks = append(m.lineTasks, "")
 		m.mu.Unlock()
 		l().Debugf("[logsview] stream closed")
 		if m.ready {
@@ -165,6 +175,17 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 		// because existing lines need to be filtered/unfiltered
 		if m.ready {
 			m.viewport.SetContent(m.buildContent())
+			if m.getFollow() {
+				m.viewport.GotoBottom()
+			}
+		}
+		return nil
+
+	case HideStoppedToggledMsg:
+		// The visible set changed; recompute search-match indices (this also
+		// rebuilds the viewport content) and re-anchor to the bottom if following.
+		if m.ready {
+			m.highlightContent()
 			if m.getFollow() {
 				m.viewport.GotoBottom()
 			}
@@ -261,6 +282,11 @@ func (m *Model) SetContent(content string) {
 		start := len(m.lines) - m.MaxLines
 		m.lines = append([]string{}, m.lines[start:]...)
 	}
+	// SetContent carries no per-line node/task metadata; reset the parallel
+	// slices to empty (length-aligned) so all lines are treated as
+	// unfilterable (always visible) and indices stay aligned.
+	m.lineNodes = make([]string, len(m.lines))
+	m.lineTasks = make([]string, len(m.lines))
 	m.searchMatches = nil
 	m.searchTerm = ""
 	m.searchIndex = 0
@@ -283,14 +309,15 @@ func (m *Model) highlightContent() {
 		m.searchMatches = []int{}
 		lower := strings.ToLower(m.searchTerm)
 		m.mu.Lock()
+		var running map[string]bool
+		if m.hideStopped {
+			running = m.runningTaskIDs()
+		}
 		visibleIdx := 0
 		for i, L := range m.lines {
-			// Skip lines hidden by node filter
-			if m.nodeFilter != "" && (i >= len(m.lineNodes) || m.lineNodes[i] != m.nodeFilter) {
-				continue
-			}
-			// Skip lines hidden by filterQuery
-			if m.filterQuery != "" && !strings.Contains(strings.ToLower(L), strings.ToLower(m.filterQuery)) {
+			// Skip lines hidden by any active filter (must match buildContent
+			// exactly so search-match indices line up with the rendered output).
+			if !m.lineVisible(i, running) {
 				continue
 			}
 			if strings.Contains(strings.ToLower(L), lower) {
@@ -317,31 +344,17 @@ func (m *Model) buildContent() string {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	// Apply node filter
-	nodeFilter := m.nodeFilter
-	var filteredLines []string
-	if nodeFilter != "" {
-		// Filter lines by node
-		for i, line := range m.lines {
-			if i < len(m.lineNodes) && m.lineNodes[i] == nodeFilter {
-				filteredLines = append(filteredLines, line)
-			}
-		}
-	} else {
-		// No filter, use all lines
-		filteredLines = m.lines
+	// Apply all active filters (node, "/" text, hide-stopped) in a single pass
+	// via the shared predicate so the visible set matches highlightContent.
+	var running map[string]bool
+	if m.hideStopped {
+		running = m.runningTaskIDs()
 	}
-
-	// Apply text filter (app-level "/" search)
-	if m.filterQuery != "" {
-		lower := strings.ToLower(m.filterQuery)
-		var textFiltered []string
-		for _, line := range filteredLines {
-			if strings.Contains(strings.ToLower(line), lower) {
-				textFiltered = append(textFiltered, line)
-			}
+	var filteredLines []string
+	for i, line := range m.lines {
+		if m.lineVisible(i, running) {
+			filteredLines = append(filteredLines, line)
 		}
-		filteredLines = textFiltered
 	}
 
 	// Join lines first

--- a/views/logs/view.go
+++ b/views/logs/view.go
@@ -24,12 +24,17 @@ func (m *Model) FrameTitle() string {
 	if nodeFilter != "" {
 		filterStatus = fmt.Sprintf("node: %s", nodeFilter)
 	}
+	stoppedStatus := "hidden"
+	if !m.getHideStopped() {
+		stoppedStatus = "shown"
+	}
 	return fmt.Sprintf(
-		"Service: %s • AutoScroll: %s • wrap: %s • Filter: %s",
+		"Service: %s • AutoScroll: %s • wrap: %s • Filter: %s • Stopped: %s",
 		m.ServiceEntry.ServiceName,
 		followStatus,
 		wrapStatus,
 		filterStatus,
+		stoppedStatus,
 	)
 }
 


### PR DESCRIPTION
## Summary

Closes #388. The log view streams `docker service logs`, which the Docker API aggregates across **all** of a service's tasks — including the stopped containers of previous deployments. After a redeploy this mixes old/dead logs into the tail view. This hides stopped-task logs **by default**, with a `t` toggle to bring them back.

Each log line already carries `com.docker.swarm.task.id` (the stream sets `Details: true`), so we plumb the full task ID per line and hide lines whose task is no longer `DesiredState == Running`, derived from the snapshot **at render time** (so it tracks current cluster state). This matches the existing `extractUniqueNodes` convention.

## Behaviour

- Default: only currently-running tasks' lines are shown. FrameTitle reads `Stopped: hidden`.
- Press `t` to toggle → old/stopped lines appear, title reads `Stopped: shown`.
- Lines with **no parseable task ID** (tty/raw service logs, `Error:` lines, `--- stream closed ---`) always stay visible.
- **Fail-open:** when no snapshot is available yet, all lines are shown (no crash on startup).

## Implementation notes

- `lineTasks []string` parallel slice tracks the full task ID per line, kept in lock-step with `lines`/`lineNodes` on append, MaxLines trim, stream err/done, and `SetContent` (which also resets the previously-stale `lineNodes`).
- A single `lineVisible()` predicate is shared by `buildContent()` and `highlightContent()` so the node filter, `/` text filter, and hide-stopped filter compose, and `n`/`N` search-match indices stay aligned with the rendered output.

## Testing

`go build ./...`, `go vet`, `gofmt -l`, `golangci-lint run` (0 issues), full `go test ./...`, and `go test -race ./views/logs/...` all pass. Added 9 new unit tests (default state, toggle key, hide/show, fail-open, empty-task-ID always visible, search-index sync, SetContent reset) and updated existing tests for the 3-field marker / title / help changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)