### PR TITLE
feat(ui): shared content-aware column layout for list views (#394)

### DIFF
--- a/ui/components/filterable/list/filerablelist.go
+++ b/ui/components/filterable/list/filerablelist.go
@@ -39,9 +39,16 @@ type FilterableList[T any] struct {
 	// Nil means no footer is rendered by RenderFooter/RenderFramedView.
 	Footer *FooterConfig
 
-	outerWidth  int
-	outerHeight int
-	colWidth    int
+	// Columns, when non-nil, enables the shared content-aware table layout:
+	// ColWidths sizes columns to content, RenderRow builds gapped/scrolled rows,
+	// and ScrollLeft/Right drive a unified horizontal scroll. Leave nil to keep
+	// the legacy equal/Pct width behavior unchanged.
+	Columns []Column[T]
+
+	outerWidth   int
+	outerHeight  int
+	colWidth     int
+	columnScroll int // unified horizontal scroll offset for flex columns (shared layout)
 }
 
 // SetOuterSize stores fallback dimensions from tea.WindowSizeMsg.
@@ -82,7 +89,43 @@ func (f *FilterableList[T]) ColWidths() []int {
 	if f.Header.ColWidthsFunc != nil {
 		return f.Header.ColWidthsFunc(w)
 	}
+	if f.Columns != nil {
+		return LayoutWidths(f.Columns, f.Filtered, w, f.sortColIndex())
+	}
 	return computeColWidths(f.Header.Columns, w)
+}
+
+// sortColIndex returns the active sort column index from the header's
+// SortIndicator, or -1 when there is none.
+func (f *FilterableList[T]) sortColIndex() int {
+	if f.Header == nil || f.Header.SortIndicator == nil {
+		return -1
+	}
+	col, _ := f.Header.SortIndicator()
+	return col
+}
+
+// RenderRow builds the plain (unstyled) row text for an item using the shared
+// content-aware layout. Callers apply their own styling/decoration.
+func (f *FilterableList[T]) RenderRow(item T, selected bool) string {
+	return RenderRow(f.Columns, f.ColWidths(), item, f.columnScroll, selected)
+}
+
+// ScrollLeft / ScrollRight / ResetColumnScroll drive the unified horizontal
+// scroll for flex columns on the selected row.
+func (f *FilterableList[T]) ScrollLeft() {
+	f.columnScroll -= 5
+	if f.columnScroll < 0 {
+		f.columnScroll = 0
+	}
+}
+
+func (f *FilterableList[T]) ScrollRight() {
+	f.columnScroll += 5
+}
+
+func (f *FilterableList[T]) ResetColumnScroll() {
+	f.columnScroll = 0
 }
 
 type ModeType int

--- a/ui/components/filterable/list/layout.go
+++ b/ui/components/filterable/list/layout.go
@@ -1,0 +1,261 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package filterlist
+
+import (
+	"fmt"
+	"strings"
+	"unicode/utf8"
+)
+
+// Column is a generic, view-agnostic column descriptor for the content-aware
+// table layout. A view declares its columns once; LayoutWidths and RenderRow
+// derive widths, the header, and each row from the same set so they can never
+// drift out of alignment.
+type Column[T any] struct {
+	Label    string         // header label; also the no-truncate width floor
+	MinWidth int            // declared content floor (excludes the inter-column gap)
+	Flex     bool           // absorbs leftover slack; horizontally scrolls when truncated on a selected row
+	Cell     func(T) string // extracts the plain cell text (the closure may capture model state)
+}
+
+// ColGap is the guaranteed minimum space between adjacent columns, baked into
+// every column's width as trailing padding so it survives even when columns are
+// shrunk to their floors on a narrow terminal.
+const ColGap = 1
+
+// displayWidth reports the rendered width of s in terminal cells, counting runes
+// (not bytes) so measurement agrees with rune-based truncation on multibyte text.
+func displayWidth(s string) int {
+	return utf8.RuneCountInString(s)
+}
+
+// TruncateRunes truncates s to maxWidth runes, adding … if needed. It slices by
+// runes so it never splits a multibyte character.
+func TruncateRunes(s string, maxWidth int) string {
+	r := []rune(s)
+	if len(r) <= maxWidth {
+		return s
+	}
+	if maxWidth <= 1 {
+		return "…"
+	}
+	return string(r[:maxWidth-1]) + "…"
+}
+
+// ScrollWindow returns the window of full beginning at offset runes, truncated to
+// maxWidth runes (with a trailing … when more remains to the right). Rune-based,
+// so the offset and width never split a multibyte character.
+func ScrollWindow(full string, offset, maxWidth int) string {
+	if full == "" {
+		return ""
+	}
+	r := []rune(full)
+	if offset > len(r) {
+		offset = len(r)
+	}
+	if offset < 0 {
+		offset = 0
+	}
+	return TruncateRunes(string(r[offset:]), maxWidth)
+}
+
+// ColumnDefs builds header ColumnDefs (labels only) from a generic column set,
+// keeping the header labels in lockstep with the layout columns.
+func ColumnDefs[T any](cols []Column[T]) []ColumnDef {
+	defs := make([]ColumnDef, len(cols))
+	for i, c := range cols {
+		defs[i] = ColumnDef{Label: c.Label}
+	}
+	return defs
+}
+
+// LayoutWidths sizes columns to their content so wide terminals no longer
+// truncate while space sits empty, and guarantees at least one space between
+// columns. sortCol is the index of the active sort column (-1 for none) so its
+// floor reserves room for the header's " ▲"/" ▼" indicator. Each returned width
+// includes the trailing gap; callers left-align text into it.
+func LayoutWidths[T any](cols []Column[T], items []T, totalWidth, sortCol int) []int {
+	if totalWidth <= 0 {
+		totalWidth = 80
+	}
+	n := len(cols)
+	if n == 0 {
+		return nil
+	}
+
+	content := make([]int, n)
+	floors := make([]int, n)
+	flex := make([]bool, n)
+	sum := 0
+	for i, c := range cols {
+		// Floor: the header label is never truncated by the renderer, so a column
+		// must never shrink below its label width (plus the sort indicator on the
+		// active sort column) or the header overflows and misaligns with the rows.
+		// Also honour the column's declared minimum.
+		fl := displayWidth(c.Label)
+		if i == sortCol {
+			fl += 2 // " ▲"/" ▼"
+		}
+		if fl < c.MinWidth {
+			fl = c.MinWidth
+		}
+		if fl < 3 {
+			fl = 3
+		}
+
+		// Natural content width: the widest of the floor and any cell.
+		w := fl
+		for _, it := range items {
+			if cw := displayWidth(c.Cell(it)); cw > w {
+				w = cw
+			}
+		}
+		floors[i] = fl
+		content[i] = w
+		flex[i] = c.Flex
+		sum += w
+	}
+
+	// Column 0 renders with a leading space (header convention); reserve one extra
+	// cell in both its natural width and its floor so the leading space never eats
+	// into the trailing gap.
+	content[0]++
+	floors[0]++
+	sum++
+
+	need := sum + ColGap*n
+	switch {
+	case need < totalWidth:
+		// Hand the leftover to flex columns (first flex column via the remainder).
+		distributeSlack(content, flex, totalWidth-need)
+	case need > totalWidth:
+		shrinkColumns(content, floors, flex, need-totalWidth)
+	}
+
+	widths := make([]int, n)
+	for i := range content {
+		widths[i] = content[i] + ColGap
+	}
+	return widths
+}
+
+// RenderRow builds the plain (unstyled) row text for an item: each column is
+// left-aligned into its width with a trailing gap; column 0 carries a leading
+// space matching the header. A selected flex column whose content overflows is
+// horizontally scrolled by scroll; otherwise content is rune-truncated.
+func RenderRow[T any](cols []Column[T], widths []int, item T, scroll int, selected bool) string {
+	if len(cols) == 0 {
+		return ""
+	}
+	if len(widths) != len(cols) {
+		return cols[0].Cell(item) // safe fallback; caller's width array is out of sync
+	}
+	cells := make([]string, len(cols))
+	for i, c := range cols {
+		raw := c.Cell(item)
+		cw := widths[i] - ColGap
+		lead := ""
+		if i == 0 {
+			lead = " "
+			cw--
+		}
+		if cw < 1 {
+			cw = 1
+		}
+		var text string
+		if selected && c.Flex && displayWidth(raw) > cw {
+			text = ScrollWindow(raw, scroll, cw)
+		} else {
+			text = TruncateRunes(raw, cw)
+		}
+		cells[i] = fmt.Sprintf("%s%-*s", lead, widths[i]-len(lead), text)
+	}
+	return strings.Join(cells, "")
+}
+
+// distributeSlack spreads leftover width across the flex columns, giving the
+// rounding remainder to the first flex column so it grows first.
+func distributeSlack(content []int, flex []bool, slack int) {
+	if slack <= 0 {
+		return
+	}
+	var idx []int
+	for i, f := range flex {
+		if f {
+			idx = append(idx, i)
+		}
+	}
+	if len(idx) == 0 {
+		return
+	}
+	per := slack / len(idx)
+	for _, i := range idx {
+		content[i] += per
+	}
+	content[idx[0]] += slack % len(idx)
+}
+
+// shrinkColumns removes overflow width, taking from flex columns first and then
+// non-flex columns, never below each column's floor so the header label still
+// fits and the trailing gap always survives.
+func shrinkColumns(content, floors []int, flex []bool, overflow int) {
+	overflow = shrinkGroup(content, floors, flex, overflow, true)
+	if overflow > 0 {
+		shrinkGroup(content, floors, flex, overflow, false)
+	}
+}
+
+// shrinkGroup reduces the columns whose flex flag matches flexOnly by up to
+// overflow cells total, distributed proportionally to each column's shrinkable
+// room. Returns the overflow it could not absorb.
+func shrinkGroup(content, floors []int, flex []bool, overflow int, flexOnly bool) int {
+	if overflow <= 0 {
+		return 0
+	}
+	room := 0
+	for i := range content {
+		if flex[i] == flexOnly {
+			room += content[i] - floors[i]
+		}
+	}
+	if room <= 0 {
+		return overflow
+	}
+	take := overflow
+	if take > room {
+		take = room
+	}
+	removed := 0
+	for i := range content {
+		if flex[i] != flexOnly {
+			continue
+		}
+		r := content[i] - floors[i]
+		if r <= 0 {
+			continue
+		}
+		cut := take * r / room
+		content[i] -= cut
+		removed += cut
+	}
+	// Assign rounding leftover one cell at a time to columns with room.
+	for leftover := take - removed; leftover > 0; {
+		progressed := false
+		for i := range content {
+			if leftover == 0 {
+				break
+			}
+			if flex[i] == flexOnly && content[i] > floors[i] {
+				content[i]--
+				leftover--
+				progressed = true
+			}
+		}
+		if !progressed {
+			break
+		}
+	}
+	return overflow - take
+}

--- a/ui/components/filterable/list/layout_test.go
+++ b/ui/components/filterable/list/layout_test.go
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package filterlist
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type row struct {
+	a, b, c string
+}
+
+func testCols() []Column[row] {
+	return []Column[row]{
+		{Label: "NAME", MinWidth: 4, Flex: true, Cell: func(r row) string { return r.a }},
+		{Label: "KIND", MinWidth: 4, Cell: func(r row) string { return r.b }},
+		{Label: "LABELS", MinWidth: 6, Flex: true, Cell: func(r row) string { return r.c }},
+	}
+}
+
+func sum(xs []int) int {
+	t := 0
+	for _, x := range xs {
+		t += x
+	}
+	return t
+}
+
+func TestLayoutWidths_WideFitsContent(t *testing.T) {
+	cols := testCols()
+	long := "this-is-a-very-long-name-value-1234567890"
+	items := []row{{a: long, b: "secret", c: "team=platform"}}
+
+	w := LayoutWidths(cols, items, 200, 0)
+	require.Len(t, w, 3)
+	require.LessOrEqual(t, sum(w), 200)
+	// Column 0 usable content width (minus gap and leading space) fits the name.
+	require.GreaterOrEqual(t, w[0]-ColGap-1, displayWidth(long))
+}
+
+func TestLayoutWidths_NarrowKeepsGapAndLabel(t *testing.T) {
+	cols := testCols()
+	items := []row{{
+		a: "this-is-a-very-long-name-value",
+		b: "kind",
+		c: "team=platform,env=prod,tier=frontend",
+	}}
+
+	w := LayoutWidths(cols, items, 30, 0)
+	require.Len(t, w, 3)
+	// Even fully shrunk, every column keeps room for its (untruncated) label plus
+	// the gap, so the header never overflows and columns never merge.
+	for i, c := range cols {
+		require.GreaterOrEqual(t, w[i]-ColGap, displayWidth(c.Label), "col %q", c.Label)
+	}
+}
+
+func TestLayoutWidths_SortArrowFloor(t *testing.T) {
+	cols := testCols()
+	items := []row{{a: "x", b: "y", c: "z"}}
+	// Sort on column 1 (KIND, label width 4) on a narrow terminal.
+	w := LayoutWidths(cols, items, 20, 1)
+	require.GreaterOrEqual(t, w[1]-ColGap, displayWidth(cols[1].Label)+2,
+		"sorted column must reserve room for the ' ▲' indicator")
+}
+
+func TestLayoutWidths_EmptyAndZeroWidth(t *testing.T) {
+	cols := testCols()
+	require.NotPanics(t, func() {
+		w := LayoutWidths(cols, nil, 0, -1) // empty items, zero width → defaults to 80
+		require.Len(t, w, 3)
+		for i, c := range cols {
+			require.GreaterOrEqual(t, w[i]-ColGap, displayWidth(c.Label), "col %q", c.Label)
+		}
+	})
+	require.Nil(t, LayoutWidths[row](nil, nil, 80, -1))
+}
+
+func TestRenderRow_WidthMatchesLayout(t *testing.T) {
+	cols := testCols()
+	items := []row{{a: "alpha", b: "kind", c: "k=v"}}
+	w := LayoutWidths(cols, items, 80, 0)
+	got := RenderRow(cols, w, items[0], 0, false)
+	require.Equal(t, sum(w), displayWidth(got), "row width must equal sum of column widths")
+}
+
+func TestRenderRow_LengthMismatchFallback(t *testing.T) {
+	cols := testCols()
+	got := RenderRow(cols, []int{5}, row{a: "alpha"}, 0, false)
+	require.Equal(t, "alpha", got)
+}
+
+func TestTruncateRunes_RuneAware(t *testing.T) {
+	require.Equal(t, "café", TruncateRunes("café", 4))
+	require.Equal(t, "ca…", TruncateRunes("café", 3))
+	require.Equal(t, "…", TruncateRunes("café", 1))
+	// 日本語 are wide-by-rune; ensure we slice on runes, not bytes.
+	require.Equal(t, "日本…", TruncateRunes("日本語テスト", 3))
+}
+
+func TestScrollWindow_RuneAware(t *testing.T) {
+	require.Equal(t, "", ScrollWindow("", 3, 10))
+	// Offset slides the window; never splits a multibyte rune.
+	require.Equal(t, "本語", ScrollWindow("日本語", 1, 10))
+	// Offset past the end clamps to empty.
+	require.Equal(t, "", ScrollWindow("abc", 99, 10))
+	// Windowed content still truncates with an ellipsis when more remains.
+	require.Equal(t, "bcde…", ScrollWindow("abcdefgh", 1, 5))
+}

--- a/views/configs/columns_test.go
+++ b/views/configs/columns_test.go
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package configsview
+
+import (
+	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/stretchr/testify/require"
+)
+
+const longConfigName = "a-very-long-config-name-that-overflows-columns"
+
+func readyConfigs(m *Model, width int, names ...string) {
+	loadConfigs(m, fakeConfigs(names...))
+	m.setRenderItem()
+	m.configsList.Viewport.Width = width
+	m.configsList.Viewport.Height = 20
+}
+
+func TestUsedHeaderIsShortened(t *testing.T) {
+	m := testModel()
+	readyConfigs(m, 120, "web")
+	header := m.configsList.RenderHeader()
+	require.Contains(t, header, "USED")
+	require.NotContains(t, header, "CONFIG USED")
+}
+
+func TestContentAwareName_WideTerminal(t *testing.T) {
+	m := testModel()
+	readyConfigs(m, 200, longConfigName, "tls")
+	row := m.configsList.RenderItem(m.configsList.Filtered[0], false, 0)
+	require.Contains(t, row, longConfigName, "full name must be visible on a wide terminal")
+}
+
+func TestHeaderRowAlignment(t *testing.T) {
+	m := testModel()
+	loadConfigs(m, fakeConfigs(longConfigName, "tls"))
+	m.setRenderItem()
+	for _, w := range []int{50, 120, 200} {
+		m.configsList.Viewport.Width = w
+		header := m.configsList.RenderHeader()
+		row := m.configsList.RenderItem(m.configsList.Filtered[0], false, 0)
+		require.Equal(t, lipgloss.Width(header), lipgloss.Width(row), "width=%d header/row mismatch", w)
+	}
+}
+
+func TestArrowScrollMovesWindow(t *testing.T) {
+	m := testModel()
+	readyConfigs(m, 60, longConfigName, "tls")
+	before := m.configsList.RenderItem(m.configsList.Filtered[0], true, 0)
+	m.Update(key("right"))
+	after := m.configsList.RenderItem(m.configsList.Filtered[0], true, 0)
+	require.NotEqual(t, before, after, "right arrow should shift the truncated cell window")
+
+	m.Update(key("left"))
+	require.Equal(t, before, m.configsList.RenderItem(m.configsList.Filtered[0], true, 0),
+		"left arrow should restore the window")
+}
+
+func TestResetScrollOnCursorMove(t *testing.T) {
+	m := testModel()
+	readyConfigs(m, 60, longConfigName, "tls")
+	m.Update(key("right"))
+	m.Update(key("right"))
+	scrolled := m.configsList.RenderItem(m.configsList.Filtered[0], true, 0)
+
+	m.Update(key("down"))
+	m.Update(key("up"))
+
+	require.NotEqual(t, scrolled, m.configsList.RenderItem(m.configsList.Filtered[0], true, 0),
+		"scroll offset must reset when the cursor moves (configs lacked this before)")
+}

--- a/views/configs/model.go
+++ b/views/configs/model.go
@@ -78,9 +78,6 @@ type Model struct {
 
 	// Spinner for slow-used-status indicator
 	spinner int
-
-	// Horizontal scroll offset for labels column
-	labelsScrollOffset int
 }
 
 type state int
@@ -105,6 +102,7 @@ func New(width, height int) *Model {
 		sortAscending: true,
 	}
 
+	cols := m.buildColumns()
 	list := filterlist.FilterableList[configItem]{
 		Viewport: vp,
 		Match: func(c configItem, query string) bool {
@@ -112,15 +110,9 @@ func New(width, height int) *Model {
 			return strings.Contains(strings.ToLower(c.Name), q) ||
 				strings.Contains(strings.ToLower(c.ID), q)
 		},
+		Columns: cols,
 		Header: &filterlist.HeaderConfig{
-			Columns: []filterlist.ColumnDef{
-				{Label: "NAME"},
-				{Label: "ID"},
-				{Label: "CONFIG USED"},
-				{Label: "CREATED AT", MinWidth: 19},
-				{Label: "UPDATED AT", MinWidth: 19},
-				{Label: "LABELS"},
-			},
+			Columns: filterlist.ColumnDefs(cols),
 			SortIndicator: func() (int, bool) {
 				return int(m.sortField), m.sortAscending
 			},

--- a/views/configs/update.go
+++ b/views/configs/update.go
@@ -16,6 +16,7 @@ import (
 	"swarmcli/views/confirmdialog"
 	helpview "swarmcli/views/help"
 	view "swarmcli/views/view"
+	"time"
 
 	"github.com/charmbracelet/bubbles/viewport"
 	tea "github.com/charmbracelet/bubbletea"
@@ -483,27 +484,13 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 			return m.getUsedByStacksCmd(cfgName)
 
 		case "left":
-			if m.labelsScrollOffset > 0 {
-				m.labelsScrollOffset -= 5
-				if m.labelsScrollOffset < 0 {
-					m.labelsScrollOffset = 0
-				}
-				m.setRenderItem()
-				m.configsList.Viewport.SetContent(m.configsList.View())
-			}
+			m.configsList.ScrollLeft()
+			m.configsList.Viewport.SetContent(m.configsList.View())
 			return nil
 
 		case "right":
-			if m.configsList.Cursor < len(m.configsList.Filtered) {
-				cfg := m.configsList.Filtered[m.configsList.Cursor]
-				labelsStr := formatLabels(cfg.Labels)
-				// Allow scrolling if labels are longer than visible width
-				if len(labelsStr) > m.labelsScrollOffset+20 {
-					m.labelsScrollOffset += 5
-					m.setRenderItem()
-					m.configsList.Viewport.SetContent(m.configsList.View())
-				}
-			}
+			m.configsList.ScrollRight()
+			m.configsList.Viewport.SetContent(m.configsList.View())
 			return nil
 
 		case "n":
@@ -628,7 +615,13 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 			return nil
 		default:
 			// Let FilterableList handle navigation keys (up/down/pgup/pgdown)
+			oldCursor := m.configsList.Cursor
 			m.configsList.HandleKey(msg)
+			// Reset horizontal scroll offset on cursor movement
+			if m.configsList.Cursor != oldCursor {
+				m.configsList.ResetColumnScroll()
+				m.configsList.Viewport.SetContent(m.configsList.View())
+			}
 			return nil
 		}
 	}
@@ -643,76 +636,43 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 	}
 }
 
-func (m *Model) setRenderItem() {
-	itemStyle := ui.ListItemStyle
-
-	m.configsList.RenderItem = func(cfg configItem, selected bool, _ int) string {
-		colWidths := m.configsList.ColWidths()
-
-		// Prepare cell texts (truncate where necessary)
-		// Reserve one character for the leading space in the first column
-		nameText := truncateWithEllipsis(cfg.Name, colWidths[0]-1)
-		idText := truncateWithEllipsis(cfg.ID, colWidths[1])
-		usedText := " "
-		if !cfg.UsedKnown {
-			// Use same spinner charset as systeminfo (14) for consistency
-			usedText = ui.SpinnerCharAt(m.spinner)
-		} else if cfg.Used {
-			usedText = "●"
-		}
-		createdStr := "N/A"
-		if !cfg.CreatedAt.IsZero() {
-			createdStr = cfg.CreatedAt.Format("2006-01-02 15:04:05")
-		}
-		updatedStr := "N/A"
-		if !cfg.UpdatedAt.IsZero() {
-			updatedStr = cfg.UpdatedAt.Format("2006-01-02 15:04:05")
-		}
-		createdText := truncateWithEllipsis(createdStr, colWidths[3])
-		updatedText := truncateWithEllipsis(updatedStr, colWidths[4])
-		// Format labels with scroll (sorted and in last column)
-		// Reserve 1 char for space before frame end
-		maxLabelsWidth := colWidths[5] - 1
-		if maxLabelsWidth < 1 {
-			maxLabelsWidth = 1
-		}
-		labelsText := formatLabelsWithScroll(cfg.Labels, m.labelsScrollOffset, maxLabelsWidth)
-
-		// Render all columns in one format string (no explicit separators, like secrets view)
-		if selected {
-			return ui.ListSelectedStyle.Render(fmt.Sprintf(" %-*s%-*s%-*s%-*s%-*s%-*s",
-				colWidths[0]-1, nameText,
-				colWidths[1], idText,
-				colWidths[2], usedText,
-				colWidths[3], createdText,
-				colWidths[4], updatedText,
-				colWidths[5], labelsText,
-			))
-		}
-
-		return itemStyle.Render(fmt.Sprintf(" %-*s%-*s%-*s%-*s%-*s%-*s",
-			colWidths[0]-1, nameText,
-			colWidths[1], idText,
-			colWidths[2], usedText,
-			colWidths[3], createdText,
-			colWidths[4], updatedText,
-			colWidths[5], labelsText,
-		))
+// buildColumns declares the configs table columns for the shared content-aware
+// layout. The USED cell closure captures the model so the spinner animates.
+func (m *Model) buildColumns() []filterlist.Column[configItem] {
+	return []filterlist.Column[configItem]{
+		{Label: "NAME", MinWidth: 4, Flex: true, Cell: func(c configItem) string { return c.Name }},
+		{Label: "ID", MinWidth: 4, Flex: true, Cell: func(c configItem) string { return c.ID }},
+		{Label: "USED", MinWidth: 4, Cell: func(c configItem) string {
+			switch {
+			case !c.UsedKnown:
+				return ui.SpinnerCharAt(m.spinner)
+			case c.Used:
+				return "●"
+			default:
+				return " "
+			}
+		}},
+		{Label: "CREATED AT", MinWidth: 19, Cell: func(c configItem) string { return formatTimestamp(c.CreatedAt) }},
+		{Label: "UPDATED AT", MinWidth: 19, Cell: func(c configItem) string { return formatTimestamp(c.UpdatedAt) }},
+		{Label: "LABELS", MinWidth: 6, Flex: true, Cell: func(c configItem) string { return formatLabels(c.Labels) }},
 	}
 }
 
-// truncateWithEllipsis truncates a string preserving room for an ellipsis
-func truncateWithEllipsis(s string, maxWidth int) string {
-	if len(s) <= maxWidth {
-		return s
+func formatTimestamp(t time.Time) string {
+	if t.IsZero() {
+		return "N/A"
 	}
-	if maxWidth <= 1 {
-		return "…"
+	return t.Format("2006-01-02 15:04:05")
+}
+
+func (m *Model) setRenderItem() {
+	m.configsList.RenderItem = func(cfg configItem, selected bool, _ int) string {
+		row := m.configsList.RenderRow(cfg, selected)
+		if selected {
+			return ui.ListSelectedStyle.Render(row)
+		}
+		return ui.ListItemStyle.Render(row)
 	}
-	if maxWidth == 2 {
-		return s[:1] + "…"
-	}
-	return s[:maxWidth-1] + "…"
 }
 
 func (m *Model) handleCreateDialogKey(msg tea.KeyMsg) tea.Cmd {

--- a/views/configs/view.go
+++ b/views/configs/view.go
@@ -301,28 +301,3 @@ func formatLabels(labels map[string]string) string {
 	}
 	return strings.Join(parts, ",")
 }
-
-// formatLabelsWithScroll formats labels with horizontal scroll offset and truncation indicator
-func formatLabelsWithScroll(labels map[string]string, offset int, maxWidth int) string {
-	full := formatLabels(labels)
-	if full == "-" {
-		return full
-	}
-
-	// Apply scroll offset
-	if offset > len(full) {
-		offset = len(full)
-	}
-	visible := full[offset:]
-
-	// Truncate if needed and add > indicator
-	if len(visible) > maxWidth {
-		if maxWidth > 1 {
-			visible = visible[:maxWidth-1] + ">"
-		} else {
-			visible = ">"
-		}
-	}
-
-	return visible
-}

--- a/views/configs/view_test.go
+++ b/views/configs/view_test.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"testing"
 
+	filterlist "swarmcli/ui/components/filterable/list"
+
 	"github.com/stretchr/testify/require"
 )
 
@@ -99,18 +101,16 @@ func TestFormatLabels_SkipsInternalLabels(t *testing.T) {
 	require.Equal(t, "env=prod", formatLabels(labels))
 }
 
-func TestFormatLabelsWithScroll(t *testing.T) {
-	labels := map[string]string{"longkey": "longvalue"}
-	full := formatLabels(labels)
+func TestLabelsScroll(t *testing.T) {
+	full := formatLabels(map[string]string{"longkey": "longvalue"})
 	require.Equal(t, "longkey=longvalue", full)
 
-	scrolled := formatLabelsWithScroll(labels, 4, 20)
-	require.Equal(t, "key=longvalue", scrolled)
+	require.Equal(t, "key=longvalue", filterlist.ScrollWindow(full, 4, 20))
 }
 
-func TestFormatLabelsWithScroll_Truncation(t *testing.T) {
-	labels := map[string]string{"a": "verylongvalue"}
-	truncated := formatLabelsWithScroll(labels, 0, 5)
-	require.Contains(t, truncated, ">")
-	require.Len(t, truncated, 5)
+func TestLabelsScroll_Truncation(t *testing.T) {
+	full := formatLabels(map[string]string{"a": "verylongvalue"})
+	truncated := filterlist.ScrollWindow(full, 0, 5)
+	require.Contains(t, truncated, "…")
+	require.Equal(t, 5, len([]rune(truncated)))
 }

--- a/views/nodes/columns_test.go
+++ b/views/nodes/columns_test.go
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package nodesview
+
+import (
+	"testing"
+
+	"swarmcli/docker"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/stretchr/testify/require"
+)
+
+const longHostname = "worker-with-a-very-long-hostname-that-overflows"
+
+func readyNodes(m *Model, width int, names ...string) {
+	loadNodes(m, fakeNodes(names...))
+	m.setRenderItem()
+	m.List.Viewport.Width = width
+	m.List.Viewport.Height = 20
+}
+
+func longNode(m *Model) docker.NodeEntry {
+	for _, n := range m.List.Filtered {
+		if n.Hostname == longHostname {
+			return n
+		}
+	}
+	return docker.NodeEntry{}
+}
+
+func TestContentAwareHostname_WideTerminal(t *testing.T) {
+	m := testModel()
+	readyNodes(m, 220, longHostname, "w2")
+	row := m.List.RenderItem(longNode(m), false, 0)
+	require.Contains(t, row, longHostname, "full hostname must be visible on a wide terminal")
+}
+
+func TestHeaderRowAlignment(t *testing.T) {
+	m := testModel()
+	loadNodes(m, fakeNodes(longHostname, "w2"))
+	m.setRenderItem()
+	for _, w := range []int{60, 120, 220} {
+		m.List.Viewport.Width = w
+		header := m.List.RenderHeader()
+		row := m.List.RenderItem(longNode(m), false, 0)
+		require.Equal(t, lipgloss.Width(header), lipgloss.Width(row), "width=%d header/row mismatch", w)
+	}
+}
+
+func TestArrowScrollMovesWindow(t *testing.T) {
+	m := testModel()
+	readyNodes(m, 70, longHostname, "w2") // narrow → flex columns overflow
+	before := m.List.RenderItem(longNode(m), true, 0)
+	m.Update(key("right"))
+	after := m.List.RenderItem(longNode(m), true, 0)
+	require.NotEqual(t, before, after, "right arrow should shift the truncated cell window")
+}
+
+func TestResetScrollOnCursorMove(t *testing.T) {
+	m := testModel()
+	readyNodes(m, 70, longHostname, "w2")
+	m.Update(key("right"))
+	m.Update(key("right"))
+	scrolled := m.List.RenderItem(longNode(m), true, 0)
+
+	m.Update(key("down"))
+	m.Update(key("up"))
+
+	require.NotEqual(t, scrolled, m.List.RenderItem(longNode(m), true, 0),
+		"scroll offset must reset when the cursor moves")
+}

--- a/views/nodes/model.go
+++ b/views/nodes/model.go
@@ -37,12 +37,10 @@ type Model struct {
 	width                 int
 	height                int
 	sortField             SortField
-	sortAscending         bool // true for ascending, false for descending
-	colWidths             map[string]int
+	sortAscending         bool   // true for ascending, false for descending
 	lastSnapshot          uint64 // Hash of last node state for change detection
 	confirmDialog         *confirmdialog.Model
 	errorDialogActive     bool
-	labelsScrollOffset    int      // Horizontal scroll offset for labels column
 	availabilityDialog    bool     // Whether availability selection dialog is visible
 	availabilityNodeID    string   // Node ID for availability change
 	availabilitySelection int      // Currently selected option (0=active, 1=pause, 2=drain)
@@ -69,17 +67,15 @@ func New(width, height int) *Model {
 		sortAscending: true,
 	}
 
+	cols := m.buildColumns()
 	list := filterlist.FilterableList[docker.NodeEntry]{
 		Viewport: vp,
 		Match: func(n docker.NodeEntry, query string) bool {
 			return strings.Contains(strings.ToLower(n.Hostname), strings.ToLower(query))
 		},
+		Columns: cols,
 		Header: &filterlist.HeaderConfig{
-			Columns: []filterlist.ColumnDef{
-				{Label: "ID"}, {Label: "HOSTNAME"}, {Label: "ROLE"}, {Label: "STATE"},
-				{Label: "Availability"}, {Label: "MANAGER"}, {Label: "MGR STATUS"},
-				{Label: "VERSION"}, {Label: "ADDRESS"}, {Label: "LABELS"},
-			},
+			Columns: filterlist.ColumnDefs(cols),
 			SortIndicator: func() (int, bool) {
 				sortColMap := map[SortField]int{
 					SortByHostname:     1,

--- a/views/nodes/model_test.go
+++ b/views/nodes/model_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"swarmcli/docker"
+	filterlist "swarmcli/ui/components/filterable/list"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/docker/docker/api/types/swarm"
@@ -272,20 +273,18 @@ func TestFormatLabels_Sorted(t *testing.T) {
 	require.Equal(t, "a=1,b=2", formatLabels(labels))
 }
 
-func TestFormatLabelsWithScroll(t *testing.T) {
-	labels := map[string]string{"longkey": "longvalue"}
-	full := formatLabels(labels)
+func TestLabelsScroll(t *testing.T) {
+	full := formatLabels(map[string]string{"longkey": "longvalue"})
 	require.Equal(t, "longkey=longvalue", full)
 
-	scrolled := formatLabelsWithScroll(labels, 4, 20)
-	require.Equal(t, "key=longvalue", scrolled)
+	require.Equal(t, "key=longvalue", filterlist.ScrollWindow(full, 4, 20))
 }
 
-func TestFormatLabelsWithScroll_Truncation(t *testing.T) {
-	labels := map[string]string{"a": "verylongvalue"}
-	truncated := formatLabelsWithScroll(labels, 0, 5)
-	require.Contains(t, truncated, ">")
-	require.Len(t, truncated, 5)
+func TestLabelsScroll_Truncation(t *testing.T) {
+	full := formatLabels(map[string]string{"a": "verylongvalue"})
+	truncated := filterlist.ScrollWindow(full, 0, 5)
+	require.Contains(t, truncated, "…")
+	require.Equal(t, 5, len([]rune(truncated)))
 }
 
 func TestGetNodesHelpContent(t *testing.T) {

--- a/views/nodes/update.go
+++ b/views/nodes/update.go
@@ -11,6 +11,7 @@ import (
 	"swarmcli/core/primitives/hash"
 	"swarmcli/docker"
 	"swarmcli/ui"
+	filterlist "swarmcli/ui/components/filterable/list"
 	"swarmcli/views/confirmdialog"
 	helpview "swarmcli/views/help"
 	inspectview "swarmcli/views/inspect"
@@ -272,26 +273,12 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 		// Handle left/right for labels scrolling
 		switch msg.String() {
 		case "left":
-			if m.labelsScrollOffset > 0 {
-				m.labelsScrollOffset -= 5
-				if m.labelsScrollOffset < 0 {
-					m.labelsScrollOffset = 0
-				}
-				m.setRenderItem() // Re-render with new offset
-				m.List.Viewport.SetContent(m.List.View())
-			}
+			m.List.ScrollLeft()
+			m.List.Viewport.SetContent(m.List.View())
 			return nil
 		case "right":
-			if m.List.Cursor < len(m.List.Filtered) {
-				node := m.List.Filtered[m.List.Cursor]
-				labelsStr := formatLabels(node.Labels)
-				// Allow scrolling if labels are longer than visible width
-				if len(labelsStr) > m.labelsScrollOffset+20 {
-					m.labelsScrollOffset += 5
-					m.setRenderItem() // Re-render with new offset
-					m.List.Viewport.SetContent(m.List.View())
-				}
-			}
+			m.List.ScrollRight()
+			m.List.Viewport.SetContent(m.List.View())
 			return nil
 		}
 
@@ -300,8 +287,7 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 
 		// Reset scroll offset on cursor movement
 		if m.List.Cursor != oldCursor {
-			m.labelsScrollOffset = 0
-			m.setRenderItem()
+			m.List.ResetColumnScroll()
 			m.List.Viewport.SetContent(m.List.View())
 		}
 
@@ -521,8 +507,6 @@ func (m *Model) SetContent(msg Msg) {
 	m.List.ApplyFilter()
 	m.applySorting()
 
-	// Calculate column widths for all columns
-	m.colWidths = calcColumnWidths(msg.Entries)
 	m.setRenderItem()
 
 	if m.ready {
@@ -533,88 +517,36 @@ func (m *Model) SetContent(msg Msg) {
 	}
 }
 
-func (m *Model) setRenderItem() {
-	// Use bright white for content and reserve leading space in first column
-	itemStyle := ui.ListItemStyle
-
-	m.List.RenderItem = func(n docker.NodeEntry, selected bool, _ int) string {
-		colWidths := m.List.ColWidths()
-		if len(colWidths) < 10 {
-			return n.Hostname
-		}
-		manager := "no"
-		if n.Manager {
-			manager = "yes"
-		}
-		mgrStatus := n.ManagerStatus
-		labelsStr := formatLabelsWithScroll(n.Labels, m.labelsScrollOffset, colWidths[9])
-		// Truncate ID so it fits the formatted field width (we render with
-		// a leading space and field width `colWidths[0]-1`). Ensure the
-		// final string length is <= colWidths[0]-1. If we need an ellipsis,
-		// reserve 3 chars for it and trim the core accordingly.
-		idStr := n.ID
-		// safeWidth is the maximum length we can print for the ID (excluding the leading space)
-		safeWidth := 0
-		if colWidths[0] > 0 {
-			safeWidth = colWidths[0] - 1
-		}
-		if safeWidth < 0 {
-			safeWidth = 0
-		}
-		if len(idStr) > safeWidth {
-			// If we can show at least 5 chars, show core + "..." and leave 1
-			// extra char to avoid colliding with the next column: core + "..." so total == safeWidth
-			if safeWidth > 4 {
-				core := safeWidth - 4
-				if core < 0 {
-					core = 0
-				}
-				if core > len(idStr) {
-					core = len(idStr)
-				}
-				idStr = idStr[:core] + "..."
-			} else if safeWidth > 0 {
-				// No room for ellipsis, just trim to fit
-				if safeWidth > len(idStr) {
-					// already fits, no-op
-				} else {
-					idStr = idStr[:safeWidth]
-				}
-			} else {
-				idStr = ""
+// buildColumns declares the nodes table columns for the shared content-aware
+// layout. ID/HOSTNAME/LABELS flex (grow + horizontally scroll); the rest are
+// fixed-width status columns.
+func (m *Model) buildColumns() []filterlist.Column[docker.NodeEntry] {
+	return []filterlist.Column[docker.NodeEntry]{
+		{Label: "ID", MinWidth: 6, Flex: true, Cell: func(n docker.NodeEntry) string { return n.ID }},
+		{Label: "HOSTNAME", MinWidth: 8, Flex: true, Cell: func(n docker.NodeEntry) string { return n.Hostname }},
+		{Label: "ROLE", Cell: func(n docker.NodeEntry) string { return n.Role }},
+		{Label: "STATE", Cell: func(n docker.NodeEntry) string { return n.State }},
+		{Label: "Availability", Cell: func(n docker.NodeEntry) string { return n.Availability }},
+		{Label: "MANAGER", Cell: func(n docker.NodeEntry) string {
+			if n.Manager {
+				return "yes"
 			}
-		}
-		// Use the pre-calculated column widths instead of the single colWidth
-		if selected {
-			selStyle := ui.ListSelectedStyle
-			// Preserve leading space for hostname when selected
-			return selStyle.Render(fmt.Sprintf(" %-*s%-*s%-*s%-*s%-*s%-*s%-*s%-*s%-*s%-*s",
-				colWidths[0]-1, idStr,
-				colWidths[1], n.Hostname,
-				colWidths[2], n.Role,
-				colWidths[3], n.State,
-				colWidths[4], n.Availability,
-				colWidths[5], manager,
-				colWidths[6], mgrStatus,
-				colWidths[7], n.Version,
-				colWidths[8], n.Addr,
-				colWidths[9], labelsStr,
-			))
-		}
+			return "no"
+		}},
+		{Label: "MGR STATUS", Cell: func(n docker.NodeEntry) string { return n.ManagerStatus }},
+		{Label: "VERSION", Cell: func(n docker.NodeEntry) string { return n.Version }},
+		{Label: "ADDRESS", Cell: func(n docker.NodeEntry) string { return n.Addr }},
+		{Label: "LABELS", MinWidth: 6, Flex: true, Cell: func(n docker.NodeEntry) string { return formatLabels(n.Labels) }},
+	}
+}
 
-		// Ensure the first column has a leading space to align with header
-		return itemStyle.Render(fmt.Sprintf(" %-*s%-*s%-*s%-*s%-*s%-*s%-*s%-*s%-*s%-*s",
-			colWidths[0]-1, idStr,
-			colWidths[1], n.Hostname,
-			colWidths[2], n.Role,
-			colWidths[3], n.State,
-			colWidths[4], n.Availability,
-			colWidths[5], manager,
-			colWidths[6], mgrStatus,
-			colWidths[7], n.Version,
-			colWidths[8], n.Addr,
-			colWidths[9], labelsStr,
-		))
+func (m *Model) setRenderItem() {
+	m.List.RenderItem = func(n docker.NodeEntry, selected bool, _ int) string {
+		row := m.List.RenderRow(n, selected)
+		if selected {
+			return ui.ListSelectedStyle.Render(row)
+		}
+		return ui.ListItemStyle.Render(row)
 	}
 }
 

--- a/views/nodes/view.go
+++ b/views/nodes/view.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"sort"
 	"strings"
-	"swarmcli/docker"
 	"swarmcli/ui"
 
 	"github.com/charmbracelet/lipgloss"
@@ -64,59 +63,6 @@ func plural(n int) string {
 		return ""
 	}
 	return "s"
-}
-
-// calcColumnWidths determines the best width per column based on the longest cell.
-func calcColumnWidths(entries []docker.NodeEntry) map[string]int {
-	widths := map[string]int{
-		"ID":           len("ID"),
-		"Hostname":     len("HOSTNAME"),
-		"Role":         len("ROLE"),
-		"State":        len("STATE"),
-		"Availability": len("Availability"),
-		"Manager":      len("MANAGER"),
-		"Version":      len("VERSION"),
-		"Addr":         len("ADDRESS"),
-		"Labels":       len("LABELS"),
-	}
-
-	for _, e := range entries {
-		if len(e.ID) > widths["ID"] {
-			widths["ID"] = len(e.ID)
-		}
-		if len(e.Hostname) > widths["Hostname"] {
-			widths["Hostname"] = len(e.Hostname)
-		}
-		if len(e.Role) > widths["Role"] {
-			widths["Role"] = len(e.Role)
-		}
-		if len(e.State) > widths["State"] {
-			widths["State"] = len(e.State)
-		}
-		if len(e.Availability) > widths["Availability"] {
-			widths["Availability"] = len(e.Availability)
-		}
-		manager := "no"
-		if e.Manager {
-			manager = "yes"
-		}
-		if len(manager) > widths["Manager"] {
-			widths["Manager"] = len(manager)
-		}
-		if len(e.Version) > widths["Version"] {
-			widths["Version"] = len(e.Version)
-		}
-		if len(e.Addr) > widths["Addr"] {
-			widths["Addr"] = len(e.Addr)
-		}
-		// Format labels as key=value pairs
-		labelsStr := formatLabels(e.Labels)
-		if len(labelsStr) > widths["Labels"] {
-			widths["Labels"] = len(labelsStr)
-		}
-	}
-
-	return widths
 }
 
 // formatLabels converts label map to comma-separated key=value string
@@ -263,29 +209,4 @@ func (m *Model) renderLabelRemoveDialog() string {
 
 	content := strings.Join(lines, "\n")
 	return borderStyle.Render(content)
-}
-
-// formatLabelsWithScroll formats labels with horizontal scroll offset and truncation indicator
-func formatLabelsWithScroll(labels map[string]string, offset int, maxWidth int) string {
-	full := formatLabels(labels)
-	if full == "-" {
-		return full
-	}
-
-	// Apply scroll offset
-	if offset > len(full) {
-		offset = len(full)
-	}
-	visible := full[offset:]
-
-	// Truncate if needed and add > indicator
-	if len(visible) > maxWidth {
-		if maxWidth > 1 {
-			visible = visible[:maxWidth-1] + ">"
-		} else {
-			visible = ">"
-		}
-	}
-
-	return visible
 }

--- a/views/secrets/columns_test.go
+++ b/views/secrets/columns_test.go
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package secretsview
+
+import (
+	"testing"
+
+	filterlist "swarmcli/ui/components/filterable/list"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/stretchr/testify/require"
+)
+
+const longSecretName = "a-very-long-secret-name-that-overflows-columns"
+
+func readySecrets(m *Model, width int, names ...string) {
+	loadSecrets(m, fakeSecrets(names...))
+	m.setRenderItem()
+	m.secretsList.Viewport.Width = width
+	m.secretsList.Viewport.Height = 20
+}
+
+func TestUsedHeaderIsShortened(t *testing.T) {
+	m := testModel()
+	readySecrets(m, 120, "web")
+	header := m.secretsList.RenderHeader()
+	require.Contains(t, header, "USED")
+	require.NotContains(t, header, "SECRET USED")
+}
+
+func TestContentAwareName_WideTerminal(t *testing.T) {
+	m := testModel()
+	readySecrets(m, 200, longSecretName, "tls")
+	row := m.secretsList.RenderItem(m.secretsList.Filtered[0], false, 0)
+	require.Contains(t, row, longSecretName, "full name must be visible on a wide terminal")
+}
+
+func TestHeaderRowAlignment(t *testing.T) {
+	m := testModel()
+	loadSecrets(m, fakeSecrets(longSecretName, "tls"))
+	m.setRenderItem()
+	for _, w := range []int{50, 120, 200} {
+		m.secretsList.Viewport.Width = w
+		header := m.secretsList.RenderHeader()
+		row := m.secretsList.RenderItem(m.secretsList.Filtered[0], false, 0)
+		require.Equal(t, lipgloss.Width(header), lipgloss.Width(row), "width=%d header/row mismatch", w)
+	}
+}
+
+func TestArrowScrollMovesWindow(t *testing.T) {
+	m := testModel()
+	readySecrets(m, 60, longSecretName, "tls") // narrow → NAME overflows and scrolls
+	before := m.secretsList.RenderItem(m.secretsList.Filtered[0], true, 0)
+	m.Update(key("right"))
+	after := m.secretsList.RenderItem(m.secretsList.Filtered[0], true, 0)
+	require.NotEqual(t, before, after, "right arrow should shift the truncated cell window")
+
+	m.Update(key("left"))
+	back := m.secretsList.RenderItem(m.secretsList.Filtered[0], true, 0)
+	require.Equal(t, before, back, "left arrow should restore the window")
+}
+
+func TestResetScrollOnCursorMove(t *testing.T) {
+	m := testModel()
+	readySecrets(m, 60, longSecretName, "tls")
+	m.Update(key("right"))
+	m.Update(key("right"))
+	scrolledRow0 := m.secretsList.RenderItem(m.secretsList.Filtered[0], true, 0)
+
+	m.Update(key("down")) // move to row 1 → scroll resets
+	m.Update(key("up"))   // back to row 0, offset should be 0 again
+
+	require.NotEqual(t, scrolledRow0, m.secretsList.RenderItem(m.secretsList.Filtered[0], true, 0),
+		"scroll offset must reset when the cursor moves")
+}
+
+func TestScrollWindowUsesSharedHelper(t *testing.T) {
+	// Sanity: the shared rune-aware window backs the labels behavior.
+	require.Equal(t, "key=longvalue", filterlist.ScrollWindow("longkey=longvalue", 4, 20))
+}

--- a/views/secrets/model.go
+++ b/views/secrets/model.go
@@ -78,9 +78,6 @@ type Model struct {
 
 	// Spinner for slow-used-status indicator
 	spinner int
-
-	// Horizontal scroll offset for labels column
-	labelsScrollOffset int
 }
 
 type state int
@@ -110,6 +107,7 @@ func New(width, height int) *Model {
 		createEncodeSecret: true,
 	}
 
+	cols := m.buildColumns()
 	list := filterlist.FilterableList[secretItem]{
 		Viewport: vp,
 		Match: func(s secretItem, query string) bool {
@@ -117,15 +115,9 @@ func New(width, height int) *Model {
 			return strings.Contains(strings.ToLower(s.Name), q) ||
 				strings.Contains(strings.ToLower(s.ID), q)
 		},
+		Columns: cols,
 		Header: &filterlist.HeaderConfig{
-			Columns: []filterlist.ColumnDef{
-				{Label: "NAME"},
-				{Label: "ID"},
-				{Label: "SECRET USED"},
-				{Label: "CREATED AT", MinWidth: 19},
-				{Label: "UPDATED AT", MinWidth: 19},
-				{Label: "LABELS"},
-			},
+			Columns: filterlist.ColumnDefs(cols),
 			SortIndicator: func() (int, bool) {
 				return int(m.sortField), m.sortAscending
 			},

--- a/views/secrets/update.go
+++ b/views/secrets/update.go
@@ -16,6 +16,7 @@ import (
 	helpview "swarmcli/views/help"
 	loading "swarmcli/views/loading"
 	view "swarmcli/views/view"
+	"time"
 
 	"github.com/charmbracelet/bubbles/viewport"
 	tea "github.com/charmbracelet/bubbletea"
@@ -389,27 +390,13 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 			return action(secName)
 
 		case "left":
-			if m.labelsScrollOffset > 0 {
-				m.labelsScrollOffset -= 5
-				if m.labelsScrollOffset < 0 {
-					m.labelsScrollOffset = 0
-				}
-				m.setRenderItem()
-				m.secretsList.Viewport.SetContent(m.secretsList.View())
-			}
+			m.secretsList.ScrollLeft()
+			m.secretsList.Viewport.SetContent(m.secretsList.View())
 			return nil
 
 		case "right":
-			if m.secretsList.Cursor < len(m.secretsList.Filtered) {
-				sec := m.secretsList.Filtered[m.secretsList.Cursor]
-				labelsStr := formatLabels(sec.Labels)
-				// Allow scrolling if labels are longer than visible width
-				if len(labelsStr) > m.labelsScrollOffset+20 {
-					m.labelsScrollOffset += 5
-					m.setRenderItem()
-					m.secretsList.Viewport.SetContent(m.secretsList.View())
-				}
-			}
+			m.secretsList.ScrollRight()
+			m.secretsList.Viewport.SetContent(m.secretsList.View())
 			return nil
 
 		case "n":
@@ -507,8 +494,7 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 			m.secretsList.HandleKey(msg)
 			// Reset scroll offset on cursor movement
 			if m.secretsList.Cursor != oldCursor {
-				m.labelsScrollOffset = 0
-				m.setRenderItem()
+				m.secretsList.ResetColumnScroll()
 				m.secretsList.Viewport.SetContent(m.secretsList.View())
 			}
 			return nil
@@ -524,78 +510,43 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 	}
 }
 
-func (m *Model) setRenderItem() {
-	itemStyle := ui.ListItemStyle
-
-	m.secretsList.RenderItem = func(sec secretItem, selected bool, _ int) string {
-		colWidths := m.secretsList.ColWidths()
-		if len(colWidths) < 6 {
-			return sec.Name
-		}
-
-		// Prepare cell texts
-		nameText := truncateWithEllipsis(sec.Name, colWidths[0]-1)
-		idText := truncateWithEllipsis(sec.ID, colWidths[1])
-		usedText := " "
-		if !sec.UsedKnown {
-			usedText = ui.SpinnerCharAt(m.spinner)
-		} else if sec.Used {
-			usedText = "●"
-		}
-		// Format timestamps
-		createdStr := "N/A"
-		if !sec.CreatedAt.IsZero() {
-			createdStr = sec.CreatedAt.Format("2006-01-02 15:04:05")
-		}
-		updatedStr := "N/A"
-		if !sec.UpdatedAt.IsZero() {
-			updatedStr = sec.UpdatedAt.Format("2006-01-02 15:04:05")
-		}
-		createdText := truncateWithEllipsis(createdStr, colWidths[3])
-		updatedText := truncateWithEllipsis(updatedStr, colWidths[4])
-		// Format labels with scroll (sorted and in last column)
-		// Reserve 1 char for space before frame end
-		maxLabelsWidth := colWidths[5] - 1
-		if maxLabelsWidth < 1 {
-			maxLabelsWidth = 1
-		}
-		labelsText := formatLabelsWithScroll(sec.Labels, m.labelsScrollOffset, maxLabelsWidth)
-
-		// Render all columns in one format string (no explicit separators, like nodes view)
-		if selected {
-			selStyle := ui.ListSelectedStyle
-			return selStyle.Render(fmt.Sprintf(" %-*s%-*s%-*s%-*s%-*s%-*s",
-				colWidths[0]-1, nameText,
-				colWidths[1], idText,
-				colWidths[2], usedText,
-				colWidths[3], createdText,
-				colWidths[4], updatedText,
-				colWidths[5], labelsText,
-			))
-		}
-
-		return itemStyle.Render(fmt.Sprintf(" %-*s%-*s%-*s%-*s%-*s%-*s",
-			colWidths[0]-1, nameText,
-			colWidths[1], idText,
-			colWidths[2], usedText,
-			colWidths[3], createdText,
-			colWidths[4], updatedText,
-			colWidths[5], labelsText,
-		))
+// buildColumns declares the secrets table columns for the shared content-aware
+// layout. The USED cell closure captures the model so the spinner animates.
+func (m *Model) buildColumns() []filterlist.Column[secretItem] {
+	return []filterlist.Column[secretItem]{
+		{Label: "NAME", MinWidth: 4, Flex: true, Cell: func(s secretItem) string { return s.Name }},
+		{Label: "ID", MinWidth: 4, Flex: true, Cell: func(s secretItem) string { return s.ID }},
+		{Label: "USED", MinWidth: 4, Cell: func(s secretItem) string {
+			switch {
+			case !s.UsedKnown:
+				return ui.SpinnerCharAt(m.spinner)
+			case s.Used:
+				return "●"
+			default:
+				return " "
+			}
+		}},
+		{Label: "CREATED AT", MinWidth: 19, Cell: func(s secretItem) string { return formatTimestamp(s.CreatedAt) }},
+		{Label: "UPDATED AT", MinWidth: 19, Cell: func(s secretItem) string { return formatTimestamp(s.UpdatedAt) }},
+		{Label: "LABELS", MinWidth: 6, Flex: true, Cell: func(s secretItem) string { return formatLabels(s.Labels) }},
 	}
 }
 
-func truncateWithEllipsis(s string, maxWidth int) string {
-	if len(s) <= maxWidth {
-		return s
+func formatTimestamp(t time.Time) string {
+	if t.IsZero() {
+		return "N/A"
 	}
-	if maxWidth <= 1 {
-		return "…"
+	return t.Format("2006-01-02 15:04:05")
+}
+
+func (m *Model) setRenderItem() {
+	m.secretsList.RenderItem = func(sec secretItem, selected bool, _ int) string {
+		row := m.secretsList.RenderRow(sec, selected)
+		if selected {
+			return ui.ListSelectedStyle.Render(row)
+		}
+		return ui.ListItemStyle.Render(row)
 	}
-	if maxWidth == 2 {
-		return s[:1] + "…"
-	}
-	return s[:maxWidth-1] + "…"
 }
 
 func (m *Model) handleCreateDialogKey(msg tea.KeyMsg) tea.Cmd {

--- a/views/secrets/view.go
+++ b/views/secrets/view.go
@@ -320,31 +320,6 @@ func formatLabels(labels map[string]string) string {
 	return strings.Join(parts, ",")
 }
 
-// formatLabelsWithScroll formats labels with horizontal scroll offset and truncation indicator
-func formatLabelsWithScroll(labels map[string]string, offset int, maxWidth int) string {
-	full := formatLabels(labels)
-	if full == "-" {
-		return full
-	}
-
-	// Apply scroll offset
-	if offset > len(full) {
-		offset = len(full)
-	}
-	visible := full[offset:]
-
-	// Truncate if needed and add > indicator
-	if len(visible) > maxWidth {
-		if maxWidth > 1 {
-			visible = visible[:maxWidth-1] + ">"
-		} else {
-			visible = ">"
-		}
-	}
-
-	return visible
-}
-
 func (m *Model) renderUsedByView() string {
 	// Safety check - if list is not properly initialized, show error
 	if m.usedByList.Viewport.Width == 0 {

--- a/views/secrets/view_test.go
+++ b/views/secrets/view_test.go
@@ -6,6 +6,8 @@ package secretsview
 import (
 	"testing"
 
+	filterlist "swarmcli/ui/components/filterable/list"
+
 	"github.com/stretchr/testify/require"
 )
 
@@ -98,21 +100,19 @@ func TestFormatLabels_SkipsInternalLabels(t *testing.T) {
 	require.Equal(t, "env=prod", formatLabels(labels))
 }
 
-func TestFormatLabelsWithScroll(t *testing.T) {
-	labels := map[string]string{"longkey": "longvalue"}
-	full := formatLabels(labels)
+func TestLabelsScroll(t *testing.T) {
+	full := formatLabels(map[string]string{"longkey": "longvalue"})
 	require.Equal(t, "longkey=longvalue", full)
 
-	// Scroll past start
-	scrolled := formatLabelsWithScroll(labels, 4, 20)
-	require.Equal(t, "key=longvalue", scrolled)
+	// Scroll past start (shared rune-aware window).
+	require.Equal(t, "key=longvalue", filterlist.ScrollWindow(full, 4, 20))
 }
 
-func TestFormatLabelsWithScroll_Truncation(t *testing.T) {
-	labels := map[string]string{"a": "verylongvalue"}
-	truncated := formatLabelsWithScroll(labels, 0, 5)
-	require.Contains(t, truncated, ">")
-	require.Len(t, truncated, 5)
+func TestLabelsScroll_Truncation(t *testing.T) {
+	full := formatLabels(map[string]string{"a": "verylongvalue"})
+	truncated := filterlist.ScrollWindow(full, 0, 5)
+	require.Contains(t, truncated, "…")
+	require.Equal(t, 5, len([]rune(truncated)))
 }
 
 func TestGetSecretsHelpContent(t *testing.T) {

--- a/views/services/columns.go
+++ b/views/services/columns.go
@@ -5,99 +5,80 @@ package servicesview
 
 import (
 	"fmt"
-	"unicode/utf8"
 
 	"swarmcli/docker"
 	filterlist "swarmcli/ui/components/filterable/list"
 )
 
-// colID identifies a logical services column independent of its position in the
-// active column set (the STACK column is dropped outside the All-Services scope).
-type colID int
-
-const (
-	colService colID = iota
-	colStack
-	colReplicas
-	colStatus
-	colMode
-	colImage
-	colPorts
-	colCreated
-	colUpdated
-	colError
-)
-
-// colSpec is the single source of truth for a services column: its header label,
-// width policy, sort mapping, and how to extract its cell text from an entry.
-// Header labels, sort indices, column widths, and row cells all derive from the
-// active []colSpec so they can never drift out of sync.
-type colSpec struct {
-	id       colID
-	label    string
-	minWidth int  // content floor (excludes the inter-column gap)
-	flex     bool // absorbs leftover slack; horizontally scrolls when truncated on a selected row
-	sort     SortField
-	hasSort  bool
-	cell     func(m *Model, e docker.ServiceEntry) string
+// serviceColumn pairs a shared-layout column with its sort metadata. The set is
+// the single source of truth for the header, widths, sort indices, and rows.
+type serviceColumn struct {
+	col     filterlist.Column[docker.ServiceEntry]
+	sort    SortField
+	hasSort bool
+	isStack bool
 }
 
-// servicesColumnTemplate is the canonical, ordered set of all services columns.
-// activeColumns derives the per-scope subset from it.
-var servicesColumnTemplate = []colSpec{
-	{id: colService, label: "SERVICE", minWidth: 8, flex: true, sort: SortByName, hasSort: true,
-		cell: func(_ *Model, e docker.ServiceEntry) string { return e.ServiceName }},
-	{id: colStack, label: "STACK", minWidth: 6,
-		cell: func(_ *Model, e docker.ServiceEntry) string { return e.StackName }},
-	{id: colReplicas, label: "REPLICAS", minWidth: 5,
-		cell: func(_ *Model, e docker.ServiceEntry) string {
-			if e.ReplicasTotal == 0 {
-				return "—"
-			}
-			return fmt.Sprintf("%d/%d", e.ReplicasOnNode, e.ReplicasTotal)
-		}},
-	{id: colStatus, label: "STATUS", minWidth: 8, sort: SortByStatus, hasSort: true,
-		cell: func(_ *Model, e docker.ServiceEntry) string { return e.Status }},
-	{id: colMode, label: "MODE", minWidth: 6,
-		cell: func(_ *Model, e docker.ServiceEntry) string { return e.Mode }},
-	{id: colImage, label: "IMAGE", minWidth: 8, flex: true, sort: SortByImage, hasSort: true,
-		cell: func(_ *Model, e docker.ServiceEntry) string { return e.Image }},
-	{id: colPorts, label: "PORTS", minWidth: 5, flex: true, sort: SortByPorts, hasSort: true,
-		cell: func(_ *Model, e docker.ServiceEntry) string { return e.Ports }},
-	{id: colCreated, label: "CREATED", minWidth: 7, sort: SortByCreated, hasSort: true,
-		cell: func(_ *Model, e docker.ServiceEntry) string { return formatRelativeTime(e.CreatedAt) }},
-	{id: colUpdated, label: "UPDATED", minWidth: 7, sort: SortByUpdated, hasSort: true,
-		cell: func(_ *Model, e docker.ServiceEntry) string { return formatRelativeTime(e.UpdatedAt) }},
-	{id: colError, label: "ERROR", minWidth: 6, flex: true, sort: SortByError, hasSort: true,
-		cell: func(m *Model, e docker.ServiceEntry) string { return m.serviceErrorText[e.ServiceID] }},
-}
-
-// activeColumns returns the columns to render for the current scope. The STACK
-// column is dropped unless we're showing services from every stack (AllFilter),
-// since in a single-stack/node scope every row carries the same stack value.
-func (m *Model) activeColumns() []colSpec {
+// serviceColumns returns the columns for the current scope. The STACK column is
+// dropped unless we're showing services from every stack (AllFilter), since in a
+// single-stack/node scope every row carries the same stack value. Cell closures
+// capture the model so the ERROR column can read the per-service error text.
+func (m *Model) serviceColumns() []serviceColumn {
+	all := []serviceColumn{
+		{sort: SortByName, hasSort: true, col: filterlist.Column[docker.ServiceEntry]{
+			Label: "SERVICE", MinWidth: 8, Flex: true,
+			Cell: func(e docker.ServiceEntry) string { return e.ServiceName }}},
+		{isStack: true, col: filterlist.Column[docker.ServiceEntry]{
+			Label: "STACK", MinWidth: 6,
+			Cell: func(e docker.ServiceEntry) string { return e.StackName }}},
+		{col: filterlist.Column[docker.ServiceEntry]{
+			Label: "REPLICAS", MinWidth: 5,
+			Cell: func(e docker.ServiceEntry) string {
+				if e.ReplicasTotal == 0 {
+					return "—"
+				}
+				return fmt.Sprintf("%d/%d", e.ReplicasOnNode, e.ReplicasTotal)
+			}}},
+		{sort: SortByStatus, hasSort: true, col: filterlist.Column[docker.ServiceEntry]{
+			Label: "STATUS", MinWidth: 8,
+			Cell: func(e docker.ServiceEntry) string { return e.Status }}},
+		{col: filterlist.Column[docker.ServiceEntry]{
+			Label: "MODE", MinWidth: 6,
+			Cell: func(e docker.ServiceEntry) string { return e.Mode }}},
+		{sort: SortByImage, hasSort: true, col: filterlist.Column[docker.ServiceEntry]{
+			Label: "IMAGE", MinWidth: 8, Flex: true,
+			Cell: func(e docker.ServiceEntry) string { return e.Image }}},
+		{sort: SortByPorts, hasSort: true, col: filterlist.Column[docker.ServiceEntry]{
+			Label: "PORTS", MinWidth: 5, Flex: true,
+			Cell: func(e docker.ServiceEntry) string { return e.Ports }}},
+		{sort: SortByCreated, hasSort: true, col: filterlist.Column[docker.ServiceEntry]{
+			Label: "CREATED", MinWidth: 7,
+			Cell: func(e docker.ServiceEntry) string { return formatRelativeTime(e.CreatedAt) }}},
+		{sort: SortByUpdated, hasSort: true, col: filterlist.Column[docker.ServiceEntry]{
+			Label: "UPDATED", MinWidth: 7,
+			Cell: func(e docker.ServiceEntry) string { return formatRelativeTime(e.UpdatedAt) }}},
+		{sort: SortByError, hasSort: true, col: filterlist.Column[docker.ServiceEntry]{
+			Label: "ERROR", MinWidth: 6, Flex: true,
+			Cell: func(e docker.ServiceEntry) string { return m.serviceErrorText[e.ServiceID] }}},
+	}
 	if m.filterType == AllFilter {
-		return servicesColumnTemplate
+		return all
 	}
-	return without(servicesColumnTemplate, colStack)
+	out := make([]serviceColumn, 0, len(all)-1)
+	for _, c := range all {
+		if !c.isStack {
+			out = append(out, c)
+		}
+	}
+	return out
 }
 
-// activeColumnLabels returns just the labels of the active columns, for building
-// the filterable-list header.
-func (m *Model) activeColumnLabels() []string {
-	active := m.activeColumns()
-	labels := make([]string, len(active))
+// layoutColumns extracts the shared-layout column set for the current scope.
+func (m *Model) layoutColumns() []filterlist.Column[docker.ServiceEntry] {
+	active := m.serviceColumns()
+	cols := make([]filterlist.Column[docker.ServiceEntry], len(active))
 	for i, c := range active {
-		labels[i] = c.label
-	}
-	return labels
-}
-
-// headerColumns builds the filterable-list header column set from labels.
-func headerColumns(labels []string) []filterlist.ColumnDef {
-	cols := make([]filterlist.ColumnDef, len(labels))
-	for i, l := range labels {
-		cols[i] = filterlist.ColumnDef{Label: l}
+		cols[i] = c.col
 	}
 	return cols
 }
@@ -106,117 +87,10 @@ func headerColumns(labels []string) []filterlist.ColumnDef {
 // the sort direction, so the header arrow tracks the column even when STACK is
 // dropped and indices shift.
 func (m *Model) sortIndicator() (int, bool) {
-	for i, spec := range m.activeColumns() {
-		if spec.hasSort && spec.sort == m.sortField {
+	for i, c := range m.serviceColumns() {
+		if c.hasSort && c.sort == m.sortField {
 			return i, m.sortAscending
 		}
 	}
 	return -1, true
-}
-
-func without(specs []colSpec, id colID) []colSpec {
-	out := make([]colSpec, 0, len(specs))
-	for _, s := range specs {
-		if s.id != id {
-			out = append(out, s)
-		}
-	}
-	return out
-}
-
-// colGap is the guaranteed minimum space between adjacent columns. It is baked
-// into every column's returned width as trailing padding, so the gap survives
-// even when columns are shrunk to their floors on a narrow terminal.
-const colGap = 1
-
-// distributeSlack spreads leftover width across the flex columns, giving the
-// rounding remainder to the first flex column (SERVICE) so names grow first.
-func distributeSlack(content []int, flex []bool, slack int) {
-	if slack <= 0 {
-		return
-	}
-	var idx []int
-	for i, f := range flex {
-		if f {
-			idx = append(idx, i)
-		}
-	}
-	if len(idx) == 0 {
-		return
-	}
-	per := slack / len(idx)
-	for _, i := range idx {
-		content[i] += per
-	}
-	content[idx[0]] += slack % len(idx)
-}
-
-// shrinkColumns removes overflow width, taking from flex columns first and then
-// non-flex columns, never below each column's floor so the header label still
-// fits and the trailing gap always survives.
-func shrinkColumns(content, floors []int, flex []bool, overflow int) {
-	overflow = shrinkGroup(content, floors, flex, overflow, true)
-	if overflow > 0 {
-		shrinkGroup(content, floors, flex, overflow, false)
-	}
-}
-
-// shrinkGroup reduces the columns whose flex flag matches flexOnly by up to
-// overflow cells total, distributed proportionally to each column's shrinkable
-// room. Returns the overflow it could not absorb.
-func shrinkGroup(content, floors []int, flex []bool, overflow int, flexOnly bool) int {
-	if overflow <= 0 {
-		return 0
-	}
-	room := 0
-	for i := range content {
-		if flex[i] == flexOnly {
-			room += content[i] - floors[i]
-		}
-	}
-	if room <= 0 {
-		return overflow
-	}
-	take := overflow
-	if take > room {
-		take = room
-	}
-	removed := 0
-	for i := range content {
-		if flex[i] != flexOnly {
-			continue
-		}
-		r := content[i] - floors[i]
-		if r <= 0 {
-			continue
-		}
-		cut := take * r / room
-		content[i] -= cut
-		removed += cut
-	}
-	// Assign rounding leftover one cell at a time to columns with room.
-	for leftover := take - removed; leftover > 0; {
-		progressed := false
-		for i := range content {
-			if leftover == 0 {
-				break
-			}
-			if flex[i] == flexOnly && content[i] > floors[i] {
-				content[i]--
-				leftover--
-				progressed = true
-			}
-		}
-		if !progressed {
-			break
-		}
-	}
-	return overflow - take
-}
-
-// displayWidth reports the rendered width of s in terminal cells. Service and
-// image names are ASCII in practice, but counting runes (not bytes) keeps width
-// measurement consistent with truncateWithEllipsis for any multibyte content.
-func displayWidth(s string) int {
-	return utf8.RuneCountInString(s)
 }

--- a/views/services/columns_test.go
+++ b/views/services/columns_test.go
@@ -4,10 +4,10 @@
 package servicesview
 
 import (
-	"strings"
 	"testing"
 
 	"swarmcli/docker"
+	filterlist "swarmcli/ui/components/filterable/list"
 
 	"github.com/charmbracelet/lipgloss"
 	"github.com/stretchr/testify/require"
@@ -20,97 +20,57 @@ func loadWithFilter(m *Model, ft FilterType, entries []docker.ServiceEntry) {
 	m.Update(Msg{Title: "T", Entries: entries, FilterType: ft})
 }
 
-// colIndex returns the position of a column id in the active set, or -1.
-func colIndex(m *Model, id colID) int {
-	for i, spec := range m.activeColumns() {
-		if spec.id == id {
+func hasColumn(m *Model, label string) bool {
+	return colLabelIndex(m, label) >= 0
+}
+
+func colLabelIndex(m *Model, label string) int {
+	for i, c := range m.layoutColumns() {
+		if c.Label == label {
 			return i
 		}
 	}
 	return -1
 }
 
-func TestActiveColumns_StackOnlyInAllFilter(t *testing.T) {
+func TestColumns_StackOnlyInAllFilter(t *testing.T) {
 	cases := []struct {
-		ft         FilterType
-		wantStack  bool
-		wantLength int
+		ft        FilterType
+		wantStack bool
+		wantLen   int
 	}{
-		{AllFilter, true, len(servicesColumnTemplate)},
-		{StackFilter, false, len(servicesColumnTemplate) - 1},
-		{NodeFilter, false, len(servicesColumnTemplate) - 1},
-		{NoStackFilter, false, len(servicesColumnTemplate) - 1},
+		{AllFilter, true, 10},
+		{StackFilter, false, 9},
+		{NodeFilter, false, 9},
+		{NoStackFilter, false, 9},
 	}
 	for _, tc := range cases {
 		m := testModel()
 		m.filterType = tc.ft
-		active := m.activeColumns()
-		require.Len(t, active, tc.wantLength, "filter %v", tc.ft)
-		require.Equal(t, tc.wantStack, colIndex(m, colStack) >= 0, "filter %v stack presence", tc.ft)
+		require.Len(t, m.layoutColumns(), tc.wantLen, "filter %v", tc.ft)
+		require.Equal(t, tc.wantStack, hasColumn(m, "STACK"), "filter %v stack presence", tc.ft)
 	}
 }
 
-func TestComputeColWidths_LengthMatchesHeader(t *testing.T) {
+func TestColWidths_LengthMatchesHeader(t *testing.T) {
 	for _, ft := range []FilterType{AllFilter, StackFilter, NodeFilter, NoStackFilter} {
 		m := testModel()
 		loadWithFilter(m, ft, fakeEntries("web", "api"))
-		widths := m.computeColWidths(120)
-		require.Len(t, widths, len(m.activeColumns()), "filter %v", ft)
-		require.Len(t, widths, len(m.List.Header.Columns), "filter %v header sync", ft)
+		require.Len(t, m.List.ColWidths(), len(m.List.Header.Columns), "filter %v header sync", ft)
 	}
 }
 
-func TestComputeColWidths_WideTerminal_ServiceFits(t *testing.T) {
+func TestColWidths_WideTerminal_ServiceFits(t *testing.T) {
 	m := testModel()
 	loadWithFilter(m, AllFilter, fakeEntries(longServiceName, "api"))
+	m.List.Viewport.Width = 200
 
-	width := 200
-	widths := m.computeColWidths(width)
-
+	widths := m.List.ColWidths()
+	svc := colLabelIndex(m, "SERVICE")
 	// Column 0 renders with a leading space and a trailing gap, so its usable
-	// content width is colWidths[0]-colGap-1. It must fit the full name.
-	svc := colIndex(m, colService)
-	content0 := widths[svc] - colGap - 1
-	require.GreaterOrEqual(t, content0, displayWidth(longServiceName),
+	// content width is width-ColGap-1; it must fit the full name on a wide term.
+	require.GreaterOrEqual(t, widths[svc]-filterlist.ColGap-1, len([]rune(longServiceName)),
 		"SERVICE column must show the full name on a wide terminal")
-
-	sum := 0
-	for _, w := range widths {
-		sum += w
-	}
-	require.LessOrEqual(t, sum, width, "columns must fit the viewport when content is small")
-}
-
-func TestComputeColWidths_GapPreservedWhenNarrow(t *testing.T) {
-	m := testModel()
-	long := fakeEntries(longServiceName, "another-fairly-long-service-name")
-	long[0].Image = "registry.example.com/team/very/long/image/path:tag"
-	long[0].Ports = "8080:8080,9090:9090,7070:7070"
-	loadWithFilter(m, AllFilter, long)
-
-	widths := m.computeColWidths(40)
-	active := m.activeColumns()
-
-	// Even fully truncated, every column keeps room for its (untruncated) header
-	// label plus the inter-column gap, so labels stay readable, the header can't
-	// overflow, and columns never merge.
-	for i, spec := range active {
-		require.GreaterOrEqual(t, widths[i]-colGap, displayWidth(spec.label),
-			"column %q must retain at least its label width", spec.label)
-	}
-}
-
-func TestComputeColWidths_EmptyAndZeroWidth(t *testing.T) {
-	m := testModel()
-	loadWithFilter(m, AllFilter, nil) // empty list
-
-	require.NotPanics(t, func() {
-		w := m.computeColWidths(0) // zero width behaves as 80
-		require.Len(t, w, len(m.activeColumns()))
-		for i, spec := range m.activeColumns() {
-			require.GreaterOrEqual(t, w[i], spec.minWidth, "column %q at least label/min width", spec.label)
-		}
-	})
 }
 
 func TestSortIndicator_ResolvesActiveIndex(t *testing.T) {
@@ -135,7 +95,6 @@ func TestSortIndicator_ResolvesActiveIndex(t *testing.T) {
 func TestView_FullServiceNameOnWideTerminal(t *testing.T) {
 	m := testModel()
 	loadWithFilter(m, AllFilter, fakeEntries(longServiceName, "api"))
-	m.setRenderItem()
 	m.List.Viewport.Width = 200
 	m.List.Viewport.Height = 20
 
@@ -144,8 +103,8 @@ func TestView_FullServiceNameOnWideTerminal(t *testing.T) {
 }
 
 func TestHeaderRowAlignment(t *testing.T) {
-	// Header and rows must share the same total width (sum of colWidths) across
-	// scopes and sort fields, including the sorted column's " ▲" indicator.
+	// Header and rows must share the same total width across scopes and sort
+	// fields, including the sorted column's " ▲" indicator (the #392 regression).
 	for _, ft := range []FilterType{AllFilter, StackFilter} {
 		for _, sf := range []SortField{SortByName, SortByStatus, SortByCreated, SortByError} {
 			m := testModel()
@@ -161,12 +120,4 @@ func TestHeaderRowAlignment(t *testing.T) {
 			}
 		}
 	}
-}
-
-func TestTruncateWithEllipsis_RuneAware(t *testing.T) {
-	require.Equal(t, "héllo", truncateWithEllipsis("héllo", 5))
-	require.Equal(t, "hé…", truncateWithEllipsis("héllo", 3))
-	require.Equal(t, "…", truncateWithEllipsis("héllo", 1))
-	// Byte-based slicing would have split the multibyte rune; rune-based must not.
-	require.True(t, strings.HasSuffix(truncateWithEllipsis("héllo", 3), "…"))
 }

--- a/views/services/model.go
+++ b/views/services/model.go
@@ -72,8 +72,6 @@ type Model struct {
 	serviceHasError map[string]bool
 	// serviceErrorText stores a representative error text per service
 	serviceErrorText map[string]string
-	// columnScrollOffset controls horizontal scroll for all columns
-	columnScrollOffset int
 
 	// Track task navigation: -1 means service row is selected, >= 0 means task at that index
 	selectedTaskIndex int
@@ -111,9 +109,9 @@ func New(width, height int) *Model {
 		Match: func(s docker.ServiceEntry, query string) bool {
 			return strings.Contains(strings.ToLower(s.ServiceName), strings.ToLower(query))
 		},
+		Columns: m.layoutColumns(),
 		Header: &filterlist.HeaderConfig{
-			Columns:       headerColumns(m.activeColumnLabels()),
-			ColWidthsFunc: m.computeColWidths,
+			Columns:       filterlist.ColumnDefs(m.layoutColumns()),
 			SortIndicator: m.sortIndicator,
 		},
 		Footer: &filterlist.FooterConfig{ItemLabel: "Node"},

--- a/views/services/update.go
+++ b/views/services/update.go
@@ -11,6 +11,7 @@ import (
 	"swarmcli/core/primitives/hash"
 	"swarmcli/docker"
 	"swarmcli/ui"
+	filterlist "swarmcli/ui/components/filterable/list"
 	"swarmcli/views/confirmdialog"
 	helpview "swarmcli/views/help"
 	inspectview "swarmcli/views/inspect"
@@ -24,20 +25,6 @@ import (
 	"github.com/charmbracelet/lipgloss"
 	"github.com/docker/docker/api/types/swarm"
 )
-
-// truncateWithEllipsis truncates a string to maxWidth runes, adding … if needed.
-// It counts and slices by runes so width measurement (displayWidth) and the
-// truncated output agree on multibyte content.
-func truncateWithEllipsis(s string, maxWidth int) string {
-	r := []rune(s)
-	if len(r) <= maxWidth {
-		return s
-	}
-	if maxWidth <= 1 {
-		return "…"
-	}
-	return string(r[:maxWidth-1]) + "…"
-}
 
 func (m *Model) Update(msg tea.Msg) tea.Cmd {
 	switch msg := msg.(type) {
@@ -282,19 +269,11 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 		// Handle left/right for column scrolling
 		switch msg.String() {
 		case "left":
-			if m.columnScrollOffset > 0 {
-				m.columnScrollOffset -= 5
-				if m.columnScrollOffset < 0 {
-					m.columnScrollOffset = 0
-				}
-				m.setRenderItem()
-				m.List.Viewport.SetContent(m.List.View())
-			}
+			m.List.ScrollLeft()
+			m.List.Viewport.SetContent(m.List.View())
 			return nil
 		case "right":
-			// Scroll right if any column has more content
-			m.columnScrollOffset += 5
-			m.setRenderItem()
+			m.List.ScrollRight()
 			m.List.Viewport.SetContent(m.List.View())
 			return nil
 		}
@@ -366,7 +345,7 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 		if oldCursor != m.List.Cursor {
 			m.selectedTaskIndex = -1
 			// Reset horizontal scroll when moving cursor
-			m.columnScrollOffset = 0
+			m.List.ResetColumnScroll()
 		}
 
 		switch msg.String() {
@@ -596,23 +575,6 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 	return cmd
 }
 
-// formatErrorWithScroll formats error text with horizontal offset and truncation indicator
-func formatErrorWithScroll(full string, offset int, maxWidth int) string {
-	if full == "" {
-		return ""
-	}
-	if offset > len(full) {
-		offset = len(full)
-	}
-	visible := full[offset:]
-
-	// Truncate to maxWidth
-	if len(visible) > maxWidth {
-		visible = truncateWithEllipsis(visible, maxWidth)
-	}
-	return visible
-}
-
 func (m *Model) SetContent(msg Msg) {
 	l().Infof("ServicesView.SetContent: Updating display with %d services", len(msg.Entries))
 
@@ -644,11 +606,13 @@ func (m *Model) SetContent(msg Msg) {
 	m.nodeID = msg.NodeID
 	m.stackName = msg.StackName
 
-	// Rebuild the header to match the active column set for this scope (STACK is
-	// dropped outside AllFilter). Header, widths, sort indices, and rows all
-	// derive from activeColumns so they stay consistent.
+	// Rebuild the columns to match the active set for this scope (STACK is
+	// dropped outside AllFilter). Widths, header, sort indices, and rows all
+	// derive from the same set so they stay consistent.
+	cols := m.layoutColumns()
+	m.List.Columns = cols
 	if m.List.Header != nil {
-		m.List.Header.Columns = headerColumns(m.activeColumnLabels())
+		m.List.Header.Columns = filterlist.ColumnDefs(cols)
 	}
 
 	m.setRenderItem()
@@ -782,112 +746,11 @@ func (m *Model) refreshServiceErrorsFromSnapshot() {
 	}
 }
 
-// computeColWidths sizes the active columns to their content so wide terminals
-// no longer truncate names while space sits empty, and guarantees at least one
-// space between columns. Each returned width includes a trailing gap; the row
-// and header renderers left-align text into it, so the gap is trailing padding.
-// Header and rows stay aligned because both derive from this same array and the
-// same active column set.
-func (m *Model) computeColWidths(width int) []int {
-	if width <= 0 {
-		width = 80
-	}
-	active := m.activeColumns()
-	n := len(active)
-	if n == 0 {
-		return nil
-	}
-
-	content := make([]int, n)
-	floors := make([]int, n)
-	flex := make([]bool, n)
-	sum := 0
-	for i, spec := range active {
-		// Floor: the header label is never truncated by the shared renderer, so a
-		// column must never shrink below its label width (plus the sort indicator
-		// on the active sort column) or the header overflows and misaligns with
-		// the rows. Also honour the column's declared minimum.
-		fl := displayWidth(spec.label)
-		if spec.hasSort && spec.sort == m.sortField {
-			fl += 2 // " ▲"/" ▼"
-		}
-		if fl < spec.minWidth {
-			fl = spec.minWidth
-		}
-		if fl < 3 {
-			fl = 3
-		}
-
-		// Natural content width: the widest of the floor and any cell.
-		w := fl
-		for _, e := range m.List.Filtered {
-			if cw := displayWidth(spec.cell(m, e)); cw > w {
-				w = cw
-			}
-		}
-		floors[i] = fl
-		content[i] = w
-		flex[i] = spec.flex
-		sum += w
-	}
-
-	// Column 0 renders with a leading space (header convention); reserve one
-	// extra cell in both its natural width and its floor so the leading space
-	// never eats into the trailing gap.
-	content[0]++
-	floors[0]++
-	sum++
-
-	need := sum + colGap*n
-	switch {
-	case need < width:
-		// Hand the leftover to flex columns (SERVICE first via the remainder).
-		distributeSlack(content, flex, width-need)
-	case need > width:
-		shrinkColumns(content, floors, flex, need-width)
-	}
-
-	colWidths := make([]int, n)
-	for i := range content {
-		colWidths[i] = content[i] + colGap
-	}
-	return colWidths
-}
-
 func (m *Model) setRenderItem() {
-	// Use shared computation for column widths to keep header and rows in sync
+	// The shared layout computes widths and the base row text; this view keeps
+	// its own decoration (error coloring, full-width highlight, task sub-rows).
 	m.List.RenderItem = func(e docker.ServiceEntry, selected bool, _ int) string {
-		active := m.activeColumns()
-		colWidths := m.List.ColWidths()
-		if len(colWidths) != len(active) {
-			return e.ServiceName
-		}
-
-		// Build each column cell from the active column set so header, widths,
-		// and rows stay in lockstep. Flex columns horizontally scroll when the
-		// selected row's content is truncated; every column keeps a trailing gap.
-		cells := make([]string, len(active))
-		for i, spec := range active {
-			raw := spec.cell(m, e)
-			cw := colWidths[i] - colGap
-			lead := ""
-			if i == 0 {
-				// Column 0 carries a leading space matching the header convention.
-				lead = " "
-				cw--
-			}
-			if cw < 1 {
-				cw = 1
-			}
-			var text string
-			if selected && spec.flex && displayWidth(raw) > cw {
-				text = formatErrorWithScroll(raw, m.columnScrollOffset, cw)
-			} else {
-				text = truncateWithEllipsis(raw, cw)
-			}
-			cells[i] = fmt.Sprintf("%s%-*s", lead, colWidths[i]-len(lead), text)
-		}
-		rowText := strings.Join(cells, "")
+		rowText := m.List.RenderRow(e, selected)
 
 		itemStyle := ui.ListItemStyle
 
@@ -927,11 +790,11 @@ func (m *Model) setRenderItem() {
 
 				// Add each task as a row
 				for taskIdx, task := range tasks {
-					taskName := truncateWithEllipsis(task.Name, 22)
-					taskNode := truncateWithEllipsis(task.NodeName, 12)
-					taskDesired := truncateWithEllipsis(task.DesiredState, 13)
-					taskCurrent := truncateWithEllipsis(task.CurrentState, 40)
-					taskErr := truncateWithEllipsis(task.Error, 30)
+					taskName := filterlist.TruncateRunes(task.Name, 22)
+					taskNode := filterlist.TruncateRunes(task.NodeName, 12)
+					taskDesired := filterlist.TruncateRunes(task.DesiredState, 13)
+					taskCurrent := filterlist.TruncateRunes(task.CurrentState, 40)
+					taskErr := filterlist.TruncateRunes(task.Error, 30)
 
 					// Check if this task is selected
 					taskSelected := selected && m.selectedTaskIndex == taskIdx


### PR DESCRIPTION
Fixes #394.

## Problem
Issue #394 asks for the services column fix (#392) on the secrets and config views: (1) keep ≥1 space after a long first column, (2) left/right arrows scroll the unseen parts of truncated cells, (3) content-aware widths that reclaim free space. The secrets, configs **and** nodes views all shared the same defects — generic equal-division widths, byte-based truncation, and an ad-hoc scroll that only moved the LABELS column.

## Change
Rather than copy the services logic into each view, the algorithm is extracted into a **reusable generic layer** in the filterable-list component and adopted by all four views (you chose this scope: secrets + configs + nodes, plus migrating services so there's a single implementation).

**New `ui/components/filterable/list/layout.go`:**
- generic `Column[T]{Label, MinWidth, Flex, Cell}`
- `LayoutWidths` — content-aware widths (floor at label width + sort-arrow reserve, col-0 leading space, baked 1-cell gap, slack to flex columns, flex-first shrink) — the #392 algorithm, generalized
- `RenderRow` — plain gapped/truncated/scrolled row text (the view applies styling)
- rune-aware `TruncateRunes` / `ScrollWindow` — **fixes the byte-slicing bug** in the old labels scroll for multibyte names/labels
- `ColumnDefs` helper to keep header labels in lockstep with the column set

`FilterableList` gains opt-in `Columns` + `columnScroll` fields and `ColWidths`/`RenderRow`/`ScrollLeft`/`ScrollRight`/`ResetColumnScroll`. **All new behavior is guarded by `Columns != nil`**, so the list views that don't opt in (stacks, contexts, networks, tasks) are byte-for-byte unchanged.

**Adoption:**
- **secrets / configs / nodes** declare their columns and delegate widths + base row text to the shared layer, keeping their own styling. The labels-only `>` scroll is replaced by the unified flex-column `…` scroll (NAME/ID/LABELS, and ID/HOSTNAME/LABELS for nodes). **Configs also gains the scroll-reset-on-cursor-move it was silently missing.**
- **services** migrated onto the shared layer; its bespoke `computeColWidths`/`distributeSlack`/`shrink`/`displayWidth`/`formatErrorWithScroll` are deleted (single source of truth). Its extras — conditional STACK column, error-row coloring, full-width highlight, expandable task sub-rows — stay view-side. The #392 alignment regression test now guards the shared engine.
- **"SECRET USED" / "CONFIG USED" → "USED"**, reclaiming ~7 columns for the flex columns (in the spirit of #394). Visible header text change.

Dead code removed: nodes `calcColumnWidths` + its unused `colWidths` map; the per-view byte-based `truncateWithEllipsis`/`formatLabelsWithScroll` copies.

## Tests
- New `layout_test.go`: width fit/shrink, gap + label-floor preserved when narrow, sort-arrow floor, header/row length, rune-aware truncate/scroll (incl. CJK).
- Per-view `columns_test.go` (secrets/configs/nodes/services): content-aware width (full name/hostname on a wide terminal), **header↔row width alignment** across widths/scopes/sort fields, left/right arrow shifts the window, reset-on-cursor-move, and the "USED" rename.
- `go test ./...`, `go vet`, `gofmt`, and `golangci-lint run ./ui/... ./views/...` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)