### PR TITLE
fix(services): content-aware column widths, drop redundant STACK (#392)

### DIFF
--- a/views/services/columns.go
+++ b/views/services/columns.go
@@ -1,0 +1,222 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package servicesview
+
+import (
+	"fmt"
+	"unicode/utf8"
+
+	"swarmcli/docker"
+	filterlist "swarmcli/ui/components/filterable/list"
+)
+
+// colID identifies a logical services column independent of its position in the
+// active column set (the STACK column is dropped outside the All-Services scope).
+type colID int
+
+const (
+	colService colID = iota
+	colStack
+	colReplicas
+	colStatus
+	colMode
+	colImage
+	colPorts
+	colCreated
+	colUpdated
+	colError
+)
+
+// colSpec is the single source of truth for a services column: its header label,
+// width policy, sort mapping, and how to extract its cell text from an entry.
+// Header labels, sort indices, column widths, and row cells all derive from the
+// active []colSpec so they can never drift out of sync.
+type colSpec struct {
+	id       colID
+	label    string
+	minWidth int  // content floor (excludes the inter-column gap)
+	flex     bool // absorbs leftover slack; horizontally scrolls when truncated on a selected row
+	sort     SortField
+	hasSort  bool
+	cell     func(m *Model, e docker.ServiceEntry) string
+}
+
+// servicesColumnTemplate is the canonical, ordered set of all services columns.
+// activeColumns derives the per-scope subset from it.
+var servicesColumnTemplate = []colSpec{
+	{id: colService, label: "SERVICE", minWidth: 8, flex: true, sort: SortByName, hasSort: true,
+		cell: func(_ *Model, e docker.ServiceEntry) string { return e.ServiceName }},
+	{id: colStack, label: "STACK", minWidth: 6,
+		cell: func(_ *Model, e docker.ServiceEntry) string { return e.StackName }},
+	{id: colReplicas, label: "REPLICAS", minWidth: 5,
+		cell: func(_ *Model, e docker.ServiceEntry) string {
+			if e.ReplicasTotal == 0 {
+				return "—"
+			}
+			return fmt.Sprintf("%d/%d", e.ReplicasOnNode, e.ReplicasTotal)
+		}},
+	{id: colStatus, label: "STATUS", minWidth: 8, sort: SortByStatus, hasSort: true,
+		cell: func(_ *Model, e docker.ServiceEntry) string { return e.Status }},
+	{id: colMode, label: "MODE", minWidth: 6,
+		cell: func(_ *Model, e docker.ServiceEntry) string { return e.Mode }},
+	{id: colImage, label: "IMAGE", minWidth: 8, flex: true, sort: SortByImage, hasSort: true,
+		cell: func(_ *Model, e docker.ServiceEntry) string { return e.Image }},
+	{id: colPorts, label: "PORTS", minWidth: 5, flex: true, sort: SortByPorts, hasSort: true,
+		cell: func(_ *Model, e docker.ServiceEntry) string { return e.Ports }},
+	{id: colCreated, label: "CREATED", minWidth: 7, sort: SortByCreated, hasSort: true,
+		cell: func(_ *Model, e docker.ServiceEntry) string { return formatRelativeTime(e.CreatedAt) }},
+	{id: colUpdated, label: "UPDATED", minWidth: 7, sort: SortByUpdated, hasSort: true,
+		cell: func(_ *Model, e docker.ServiceEntry) string { return formatRelativeTime(e.UpdatedAt) }},
+	{id: colError, label: "ERROR", minWidth: 6, flex: true, sort: SortByError, hasSort: true,
+		cell: func(m *Model, e docker.ServiceEntry) string { return m.serviceErrorText[e.ServiceID] }},
+}
+
+// activeColumns returns the columns to render for the current scope. The STACK
+// column is dropped unless we're showing services from every stack (AllFilter),
+// since in a single-stack/node scope every row carries the same stack value.
+func (m *Model) activeColumns() []colSpec {
+	if m.filterType == AllFilter {
+		return servicesColumnTemplate
+	}
+	return without(servicesColumnTemplate, colStack)
+}
+
+// activeColumnLabels returns just the labels of the active columns, for building
+// the filterable-list header.
+func (m *Model) activeColumnLabels() []string {
+	active := m.activeColumns()
+	labels := make([]string, len(active))
+	for i, c := range active {
+		labels[i] = c.label
+	}
+	return labels
+}
+
+// headerColumns builds the filterable-list header column set from labels.
+func headerColumns(labels []string) []filterlist.ColumnDef {
+	cols := make([]filterlist.ColumnDef, len(labels))
+	for i, l := range labels {
+		cols[i] = filterlist.ColumnDef{Label: l}
+	}
+	return cols
+}
+
+// sortIndicator reports which active column carries the current sort field and
+// the sort direction, so the header arrow tracks the column even when STACK is
+// dropped and indices shift.
+func (m *Model) sortIndicator() (int, bool) {
+	for i, spec := range m.activeColumns() {
+		if spec.hasSort && spec.sort == m.sortField {
+			return i, m.sortAscending
+		}
+	}
+	return -1, true
+}
+
+func without(specs []colSpec, id colID) []colSpec {
+	out := make([]colSpec, 0, len(specs))
+	for _, s := range specs {
+		if s.id != id {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+// colGap is the guaranteed minimum space between adjacent columns. It is baked
+// into every column's returned width as trailing padding, so the gap survives
+// even when columns are shrunk to their floors on a narrow terminal.
+const colGap = 1
+
+// distributeSlack spreads leftover width across the flex columns, giving the
+// rounding remainder to the first flex column (SERVICE) so names grow first.
+func distributeSlack(content []int, flex []bool, slack int) {
+	if slack <= 0 {
+		return
+	}
+	var idx []int
+	for i, f := range flex {
+		if f {
+			idx = append(idx, i)
+		}
+	}
+	if len(idx) == 0 {
+		return
+	}
+	per := slack / len(idx)
+	for _, i := range idx {
+		content[i] += per
+	}
+	content[idx[0]] += slack % len(idx)
+}
+
+// shrinkColumns removes overflow width, taking from flex columns first and then
+// non-flex columns, never below each column's floor so the header label still
+// fits and the trailing gap always survives.
+func shrinkColumns(content, floors []int, flex []bool, overflow int) {
+	overflow = shrinkGroup(content, floors, flex, overflow, true)
+	if overflow > 0 {
+		shrinkGroup(content, floors, flex, overflow, false)
+	}
+}
+
+// shrinkGroup reduces the columns whose flex flag matches flexOnly by up to
+// overflow cells total, distributed proportionally to each column's shrinkable
+// room. Returns the overflow it could not absorb.
+func shrinkGroup(content, floors []int, flex []bool, overflow int, flexOnly bool) int {
+	if overflow <= 0 {
+		return 0
+	}
+	room := 0
+	for i := range content {
+		if flex[i] == flexOnly {
+			room += content[i] - floors[i]
+		}
+	}
+	if room <= 0 {
+		return overflow
+	}
+	take := overflow
+	if take > room {
+		take = room
+	}
+	removed := 0
+	for i := range content {
+		if flex[i] != flexOnly {
+			continue
+		}
+		r := content[i] - floors[i]
+		if r <= 0 {
+			continue
+		}
+		cut := take * r / room
+		content[i] -= cut
+		removed += cut
+	}
+	// Assign rounding leftover one cell at a time to columns with room.
+	for leftover := take - removed; leftover > 0; {
+		progressed := false
+		for i := range content {
+			if leftover == 0 {
+				break
+			}
+			if flex[i] == flexOnly && content[i] > floors[i] {
+				content[i]--
+				leftover--
+				progressed = true
+			}
+		}
+		if !progressed {
+			break
+		}
+	}
+	return overflow - take
+}
+
+// displayWidth reports the rendered width of s in terminal cells. Service and
+// image names are ASCII in practice, but counting runes (not bytes) keeps width
+// measurement consistent with truncateWithEllipsis for any multibyte content.
+func displayWidth(s string) int {
+	return utf8.RuneCountInString(s)
+}

--- a/views/services/columns_test.go
+++ b/views/services/columns_test.go
@@ -1,0 +1,172 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package servicesview
+
+import (
+	"strings"
+	"testing"
+
+	"swarmcli/docker"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/stretchr/testify/require"
+)
+
+const longServiceName = "myproject_some-very-long-service-name"
+
+// loadWithFilter pushes entries into the model under a given scope.
+func loadWithFilter(m *Model, ft FilterType, entries []docker.ServiceEntry) {
+	m.Update(Msg{Title: "T", Entries: entries, FilterType: ft})
+}
+
+// colIndex returns the position of a column id in the active set, or -1.
+func colIndex(m *Model, id colID) int {
+	for i, spec := range m.activeColumns() {
+		if spec.id == id {
+			return i
+		}
+	}
+	return -1
+}
+
+func TestActiveColumns_StackOnlyInAllFilter(t *testing.T) {
+	cases := []struct {
+		ft         FilterType
+		wantStack  bool
+		wantLength int
+	}{
+		{AllFilter, true, len(servicesColumnTemplate)},
+		{StackFilter, false, len(servicesColumnTemplate) - 1},
+		{NodeFilter, false, len(servicesColumnTemplate) - 1},
+		{NoStackFilter, false, len(servicesColumnTemplate) - 1},
+	}
+	for _, tc := range cases {
+		m := testModel()
+		m.filterType = tc.ft
+		active := m.activeColumns()
+		require.Len(t, active, tc.wantLength, "filter %v", tc.ft)
+		require.Equal(t, tc.wantStack, colIndex(m, colStack) >= 0, "filter %v stack presence", tc.ft)
+	}
+}
+
+func TestComputeColWidths_LengthMatchesHeader(t *testing.T) {
+	for _, ft := range []FilterType{AllFilter, StackFilter, NodeFilter, NoStackFilter} {
+		m := testModel()
+		loadWithFilter(m, ft, fakeEntries("web", "api"))
+		widths := m.computeColWidths(120)
+		require.Len(t, widths, len(m.activeColumns()), "filter %v", ft)
+		require.Len(t, widths, len(m.List.Header.Columns), "filter %v header sync", ft)
+	}
+}
+
+func TestComputeColWidths_WideTerminal_ServiceFits(t *testing.T) {
+	m := testModel()
+	loadWithFilter(m, AllFilter, fakeEntries(longServiceName, "api"))
+
+	width := 200
+	widths := m.computeColWidths(width)
+
+	// Column 0 renders with a leading space and a trailing gap, so its usable
+	// content width is colWidths[0]-colGap-1. It must fit the full name.
+	svc := colIndex(m, colService)
+	content0 := widths[svc] - colGap - 1
+	require.GreaterOrEqual(t, content0, displayWidth(longServiceName),
+		"SERVICE column must show the full name on a wide terminal")
+
+	sum := 0
+	for _, w := range widths {
+		sum += w
+	}
+	require.LessOrEqual(t, sum, width, "columns must fit the viewport when content is small")
+}
+
+func TestComputeColWidths_GapPreservedWhenNarrow(t *testing.T) {
+	m := testModel()
+	long := fakeEntries(longServiceName, "another-fairly-long-service-name")
+	long[0].Image = "registry.example.com/team/very/long/image/path:tag"
+	long[0].Ports = "8080:8080,9090:9090,7070:7070"
+	loadWithFilter(m, AllFilter, long)
+
+	widths := m.computeColWidths(40)
+	active := m.activeColumns()
+
+	// Even fully truncated, every column keeps room for its (untruncated) header
+	// label plus the inter-column gap, so labels stay readable, the header can't
+	// overflow, and columns never merge.
+	for i, spec := range active {
+		require.GreaterOrEqual(t, widths[i]-colGap, displayWidth(spec.label),
+			"column %q must retain at least its label width", spec.label)
+	}
+}
+
+func TestComputeColWidths_EmptyAndZeroWidth(t *testing.T) {
+	m := testModel()
+	loadWithFilter(m, AllFilter, nil) // empty list
+
+	require.NotPanics(t, func() {
+		w := m.computeColWidths(0) // zero width behaves as 80
+		require.Len(t, w, len(m.activeColumns()))
+		for i, spec := range m.activeColumns() {
+			require.GreaterOrEqual(t, w[i], spec.minWidth, "column %q at least label/min width", spec.label)
+		}
+	})
+}
+
+func TestSortIndicator_ResolvesActiveIndex(t *testing.T) {
+	// AllFilter: SERVICE,STACK,REPLICAS,STATUS,... -> STATUS at index 3.
+	mAll := testModel()
+	mAll.filterType = AllFilter
+	mAll.sortField = SortByStatus
+	idx, asc := mAll.sortIndicator()
+	require.Equal(t, 3, idx)
+	require.True(t, asc)
+
+	// StackFilter drops STACK: SERVICE,REPLICAS,STATUS,... -> STATUS at index 2.
+	mStack := testModel()
+	mStack.filterType = StackFilter
+	mStack.sortField = SortByStatus
+	mStack.sortAscending = false
+	idx, asc = mStack.sortIndicator()
+	require.Equal(t, 2, idx)
+	require.False(t, asc)
+}
+
+func TestView_FullServiceNameOnWideTerminal(t *testing.T) {
+	m := testModel()
+	loadWithFilter(m, AllFilter, fakeEntries(longServiceName, "api"))
+	m.setRenderItem()
+	m.List.Viewport.Width = 200
+	m.List.Viewport.Height = 20
+
+	out := m.View()
+	require.Contains(t, out, longServiceName, "full name must be visible, not truncated (#392)")
+}
+
+func TestHeaderRowAlignment(t *testing.T) {
+	// Header and rows must share the same total width (sum of colWidths) across
+	// scopes and sort fields, including the sorted column's " ▲" indicator.
+	for _, ft := range []FilterType{AllFilter, StackFilter} {
+		for _, sf := range []SortField{SortByName, SortByStatus, SortByCreated, SortByError} {
+			m := testModel()
+			loadWithFilter(m, ft, fakeEntries(longServiceName, "api"))
+			m.sortField = sf
+			m.setRenderItem()
+			for _, w := range []int{40, 120, 200} {
+				m.List.Viewport.Width = w
+				header := m.List.RenderHeader()
+				row := m.List.RenderItem(m.List.Filtered[0], false, 0)
+				require.Equal(t, lipgloss.Width(header), lipgloss.Width(row),
+					"filter=%v sort=%v width=%d header/row width mismatch", ft, sf, w)
+			}
+		}
+	}
+}
+
+func TestTruncateWithEllipsis_RuneAware(t *testing.T) {
+	require.Equal(t, "héllo", truncateWithEllipsis("héllo", 5))
+	require.Equal(t, "hé…", truncateWithEllipsis("héllo", 3))
+	require.Equal(t, "…", truncateWithEllipsis("héllo", 1))
+	// Byte-based slicing would have split the multibyte rune; rune-based must not.
+	require.True(t, strings.HasSuffix(truncateWithEllipsis("héllo", 3), "…"))
+}

--- a/views/services/model.go
+++ b/views/services/model.go
@@ -51,10 +51,6 @@ type Model struct {
 	height       int
 	lastSnapshot uint64 // hash of last snapshot for change detection
 
-	// Column widths cached after computation
-	colServiceWidth int
-	colStackWidth   int
-
 	// Filter
 	filterType FilterType
 	nodeID     string
@@ -116,23 +112,9 @@ func New(width, height int) *Model {
 			return strings.Contains(strings.ToLower(s.ServiceName), strings.ToLower(query))
 		},
 		Header: &filterlist.HeaderConfig{
-			Columns: []filterlist.ColumnDef{
-				{Label: "SERVICE"}, {Label: "STACK"}, {Label: "REPLICAS"},
-				{Label: "STATUS"}, {Label: "MODE"}, {Label: "IMAGE"},
-				{Label: "PORTS"}, {Label: "CREATED"}, {Label: "UPDATED"}, {Label: "ERROR"},
-			},
+			Columns:       headerColumns(m.activeColumnLabels()),
 			ColWidthsFunc: m.computeColWidths,
-			SortIndicator: func() (int, bool) {
-				colMap := map[SortField]int{
-					SortByName: 0, SortByStatus: 3, SortByImage: 5,
-					SortByPorts: 6, SortByCreated: 7, SortByUpdated: 8, SortByError: 9,
-				}
-				col, ok := colMap[m.sortField]
-				if !ok {
-					return -1, true
-				}
-				return col, m.sortAscending
-			},
+			SortIndicator: m.sortIndicator,
 		},
 		Footer: &filterlist.FooterConfig{ItemLabel: "Node"},
 	}

--- a/views/services/update.go
+++ b/views/services/update.go
@@ -25,18 +25,18 @@ import (
 	"github.com/docker/docker/api/types/swarm"
 )
 
-// truncateWithEllipsis truncates a string to maxWidth, adding … if needed
+// truncateWithEllipsis truncates a string to maxWidth runes, adding … if needed.
+// It counts and slices by runes so width measurement (displayWidth) and the
+// truncated output agree on multibyte content.
 func truncateWithEllipsis(s string, maxWidth int) string {
-	if len(s) <= maxWidth {
+	r := []rune(s)
+	if len(r) <= maxWidth {
 		return s
 	}
 	if maxWidth <= 1 {
 		return "…"
 	}
-	if maxWidth == 2 {
-		return s[:1] + "…"
-	}
-	return s[:maxWidth-1] + "…"
+	return string(r[:maxWidth-1]) + "…"
 }
 
 func (m *Model) Update(msg tea.Msg) tea.Cmd {
@@ -644,6 +644,13 @@ func (m *Model) SetContent(msg Msg) {
 	m.nodeID = msg.NodeID
 	m.stackName = msg.StackName
 
+	// Rebuild the header to match the active column set for this scope (STACK is
+	// dropped outside AllFilter). Header, widths, sort indices, and rows all
+	// derive from activeColumns so they stay consistent.
+	if m.List.Header != nil {
+		m.List.Header.Columns = headerColumns(m.activeColumnLabels())
+	}
+
 	m.setRenderItem()
 
 	if m.ready {
@@ -775,58 +782,74 @@ func (m *Model) refreshServiceErrorsFromSnapshot() {
 	}
 }
 
-// computeColWidths centralizes column width calculation so header and rows
-// use the exact same sizes. Uses equal division like CONFIG view.
+// computeColWidths sizes the active columns to their content so wide terminals
+// no longer truncate names while space sits empty, and guarantees at least one
+// space between columns. Each returned width includes a trailing gap; the row
+// and header renderers left-align text into it, so the gap is trailing padding.
+// Header and rows stay aligned because both derive from this same array and the
+// same active column set.
 func (m *Model) computeColWidths(width int) []int {
 	if width <= 0 {
 		width = 80
 	}
-	cols := 10
-	starts := make([]int, cols)
-	for i := 0; i < cols; i++ {
-		starts[i] = (i * width) / cols
-	}
-	colWidths := make([]int, cols)
-	for i := 0; i < cols; i++ {
-		if i == cols-1 {
-			colWidths[i] = width - starts[i]
-		} else {
-			colWidths[i] = starts[i+1] - starts[i]
-		}
-		if colWidths[i] < 1 {
-			colWidths[i] = 1
-		}
+	active := m.activeColumns()
+	n := len(active)
+	if n == 0 {
+		return nil
 	}
 
-	// Ensure STATUS and UPDATED columns have at least 10 chars
-	minStatus := 10
-	minUpdated := 10
-	cur := colWidths[3] + colWidths[8]
-	if cur < minStatus+minUpdated {
-		deficit := minStatus + minUpdated - cur
-		for i := 2; i >= 0 && deficit > 0; i-- {
-			take := deficit
-			if colWidths[i] > take+5 {
-				colWidths[i] -= take
-				deficit = 0
-			} else {
-				take = colWidths[i] - 5
-				if take > 0 {
-					colWidths[i] -= take
-					deficit -= take
-				}
+	content := make([]int, n)
+	floors := make([]int, n)
+	flex := make([]bool, n)
+	sum := 0
+	for i, spec := range active {
+		// Floor: the header label is never truncated by the shared renderer, so a
+		// column must never shrink below its label width (plus the sort indicator
+		// on the active sort column) or the header overflows and misaligns with
+		// the rows. Also honour the column's declared minimum.
+		fl := displayWidth(spec.label)
+		if spec.hasSort && spec.sort == m.sortField {
+			fl += 2 // " ▲"/" ▼"
+		}
+		if fl < spec.minWidth {
+			fl = spec.minWidth
+		}
+		if fl < 3 {
+			fl = 3
+		}
+
+		// Natural content width: the widest of the floor and any cell.
+		w := fl
+		for _, e := range m.List.Filtered {
+			if cw := displayWidth(spec.cell(m, e)); cw > w {
+				w = cw
 			}
 		}
-		if colWidths[3] < minStatus {
-			colWidths[3] = minStatus
-		}
-		if colWidths[8] < minUpdated {
-			colWidths[8] = minUpdated
-		}
+		floors[i] = fl
+		content[i] = w
+		flex[i] = spec.flex
+		sum += w
 	}
 
-	if colWidths[2] < 1 {
-		colWidths[2] = 1
+	// Column 0 renders with a leading space (header convention); reserve one
+	// extra cell in both its natural width and its floor so the leading space
+	// never eats into the trailing gap.
+	content[0]++
+	floors[0]++
+	sum++
+
+	need := sum + colGap*n
+	switch {
+	case need < width:
+		// Hand the leftover to flex columns (SERVICE first via the remainder).
+		distributeSlack(content, flex, width-need)
+	case need > width:
+		shrinkColumns(content, floors, flex, need-width)
+	}
+
+	colWidths := make([]int, n)
+	for i := range content {
+		colWidths[i] = content[i] + colGap
 	}
 	return colWidths
 }
@@ -834,83 +857,45 @@ func (m *Model) computeColWidths(width int) []int {
 func (m *Model) setRenderItem() {
 	// Use shared computation for column widths to keep header and rows in sync
 	m.List.RenderItem = func(e docker.ServiceEntry, selected bool, _ int) string {
+		active := m.activeColumns()
 		colWidths := m.List.ColWidths()
-		if len(colWidths) < 10 {
+		if len(colWidths) != len(active) {
 			return e.ServiceName
 		}
 
-		// Cache for header alignment
-		m.colServiceWidth = colWidths[0]
-		m.colStackWidth = colWidths[1]
-
-		// Prepare texts
-		replicasText := fmt.Sprintf("%d/%d", e.ReplicasOnNode, e.ReplicasTotal)
-		if e.ReplicasTotal == 0 {
-			replicasText = "—"
+		// Build each column cell from the active column set so header, widths,
+		// and rows stay in lockstep. Flex columns horizontally scroll when the
+		// selected row's content is truncated; every column keeps a trailing gap.
+		cells := make([]string, len(active))
+		for i, spec := range active {
+			raw := spec.cell(m, e)
+			cw := colWidths[i] - colGap
+			lead := ""
+			if i == 0 {
+				// Column 0 carries a leading space matching the header convention.
+				lead = " "
+				cw--
+			}
+			if cw < 1 {
+				cw = 1
+			}
+			var text string
+			if selected && spec.flex && displayWidth(raw) > cw {
+				text = formatErrorWithScroll(raw, m.columnScrollOffset, cw)
+			} else {
+				text = truncateWithEllipsis(raw, cw)
+			}
+			cells[i] = fmt.Sprintf("%s%-*s", lead, colWidths[i]-len(lead), text)
 		}
-
-		// For selected row, apply scrolling only to columns that are actually truncated
-		var serviceName, stackName, statusText, modeText, imageText, portsText, created, updated, errText string
-
-		if selected {
-			// Check each column - only scroll if truncated
-			if len(e.ServiceName) > colWidths[0]-1 {
-				serviceName = formatErrorWithScroll(e.ServiceName, m.columnScrollOffset, colWidths[0]-1)
-			} else {
-				serviceName = truncateWithEllipsis(e.ServiceName, colWidths[0]-1)
-			}
-
-			if len(e.Image) > colWidths[5] {
-				imageText = formatErrorWithScroll(e.Image, m.columnScrollOffset, colWidths[5])
-			} else {
-				imageText = truncateWithEllipsis(e.Image, colWidths[5])
-			}
-
-			if len(e.Ports) > colWidths[6] {
-				portsText = formatErrorWithScroll(e.Ports, m.columnScrollOffset, colWidths[6])
-			} else {
-				portsText = truncateWithEllipsis(e.Ports, colWidths[6])
-			}
-
-			errStr := m.serviceErrorText[e.ServiceID]
-			if len(errStr) > colWidths[9] {
-				errText = formatErrorWithScroll(errStr, m.columnScrollOffset, colWidths[9])
-			} else {
-				errText = truncateWithEllipsis(errStr, colWidths[9])
-			}
-
-			// These columns rarely need scrolling, just truncate
-			stackName = truncateWithEllipsis(e.StackName, colWidths[1])
-			statusText = truncateWithEllipsis(e.Status, colWidths[3])
-			modeText = truncateWithEllipsis(e.Mode, colWidths[4])
-			created = truncateWithEllipsis(formatRelativeTime(e.CreatedAt), colWidths[7])
-			updated = truncateWithEllipsis(formatRelativeTime(e.UpdatedAt), colWidths[8])
-		} else {
-			// For non-selected rows, just truncate normally
-			serviceName = truncateWithEllipsis(e.ServiceName, colWidths[0]-1)
-			stackName = truncateWithEllipsis(e.StackName, colWidths[1])
-			statusText = truncateWithEllipsis(e.Status, colWidths[3])
-			modeText = truncateWithEllipsis(e.Mode, colWidths[4])
-			imageText = truncateWithEllipsis(e.Image, colWidths[5])
-			portsText = truncateWithEllipsis(e.Ports, colWidths[6])
-			created = truncateWithEllipsis(formatRelativeTime(e.CreatedAt), colWidths[7])
-			updated = truncateWithEllipsis(formatRelativeTime(e.UpdatedAt), colWidths[8])
-			errText = truncateWithEllipsis(m.serviceErrorText[e.ServiceID], colWidths[9])
-		}
+		rowText := strings.Join(cells, "")
 
 		itemStyle := ui.ListItemStyle
-
-		// Build format string with all columns at once (like CONFIG view)
-		formatStr := fmt.Sprintf(" %%-%ds%%-%ds%%-%ds%%-%ds%%-%ds%%-%ds%%-%ds%%-%ds%%-%ds%%-%ds",
-			colWidths[0]-1, colWidths[1], colWidths[2], colWidths[3], colWidths[4],
-			colWidths[5], colWidths[6], colWidths[7], colWidths[8], colWidths[9])
 
 		var lineStr string
 		if selected && m.selectedTaskIndex == -1 {
 			// Only highlight service row if no task is selected
 			selBase := ui.ListSelectedStyle
-			lineStr = selBase.Render(fmt.Sprintf(formatStr,
-				serviceName, stackName, replicasText, statusText, modeText, imageText, portsText, created, updated, errText))
+			lineStr = selBase.Render(rowText)
 
 			// Ensure highlight background fills the full viewport width
 			if m.List.Viewport.Width > 0 {
@@ -923,12 +908,10 @@ func (m *Model) setRenderItem() {
 		} else if m.serviceHasError[e.ServiceID] {
 			// Color non-selected error rows red
 			errStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("9"))
-			lineStr = errStyle.Render(fmt.Sprintf(formatStr,
-				serviceName, stackName, replicasText, statusText, modeText, imageText, portsText, created, updated, errText))
+			lineStr = errStyle.Render(rowText)
 		} else {
 			// Normal rendering
-			lineStr = itemStyle.Render(fmt.Sprintf(formatStr,
-				serviceName, stackName, replicasText, statusText, modeText, imageText, portsText, created, updated, errText))
+			lineStr = itemStyle.Render(rowText)
 		}
 
 		// Check if service is expanded and add task rows


### PR DESCRIPTION
Fixes #392.

## Problem
The services view split the viewport into 10 **equal** column slices regardless of content, so the SERVICE name was truncated with `…` even on a wide terminal while STATUS/MODE/REPLICAS and an empty ERROR column sat half-empty. Columns also abutted with no separating space, and STACK was shown even when every row had the same stack.

## Change
- **Single source of truth for columns.** Replaced the four parallel hardcoded lists (header labels, the sort-index map, the width array, the row format specifiers) with one ordered `[]colSpec` (`views/services/columns.go`) carrying each column's label, sort field, width policy, and cell extractor. Header labels, sort indices, widths, and row cells all derive from it, so they can't drift out of sync.
- **Content-aware widths.** Each column sizes to the widest of its header label and any visible cell; a 1-space inter-column gap is baked into every width; leftover slack goes to the flex columns (SERVICE/IMAGE/PORTS/ERROR), and on overflow flex columns shrink first with floors that never drop below the (untruncated) header label — so the header stays aligned with rows and the gap always survives. The sorted column reserves room for its ` ▲`/` ▼` indicator.
- **STACK dropped when redundant.** Removed only outside the *All Services* scope (single stack/node), where every row carries the same value. Kept in *All Services* where it varies — see note below.
- **Rune-aware truncation.** `truncateWithEllipsis` now counts/slices by runes so width measurement and output agree.
- Selected-row horizontal scroll, full-width highlight, red error rows, and the expanded task sub-rows are unchanged.

## Note on the issue
The issue asked to "remove the stack column". I scoped that to *redundant* cases only: in the *All Services* view STACK is the only per-row stack indicator and genuinely varies, so removing it there would regress that view. It's dropped in single-stack/node scopes (the reporter's context) and kept in All-Services.

## Tests
New `views/services/columns_test.go`: STACK presence per scope, header/width length sync, full SERVICE name on a wide terminal (#392 regression), label-width floor preserved when narrow, empty/zero-width safety, sort-index resolution across the STACK shift, **header↔row width alignment across scopes/sort-fields/widths**, and rune-aware truncation. `go test ./...`, `go vet`, and `golangci-lint run ./views/services/...` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)