### PR TITLE
feat(volumes): read-only Docker volumes view (#260)

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ TEST_LOG=1 ./test-setup/testenv.sh test
 | `:node`  | Navigate to Nodes       |
 | `:config`  | Navigate to Config    |
 | `:secret`  | Navigate to Secret    |
+| `:volume`  | Navigate to Volumes   |
 | `:node`  | Navigate to Nodes       |
 | `l`      | View Logs               |
 | `s`      | Scale Service           |

--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ TEST_LOG=1 ./test-setup/testenv.sh test
 | `:node`  | Navigate to Nodes       |
 | `:config`  | Navigate to Config    |
 | `:secret`  | Navigate to Secret    |
+| `:network` | Navigate to Networks  |
 | `:volume`  | Navigate to Volumes   |
 | `:node`  | Navigate to Nodes       |
 | `l`      | View Logs               |

--- a/commands/autoload.go
+++ b/commands/autoload.go
@@ -10,4 +10,5 @@ import (
 	_ "swarmcli/commands/command/docker/network"
 	_ "swarmcli/commands/command/docker/node"
 	_ "swarmcli/commands/command/docker/secret"
+	_ "swarmcli/commands/command/docker/volume"
 )

--- a/commands/command/docker/volume/ls.go
+++ b/commands/command/docker/volume/ls.go
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package volume
+
+import (
+	"swarmcli/args"
+	"swarmcli/registry"
+	"swarmcli/views/view"
+	volumesview "swarmcli/views/volumes"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+type DockerVolumeLs struct{}
+
+func (DockerVolumeLs) Name() string        { return "volume" }
+func (DockerVolumeLs) Description() string { return "docker volume ls" }
+
+func (DockerVolumeLs) Spec() registry.CommandSpec {
+	return registry.CommandSpec{
+		Detail: "Opens the Docker Volumes list, where you can browse and " +
+			"inspect volumes. The list covers the connected node only; " +
+			"listing volumes across all swarm nodes is a Business Edition " +
+			"feature.",
+		Examples: []string{":volume"},
+	}
+}
+
+func (DockerVolumeLs) Execute(ctx any, args args.Args) tea.Cmd {
+	return func() tea.Msg {
+		return view.NavigateToMsg{
+			ViewName: volumesview.ViewName,
+			Payload:  nil,
+		}
+	}
+}
+
+var lsCmd = DockerVolumeLs{}
+
+func init() {
+	registry.Register(lsCmd)
+}

--- a/docker/ops.go
+++ b/docker/ops.go
@@ -14,6 +14,7 @@ type Deps struct {
 	Configs     ConfigOps
 	Secrets     SecretOps
 	Networks    NetworkOps
+	Volumes     VolumeOps
 	Contexts    ContextOps
 	Snapshot    SnapshotOps
 	ClusterInfo ClusterInfoOps
@@ -34,6 +35,7 @@ func DefaultDeps() Deps {
 		Configs:     defaultConfigOps{},
 		Secrets:     defaultSecretOps{},
 		Networks:    defaultNetworkOps{},
+		Volumes:     defaultVolumeOps{},
 		Contexts:    defaultContextOps{},
 		Snapshot:    defaultSnapshotOps{},
 		ClusterInfo: defaultClusterInfoOps{},

--- a/docker/volume.go
+++ b/docker/volume.go
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package docker
+
+import (
+	"context"
+	"time"
+
+	"github.com/docker/docker/api/types/volume"
+)
+
+// VolumeInfo is the edition-agnostic view of a Docker volume consumed by the
+// volumes view. The default (CE) implementation populates it from the
+// connected node only; the Host field is an extension point so an
+// implementation that aggregates across all swarm nodes can report which node
+// each volume lives on.
+type VolumeInfo struct {
+	Name       string
+	Stack      string // com.docker.stack.namespace label, "" if not stack-managed
+	Driver     string
+	Mountpoint string
+	Created    time.Time
+	Host       string // node the volume lives on
+	Labels     map[string]string
+	Raw        *volume.Volume // underlying SDK object, for inspect
+}
+
+// ListVolumes returns the volumes on the connected Docker node.
+//
+// docker volume ls is per-node: this lists only the volumes local to the
+// daemon the current context points at. Listing volumes across every swarm
+// node requires reaching each node individually and is left as an extension
+// point (see VolumeOps).
+func ListVolumes(ctx context.Context) ([]VolumeInfo, error) {
+	cli, err := GetClient()
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := cli.VolumeList(ctx, volume.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	// The connected daemon's hostname is the node every listed volume lives on.
+	host := ""
+	if info, infoErr := cli.Info(ctx); infoErr == nil {
+		host = info.Name
+	}
+
+	items := make([]VolumeInfo, 0, len(resp.Volumes))
+	for _, v := range resp.Volumes {
+		if v == nil {
+			continue
+		}
+		items = append(items, volumeInfoFromSummary(v, host))
+	}
+	return items, nil
+}
+
+// InspectVolume returns the raw SDK volume for the given name on the
+// connected node.
+func InspectVolume(ctx context.Context, name string) (volume.Volume, error) {
+	cli, err := GetClient()
+	if err != nil {
+		return volume.Volume{}, err
+	}
+	return cli.VolumeInspect(ctx, name)
+}
+
+// volumeInfoFromSummary maps an SDK volume to a VolumeInfo, parsing the
+// creation timestamp and extracting the stack label. host is the node the
+// volume lives on.
+func volumeInfoFromSummary(v *volume.Volume, host string) VolumeInfo {
+	var created time.Time
+	if v.CreatedAt != "" {
+		if t, err := time.Parse(time.RFC3339, v.CreatedAt); err == nil {
+			created = t
+		}
+	}
+	return VolumeInfo{
+		Name:       v.Name,
+		Stack:      v.Labels["com.docker.stack.namespace"],
+		Driver:     v.Driver,
+		Mountpoint: v.Mountpoint,
+		Created:    created,
+		Host:       host,
+		Labels:     v.Labels,
+		Raw:        v,
+	}
+}

--- a/docker/volume_ops.go
+++ b/docker/volume_ops.go
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package docker
+
+import (
+	"context"
+
+	"github.com/docker/docker/api/types/volume"
+)
+
+// VolumeOps abstracts volume operations for testability and extensibility.
+//
+// The default implementation lists volumes on the connected node only.
+// Implementations that aggregate volumes across all swarm nodes can be
+// substituted via Deps without changing the volumes view.
+type VolumeOps interface {
+	ListVolumes(ctx context.Context) ([]VolumeInfo, error)
+	InspectVolume(ctx context.Context, name string) (volume.Volume, error)
+}
+
+type defaultVolumeOps struct{}
+
+func (defaultVolumeOps) ListVolumes(ctx context.Context) ([]VolumeInfo, error) {
+	return ListVolumes(ctx)
+}
+func (defaultVolumeOps) InspectVolume(ctx context.Context, name string) (volume.Volume, error) {
+	return InspectVolume(ctx, name)
+}

--- a/docker/volume_test.go
+++ b/docker/volume_test.go
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package docker
+
+import (
+	"testing"
+
+	"github.com/docker/docker/api/types/volume"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVolumeInfoFromSummary_FullMapping(t *testing.T) {
+	v := &volume.Volume{
+		Name:       "vol1",
+		Driver:     "local",
+		Mountpoint: "/var/lib/docker/volumes/vol1/_data",
+		CreatedAt:  "2026-01-02T15:04:05Z",
+		Labels:     map[string]string{"com.docker.stack.namespace": "mystack"},
+	}
+	info := volumeInfoFromSummary(v, "node-1")
+
+	require.Equal(t, "vol1", info.Name)
+	require.Equal(t, "mystack", info.Stack)
+	require.Equal(t, "local", info.Driver)
+	require.Equal(t, "/var/lib/docker/volumes/vol1/_data", info.Mountpoint)
+	require.Equal(t, "node-1", info.Host)
+	require.Equal(t, 2026, info.Created.UTC().Year())
+	require.Same(t, v, info.Raw)
+}
+
+func TestVolumeInfoFromSummary_EmptyOptionalFields(t *testing.T) {
+	info := volumeInfoFromSummary(&volume.Volume{Name: "anon", Driver: "local"}, "")
+	require.Empty(t, info.Stack)
+	require.Empty(t, info.Host)
+	require.True(t, info.Created.IsZero())
+}
+
+func TestVolumeInfoFromSummary_InvalidTimestamp(t *testing.T) {
+	info := volumeInfoFromSummary(&volume.Volume{Name: "x", CreatedAt: "not-a-time"}, "n")
+	require.True(t, info.Created.IsZero())
+}

--- a/integration-tests/docker/volume/volume_test.go
+++ b/integration-tests/docker/volume/volume_test.go
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+//go:build integration
+
+package volume
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"swarmcli/docker"
+	swarmlog "swarmcli/utils/log"
+
+	"github.com/docker/docker/api/types/volume"
+	"github.com/stretchr/testify/require"
+)
+
+func uniqueName(base string) string {
+	return fmt.Sprintf("%s-%d", base, time.Now().UnixNano())
+}
+
+// TestListVolumes_IncludesCreatedVolume verifies the connected-node listing
+// path end-to-end. docker volume ls is per-node, so rather than depend on
+// where swarm scheduled the test stack's tasks, we create a volume on the
+// connected (manager) node and assert it surfaces with mapped fields.
+func TestListVolumes_IncludesCreatedVolume(t *testing.T) {
+	swarmlog.InitTestIfTestLogEnv()
+	ctx := context.Background()
+
+	cli, err := docker.GetClient()
+	require.NoError(t, err)
+
+	name := uniqueName("test_vol")
+	_, err = cli.VolumeCreate(ctx, volume.CreateOptions{
+		Name:   name,
+		Driver: "local",
+		Labels: map[string]string{"com.docker.stack.namespace": "demo"},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = cli.VolumeRemove(ctx, name, true) })
+
+	volumes, err := docker.ListVolumes(ctx)
+	require.NoError(t, err)
+	require.NotEmpty(t, volumes)
+
+	var found *docker.VolumeInfo
+	for i := range volumes {
+		if volumes[i].Name == name {
+			found = &volumes[i]
+			break
+		}
+	}
+	require.NotNil(t, found, "created volume %q should appear in ListVolumes", name)
+	require.Equal(t, "local", found.Driver)
+	require.Equal(t, "demo", found.Stack)
+	require.NotEmpty(t, found.Mountpoint)
+	require.NotEmpty(t, found.Host, "host should be the connected node's hostname")
+}
+
+func TestInspectVolume(t *testing.T) {
+	swarmlog.InitTestIfTestLogEnv()
+	ctx := context.Background()
+
+	cli, err := docker.GetClient()
+	require.NoError(t, err)
+
+	name := uniqueName("test_vol_inspect")
+	_, err = cli.VolumeCreate(ctx, volume.CreateOptions{Name: name, Driver: "local"})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = cli.VolumeRemove(ctx, name, true) })
+
+	v, err := docker.InspectVolume(ctx, name)
+	require.NoError(t, err)
+	require.Equal(t, name, v.Name)
+	require.Equal(t, "local", v.Driver)
+}

--- a/views/autoload.go
+++ b/views/autoload.go
@@ -17,4 +17,5 @@ import (
 	_ "swarmcli/views/services"
 	_ "swarmcli/views/stacks"
 	_ "swarmcli/views/tasks"
+	_ "swarmcli/views/volumes"
 )

--- a/views/view/constants.go
+++ b/views/view/constants.go
@@ -17,12 +17,13 @@ const (
 	NameLogs     = "logs"
 	NameLoading  = "loading"
 	NameNetworks = "networks"
+	NameVolumes  = "volumes"
 )
 
 var topLevelViews = map[string]bool{
 	NameStacks: true, NameNodes: true, NameConfigs: true,
-	NameSecrets: true, NameNetworks: true, NameContexts: true,
-	NameLoading: true, NameHelp: true,
+	NameSecrets: true, NameNetworks: true, NameVolumes: true,
+	NameContexts: true, NameLoading: true, NameHelp: true,
 }
 
 // RegisterTopLevel marks a view name as top-level. Called from init() by

--- a/views/view/constants_test.go
+++ b/views/view/constants_test.go
@@ -12,7 +12,7 @@ import (
 func TestIsTopLevel(t *testing.T) {
 	topLevel := []string{
 		NameStacks, NameNodes, NameConfigs, NameSecrets,
-		NameNetworks, NameContexts, NameLoading, NameHelp,
+		NameNetworks, NameVolumes, NameContexts, NameLoading, NameHelp,
 	}
 	for _, name := range topLevel {
 		require.True(t, IsTopLevel(name), "expected %q to be top-level", name)

--- a/views/volumes/actions.go
+++ b/views/volumes/actions.go
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package volumesview
+
+import (
+	"fmt"
+	"time"
+)
+
+type volumeItem struct {
+	Name       string
+	Stack      string
+	Driver     string
+	Mountpoint string
+	Created    time.Time
+	Host       string
+}
+
+func (i volumeItem) FilterValue() string { return i.Name }
+func (i volumeItem) Title() string       { return i.Name }
+func (i volumeItem) Description() string {
+	createdStr := "N/A"
+	if !i.Created.IsZero() {
+		createdStr = i.Created.Format("2006-01-02 15:04:05")
+	}
+	return fmt.Sprintf("Stack: %s        Driver: %s        Mount: %s        Created: %s        Host: %s",
+		displayOrDash(i.Stack), i.Driver, i.Mountpoint, createdStr, displayOrDash(i.Host))
+}
+
+// displayOrDash renders an em-dash for empty optional fields.
+func displayOrDash(s string) string {
+	if s == "" {
+		return "—"
+	}
+	return s
+}

--- a/views/volumes/columns_test.go
+++ b/views/volumes/columns_test.go
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package volumesview
+
+import (
+	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/stretchr/testify/require"
+)
+
+func TestColWidths_SumToWidth(t *testing.T) {
+	for _, w := range []int{60, 80, 100, 120, 200} {
+		widths := (&Model{}).volumeColWidths(w)
+		require.Len(t, widths, 6)
+		sum := 0
+		for _, cw := range widths {
+			require.Greater(t, cw, 0)
+			sum += cw
+		}
+		// columns + 5 two-space separators reconstruct the effective width.
+		require.LessOrEqual(t, sum+5*2, w+1, "columns must fit within the available width at w=%d", w)
+	}
+}
+
+func TestHeaderAndRow_Aligned(t *testing.T) {
+	for _, w := range []int{80, 120} {
+		m := testModel()
+		m.volumesList.Viewport.Width = w
+		loadVolumes(m, fakeVolumes("alpha"))
+
+		header := m.renderVolumesHeader()
+		row := m.volumesList.RenderItem(m.volumesList.Filtered[0], false, 0)
+		require.Equal(t, lipgloss.Width(header), lipgloss.Width(row),
+			"header and row widths must match at width %d", w)
+	}
+}

--- a/views/volumes/help.go
+++ b/views/volumes/help.go
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package volumesview
+
+import helpview "swarmcli/views/help"
+
+// GetVolumesHelpContent returns categorized help for the volumes view.
+func GetVolumesHelpContent() []helpview.HelpCategory {
+	return []helpview.HelpCategory{
+		{
+			Title: "General",
+			Items: []helpview.HelpItem{
+				{Keys: "<i/enter>", Description: "Inspect selected volume"},
+				{Keys: "</>", Description: "Filter volumes"},
+				{Keys: "<?>", Description: "Open this help"},
+			},
+		},
+		{
+			Title: "Sorting",
+			Items: []helpview.HelpItem{
+				{Keys: "<shift+n>", Description: "Order by Name"},
+				{Keys: "<shift+s>", Description: "Order by Stack"},
+				{Keys: "<shift+d>", Description: "Order by Driver"},
+				{Keys: "<shift+c>", Description: "Order by Created"},
+				{Keys: "<shift+h>", Description: "Order by Host"},
+				{Keys: "(repeat key)", Description: "Toggle ascending/descending"},
+			},
+		},
+		{
+			Title: "Navigation",
+			Items: []helpview.HelpItem{
+				{Keys: "<↑/↓>", Description: "Move cursor"},
+				{Keys: "<pgup>", Description: "Page up"},
+				{Keys: "<pgdown>", Description: "Page down"},
+				{Keys: "<esc/q>", Description: "Back"},
+			},
+		},
+	}
+}

--- a/views/volumes/messages.go
+++ b/views/volumes/messages.go
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package volumesview
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"swarmcli/core/primitives/hash"
+	"swarmcli/docker"
+	inspectview "swarmcli/views/inspect"
+	"swarmcli/views/view"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+const PollInterval = 5 * time.Second
+
+type TickMsg time.Time
+
+// PollRetryMsg signals that polling found no changes; the Update handler
+// should schedule the next tick.
+type PollRetryMsg struct{}
+
+type SpinnerTickMsg time.Time
+
+type VolumesLoadedMsg struct {
+	Volumes []volumeItem
+	Err     error
+}
+
+func (m *Model) loadVolumesCmd() tea.Cmd {
+	volumeOps := m.deps.Volumes
+	return func() tea.Msg {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+
+		volumes, err := volumeOps.ListVolumes(ctx)
+		if err != nil {
+			return VolumesLoadedMsg{Err: fmt.Errorf("failed to list volumes: %w", err)}
+		}
+		return VolumesLoadedMsg{Volumes: toVolumeItems(volumes)}
+	}
+}
+
+// checkVolumesCmd reloads only when the volume set has changed since lastHash.
+func (m *Model) checkVolumesCmd(lastHash uint64) tea.Cmd {
+	volumeOps := m.deps.Volumes
+	return func() tea.Msg {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+
+		volumes, err := volumeOps.ListVolumes(ctx)
+		if err != nil {
+			return VolumesLoadedMsg{Err: err}
+		}
+		items := toVolumeItems(volumes)
+		newHash, hErr := hash.Compute(stableVolumes(items))
+		if hErr != nil {
+			l().Errorf("Error computing hash: %v", hErr)
+			return PollRetryMsg{}
+		}
+		if newHash != lastHash {
+			l().Info("Volumes changed, reloading")
+			return VolumesLoadedMsg{Volumes: items}
+		}
+		return PollRetryMsg{}
+	}
+}
+
+func (m *Model) inspectVolumeCmd(name string) tea.Cmd {
+	volumeOps := m.deps.Volumes
+	return func() tea.Msg {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+
+		title := fmt.Sprintf("Volume: %s", name)
+
+		vol, err := volumeOps.InspectVolume(ctx, name)
+		if err != nil {
+			return view.NavigateToMsg{
+				ViewName: inspectview.ViewName,
+				Payload: map[string]any{
+					"title":  title,
+					"json":   fmt.Sprintf("# Error inspecting volume:\n# %v", err),
+					"format": inspectview.FormatRaw,
+				},
+			}
+		}
+
+		content, jsonErr := json.MarshalIndent(vol, "", "  ")
+		if jsonErr != nil {
+			return view.NavigateToMsg{
+				ViewName: inspectview.ViewName,
+				Payload: map[string]any{
+					"title":  title,
+					"json":   fmt.Sprintf("# Error marshalling volume:\n# %v", jsonErr),
+					"format": inspectview.FormatRaw,
+				},
+			}
+		}
+
+		return view.NavigateToMsg{
+			ViewName: inspectview.ViewName,
+			Payload: map[string]any{
+				"title": title,
+				"json":  string(content),
+			},
+		}
+	}
+}
+
+func toVolumeItems(volumes []docker.VolumeInfo) []volumeItem {
+	items := make([]volumeItem, len(volumes))
+	for i, v := range volumes {
+		items[i] = volumeItem{
+			Name:       v.Name,
+			Stack:      v.Stack,
+			Driver:     v.Driver,
+			Mountpoint: v.Mountpoint,
+			Created:    v.Created,
+			Host:       v.Host,
+		}
+	}
+	return items
+}
+
+// stableVolumes projects the fields that define a meaningful change for
+// change-detection hashing.
+func stableVolumes(items []volumeItem) []struct {
+	Name, Driver, Mountpoint, Host string
+} {
+	out := make([]struct {
+		Name, Driver, Mountpoint, Host string
+	}, len(items))
+	for i, it := range items {
+		out[i] = struct {
+			Name, Driver, Mountpoint, Host string
+		}{it.Name, it.Driver, it.Mountpoint, it.Host}
+	}
+	return out
+}

--- a/views/volumes/model.go
+++ b/views/volumes/model.go
@@ -11,7 +11,6 @@ import (
 	"swarmcli/docker"
 	filterlist "swarmcli/ui/components/filterable/list"
 	"swarmcli/views/helpbar"
-	loading "swarmcli/views/loading"
 
 	"github.com/charmbracelet/bubbles/viewport"
 	tea "github.com/charmbracelet/bubbletea"
@@ -52,7 +51,6 @@ type Model struct {
 	err   error
 
 	errorDialogActive bool
-	loadingView       *loading.Model
 
 	spinner int
 
@@ -70,7 +68,6 @@ func New(width, height int) *Model {
 		firstResize:   true,
 		state:         stateLoading,
 		visible:       true,
-		loadingView:   loading.New(width, height, false, "Loading Docker volumes..."),
 		sortField:     SortByName,
 		sortAscending: true,
 	}
@@ -186,9 +183,6 @@ func (m *Model) SetVisible(visible bool) {
 func (m *Model) SetSize(width, height int) {
 	m.width = width
 	m.height = height
-	if m.loadingView != nil {
-		m.loadingView.SetSize(width, height)
-	}
 	m.volumesList.Viewport.Width = width
 	m.volumesList.Viewport.Height = height
 	m.volumesList.SetOuterSize(width, height)

--- a/views/volumes/model.go
+++ b/views/volumes/model.go
@@ -1,0 +1,212 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package volumesview
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"swarmcli/docker"
+	filterlist "swarmcli/ui/components/filterable/list"
+	"swarmcli/views/helpbar"
+	loading "swarmcli/views/loading"
+
+	"github.com/charmbracelet/bubbles/viewport"
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+type SortField int
+
+const (
+	SortByName SortField = iota
+	SortByStack
+	SortByDriver
+	SortByCreated
+	SortByHost
+)
+
+type state int
+
+const (
+	stateLoading state = iota
+	stateReady
+	stateError
+)
+
+type Model struct {
+	deps          docker.Deps
+	volumesList   filterlist.FilterableList[volumeItem]
+	width         int
+	height        int
+	firstResize   bool
+	lastSnapshot  uint64
+	visible       bool
+	sortField     SortField
+	sortAscending bool
+
+	resetCursorOnNextLoad bool
+
+	state state
+	err   error
+
+	errorDialogActive bool
+	loadingView       *loading.Model
+
+	spinner int
+
+	toastMessage string
+	toastUntil   time.Time
+}
+
+func New(width, height int) *Model {
+	vp := viewport.New(width, height)
+	vp.SetContent("")
+
+	m := &Model{
+		width:         width,
+		height:        height,
+		firstResize:   true,
+		state:         stateLoading,
+		visible:       true,
+		loadingView:   loading.New(width, height, false, "Loading Docker volumes..."),
+		sortField:     SortByName,
+		sortAscending: true,
+	}
+
+	list := filterlist.FilterableList[volumeItem]{
+		Viewport: vp,
+		Match: func(v volumeItem, query string) bool {
+			q := strings.ToLower(query)
+			return strings.Contains(strings.ToLower(v.Name), q) ||
+				strings.Contains(strings.ToLower(v.Stack), q) ||
+				strings.Contains(strings.ToLower(v.Driver), q) ||
+				strings.Contains(strings.ToLower(v.Mountpoint), q) ||
+				strings.Contains(strings.ToLower(v.Host), q)
+		},
+		Header: &filterlist.HeaderConfig{
+			Columns: []filterlist.ColumnDef{
+				{Label: "NAME"}, {Label: "STACK"}, {Label: "DRIVER"},
+				{Label: "MOUNT POINT"}, {Label: "CREATED"}, {Label: "HOST"},
+			},
+			ColWidthsFunc: func(w int) []int {
+				return m.volumeColWidths(w)
+			},
+		},
+		Footer: &filterlist.FooterConfig{
+			ItemLabel: "Volume",
+			Override: func(cursor, filteredCount int, mode filterlist.ModeType, query string) string {
+				return m.renderVolumesFooter()
+			},
+		},
+	}
+	// Non-nil slices so the renderer pads content while loading.
+	list.Items = []volumeItem{}
+	list.Filtered = []volumeItem{}
+	list.SetOuterSize(width, height)
+
+	m.volumesList = list
+	m.setRenderItem()
+	return m
+}
+
+func (m *Model) Name() string { return ViewName }
+
+func (m *Model) Init() tea.Cmd {
+	l().Info("VolumesView: Init() called - starting ticker and loading volumes")
+	return tea.Batch(tickCmd(), m.spinnerTickCmd(), m.loadVolumesCmd())
+}
+
+func (m *Model) spinnerTickCmd() tea.Cmd {
+	return tea.Tick(80*time.Millisecond, func(t time.Time) tea.Msg {
+		return SpinnerTickMsg(t)
+	})
+}
+
+func tickCmd() tea.Cmd {
+	return tea.Tick(PollInterval, func(t time.Time) tea.Msg {
+		return TickMsg(t)
+	})
+}
+
+// HasActiveFilter reports whether a filter query is active.
+func (m *Model) HasActiveFilter() bool {
+	return m.volumesList.Query != ""
+}
+
+// CapturesInput reports whether the view is currently capturing all input.
+func (m *Model) CapturesInput() bool {
+	return m.errorDialogActive
+}
+
+// ApplySearchQuery sets the filter query on the volumes list (app-level "/").
+func (m *Model) ApplySearchQuery(query string) {
+	m.volumesList.Query = query
+	m.volumesList.ApplyFilter()
+	m.applySorting()
+}
+
+// ClearSearchQuery clears the active filter.
+func (m *Model) ClearSearchQuery() {
+	m.volumesList.Query = ""
+	m.volumesList.ApplyFilter()
+	m.volumesList.Cursor = 0
+	m.volumesList.Viewport.GotoTop()
+	m.applySorting()
+}
+
+func (m *Model) ShortHelpItems() []helpbar.HelpEntry {
+	return []helpbar.HelpEntry{
+		{Key: "↑/↓", Desc: "Navigate"},
+		{Key: "i", Desc: "Inspect"},
+		{Key: "/", Desc: "Filter"},
+		{Key: "?", Desc: "Help"},
+		{Key: "esc", Desc: "Back"},
+	}
+}
+
+func (m *Model) showToast(msg string) {
+	if msg == "" {
+		return
+	}
+	m.toastMessage = msg
+	d := 2 * time.Second
+	if strings.Contains(msg, "\n") {
+		d = 5 * time.Second
+	}
+	m.toastUntil = time.Now().Add(d)
+}
+
+func (m *Model) SetVisible(visible bool) {
+	m.visible = visible
+	l().Info(fmt.Sprintf("VolumesView: SetVisible(%v)", visible))
+}
+
+func (m *Model) SetSize(width, height int) {
+	m.width = width
+	m.height = height
+	if m.loadingView != nil {
+		m.loadingView.SetSize(width, height)
+	}
+	m.volumesList.Viewport.Width = width
+	m.volumesList.Viewport.Height = height
+	m.volumesList.SetOuterSize(width, height)
+}
+
+func (m *Model) OnEnter() tea.Cmd {
+	m.visible = true
+	l().Info("VolumesView: OnEnter() - view is now visible")
+	m.resetCursorOnNextLoad = true
+	m.volumesList.Cursor = 0
+	m.volumesList.Viewport.YOffset = 0
+	return m.loadVolumesCmd()
+}
+
+func (m *Model) OnExit() tea.Cmd {
+	m.visible = false
+	l().Info("VolumesView: OnExit() - view is no longer visible")
+	return nil
+}
+
+func (m *Model) HasErrors() bool { return false }

--- a/views/volumes/model_test.go
+++ b/views/volumes/model_test.go
@@ -1,0 +1,197 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package volumesview
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"swarmcli/docker"
+	inspectview "swarmcli/views/inspect"
+	"swarmcli/views/view"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/docker/docker/api/types/volume"
+	"github.com/stretchr/testify/require"
+)
+
+// --- mocks ---
+
+type mockVolumeOps struct {
+	listVolumesFn   func(ctx context.Context) ([]docker.VolumeInfo, error)
+	inspectVolumeFn func(ctx context.Context, name string) (volume.Volume, error)
+}
+
+func (m *mockVolumeOps) ListVolumes(ctx context.Context) ([]docker.VolumeInfo, error) {
+	return m.listVolumesFn(ctx)
+}
+func (m *mockVolumeOps) InspectVolume(ctx context.Context, name string) (volume.Volume, error) {
+	return m.inspectVolumeFn(ctx, name)
+}
+
+func noopVolumeOps() *mockVolumeOps {
+	return &mockVolumeOps{
+		listVolumesFn: func(_ context.Context) ([]docker.VolumeInfo, error) {
+			return nil, nil
+		},
+		inspectVolumeFn: func(_ context.Context, _ string) (volume.Volume, error) {
+			return volume.Volume{}, nil
+		},
+	}
+}
+
+// --- helpers ---
+
+func key(s string) tea.KeyMsg {
+	switch s {
+	case "enter":
+		return tea.KeyMsg{Type: tea.KeyEnter}
+	case "esc":
+		return tea.KeyMsg{Type: tea.KeyEsc}
+	case "up":
+		return tea.KeyMsg{Type: tea.KeyUp}
+	case "down":
+		return tea.KeyMsg{Type: tea.KeyDown}
+	}
+	return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(s)}
+}
+
+func runCmd(cmd tea.Cmd) tea.Msg {
+	if cmd == nil {
+		return nil
+	}
+	return cmd()
+}
+
+func testModel(opts ...func(*Model)) *Model {
+	m := New(80, 24)
+	m.deps = docker.Deps{Volumes: noopVolumeOps()}
+	for _, o := range opts {
+		o(m)
+	}
+	return m
+}
+
+func fakeVolumes(names ...string) []volumeItem {
+	now := time.Now()
+	items := make([]volumeItem, len(names))
+	for i, name := range names {
+		items[i] = volumeItem{
+			Name:       name,
+			Stack:      "mystack",
+			Driver:     "local",
+			Mountpoint: "/var/lib/docker/volumes/" + name + "/_data",
+			Created:    now,
+			Host:       "node-1",
+		}
+	}
+	return items
+}
+
+func loadVolumes(m *Model, items []volumeItem) {
+	m.Update(VolumesLoadedMsg{Volumes: items})
+}
+
+// --- Tests ---
+
+func TestNew(t *testing.T) {
+	m := New(80, 24)
+	require.Equal(t, 80, m.width)
+	require.Equal(t, 24, m.height)
+	require.Equal(t, stateLoading, m.state)
+	require.True(t, m.visible)
+	require.Equal(t, SortByName, m.sortField)
+	require.True(t, m.sortAscending)
+}
+
+func TestName(t *testing.T) {
+	require.Equal(t, "volumes", testModel().Name())
+}
+
+func TestCapturesInput(t *testing.T) {
+	m := testModel()
+	require.False(t, m.CapturesInput())
+	m.errorDialogActive = true
+	require.True(t, m.CapturesInput())
+}
+
+func TestHasActiveFilter(t *testing.T) {
+	m := testModel()
+	require.False(t, m.HasActiveFilter())
+	m.ApplySearchQuery("x")
+	require.True(t, m.HasActiveFilter())
+}
+
+func TestHasErrors(t *testing.T) {
+	require.False(t, testModel().HasErrors())
+}
+
+func TestOnEnter_SetsVisible(t *testing.T) {
+	m := testModel()
+	m.visible = false
+	cmd := m.OnEnter()
+	require.True(t, m.visible)
+	require.True(t, m.resetCursorOnNextLoad)
+	require.NotNil(t, cmd)
+}
+
+func TestOnExit_ClearsVisible(t *testing.T) {
+	m := testModel()
+	m.OnExit()
+	require.False(t, m.visible)
+}
+
+func TestLoaded_SetsReadyAndSorts(t *testing.T) {
+	m := testModel()
+	loadVolumes(m, fakeVolumes("beta", "alpha", "gamma"))
+	require.Equal(t, stateReady, m.state)
+	require.Len(t, m.volumesList.Filtered, 3)
+	// default sort: name ascending
+	require.Equal(t, "alpha", m.volumesList.Filtered[0].Name)
+	require.Equal(t, "gamma", m.volumesList.Filtered[2].Name)
+}
+
+func TestSort_ToggleNameDescending(t *testing.T) {
+	m := testModel()
+	loadVolumes(m, fakeVolumes("beta", "alpha", "gamma"))
+	m.Update(key("N")) // already SortByName -> toggles to descending
+	require.False(t, m.sortAscending)
+	require.Equal(t, "gamma", m.volumesList.Filtered[0].Name)
+}
+
+func TestFilter_NarrowsResults(t *testing.T) {
+	m := testModel()
+	loadVolumes(m, fakeVolumes("alpha", "beta", "gamma"))
+	m.ApplySearchQuery("alp")
+	require.Len(t, m.volumesList.Filtered, 1)
+	require.Equal(t, "alpha", m.volumesList.Filtered[0].Name)
+
+	m.ClearSearchQuery()
+	require.Len(t, m.volumesList.Filtered, 3)
+}
+
+func TestInspect_NavigatesToInspectView(t *testing.T) {
+	m := testModel(func(m *Model) {
+		m.deps = docker.Deps{Volumes: &mockVolumeOps{
+			listVolumesFn: func(_ context.Context) ([]docker.VolumeInfo, error) { return nil, nil },
+			inspectVolumeFn: func(_ context.Context, name string) (volume.Volume, error) {
+				return volume.Volume{Name: name, Driver: "local"}, nil
+			},
+		}}
+	})
+	loadVolumes(m, fakeVolumes("vol1"))
+	msg := runCmd(m.Update(key("i")))
+	nav, ok := msg.(view.NavigateToMsg)
+	require.True(t, ok)
+	require.Equal(t, inspectview.ViewName, nav.ViewName)
+	payload, ok := nav.Payload.(map[string]any)
+	require.True(t, ok)
+	require.Contains(t, payload["title"], "vol1")
+}
+
+func TestInspect_NoVolumes_NoOp(t *testing.T) {
+	m := testModel()
+	require.Nil(t, m.Update(key("i")))
+}

--- a/views/volumes/register.go
+++ b/views/volumes/register.go
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package volumesview
+
+import (
+	"swarmcli/docker"
+	"swarmcli/views/view"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func init() {
+	view.RegisterView(ViewName, factory)
+}
+
+func factory(deps docker.Deps, w, h int, _ any) (view.View, tea.Cmd) {
+	model := New(w, h)
+	model.deps = deps
+	return model, model.Init()
+}

--- a/views/volumes/update.go
+++ b/views/volumes/update.go
@@ -118,7 +118,7 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 		return m.handleVolumesLoaded(msg)
 
 	case TickMsg:
-		if m.visible && m.state == stateReady && !m.errorDialogActive && !m.loadingView.Visible() {
+		if m.visible && m.state == stateReady && !m.errorDialogActive {
 			return tea.Batch(m.checkVolumesCmd(m.lastSnapshot), tickCmd())
 		}
 		return tickCmd()

--- a/views/volumes/update.go
+++ b/views/volumes/update.go
@@ -1,0 +1,357 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package volumesview
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"swarmcli/core/primitives/hash"
+	"swarmcli/ui"
+	helpview "swarmcli/views/help"
+	view "swarmcli/views/view"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+func truncateWithEllipsis(s string, maxWidth int) string {
+	if maxWidth <= 0 {
+		return ""
+	}
+	if maxWidth <= 1 {
+		return "…"
+	}
+	if lipgloss.Width(s) <= maxWidth {
+		return s
+	}
+	if maxWidth == 2 {
+		return s[:1] + "…"
+	}
+	return s[:maxWidth-1] + "…"
+}
+
+func formatCreated(t time.Time) string {
+	if t.IsZero() {
+		return "—"
+	}
+	return t.Format("2006-01-02 15:04")
+}
+
+// volumeColWidths allocates the six column widths as percentages of the
+// available width, with the MOUNT POINT column absorbing rounding remainder.
+func (m *Model) volumeColWidths(totalWidth int) []int {
+	if totalWidth <= 0 {
+		totalWidth = 80
+	}
+	const (
+		sepLen  = 2
+		numCols = 6
+		flexCol = 3 // MOUNT POINT
+	)
+	effWidth := totalWidth - (numCols-1)*sepLen
+	if effWidth < 30 {
+		effWidth = totalWidth
+	}
+
+	weights := []int{20, 12, 9, 21, 24, 14} // NAME STACK DRIVER MOUNT CREATED HOST
+	mins := []int{8, 5, 5, 10, 12, 5}
+
+	widths := make([]int, numCols)
+	sum := 0
+	for i := 0; i < numCols; i++ {
+		w := (effWidth * weights[i]) / 100
+		if w < 1 {
+			w = 1
+		}
+		widths[i] = w
+		sum += w
+	}
+	widths[flexCol] += effWidth - sum
+
+	for i := range widths {
+		if widths[i] < mins[i] {
+			widths[i] = mins[i]
+		}
+	}
+
+	sum = 0
+	for _, w := range widths {
+		sum += w
+	}
+	if sum != effWidth {
+		widths[flexCol] += effWidth - sum
+		if widths[flexCol] < mins[flexCol] {
+			widths[flexCol] = mins[flexCol]
+		}
+	}
+	return widths
+}
+
+func (m *Model) Update(msg tea.Msg) tea.Cmd {
+	switch msg := msg.(type) {
+	case SpinnerTickMsg:
+		m.spinner++
+		if m.state == stateLoading {
+			m.volumesList.Viewport.SetContent(m.volumesList.View())
+		}
+		return m.spinnerTickCmd()
+
+	case tea.WindowSizeMsg:
+		m.width = msg.Width
+		m.height = msg.Height
+		m.volumesList.Viewport.Width = msg.Width
+		m.volumesList.Viewport.Height = msg.Height
+		m.volumesList.SetOuterSize(msg.Width, msg.Height)
+		if m.firstResize {
+			m.volumesList.Viewport.YOffset = 0
+			m.firstResize = false
+		} else if m.volumesList.Cursor == 0 {
+			m.volumesList.Viewport.YOffset = 0
+		}
+		return nil
+
+	case VolumesLoadedMsg:
+		return m.handleVolumesLoaded(msg)
+
+	case TickMsg:
+		if m.visible && m.state == stateReady && !m.errorDialogActive && !m.loadingView.Visible() {
+			return tea.Batch(m.checkVolumesCmd(m.lastSnapshot), tickCmd())
+		}
+		return tickCmd()
+
+	case PollRetryMsg:
+		return tickCmd()
+
+	case tea.KeyMsg:
+		if m.errorDialogActive {
+			if msg.String() == "enter" || msg.String() == "esc" {
+				m.errorDialogActive = false
+			}
+			return nil
+		}
+		return m.handleNormalKeys(msg)
+	}
+	return nil
+}
+
+func (m *Model) handleVolumesLoaded(msg VolumesLoadedMsg) tea.Cmd {
+	if msg.Err != nil {
+		// Background refresh failure with existing data: keep current view.
+		if m.state == stateReady && len(m.volumesList.Items) > 0 {
+			l().Warnf("VolumesView: background refresh failed: %v", msg.Err)
+			m.showToast("Refresh failed (will retry)")
+			return nil
+		}
+		m.state = stateError
+		m.err = msg.Err
+		m.errorDialogActive = true
+		return nil
+	}
+
+	selectedName := ""
+	if !m.resetCursorOnNextLoad && m.volumesList.Cursor < len(m.volumesList.Filtered) {
+		selectedName = m.volumesList.Filtered[m.volumesList.Cursor].Name
+	}
+
+	if h, err := hash.Compute(stableVolumes(msg.Volumes)); err == nil {
+		m.lastSnapshot = h
+	} else {
+		l().Errorf("VolumesView: Error computing hash: %v", err)
+	}
+
+	m.volumesList.Items = msg.Volumes
+	m.volumesList.ApplyFilter()
+	m.applySorting()
+
+	if m.resetCursorOnNextLoad {
+		m.volumesList.Cursor = 0
+		m.volumesList.Viewport.YOffset = 0
+		m.resetCursorOnNextLoad = false
+	} else if selectedName != "" {
+		for i, v := range m.volumesList.Filtered {
+			if v.Name == selectedName {
+				m.volumesList.Cursor = i
+				break
+			}
+		}
+	}
+
+	m.state = stateReady
+	m.volumesList.Viewport.SetContent(m.volumesList.View())
+	return nil
+}
+
+func (m *Model) handleNormalKeys(msg tea.KeyMsg) tea.Cmd {
+	switch msg.String() {
+	case "esc":
+		// Volumes is a root view, no back navigation.
+		return nil
+	case "?":
+		return func() tea.Msg {
+			return view.NavigateToMsg{ViewName: helpview.ViewName, Payload: GetVolumesHelpContent()}
+		}
+	case "N":
+		m.toggleSort(SortByName)
+		return nil
+	case "S":
+		m.toggleSort(SortByStack)
+		return nil
+	case "D":
+		m.toggleSort(SortByDriver)
+		return nil
+	case "C":
+		m.toggleSort(SortByCreated)
+		return nil
+	case "H":
+		m.toggleSort(SortByHost)
+		return nil
+	case "up", "k":
+		if m.volumesList.Cursor > 0 {
+			m.volumesList.Cursor--
+			m.volumesList.Viewport.SetContent(m.volumesList.View())
+		}
+	case "down", "j":
+		if m.volumesList.Cursor < len(m.volumesList.Filtered)-1 {
+			m.volumesList.Cursor++
+			m.volumesList.Viewport.SetContent(m.volumesList.View())
+		}
+	case "pgup":
+		page := m.volumesList.Viewport.Height
+		if page < 1 {
+			page = 10
+		}
+		m.volumesList.Cursor -= page
+		if m.volumesList.Cursor < 0 {
+			m.volumesList.Cursor = 0
+		}
+		m.volumesList.Viewport.SetContent(m.volumesList.View())
+	case "pgdown":
+		page := m.volumesList.Viewport.Height
+		if page < 1 {
+			page = 10
+		}
+		m.volumesList.Cursor += page
+		if m.volumesList.Cursor >= len(m.volumesList.Filtered) {
+			m.volumesList.Cursor = len(m.volumesList.Filtered) - 1
+		}
+		m.volumesList.Viewport.SetContent(m.volumesList.View())
+	case "i", "enter":
+		if len(m.volumesList.Filtered) == 0 {
+			return nil
+		}
+		selected := m.volumesList.Filtered[m.volumesList.Cursor]
+		return m.inspectVolumeCmd(selected.Name)
+	}
+	return nil
+}
+
+func (m *Model) toggleSort(field SortField) {
+	if m.sortField == field {
+		m.sortAscending = !m.sortAscending
+	} else {
+		m.sortField = field
+		m.sortAscending = true
+	}
+	m.applySorting()
+}
+
+func cmpStr(a, b string, asc bool) bool {
+	if asc {
+		return a < b
+	}
+	return a > b
+}
+
+func (m *Model) applySorting() {
+	if len(m.volumesList.Filtered) == 0 {
+		return
+	}
+	cursorName := ""
+	if m.volumesList.Cursor < len(m.volumesList.Filtered) {
+		cursorName = m.volumesList.Filtered[m.volumesList.Cursor].Name
+	}
+
+	f := m.volumesList.Filtered
+	asc := m.sortAscending
+	switch m.sortField {
+	case SortByName:
+		sort.SliceStable(f, func(i, j int) bool {
+			return cmpStr(strings.ToLower(f[i].Name), strings.ToLower(f[j].Name), asc)
+		})
+	case SortByStack:
+		sort.SliceStable(f, func(i, j int) bool {
+			if f[i].Stack == f[j].Stack {
+				return strings.ToLower(f[i].Name) < strings.ToLower(f[j].Name)
+			}
+			return cmpStr(strings.ToLower(f[i].Stack), strings.ToLower(f[j].Stack), asc)
+		})
+	case SortByDriver:
+		sort.SliceStable(f, func(i, j int) bool {
+			return cmpStr(strings.ToLower(f[i].Driver), strings.ToLower(f[j].Driver), asc)
+		})
+	case SortByHost:
+		sort.SliceStable(f, func(i, j int) bool {
+			return cmpStr(strings.ToLower(f[i].Host), strings.ToLower(f[j].Host), asc)
+		})
+	case SortByCreated:
+		sort.SliceStable(f, func(i, j int) bool {
+			if asc {
+				return f[i].Created.Before(f[j].Created)
+			}
+			return f[i].Created.After(f[j].Created)
+		})
+	}
+
+	if cursorName != "" {
+		for i, v := range f {
+			if v.Name == cursorName {
+				m.volumesList.Cursor = i
+				break
+			}
+		}
+	}
+	m.volumesList.Viewport.SetContent(m.volumesList.View())
+}
+
+func (m *Model) setRenderItem() {
+	m.volumesList.RenderItem = func(item volumeItem, selected bool, colWidth int) string {
+		style := ui.ListItemStyle
+		if selected {
+			style = ui.ListSelectedStyle
+		}
+
+		widths := m.volumesList.ColWidths()
+		if len(widths) < 6 {
+			return item.Name
+		}
+		nameW, stackW, driverW := widths[0], widths[1], widths[2]
+		mountW, createdW, hostW := widths[3], widths[4], widths[5]
+
+		innerNameW := nameW
+		if innerNameW > 1 {
+			innerNameW--
+		}
+		name := " " + truncateWithEllipsis(item.Name, innerNameW)
+		stack := truncateWithEllipsis(displayOrDash(item.Stack), stackW)
+		driver := truncateWithEllipsis(item.Driver, driverW)
+		mount := truncateWithEllipsis(item.Mountpoint, mountW)
+		created := truncateWithEllipsis(formatCreated(item.Created), createdW)
+		host := truncateWithEllipsis(displayOrDash(item.Host), hostW)
+
+		sep := strings.Repeat(" ", 2)
+		line := fmt.Sprintf("%-*s%s%-*s%s%-*s%s%-*s%s%-*s%s%-*s",
+			nameW, name, sep,
+			stackW, stack, sep,
+			driverW, driver, sep,
+			mountW, mount, sep,
+			createdW, created, sep,
+			hostW, host,
+		)
+		return style.Render(line)
+	}
+	m.volumesList.Viewport.SetContent(m.volumesList.View())
+}

--- a/views/volumes/view.go
+++ b/views/volumes/view.go
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package volumesview
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"swarmcli/features"
+	"swarmcli/ui"
+	"swarmcli/ui/components/errordialog"
+	"swarmcli/ui/components/sorting"
+	"swarmcli/views/view"
+)
+
+// connectedNodeHint is shown in the footer while the all-nodes capability is
+// unavailable, making the connected-node-only scope explicit.
+var connectedNodeHint = "Connected node only · listing volumes on all nodes is a Business Edition feature: " + view.BELandingURL
+
+func (m *Model) FrameTitle() string {
+	return fmt.Sprintf("Docker Volumes (%d)", len(m.volumesList.Filtered))
+}
+
+func (m *Model) FrameHeader() string {
+	return m.renderVolumesHeader()
+}
+
+func (m *Model) FrameFooter() string {
+	return m.volumesList.RenderFooter()
+}
+
+func (m *Model) FrameContent() string {
+	return m.buildMainContent()
+}
+
+func (m *Model) View() string {
+	return ui.RenderViewFrame(m.FrameTitle(), m.FrameHeader(), m.FrameContent(), m.FrameFooter(),
+		m.volumesList.Viewport.Width, m.volumesList.Viewport.Height, false)
+}
+
+func (m *Model) buildMainContent() string {
+	width := 80
+	if m.volumesList.Viewport.Width > 0 {
+		width = m.volumesList.Viewport.Width
+	} else if m.width > 0 {
+		width = m.width
+	}
+
+	header := m.FrameHeader()
+	footer := m.FrameFooter()
+	frame := ui.ComputeFrameDimensions(
+		m.volumesList.Viewport.Width, m.volumesList.Viewport.Height,
+		m.width, m.height, header, footer,
+	)
+
+	content := m.volumesList.VisibleContent(frame.DesiredContentLines)
+	if m.state == stateLoading && len(m.volumesList.Items) == 0 {
+		lines := frame.DesiredContentLines
+		if lines < 1 {
+			lines = 1
+		}
+		parts := make([]string, lines)
+		parts[0] = "Loading..."
+		for i := 1; i < lines; i++ {
+			parts[i] = ""
+		}
+		content = strings.Join(parts, "\n")
+	}
+
+	if m.errorDialogActive {
+		errorDialog := errordialog.Render(fmt.Sprintf("%v", m.err))
+		content = ui.OverlayCentered(content, errorDialog, width, 0)
+	}
+	return content
+}
+
+func (m *Model) renderVolumesHeader() string {
+	widths := m.volumesList.ColWidths()
+	if len(widths) < 6 {
+		return ""
+	}
+
+	labels := []string{" NAME", "STACK", "DRIVER", "MOUNT POINT", "CREATED", "HOST"}
+
+	arrow := func() string {
+		if m.sortAscending {
+			return sorting.SortArrow(sorting.Ascending)
+		}
+		return sorting.SortArrow(sorting.Descending)
+	}
+	switch m.sortField {
+	case SortByName:
+		labels[0] = " NAME " + arrow()
+	case SortByStack:
+		labels[1] = "STACK " + arrow()
+	case SortByDriver:
+		labels[2] = "DRIVER " + arrow()
+	case SortByCreated:
+		labels[4] = "CREATED " + arrow()
+	case SortByHost:
+		labels[5] = "HOST " + arrow()
+	}
+
+	sep := strings.Repeat(" ", 2)
+	line := fmt.Sprintf("%-*s%s%-*s%s%-*s%s%-*s%s%-*s%s%-*s",
+		widths[0], labels[0], sep,
+		widths[1], labels[1], sep,
+		widths[2], labels[2], sep,
+		widths[3], labels[3], sep,
+		widths[4], labels[4], sep,
+		widths[5], labels[5],
+	)
+	return ui.FrameHeaderStyle.Render(line)
+}
+
+func (m *Model) renderVolumesFooter() string {
+	base := m.baseFooter()
+	if features.IsEnabled(allNodesFeature) {
+		return base
+	}
+	return base + "\n" + ui.StatusBarStyle.Render(connectedNodeHint)
+}
+
+func (m *Model) baseFooter() string {
+	if m.toastMessage != "" && time.Now().Before(m.toastUntil) {
+		return ui.StatusBarStyle.Render(m.toastMessage)
+	}
+	if m.toastMessage != "" && time.Now().After(m.toastUntil) {
+		m.toastMessage = ""
+	}
+
+	if m.state == stateLoading {
+		return ui.StatusBarStyle.Render(fmt.Sprintf("Loading Docker volumes… %s", ui.SpinnerCharAt(m.spinner)))
+	}
+
+	total := len(m.volumesList.Items)
+	filtered := len(m.volumesList.Filtered)
+	cursor := m.volumesList.Cursor + 1
+
+	if filtered == 0 {
+		return ui.StatusBarStyle.Render("No volumes")
+	}
+	if m.HasActiveFilter() {
+		return ui.StatusBarStyle.Render(fmt.Sprintf("%d/%d (filtered from %d)", cursor, filtered, total))
+	}
+	return ui.StatusBarStyle.Render(fmt.Sprintf("%d/%d", cursor, total))
+}

--- a/views/volumes/view_test.go
+++ b/views/volumes/view_test.go
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package volumesview
+
+import (
+	"strings"
+	"testing"
+
+	"swarmcli/features"
+	"swarmcli/views/view"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestView_LoadingState(t *testing.T) {
+	m := testModel()
+	m.state = stateLoading
+	require.Contains(t, m.View(), "Docker Volumes")
+}
+
+func TestView_ReadyState_ShowsVolumes(t *testing.T) {
+	m := testModel()
+	loadVolumes(m, fakeVolumes("alpha", "beta"))
+	m.volumesList.Viewport.Width = 100
+	m.volumesList.Viewport.Height = 20
+	out := m.View()
+	require.Contains(t, out, "Docker Volumes (2)")
+	require.Contains(t, out, "alpha")
+	require.Contains(t, out, "beta")
+}
+
+func TestHeader_ShowsAllColumns(t *testing.T) {
+	m := testModel()
+	m.volumesList.Viewport.Width = 120
+	header := m.renderVolumesHeader()
+	for _, col := range []string{"NAME", "STACK", "DRIVER", "MOUNT POINT", "CREATED", "HOST"} {
+		require.Contains(t, header, col)
+	}
+}
+
+func TestFooter_BusinessEditionHint(t *testing.T) {
+	m := testModel()
+	loadVolumes(m, fakeVolumes("vol1"))
+
+	// Flag off (default): connected-node hint is shown.
+	require.Contains(t, m.renderVolumesFooter(), view.BELandingURL)
+
+	// Flag on: hint suppressed.
+	features.Enable(allNodesFeature)
+	t.Cleanup(func() { features.Disable(allNodesFeature) })
+	require.NotContains(t, m.renderVolumesFooter(), view.BELandingURL)
+}
+
+func TestDescription_RendersOptionalDashes(t *testing.T) {
+	it := volumeItem{Name: "v", Driver: "local"}
+	desc := it.Description()
+	require.True(t, strings.Contains(desc, "—"), "empty stack/host should render an em-dash")
+}

--- a/views/volumes/volumes.go
+++ b/views/volumes/volumes.go
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package volumesview
+
+import swarmlog "swarmcli/utils/log"
+
+const ViewName = "volumes"
+
+// allNodesFeature gates the "list volumes across all nodes" capability. The
+// base build lists the connected node only; an extension build enables this
+// flag when it provides a multi-node volume implementation, which suppresses
+// the connected-node-only footer hint.
+const allNodesFeature = "volumes-all-nodes"
+
+func l() *swarmlog.SwarmLogger {
+	return swarmlog.L().With("views", "volumes")
+}


### PR DESCRIPTION
Closes #260. Lays the CE groundwork for the BE follow-up Eldara-Tech/swarmcli-be#204.

## What
A read-only `:volume` view listing Docker volumes with the requested columns: **NAME, STACK, DRIVER, MOUNT POINT, CREATED, HOST**. Supports column sorting (`N`/`S`/`D`/`C`/`H`), `/` filtering, and `i`/`enter` JSON inspect. Mirrors the `networks` view, minus all mutation.

## Why read-only / connected-node-only
`docker volume ls` is **per-node** and the manager API cannot read another node's volume state, so CE lists the **connected node only** with fully correct data. The `HOST` column is populated with the connected node's hostname. Cross-node aggregation, creation, and file browse/rename are owned by BE #204 (which uses the licensed agent).

## BE integration seams (no CE changes needed later)
- **Data:** new `docker.VolumeOps` interface + `Deps.Volumes`, returning an edition-agnostic `VolumeInfo`. BE swaps in an agent-backed all-nodes implementation.
- **Messaging:** a `volumes-all-nodes` feature flag gates a footer hint that all-node listing is a Business Edition feature (reuses `view.BELandingURL`). BE calls `features.Enable(...)` to suppress it.

Both are generic extension points — no pro internals in OSS.

## Changes
- `docker/volume.go`, `docker/volume_ops.go`, `docker/ops.go` — ops layer + `VolumeInfo`
- `views/volumes/` — the view (read-only)
- `commands/command/docker/volume/ls.go` + autoload wiring; `view.NameVolumes` top-level registration
- Unit tests (mapping, model behavior, column alignment, footer gating) + an integration test that creates a volume on the connected node and verifies the list/inspect path

## Verification
`go build -tags=integration ./...`, `go vet ./...`, `go test ./...`, and `golangci-lint run ./... --build-tags=integration` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)