### PR TITLE
ci(goreleaser): skip cask/scoop upload on prereleases

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -118,6 +118,8 @@ changelog:
 # Homebrew tap (cask)
 homebrew_casks:
   - name: swarmcli
+    # Don't update the public tap for prereleases (-rc) or snapshots; GA only.
+    skip_upload: "auto"
     ids:
       - default
     binaries:
@@ -147,6 +149,8 @@ homebrew_casks:
 # Scoop bucket for Windows
 scoops:
   - name: swarmcli
+    # Don't update the public bucket for prereleases (-rc) or snapshots; GA only.
+    skip_upload: "auto"
     ids:
       - default
     repository:


### PR DESCRIPTION
Add `skip_upload: "auto"` to `homebrew_casks` and `scoops` so RC/snapshot tags no longer publish to the public Homebrew tap / Scoop bucket; GA releases still publish. Docker images are unaffected (RCs still build, and `:latest` is already guarded by the dockers_v2 prerelease check). `goreleaser check` passes.