### PR TITLE
feat(volumes): extension seams for cross-node volume management

### DIFF
--- a/docker/partiallisterror_test.go
+++ b/docker/partiallisterror_test.go
@@ -18,6 +18,11 @@ func TestPartialListError_Message(t *testing.T) {
 	require.Equal(t, "2 nodes unreachable", (&PartialListError{
 		NodeErrors: map[string]string{"n1": "timeout", "n2": "refused"},
 	}).Error())
+	// Note overrides the node-count message.
+	require.Equal(t, "connected node only", (&PartialListError{
+		Note:       "connected node only",
+		NodeErrors: map[string]string{"n1": "timeout"},
+	}).Error())
 }
 
 func TestPartialListError_RoundTripsThroughErrorsAs(t *testing.T) {

--- a/docker/partiallisterror_test.go
+++ b/docker/partiallisterror_test.go
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package docker
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPartialListError_Message(t *testing.T) {
+	require.Equal(t, "1 node unreachable", (&PartialListError{
+		NodeErrors: map[string]string{"n1": "timeout"},
+	}).Error())
+	require.Equal(t, "2 nodes unreachable", (&PartialListError{
+		NodeErrors: map[string]string{"n1": "timeout", "n2": "refused"},
+	}).Error())
+}
+
+func TestPartialListError_RoundTripsThroughErrorsAs(t *testing.T) {
+	orig := &PartialListError{NodeErrors: map[string]string{"n1": "timeout"}}
+	// Wrapped, as a caller might return it.
+	wrapped := fmt.Errorf("listing failed: %w", orig)
+
+	var got *PartialListError
+	require.True(t, errors.As(wrapped, &got))
+	require.Equal(t, orig.NodeErrors, got.NodeErrors)
+}

--- a/docker/volume.go
+++ b/docker/volume.go
@@ -28,16 +28,22 @@ type VolumeInfo struct {
 	Raw        *volume.Volume // underlying SDK object, for inspect
 }
 
-// PartialListError reports that a cross-node listing partially succeeded: the
-// returned items are valid, but one or more nodes could not be reached. An
-// aggregating implementation returns it alongside the successful results so the
-// view can show the data plus a non-fatal banner instead of failing outright.
-// The default single-node implementation never returns it.
+// PartialListError reports that a listing succeeded but is degraded: the
+// returned items are valid and shown, with a non-fatal banner explaining the
+// limitation, instead of failing outright. An aggregating implementation
+// returns it when some nodes are unreachable (NodeErrors), or with a custom
+// Note when the listing fell back to a narrower scope (e.g. connected-node
+// only because the cross-node path is unavailable). The default single-node
+// implementation never returns it.
 type PartialListError struct {
 	NodeErrors map[string]string // node identifier -> error summary
+	Note       string            // optional banner override; takes precedence over NodeErrors
 }
 
 func (e *PartialListError) Error() string {
+	if e.Note != "" {
+		return e.Note
+	}
 	if len(e.NodeErrors) == 1 {
 		return "1 node unreachable"
 	}

--- a/docker/volume.go
+++ b/docker/volume.go
@@ -5,6 +5,7 @@ package docker
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/docker/docker/api/types/volume"
@@ -21,9 +22,26 @@ type VolumeInfo struct {
 	Driver     string
 	Mountpoint string
 	Created    time.Time
-	Host       string // node the volume lives on
+	Host       string // node hostname the volume lives on (display)
+	NodeID     string // swarm node ID the volume lives on; "" for the CE single-node impl, filled by aggregating implementations for node-addressed actions
 	Labels     map[string]string
 	Raw        *volume.Volume // underlying SDK object, for inspect
+}
+
+// PartialListError reports that a cross-node listing partially succeeded: the
+// returned items are valid, but one or more nodes could not be reached. An
+// aggregating implementation returns it alongside the successful results so the
+// view can show the data plus a non-fatal banner instead of failing outright.
+// The default single-node implementation never returns it.
+type PartialListError struct {
+	NodeErrors map[string]string // node identifier -> error summary
+}
+
+func (e *PartialListError) Error() string {
+	if len(e.NodeErrors) == 1 {
+		return "1 node unreachable"
+	}
+	return fmt.Sprintf("%d nodes unreachable", len(e.NodeErrors))
 }
 
 // ListVolumes returns the volumes on the connected Docker node.

--- a/integration-tests/docker/volume/volume_test.go
+++ b/integration-tests/docker/volume/volume_test.go
@@ -60,6 +60,36 @@ func TestListVolumes_IncludesCreatedVolume(t *testing.T) {
 	require.NotEmpty(t, found.Host, "host should be the connected node's hostname")
 }
 
+// TestDefaultVolumeOps_ListsViaInterface exercises the VolumeOps seam BE swaps:
+// the default (connected-node) implementation lists the volume and leaves
+// NodeID empty (the field an aggregating implementation fills).
+func TestDefaultVolumeOps_ListsViaInterface(t *testing.T) {
+	swarmlog.InitTestIfTestLogEnv()
+	ctx := context.Background()
+
+	cli, err := docker.GetClient()
+	require.NoError(t, err)
+
+	name := uniqueName("test_vol_ops")
+	_, err = cli.VolumeCreate(ctx, volume.CreateOptions{Name: name, Driver: "local"})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = cli.VolumeRemove(ctx, name, true) })
+
+	ops := docker.DefaultDeps().Volumes
+	volumes, err := ops.ListVolumes(ctx)
+	require.NoError(t, err)
+
+	var found *docker.VolumeInfo
+	for i := range volumes {
+		if volumes[i].Name == name {
+			found = &volumes[i]
+			break
+		}
+	}
+	require.NotNil(t, found, "volume %q should appear via the VolumeOps seam", name)
+	require.Empty(t, found.NodeID, "CE single-node impl leaves NodeID empty")
+}
+
 func TestInspectVolume(t *testing.T) {
 	swarmlog.InitTestIfTestLogEnv()
 	ctx := context.Background()

--- a/views/view/ref.go
+++ b/views/view/ref.go
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package view
+
+import "strings"
+
+// refSep packs multiple fields into a single Action argument. The unit
+// separator can't appear in Docker resource names or swarm node IDs, so it is
+// an unambiguous delimiter.
+const refSep = "\x1f"
+
+// EncodeRef packs fields into one Action argument string. It is the shared
+// contract for actions that need more than a bare resource name — e.g. volume
+// actions need the swarm node ID plus the volume name, because a volume name
+// is only unique per node. Decode with DecodeRef.
+func EncodeRef(parts ...string) string { return strings.Join(parts, refSep) }
+
+// DecodeRef unpacks an argument produced by EncodeRef.
+func DecodeRef(s string) []string { return strings.Split(s, refSep) }

--- a/views/volumes/actions.go
+++ b/views/volumes/actions.go
@@ -15,6 +15,7 @@ type volumeItem struct {
 	Mountpoint string
 	Created    time.Time
 	Host       string
+	NodeID     string // swarm node ID; populated by the cross-node impl, used to address node-scoped actions
 }
 
 func (i volumeItem) FilterValue() string { return i.Name }

--- a/views/volumes/extension_test.go
+++ b/views/volumes/extension_test.go
@@ -50,7 +50,7 @@ func TestKey_Browse_PassesEncodedNodeAndName(t *testing.T) {
 	msg := runCmd(m.Update(key("b")))
 	require.IsType(t, sentinelMsg{}, msg)
 	parts := view.DecodeRef(*got)
-	require.Equal(t, []string{"node-id-123", "vol1"}, parts)
+	require.Equal(t, []string{"node-id-123", "vol1", "node-1"}, parts)
 }
 
 func TestKey_Delete_PassesEncodedNodeAndName(t *testing.T) {
@@ -62,7 +62,7 @@ func TestKey_Delete_PassesEncodedNodeAndName(t *testing.T) {
 
 	msg := runCmd(m.Update(tea.KeyMsg{Type: tea.KeyCtrlD}))
 	require.IsType(t, sentinelMsg{}, msg)
-	require.Equal(t, []string{"node-id-123", "vol1"}, view.DecodeRef(*got))
+	require.Equal(t, []string{"node-id-123", "vol1", "node-1"}, view.DecodeRef(*got))
 }
 
 func TestKey_Action_Unregistered_ShowsBEDialog(t *testing.T) {

--- a/views/volumes/extension_test.go
+++ b/views/volumes/extension_test.go
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package volumesview
+
+import (
+	"context"
+	"testing"
+
+	"swarmcli/docker"
+	"swarmcli/views/view"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/stretchr/testify/require"
+)
+
+// sentinelMsg is returned by stub actions so tests can assert they fired.
+type sentinelMsg struct{ arg string }
+
+// registerStubAction registers a temporary action capturing its argument.
+func registerStubAction(t *testing.T, name string) *string {
+	t.Helper()
+	var got string
+	view.RegisterAction(name, func(arg string) tea.Cmd {
+		got = arg
+		return func() tea.Msg { return sentinelMsg{arg: arg} }
+	})
+	t.Cleanup(func() { view.UnregisterActionForTest(name) })
+	return &got
+}
+
+func TestKey_Create_DispatchesAction(t *testing.T) {
+	got := registerStubAction(t, "volume-create")
+	m := testModel()
+	loadVolumes(m, fakeVolumes("vol1"))
+
+	msg := runCmd(m.Update(key("c")))
+	require.IsType(t, sentinelMsg{}, msg)
+	require.Equal(t, "", *got) // create is selection-independent
+	require.False(t, m.errorDialogActive)
+}
+
+func TestKey_Browse_PassesEncodedNodeAndName(t *testing.T) {
+	got := registerStubAction(t, "volume-browse")
+	m := testModel()
+	items := fakeVolumes("vol1")
+	items[0].NodeID = "node-id-123"
+	loadVolumes(m, items)
+
+	msg := runCmd(m.Update(key("b")))
+	require.IsType(t, sentinelMsg{}, msg)
+	parts := view.DecodeRef(*got)
+	require.Equal(t, []string{"node-id-123", "vol1"}, parts)
+}
+
+func TestKey_Delete_PassesEncodedNodeAndName(t *testing.T) {
+	got := registerStubAction(t, "volume-delete")
+	m := testModel()
+	items := fakeVolumes("vol1")
+	items[0].NodeID = "node-id-123"
+	loadVolumes(m, items)
+
+	msg := runCmd(m.Update(tea.KeyMsg{Type: tea.KeyCtrlD}))
+	require.IsType(t, sentinelMsg{}, msg)
+	require.Equal(t, []string{"node-id-123", "vol1"}, view.DecodeRef(*got))
+}
+
+func TestKey_Action_Unregistered_ShowsBEDialog(t *testing.T) {
+	m := testModel()
+	loadVolumes(m, fakeVolumes("vol1"))
+
+	cmd := m.Update(key("c")) // no "volume-create" registered
+	require.Nil(t, cmd)
+	require.True(t, m.errorDialogActive)
+	require.ErrorContains(t, m.err, "Business Edition")
+}
+
+func TestKey_Browse_NoSelection_NoOp(t *testing.T) {
+	registerStubAction(t, "volume-browse")
+	m := testModel() // empty list
+	require.Nil(t, m.Update(key("b")))
+	require.False(t, m.errorDialogActive)
+}
+
+func TestPartialList_ShowsBannerNotErrorDialog(t *testing.T) {
+	m := testModel()
+	m.Update(VolumesLoadedMsg{Volumes: fakeVolumes("vol1", "vol2"), Warn: "2 nodes unreachable"})
+
+	require.Equal(t, stateReady, m.state)
+	require.False(t, m.errorDialogActive)
+	require.Len(t, m.volumesList.Filtered, 2)
+	require.Contains(t, m.renderVolumesFooter(), "2 nodes unreachable")
+
+	// A subsequent full load clears the banner.
+	m.Update(VolumesLoadedMsg{Volumes: fakeVolumes("vol1", "vol2")})
+	require.Empty(t, m.partialWarn)
+	require.NotContains(t, m.renderVolumesFooter(), "unreachable")
+}
+
+func TestLoadVolumesCmd_MapsPartialListErrorToWarn(t *testing.T) {
+	m := testModel(func(m *Model) {
+		m.deps = docker.Deps{Volumes: &mockVolumeOps{
+			listVolumesFn: func(_ context.Context) ([]docker.VolumeInfo, error) {
+				return []docker.VolumeInfo{{Name: "vol1", NodeID: "n1"}},
+					&docker.PartialListError{NodeErrors: map[string]string{"n2": "timeout"}}
+			},
+		}}
+	})
+
+	msg := runCmd(m.loadVolumesCmd())
+	loaded, ok := msg.(VolumesLoadedMsg)
+	require.True(t, ok)
+	require.NoError(t, loaded.Err)
+	require.Equal(t, "1 node unreachable", loaded.Warn)
+	require.Len(t, loaded.Volumes, 1)
+	require.Equal(t, "n1", loaded.Volumes[0].NodeID)
+}

--- a/views/volumes/help.go
+++ b/views/volumes/help.go
@@ -25,6 +25,7 @@ func GetVolumesHelpContent() []helpview.HelpCategory {
 				{Keys: "<c>", Description: view.BEHelpDesc("volume-create", "Create a volume")},
 				{Keys: "<b>", Description: view.BEHelpDesc("volume-browse", "Browse files in the selected volume")},
 				{Keys: "<ctrl+d>", Description: view.BEHelpDesc("volume-delete", "Delete the selected volume")},
+				{Keys: "<p>", Description: view.BEHelpDesc("volume-prune", "Prune unused volumes on a node")},
 			},
 		},
 		{

--- a/views/volumes/help.go
+++ b/views/volumes/help.go
@@ -3,7 +3,10 @@
 
 package volumesview
 
-import helpview "swarmcli/views/help"
+import (
+	helpview "swarmcli/views/help"
+	"swarmcli/views/view"
+)
 
 // GetVolumesHelpContent returns categorized help for the volumes view.
 func GetVolumesHelpContent() []helpview.HelpCategory {
@@ -14,6 +17,14 @@ func GetVolumesHelpContent() []helpview.HelpCategory {
 				{Keys: "<i/enter>", Description: "Inspect selected volume"},
 				{Keys: "</>", Description: "Filter volumes"},
 				{Keys: "<?>", Description: "Open this help"},
+			},
+		},
+		{
+			Title: "Manage",
+			Items: []helpview.HelpItem{
+				{Keys: "<c>", Description: view.BEHelpDesc("volume-create", "Create a volume")},
+				{Keys: "<b>", Description: view.BEHelpDesc("volume-browse", "Browse files in the selected volume")},
+				{Keys: "<ctrl+d>", Description: view.BEHelpDesc("volume-delete", "Delete the selected volume")},
 			},
 		},
 		{

--- a/views/volumes/messages.go
+++ b/views/volumes/messages.go
@@ -6,6 +6,7 @@ package volumesview
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
@@ -30,6 +31,10 @@ type SpinnerTickMsg time.Time
 type VolumesLoadedMsg struct {
 	Volumes []volumeItem
 	Err     error
+	// Warn is a non-fatal banner message. Set when ListVolumes reports a
+	// docker.PartialListError: the data is usable but some nodes were
+	// unreachable. Empty on a fully successful load (which clears the banner).
+	Warn string
 }
 
 func (m *Model) loadVolumesCmd() tea.Cmd {
@@ -40,6 +45,10 @@ func (m *Model) loadVolumesCmd() tea.Cmd {
 
 		volumes, err := volumeOps.ListVolumes(ctx)
 		if err != nil {
+			var partial *docker.PartialListError
+			if errors.As(err, &partial) {
+				return VolumesLoadedMsg{Volumes: toVolumeItems(volumes), Warn: partial.Error()}
+			}
 			return VolumesLoadedMsg{Err: fmt.Errorf("failed to list volumes: %w", err)}
 		}
 		return VolumesLoadedMsg{Volumes: toVolumeItems(volumes)}
@@ -54,8 +63,14 @@ func (m *Model) checkVolumesCmd(lastHash uint64) tea.Cmd {
 		defer cancel()
 
 		volumes, err := volumeOps.ListVolumes(ctx)
+		warn := ""
 		if err != nil {
-			return VolumesLoadedMsg{Err: err}
+			var partial *docker.PartialListError
+			if !errors.As(err, &partial) {
+				return VolumesLoadedMsg{Err: err}
+			}
+			// Partial failure: the returned volumes are still usable.
+			warn = partial.Error()
 		}
 		items := toVolumeItems(volumes)
 		newHash, hErr := hash.Compute(stableVolumes(items))
@@ -65,7 +80,7 @@ func (m *Model) checkVolumesCmd(lastHash uint64) tea.Cmd {
 		}
 		if newHash != lastHash {
 			l().Info("Volumes changed, reloading")
-			return VolumesLoadedMsg{Volumes: items}
+			return VolumesLoadedMsg{Volumes: items, Warn: warn}
 		}
 		return PollRetryMsg{}
 	}
@@ -123,6 +138,7 @@ func toVolumeItems(volumes []docker.VolumeInfo) []volumeItem {
 			Mountpoint: v.Mountpoint,
 			Created:    v.Created,
 			Host:       v.Host,
+			NodeID:     v.NodeID,
 		}
 	}
 	return items

--- a/views/volumes/model.go
+++ b/views/volumes/model.go
@@ -165,6 +165,7 @@ func (m *Model) ShortHelpItems() []helpbar.HelpEntry {
 		{Key: "c", Desc: view.BEHelpDesc("volume-create", "Create"), Disabled: !view.HasAction("volume-create")},
 		{Key: "b", Desc: view.BEHelpDesc("volume-browse", "Browse"), Disabled: !view.HasAction("volume-browse")},
 		{Key: "ctrl+d", Desc: view.BEHelpDesc("volume-delete", "Delete"), Disabled: !view.HasAction("volume-delete")},
+		{Key: "p", Desc: view.BEHelpDesc("volume-prune", "Prune"), Disabled: !view.HasAction("volume-prune")},
 		{Key: "/", Desc: "Filter"},
 		{Key: "?", Desc: "Help"},
 		{Key: "esc", Desc: "Back"},

--- a/views/volumes/model.go
+++ b/views/volumes/model.go
@@ -11,6 +11,7 @@ import (
 	"swarmcli/docker"
 	filterlist "swarmcli/ui/components/filterable/list"
 	"swarmcli/views/helpbar"
+	"swarmcli/views/view"
 
 	"github.com/charmbracelet/bubbles/viewport"
 	tea "github.com/charmbracelet/bubbletea"
@@ -56,6 +57,10 @@ type Model struct {
 
 	toastMessage string
 	toastUntil   time.Time
+
+	// partialWarn is a persistent non-fatal banner shown while a cross-node
+	// listing is degraded (some nodes unreachable). Cleared on a full load.
+	partialWarn string
 }
 
 func New(width, height int) *Model {
@@ -157,6 +162,9 @@ func (m *Model) ShortHelpItems() []helpbar.HelpEntry {
 	return []helpbar.HelpEntry{
 		{Key: "↑/↓", Desc: "Navigate"},
 		{Key: "i", Desc: "Inspect"},
+		{Key: "c", Desc: view.BEHelpDesc("volume-create", "Create"), Disabled: !view.HasAction("volume-create")},
+		{Key: "b", Desc: view.BEHelpDesc("volume-browse", "Browse"), Disabled: !view.HasAction("volume-browse")},
+		{Key: "ctrl+d", Desc: view.BEHelpDesc("volume-delete", "Delete"), Disabled: !view.HasAction("volume-delete")},
 		{Key: "/", Desc: "Filter"},
 		{Key: "?", Desc: "Help"},
 		{Key: "esc", Desc: "Back"},

--- a/views/volumes/update.go
+++ b/views/volumes/update.go
@@ -152,6 +152,9 @@ func (m *Model) handleVolumesLoaded(msg VolumesLoadedMsg) tea.Cmd {
 		return nil
 	}
 
+	// Persist (or clear) the non-fatal partial-failure banner.
+	m.partialWarn = msg.Warn
+
 	selectedName := ""
 	if !m.resetCursorOnNextLoad && m.volumesList.Cursor < len(m.volumesList.Filtered) {
 		selectedName = m.volumesList.Filtered[m.volumesList.Cursor].Name
@@ -245,8 +248,42 @@ func (m *Model) handleNormalKeys(msg tea.KeyMsg) tea.Cmd {
 		}
 		selected := m.volumesList.Filtered[m.volumesList.Cursor]
 		return m.inspectVolumeCmd(selected.Name)
+	case "c":
+		// Create is selection-independent; the action owns the node picker.
+		return m.dispatchAction("volume-create", "Create volume", "")
+	case "b":
+		if sel, ok := m.selectedVolume(); ok {
+			return m.dispatchAction("volume-browse", "Volume browser", view.EncodeRef(sel.NodeID, sel.Name))
+		}
+		return nil
+	case "ctrl+d":
+		if sel, ok := m.selectedVolume(); ok {
+			return m.dispatchAction("volume-delete", "Delete volume", view.EncodeRef(sel.NodeID, sel.Name))
+		}
+		return nil
 	}
 	return nil
+}
+
+// selectedVolume returns the volume under the cursor, or false if the list is empty.
+func (m *Model) selectedVolume() (volumeItem, bool) {
+	if len(m.volumesList.Filtered) == 0 {
+		return volumeItem{}, false
+	}
+	return m.volumesList.Filtered[m.volumesList.Cursor], true
+}
+
+// dispatchAction invokes a registered action, or surfaces the standard
+// "Business Edition feature" dialog when it is not available. The action
+// keybindings are inert in builds that do not register them.
+func (m *Model) dispatchAction(actionName, label, arg string) tea.Cmd {
+	action, ok := view.GetAction(actionName)
+	if !ok {
+		m.err = view.BEUnavailableErr(label)
+		m.errorDialogActive = true
+		return nil
+	}
+	return action(arg)
 }
 
 func (m *Model) toggleSort(field SortField) {

--- a/views/volumes/update.go
+++ b/views/volumes/update.go
@@ -253,12 +253,12 @@ func (m *Model) handleNormalKeys(msg tea.KeyMsg) tea.Cmd {
 		return m.dispatchAction("volume-create", "Create volume", "")
 	case "b":
 		if sel, ok := m.selectedVolume(); ok {
-			return m.dispatchAction("volume-browse", "Volume browser", view.EncodeRef(sel.NodeID, sel.Name))
+			return m.dispatchAction("volume-browse", "Volume browser", view.EncodeRef(sel.NodeID, sel.Name, sel.Host))
 		}
 		return nil
 	case "ctrl+d":
 		if sel, ok := m.selectedVolume(); ok {
-			return m.dispatchAction("volume-delete", "Delete volume", view.EncodeRef(sel.NodeID, sel.Name))
+			return m.dispatchAction("volume-delete", "Delete volume", view.EncodeRef(sel.NodeID, sel.Name, sel.Host))
 		}
 		return nil
 	}

--- a/views/volumes/update.go
+++ b/views/volumes/update.go
@@ -251,6 +251,9 @@ func (m *Model) handleNormalKeys(msg tea.KeyMsg) tea.Cmd {
 	case "c":
 		// Create is selection-independent; the action owns the node picker.
 		return m.dispatchAction("volume-create", "Create volume", "")
+	case "p":
+		// Prune is selection-independent; the action owns the node picker.
+		return m.dispatchAction("volume-prune", "Prune volumes", "")
 	case "b":
 		if sel, ok := m.selectedVolume(); ok {
 			return m.dispatchAction("volume-browse", "Volume browser", view.EncodeRef(sel.NodeID, sel.Name, sel.Host))

--- a/views/volumes/view.go
+++ b/views/volumes/view.go
@@ -117,6 +117,9 @@ func (m *Model) renderVolumesHeader() string {
 
 func (m *Model) renderVolumesFooter() string {
 	base := m.baseFooter()
+	if m.partialWarn != "" {
+		base += "\n" + ui.StatusBarStyle.Render("⚠ "+m.partialWarn)
+	}
 	if features.IsEnabled(allNodesFeature) {
 		return base
 	}


### PR DESCRIPTION
## What

Adds the CE-side extension seams that a cross-node (Business Edition) volume management implementation builds on. Everything here is **inert in CE** until the actions are registered by an extension build — same pattern the services view already uses for `shell`/`port-forward`.

## Why

Groundwork for **real volume management** (Eldara-Tech/swarmcli-be#204, extends CE #260): cross-node listing, create/delete, and in-volume file browse. The CE volumes view shipped read-only with no action-dispatch hooks; this adds them generically.

## Changes

- **`docker.VolumeInfo.NodeID`** — additive field for addressing node-scoped actions (a volume name is only unique per node). CE single-node impl leaves it `""`.
- **`docker.PartialListError`** — lets an aggregating implementation return the successful volumes *plus* a non-fatal "N nodes unreachable" signal.
- **`view.EncodeRef` / `view.DecodeRef`** — shared `\x1f` codec packing multi-field action args (node_id + name) into the single-string `Action` signature.
- **volumes view keybindings** — `c` (create), `b` (browse), `ctrl+d` (delete) dispatch via `view.GetAction`; unregistered → standard "Business Edition feature" dialog. Help shows them with the `(BE)` suffix. (`b` chosen because `f` is the global fullscreen toggle.)
- **partial-failure banner** — when `ListVolumes` reports a `PartialListError`, the view renders the volumes plus a persistent `⚠ N nodes unreachable` footer line instead of a blocking error dialog.

## Tests

`go test ./...` green; `golangci-lint` 0 issues. Added: `PartialListError` (message + `errors.As`), gated-keybinding dispatch (fires with stub action, passes encoded node_id+name, BE dialog when absent), partial-banner state transition.

## Notes

No behavior change for existing CE users beyond three new keybindings that surface the BE-feature dialog (consistent with the services view). Pro Feature Boundary respected — only generic extension points, no pro internals.