### PR TITLE
feat(ports): add network healthcheck between ports

### DIFF
--- a/commands/command/ports.go
+++ b/commands/command/ports.go
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package command
+
+import (
+	"swarmcli/args"
+	"swarmcli/registry"
+	portsview "swarmcli/views/ports"
+	"swarmcli/views/view"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+type Ports struct{}
+
+func (Ports) Name() string        { return "ports" }
+func (Ports) Description() string { return "Show required Swarm cluster ports" }
+
+func (Ports) Spec() registry.CommandSpec {
+	return registry.CommandSpec{
+		Detail: "Opens the required Swarm cluster ports (node-to-node) reference view, " +
+			"showing which ports must be open between Swarm nodes (managers and workers) for " +
+			"cluster management, node communication, and overlay network VXLAN traffic.",
+		Examples: []string{":ports", ":port"},
+	}
+}
+
+func (Ports) Execute(ctx any, args args.Args) tea.Cmd {
+	return func() tea.Msg {
+		return view.NavigateToMsg{
+			ViewName: portsview.ViewName,
+			Payload:  nil,
+		}
+	}
+}
+
+var portsCmd = Ports{}
+
+func init() {
+	registry.Register(portsCmd)
+	registry.Register(aliasCommand{name: "port", target: portsCmd})
+}

--- a/commands/command/ports_test.go
+++ b/commands/command/ports_test.go
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package command
+
+import (
+	"testing"
+
+	"swarmcli/args"
+	"swarmcli/registry"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPorts_Name(t *testing.T) {
+	require.Equal(t, "ports", portsCmd.Name())
+}
+
+func TestPorts_Description(t *testing.T) {
+	require.NotEmpty(t, portsCmd.Description())
+}
+
+func TestPorts_Execute(t *testing.T) {
+	cmd := portsCmd.Execute(nil, args.Args{})
+	require.NotNil(t, cmd)
+}
+
+func TestPorts_RegisteredAlias(t *testing.T) {
+	cmd, ok := registry.Get("port")
+	require.True(t, ok)
+	a, ok := cmd.(registry.Aliaser)
+	require.True(t, ok)
+	require.Equal(t, "ports", a.AliasOf())
+}

--- a/docker/portprobe.go
+++ b/docker/portprobe.go
@@ -1,0 +1,159 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package docker
+
+import (
+	"fmt"
+	"net"
+	"sync"
+	"time"
+)
+
+// PortStatus is the result of a single port probe.
+type PortStatus int
+
+const (
+	PortOpen     PortStatus = iota // SYN+ACK received (TCP) or no ICMP unreachable (UDP)
+	PortRefused                    // RST received — host reachable but port closed
+	PortFiltered                   // Timeout — firewall silently dropping packets
+	PortUnknown                    // Probe not yet run or IP missing
+)
+
+func (p PortStatus) String() string {
+	switch p {
+	case PortOpen:
+		return "OPEN"
+	case PortRefused:
+		return "CLOSED"
+	case PortFiltered:
+		return "FILTERED"
+	default:
+		return "UNKNOWN"
+	}
+}
+
+// ProbeTimeout is how long each dial attempt waits before giving up.
+const ProbeTimeout = 2 * time.Second
+
+// NodeProbeResult holds per-node, per-port probe outcomes.
+type NodeProbeResult struct {
+	NodeID    string
+	Hostname  string
+	Addr      string     // IP address probed
+	NodeState string     // Docker-reported state ("ready", "down", …)
+	TCP2377   PortStatus
+	TCP7946   PortStatus
+	UDP7946   PortStatus
+	// UDP4789 is kernel-level VXLAN; not directly probeable from userspace.
+}
+
+// ProbeNodePorts runs TCP and UDP probes against a single node IP.
+// It is safe to call concurrently.
+func ProbeNodePorts(entry NodeEntry) NodeProbeResult {
+	ip := entry.Addr
+	if ip == "" {
+		return NodeProbeResult{
+			NodeID:    entry.ID,
+			Hostname:  entry.Hostname,
+			NodeState: entry.State,
+			Addr:      "",
+			TCP2377:   PortUnknown,
+			TCP7946:   PortUnknown,
+			UDP7946:   PortUnknown,
+		}
+	}
+
+	return NodeProbeResult{
+		NodeID:    entry.ID,
+		Hostname:  entry.Hostname,
+		NodeState: entry.State,
+		Addr:      ip,
+		TCP2377:   probeTCP(ip, 2377),
+		TCP7946:   probeTCP(ip, 7946),
+		UDP7946:   probeUDP(ip, 7946),
+	}
+}
+
+// ProbeAllNodes fans out probes to every node in the snapshot concurrently
+// and returns one result per node, in the same order as entries.
+func ProbeAllNodes(entries []NodeEntry) []NodeProbeResult {
+	results := make([]NodeProbeResult, len(entries))
+	var wg sync.WaitGroup
+	for i, entry := range entries {
+		wg.Add(1)
+		go func(idx int, e NodeEntry) {
+			defer wg.Done()
+			results[idx] = ProbeNodePorts(e)
+		}(i, entry)
+	}
+	wg.Wait()
+	return results
+}
+
+// probeTCP attempts a TCP connection to host:port.
+func probeTCP(host string, port int) PortStatus {
+	addr := fmt.Sprintf("%s:%d", host, port)
+	conn, err := net.DialTimeout("tcp", addr, ProbeTimeout)
+	if err == nil {
+		conn.Close()
+		return PortOpen
+	}
+	if isRefused(err) {
+		return PortRefused
+	}
+	return PortFiltered
+}
+
+// probeUDP sends a zero-byte datagram to host:port and reads with a short
+// deadline. On most kernels, a closed UDP port triggers an ICMP port-
+// unreachable, which surfaces as a "connection refused" read error.
+// Silence (timeout) means the port is open or the ICMP is being dropped.
+func probeUDP(host string, port int) PortStatus {
+	addr := fmt.Sprintf("%s:%d", host, port)
+	conn, err := net.DialTimeout("udp", addr, ProbeTimeout)
+	if err != nil {
+		return PortFiltered
+	}
+	defer conn.Close()
+
+	// Send a probe datagram so the kernel has something to respond to.
+	_ = conn.SetDeadline(time.Now().Add(ProbeTimeout))
+	_, _ = conn.Write([]byte{})
+
+	// Attempt a read; ICMP unreachable turns into a read error.
+	buf := make([]byte, 1)
+	_, readErr := conn.Read(buf)
+	if readErr != nil {
+		if isRefused(readErr) {
+			return PortRefused
+		}
+		// Timeout → open or silently filtered
+		return PortOpen
+	}
+	// We actually read data — port is responding.
+	return PortOpen
+}
+
+// isRefused returns true if the error represents a connection refused.
+func isRefused(err error) bool {
+	if err == nil {
+		return false
+	}
+	// net.OpError wraps a syscall error; the string is the most portable check.
+	e := err.Error()
+	return contains(e, "connection refused") || contains(e, "refused")
+}
+
+func contains(s, sub string) bool {
+	return len(s) >= len(sub) && (s == sub || len(s) > 0 && containsStr(s, sub))
+}
+
+func containsStr(s, sub string) bool {
+	for i := 0; i <= len(s)-len(sub); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/docker/portprobe.go
+++ b/docker/portprobe.go
@@ -40,8 +40,8 @@ const ProbeTimeout = 2 * time.Second
 type NodeProbeResult struct {
 	NodeID    string
 	Hostname  string
-	Addr      string     // IP address probed
-	NodeState string     // Docker-reported state ("ready", "down", …)
+	Addr      string // IP address probed
+	NodeState string // Docker-reported state ("ready", "down", …)
 	TCP2377   PortStatus
 	TCP7946   PortStatus
 	UDP7946   PortStatus
@@ -93,7 +93,7 @@ func ProbeAllNodes(entries []NodeEntry) []NodeProbeResult {
 
 // probeTCP attempts a TCP connection to host:port.
 func probeTCP(host string, port int) PortStatus {
-	addr := fmt.Sprintf("%s:%d", host, port)
+	addr := net.JoinHostPort(host, fmt.Sprintf("%d", port))
 	conn, err := net.DialTimeout("tcp", addr, ProbeTimeout)
 	if err == nil {
 		conn.Close()
@@ -110,7 +110,7 @@ func probeTCP(host string, port int) PortStatus {
 // unreachable, which surfaces as a "connection refused" read error.
 // Silence (timeout) means the port is open or the ICMP is being dropped.
 func probeUDP(host string, port int) PortStatus {
-	addr := fmt.Sprintf("%s:%d", host, port)
+	addr := net.JoinHostPort(host, fmt.Sprintf("%d", port))
 	conn, err := net.DialTimeout("udp", addr, ProbeTimeout)
 	if err != nil {
 		return PortFiltered

--- a/views/autoload.go
+++ b/views/autoload.go
@@ -13,6 +13,7 @@ import (
 	_ "swarmcli/views/logs"
 	_ "swarmcli/views/networks"
 	_ "swarmcli/views/nodes"
+	_ "swarmcli/views/ports"
 	_ "swarmcli/views/secrets"
 	_ "swarmcli/views/services"
 	_ "swarmcli/views/stacks"

--- a/views/nodes/model.go
+++ b/views/nodes/model.go
@@ -124,6 +124,7 @@ func (m *Model) ShortHelpItems() []helpbar.HelpEntry {
 		{Key: "Ctrl+T", Desc: "Demote node"},
 		{Key: "Ctrl+O", Desc: "Promote node"},
 		{Key: "Ctrl+D", Desc: "Remove node"},
+		{Key: "Ctrl+P", Desc: "Ports"},
 		{Key: "↑/↓", Desc: "Navigate"},
 		{Key: "/", Desc: "Filter"},
 		{Key: "?", Desc: "Help"},

--- a/views/nodes/update.go
+++ b/views/nodes/update.go
@@ -490,6 +490,13 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 				m.confirmDialog.ErrorMode = false
 				m.confirmDialog.Message = fmt.Sprintf("Remove node %q from swarm?\nWarning: This action cannot be undone.", node.Hostname)
 			}
+		case "ctrl+p":
+			return func() tea.Msg {
+				return view.NavigateToMsg{
+					ViewName: view.NamePorts,
+					Payload:  nil,
+				}
+			}
 		}
 
 		return nil
@@ -725,6 +732,7 @@ func GetNodesHelpContent() []helpview.HelpCategory {
 				{Keys: "<ctrl+o>", Description: "Promote to manager"},
 				{Keys: "<ctrl+t>", Description: "Demote to worker"},
 				{Keys: "<ctrl+d>", Description: "Remove node"},
+				{Keys: "<ctrl+p>", Description: "Show required Swarm ports"},
 				{Keys: "</>", Description: "Filter"},
 			},
 		},

--- a/views/nodes/update_test.go
+++ b/views/nodes/update_test.go
@@ -174,6 +174,16 @@ func TestKey_Help(t *testing.T) {
 	require.Equal(t, view.NameHelp, nav.ViewName)
 }
 
+func TestKey_CtrlP_ShowsPorts(t *testing.T) {
+	m := testModel()
+	loadNodes(m, fakeNodes("n1"))
+	cmd := m.Update(key("ctrl+p"))
+	msg := runCmd(cmd)
+	nav, ok := msg.(view.NavigateToMsg)
+	require.True(t, ok)
+	require.Equal(t, view.NamePorts, nav.ViewName)
+}
+
 func TestKey_CtrlD_OpensRemoveConfirm(t *testing.T) {
 	m := testModel()
 	loadNodes(m, fakeNodes("mynode"))

--- a/views/ports/model.go
+++ b/views/ports/model.go
@@ -6,6 +6,7 @@ package portsview
 import (
 	"swarmcli/docker"
 	"swarmcli/views/helpbar"
+	"sync"
 	"time"
 
 	"github.com/charmbracelet/bubbles/viewport"
@@ -18,6 +19,12 @@ type Model struct {
 	width    int
 	height   int
 	ready    bool
+
+	// probe state
+	probeMu      sync.RWMutex
+	probeResults []docker.NodeProbeResult
+	probing      bool // true while a probe round is in-flight
+	lastProbeAt  time.Time
 }
 
 func New(width, height int) *Model {
@@ -46,6 +53,7 @@ func (m *Model) Name() string {
 
 func (m *Model) ShortHelpItems() []helpbar.HelpEntry {
 	return []helpbar.HelpEntry{
+		{Key: "r", Desc: "Re-probe"},
 		{Key: "esc", Desc: "Back"},
 	}
 }
@@ -60,4 +68,23 @@ func (m *Model) OnExit() tea.Cmd {
 
 func (m *Model) HasErrors() bool {
 	return false
+}
+
+// getProbeResults returns a snapshot of the latest probe results, safe to call
+// from the render path.
+func (m *Model) getProbeResults() []docker.NodeProbeResult {
+	m.probeMu.RLock()
+	defer m.probeMu.RUnlock()
+	out := make([]docker.NodeProbeResult, len(m.probeResults))
+	copy(out, m.probeResults)
+	return out
+}
+
+// setProbeResults stores results delivered by the background probe goroutine.
+func (m *Model) setProbeResults(results []docker.NodeProbeResult) {
+	m.probeMu.Lock()
+	defer m.probeMu.Unlock()
+	m.probeResults = results
+	m.probing = false
+	m.lastProbeAt = time.Now()
 }

--- a/views/ports/model.go
+++ b/views/ports/model.go
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package portsview
+
+import (
+	"swarmcli/docker"
+	"swarmcli/views/helpbar"
+	"time"
+
+	"github.com/charmbracelet/bubbles/viewport"
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+type Model struct {
+	deps     docker.Deps
+	viewport viewport.Model
+	width    int
+	height   int
+	ready    bool
+}
+
+func New(width, height int) *Model {
+	vp := viewport.New(width, height)
+	vp.SetContent("")
+	return &Model{
+		viewport: vp,
+		width:    width,
+		height:   height,
+	}
+}
+
+func (m *Model) Init() tea.Cmd {
+	return tickCmd()
+}
+
+func tickCmd() tea.Cmd {
+	return tea.Tick(PollInterval, func(t time.Time) tea.Msg {
+		return TickMsg(t)
+	})
+}
+
+func (m *Model) Name() string {
+	return ViewName
+}
+
+func (m *Model) ShortHelpItems() []helpbar.HelpEntry {
+	return []helpbar.HelpEntry{
+		{Key: "esc", Desc: "Back"},
+	}
+}
+
+func (m *Model) OnEnter() tea.Cmd {
+	return nil
+}
+
+func (m *Model) OnExit() tea.Cmd {
+	return nil
+}
+
+func (m *Model) HasErrors() bool {
+	return false
+}

--- a/views/ports/ports.go
+++ b/views/ports/ports.go
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package portsview
+
+import (
+	"time"
+
+	swarmlog "swarmcli/utils/log"
+)
+
+const ViewName = "ports"
+
+type TickMsg time.Time
+
+const PollInterval = 3 * time.Second
+
+func l() *swarmlog.SwarmLogger {
+	return swarmlog.L().With("view", "ports")
+}

--- a/views/ports/ports.go
+++ b/views/ports/ports.go
@@ -4,6 +4,7 @@
 package portsview
 
 import (
+	"swarmcli/docker"
 	"time"
 
 	swarmlog "swarmcli/utils/log"
@@ -11,9 +12,19 @@ import (
 
 const ViewName = "ports"
 
+// PollInterval is how often the tick fires to re-render diagnostics.
+const PollInterval = 3 * time.Second
+
+// ProbeInterval is how often we launch a fresh round of port probes.
+// Probes involve real network I/O, so we space them out more than renders.
+const ProbeInterval = 10 * time.Second
+
 type TickMsg time.Time
 
-const PollInterval = 3 * time.Second
+// ProbeResultMsg carries finished probe results back to the Update loop.
+type ProbeResultMsg struct {
+	Results []docker.NodeProbeResult
+}
 
 func l() *swarmlog.SwarmLogger {
 	return swarmlog.L().With("view", "ports")

--- a/views/ports/ports.go
+++ b/views/ports/ports.go
@@ -6,8 +6,6 @@ package portsview
 import (
 	"swarmcli/docker"
 	"time"
-
-	swarmlog "swarmcli/utils/log"
 )
 
 const ViewName = "ports"
@@ -24,8 +22,4 @@ type TickMsg time.Time
 // ProbeResultMsg carries finished probe results back to the Update loop.
 type ProbeResultMsg struct {
 	Results []docker.NodeProbeResult
-}
-
-func l() *swarmlog.SwarmLogger {
-	return swarmlog.L().With("view", "ports")
 }

--- a/views/ports/ports_test.go
+++ b/views/ports/ports_test.go
@@ -5,6 +5,7 @@ package portsview
 
 import (
 	"testing"
+	"time"
 
 	"swarmcli/docker"
 	"swarmcli/views/view"
@@ -13,6 +14,25 @@ import (
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/stretchr/testify/require"
 )
+
+// ── snapshot mock ─────────────────────────────────────────────────────────────
+
+type mockSnapshotOps struct {
+	docker.SnapshotOps
+	snap *docker.SwarmSnapshot
+}
+
+func (m mockSnapshotOps) GetSnapshot() *docker.SwarmSnapshot            { return m.snap }
+func (m mockSnapshotOps) TriggerRefreshIfNeeded()                       {}
+func (m mockSnapshotOps) RefreshSnapshotAsync()                         {}
+func (m mockSnapshotOps) SetSnapshot(s *docker.SwarmSnapshot)           {}
+func (m mockSnapshotOps) InvalidateSnapshot()                           {}
+func (m mockSnapshotOps) RefreshSnapshot() (*docker.SwarmSnapshot, error) { return m.snap, nil }
+func (m mockSnapshotOps) GetOrRefreshSnapshot() (*docker.SwarmSnapshot, error) {
+	return m.snap, nil
+}
+
+// ── basic construction ────────────────────────────────────────────────────────
 
 func TestNew(t *testing.T) {
 	m := New(80, 20)
@@ -25,41 +45,116 @@ func TestNew(t *testing.T) {
 	require.False(t, m.HasErrors())
 }
 
+// ── window-size msg ───────────────────────────────────────────────────────────
+
 func TestUpdate_WindowSize(t *testing.T) {
 	m := New(80, 20)
-	msg := tea.WindowSizeMsg{Width: 100, Height: 40}
-	cmd := m.Update(msg)
-	require.Nil(t, cmd)
+	cmd := m.Update(tea.WindowSizeMsg{Width: 100, Height: 40})
+	require.NotNil(t, cmd)        // batch (tick + probe launch)
+	require.True(t, m.ready)
 	require.Equal(t, 100, m.width)
 	require.Equal(t, 40, m.height)
-	require.True(t, m.ready)
 
-	// Content should be set in viewport
 	content := m.viewport.View()
 	require.Contains(t, content, "2377")
 	require.Contains(t, content, "7946")
 	require.Contains(t, content, "4789")
 }
 
-func TestUpdate_Keys(t *testing.T) {
+// ── esc key ───────────────────────────────────────────────────────────────────
+
+func TestUpdate_EscKey(t *testing.T) {
 	m := New(80, 20)
 	m.ready = true
-
-	// Test Esc key returns GoBackMsg
-	msg := tea.KeyMsg{Type: tea.KeyEsc}
-	cmd := m.Update(msg)
+	cmd := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
 	require.NotNil(t, cmd)
-	
-	res := cmd()
-	require.IsType(t, view.GoBackMsg{}, res)
+	require.IsType(t, view.GoBackMsg{}, cmd())
 }
 
-func TestView(t *testing.T) {
-	m := New(80, 40)
-	// View is empty before ready
-	require.Empty(t, m.View())
+// ── r key (re-probe) ──────────────────────────────────────────────────────────
 
-	// Once ready, View is not empty and has frame elements
+func TestUpdate_RKey_LaunchesProbe(t *testing.T) {
+	m := New(80, 20)
+	m.ready = true
+	m.deps = docker.Deps{Snapshot: mockSnapshotOps{snap: &docker.SwarmSnapshot{}}}
+
+	cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("r")})
+	require.NotNil(t, cmd, "r should return a probe command")
+
+	// Running the command should produce a ProbeResultMsg.
+	msg := cmd()
+	require.IsType(t, ProbeResultMsg{}, msg)
+}
+
+func TestUpdate_RKey_NoopWhileProbing(t *testing.T) {
+	m := New(80, 20)
+	m.ready = true
+	m.probing = true // simulate an in-flight probe
+
+	cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("r")})
+	require.Nil(t, cmd, "should not launch a second probe while one is in-flight")
+}
+
+// ── ProbeResultMsg delivery ───────────────────────────────────────────────────
+
+func TestUpdate_ProbeResultMsg(t *testing.T) {
+	m := New(80, 40)
+	m.ready = true
+	m.updateViewport()
+
+	results := []docker.NodeProbeResult{
+		{NodeID: "n1", Hostname: "node-1", Addr: "10.0.0.1", TCP2377: docker.PortOpen, TCP7946: docker.PortOpen, UDP7946: docker.PortOpen},
+		{NodeID: "n2", Hostname: "node-2", Addr: "10.0.0.2", TCP2377: docker.PortFiltered, TCP7946: docker.PortOpen, UDP7946: docker.PortRefused},
+	}
+
+	cmd := m.Update(ProbeResultMsg{Results: results})
+	require.Nil(t, cmd)
+
+	stored := m.getProbeResults()
+	require.Len(t, stored, 2)
+	require.Equal(t, docker.PortOpen, stored[0].TCP2377)
+	require.Equal(t, docker.PortFiltered, stored[1].TCP2377)
+	require.Equal(t, docker.PortRefused, stored[1].UDP7946)
+
+	// Viewport should now contain the node hostnames.
+	content := m.viewport.View()
+	require.Contains(t, content, "node-1")
+	require.Contains(t, content, "node-2")
+}
+
+// ── TickMsg triggers refresh + probe ─────────────────────────────────────────
+
+func TestUpdate_TickMsg_OldProbeTriggersNewProbe(t *testing.T) {
+	m := New(80, 40)
+	m.ready = true
+	m.lastProbeAt = time.Now().Add(-ProbeInterval - time.Second) // expired
+	m.deps = docker.Deps{Snapshot: mockSnapshotOps{snap: &docker.SwarmSnapshot{}}}
+
+	cmd := m.Update(TickMsg(time.Now()))
+	// Should return a batch that includes a probe launch.
+	require.NotNil(t, cmd)
+}
+
+func TestUpdate_TickMsg_FreshProbeSkipsNewProbe(t *testing.T) {
+	m := New(80, 40)
+	m.ready = true
+	m.lastProbeAt = time.Now()                                // just probed
+	m.deps = docker.Deps{Snapshot: mockSnapshotOps{snap: &docker.SwarmSnapshot{}}}
+
+	cmd := m.Update(TickMsg(time.Now()))
+	// Should only return a tickCmd, not a full batch.
+	require.NotNil(t, cmd)
+}
+
+// ── view output ───────────────────────────────────────────────────────────────
+
+func TestView_BeforeReady(t *testing.T) {
+	m := New(80, 40)
+	require.Empty(t, m.View())
+}
+
+func TestView_AfterReady(t *testing.T) {
+	m := New(80, 40)
 	m.ready = true
 	m.updateViewport()
 	out := m.View()
@@ -70,86 +165,122 @@ func TestView(t *testing.T) {
 	require.Contains(t, out, "4789")
 }
 
-type mockSnapshotOps struct {
-	docker.SnapshotOps
-	snap *docker.SwarmSnapshot
+func TestView_ShowsProbeResults(t *testing.T) {
+	m := New(120, 60)
+	m.ready = true
+	m.probeResults = []docker.NodeProbeResult{
+		{NodeID: "n1", Hostname: "manager-1", Addr: "192.168.1.10", NodeState: "ready", TCP2377: docker.PortOpen, TCP7946: docker.PortOpen, UDP7946: docker.PortOpen},
+		{NodeID: "n2", Hostname: "worker-1", Addr: "192.168.1.11", NodeState: "ready", TCP2377: docker.PortFiltered, TCP7946: docker.PortRefused, UDP7946: docker.PortFiltered},
+	}
+	m.updateViewport()
+	out := m.View()
+	require.Contains(t, out, "manager-1")
+	require.Contains(t, out, "worker-1")
+	require.Contains(t, out, "OPEN")
+	require.Contains(t, out, "FILTERED")
+	require.Contains(t, out, "CLOSED")
 }
 
-func (m mockSnapshotOps) GetSnapshot() *docker.SwarmSnapshot {
-	return m.snap
+// TestView_NodeDown_ShowsNodeDown verifies that a stopped node renders "NODE DOWN"
+// across all port columns instead of the misleading FILTERED that a timed-out
+// probe produces on a dead host.
+func TestView_NodeDown_ShowsNodeDown(t *testing.T) {
+	m := New(120, 60)
+	m.ready = true
+	m.probeResults = []docker.NodeProbeResult{
+		// Running node — probe timed out on TCP 2377 (firewall), so FILTERED.
+		{NodeID: "n1", Hostname: "manager-1", Addr: "192.168.1.10", NodeState: "ready", TCP2377: docker.PortFiltered, TCP7946: docker.PortOpen, UDP7946: docker.PortOpen},
+		// Stopped node — probe also timed out, but Docker says it's "down".
+		{NodeID: "n2", Hostname: "worker-stopped", Addr: "192.168.1.11", NodeState: "down", TCP2377: docker.PortFiltered, TCP7946: docker.PortFiltered, UDP7946: docker.PortOpen},
+	}
+	m.updateViewport()
+	out := m.View()
+
+	require.Contains(t, out, "NODE DOWN", "stopped node should show NODE DOWN, not FILTERED")
+	require.Contains(t, out, "manager-1")
+	require.Contains(t, out, "worker-stopped")
+	// The running node's FILTERED should still appear (firewall signal).
+	require.Contains(t, out, "FILTERED")
 }
 
-func TestGetDiagnosticStatus(t *testing.T) {
-	// 1. Nil snapshot
+// ── getDiagnosticStatus ───────────────────────────────────────────────────────
+
+func TestGetDiagnosticStatus_NilSnapshot(t *testing.T) {
 	m := New(80, 40)
 	require.Empty(t, m.getDiagnosticStatus())
+}
 
-	// Set up dependencies
-	m.deps = docker.Deps{}
-	
-	// 2. Mock snap with empty nodes
-	mockOps := mockSnapshotOps{
-		snap: &docker.SwarmSnapshot{},
-	}
-	m.deps.Snapshot = mockOps
+func TestGetDiagnosticStatus_EmptyNodes(t *testing.T) {
+	m := New(80, 40)
+	m.deps = docker.Deps{Snapshot: mockSnapshotOps{snap: &docker.SwarmSnapshot{}}}
 	require.Contains(t, m.getDiagnosticStatus(), "No nodes found")
+}
 
-	// Helper to build node entries
-	// 3. Healthy single node manager
-	snap := &docker.SwarmSnapshot{
-		Nodes: []swarm.Node{
-			{
-				ID: "node1",
-				Spec: swarm.NodeSpec{
-					Role: swarm.NodeRoleManager,
-				},
-				Status: swarm.NodeStatus{
-					State: swarm.NodeStateReady,
-				},
-				ManagerStatus: &swarm.ManagerStatus{
-					Leader: true,
-				},
-			},
+func TestGetDiagnosticStatus_HealthyManager(t *testing.T) {
+	m := New(80, 40)
+	m.deps = docker.Deps{Snapshot: mockSnapshotOps{
+		snap: &docker.SwarmSnapshot{
+			Nodes: []swarm.Node{{
+				ID:   "n1",
+				Spec: swarm.NodeSpec{Role: swarm.NodeRoleManager},
+				Status: swarm.NodeStatus{State: swarm.NodeStateReady},
+				ManagerStatus: &swarm.ManagerStatus{Leader: true},
+			}},
 		},
-	}
-	mockOps.snap = snap
-	m.deps.Snapshot = mockOps
-	
+	}}
 	diag := m.getDiagnosticStatus()
 	require.Contains(t, diag, "HEALTHY / ONLINE")
 	require.Contains(t, diag, "TCP 2377")
 	require.Contains(t, diag, "TCP/UDP 7946")
 	require.Contains(t, diag, "UDP 4789")
+}
 
-	// 4. Degraded gossip network (offline worker)
-	snap.Nodes = append(snap.Nodes, swarm.Node{
-		ID: "node2",
-		Spec: swarm.NodeSpec{
-			Role: swarm.NodeRoleWorker,
+func TestGetDiagnosticStatus_DegradedGossip(t *testing.T) {
+	m := New(80, 40)
+	m.deps = docker.Deps{Snapshot: mockSnapshotOps{
+		snap: &docker.SwarmSnapshot{
+			Nodes: []swarm.Node{
+				{
+					ID:     "n1",
+					Spec:   swarm.NodeSpec{Role: swarm.NodeRoleManager},
+					Status: swarm.NodeStatus{State: swarm.NodeStateReady},
+					ManagerStatus: &swarm.ManagerStatus{Leader: true},
+				},
+				{
+					ID:     "n2",
+					Spec:   swarm.NodeSpec{Role: swarm.NodeRoleWorker},
+					Status: swarm.NodeStatus{State: swarm.NodeStateDown},
+				},
+			},
 		},
-		Status: swarm.NodeStatus{
-			State: swarm.NodeStateDown,
-		},
-	})
-	diag = m.getDiagnosticStatus()
+	}}
+	diag := m.getDiagnosticStatus()
 	require.Contains(t, diag, "DEGRADED / DISRUPTED")
-	require.Contains(t, diag, "offline")
+}
 
-	// 5. Unreachable manager status
-	snap.Nodes = []swarm.Node{
-		{
-			ID: "node1",
-			Spec: swarm.NodeSpec{
-				Role: swarm.NodeRoleManager,
-			},
-			Status: swarm.NodeStatus{
-				State: swarm.NodeStateReady,
-			},
-			ManagerStatus: &swarm.ManagerStatus{
-				Reachability: swarm.ReachabilityUnreachable,
-			},
+func TestGetDiagnosticStatus_UnreachableManager(t *testing.T) {
+	m := New(80, 40)
+	m.deps = docker.Deps{Snapshot: mockSnapshotOps{
+		snap: &docker.SwarmSnapshot{
+			Nodes: []swarm.Node{{
+				ID:   "n1",
+				Spec: swarm.NodeSpec{Role: swarm.NodeRoleManager},
+				Status: swarm.NodeStatus{State: swarm.NodeStateReady},
+				ManagerStatus: &swarm.ManagerStatus{
+					Reachability: swarm.ReachabilityUnreachable,
+				},
+			}},
 		},
-	}
-	diag = m.getDiagnosticStatus()
+	}}
+	diag := m.getDiagnosticStatus()
 	require.Contains(t, diag, "UNREACHABLE / BLOCKED")
+}
+
+// ── PortStatus.String ─────────────────────────────────────────────────────────
+
+func TestPortStatus_String(t *testing.T) {
+	require.Equal(t, "OPEN", docker.PortOpen.String())
+	require.Equal(t, "CLOSED", docker.PortRefused.String())
+	require.Equal(t, "FILTERED", docker.PortFiltered.String())
+	require.Equal(t, "UNKNOWN", docker.PortUnknown.String())
 }

--- a/views/ports/ports_test.go
+++ b/views/ports/ports_test.go
@@ -22,11 +22,11 @@ type mockSnapshotOps struct {
 	snap *docker.SwarmSnapshot
 }
 
-func (m mockSnapshotOps) GetSnapshot() *docker.SwarmSnapshot            { return m.snap }
-func (m mockSnapshotOps) TriggerRefreshIfNeeded()                       {}
-func (m mockSnapshotOps) RefreshSnapshotAsync()                         {}
-func (m mockSnapshotOps) SetSnapshot(s *docker.SwarmSnapshot)           {}
-func (m mockSnapshotOps) InvalidateSnapshot()                           {}
+func (m mockSnapshotOps) GetSnapshot() *docker.SwarmSnapshot              { return m.snap }
+func (m mockSnapshotOps) TriggerRefreshIfNeeded()                         {}
+func (m mockSnapshotOps) RefreshSnapshotAsync()                           {}
+func (m mockSnapshotOps) SetSnapshot(s *docker.SwarmSnapshot)             {}
+func (m mockSnapshotOps) InvalidateSnapshot()                             {}
 func (m mockSnapshotOps) RefreshSnapshot() (*docker.SwarmSnapshot, error) { return m.snap, nil }
 func (m mockSnapshotOps) GetOrRefreshSnapshot() (*docker.SwarmSnapshot, error) {
 	return m.snap, nil
@@ -50,7 +50,7 @@ func TestNew(t *testing.T) {
 func TestUpdate_WindowSize(t *testing.T) {
 	m := New(80, 20)
 	cmd := m.Update(tea.WindowSizeMsg{Width: 100, Height: 40})
-	require.NotNil(t, cmd)        // batch (tick + probe launch)
+	require.NotNil(t, cmd) // batch (tick + probe launch)
 	require.True(t, m.ready)
 	require.Equal(t, 100, m.width)
 	require.Equal(t, 40, m.height)
@@ -138,7 +138,7 @@ func TestUpdate_TickMsg_OldProbeTriggersNewProbe(t *testing.T) {
 func TestUpdate_TickMsg_FreshProbeSkipsNewProbe(t *testing.T) {
 	m := New(80, 40)
 	m.ready = true
-	m.lastProbeAt = time.Now()                                // just probed
+	m.lastProbeAt = time.Now() // just probed
 	m.deps = docker.Deps{Snapshot: mockSnapshotOps{snap: &docker.SwarmSnapshot{}}}
 
 	cmd := m.Update(TickMsg(time.Now()))
@@ -221,9 +221,9 @@ func TestGetDiagnosticStatus_HealthyManager(t *testing.T) {
 	m.deps = docker.Deps{Snapshot: mockSnapshotOps{
 		snap: &docker.SwarmSnapshot{
 			Nodes: []swarm.Node{{
-				ID:   "n1",
-				Spec: swarm.NodeSpec{Role: swarm.NodeRoleManager},
-				Status: swarm.NodeStatus{State: swarm.NodeStateReady},
+				ID:            "n1",
+				Spec:          swarm.NodeSpec{Role: swarm.NodeRoleManager},
+				Status:        swarm.NodeStatus{State: swarm.NodeStateReady},
 				ManagerStatus: &swarm.ManagerStatus{Leader: true},
 			}},
 		},
@@ -241,9 +241,9 @@ func TestGetDiagnosticStatus_DegradedGossip(t *testing.T) {
 		snap: &docker.SwarmSnapshot{
 			Nodes: []swarm.Node{
 				{
-					ID:     "n1",
-					Spec:   swarm.NodeSpec{Role: swarm.NodeRoleManager},
-					Status: swarm.NodeStatus{State: swarm.NodeStateReady},
+					ID:            "n1",
+					Spec:          swarm.NodeSpec{Role: swarm.NodeRoleManager},
+					Status:        swarm.NodeStatus{State: swarm.NodeStateReady},
 					ManagerStatus: &swarm.ManagerStatus{Leader: true},
 				},
 				{
@@ -263,8 +263,8 @@ func TestGetDiagnosticStatus_UnreachableManager(t *testing.T) {
 	m.deps = docker.Deps{Snapshot: mockSnapshotOps{
 		snap: &docker.SwarmSnapshot{
 			Nodes: []swarm.Node{{
-				ID:   "n1",
-				Spec: swarm.NodeSpec{Role: swarm.NodeRoleManager},
+				ID:     "n1",
+				Spec:   swarm.NodeSpec{Role: swarm.NodeRoleManager},
 				Status: swarm.NodeStatus{State: swarm.NodeStateReady},
 				ManagerStatus: &swarm.ManagerStatus{
 					Reachability: swarm.ReachabilityUnreachable,

--- a/views/ports/ports_test.go
+++ b/views/ports/ports_test.go
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package portsview
+
+import (
+	"testing"
+
+	"swarmcli/docker"
+	"swarmcli/views/view"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/docker/docker/api/types/swarm"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNew(t *testing.T) {
+	m := New(80, 20)
+	require.NotNil(t, m)
+	require.Equal(t, 80, m.width)
+	require.Equal(t, 20, m.height)
+	require.False(t, m.ready)
+	require.Equal(t, ViewName, m.Name())
+	require.NotEmpty(t, m.ShortHelpItems())
+	require.False(t, m.HasErrors())
+}
+
+func TestUpdate_WindowSize(t *testing.T) {
+	m := New(80, 20)
+	msg := tea.WindowSizeMsg{Width: 100, Height: 40}
+	cmd := m.Update(msg)
+	require.Nil(t, cmd)
+	require.Equal(t, 100, m.width)
+	require.Equal(t, 40, m.height)
+	require.True(t, m.ready)
+
+	// Content should be set in viewport
+	content := m.viewport.View()
+	require.Contains(t, content, "2377")
+	require.Contains(t, content, "7946")
+	require.Contains(t, content, "4789")
+}
+
+func TestUpdate_Keys(t *testing.T) {
+	m := New(80, 20)
+	m.ready = true
+
+	// Test Esc key returns GoBackMsg
+	msg := tea.KeyMsg{Type: tea.KeyEsc}
+	cmd := m.Update(msg)
+	require.NotNil(t, cmd)
+	
+	res := cmd()
+	require.IsType(t, view.GoBackMsg{}, res)
+}
+
+func TestView(t *testing.T) {
+	m := New(80, 40)
+	// View is empty before ready
+	require.Empty(t, m.View())
+
+	// Once ready, View is not empty and has frame elements
+	m.ready = true
+	m.updateViewport()
+	out := m.View()
+	require.NotEmpty(t, out)
+	require.Contains(t, out, "Required Swarm Ports")
+	require.Contains(t, out, "2377")
+	require.Contains(t, out, "7946")
+	require.Contains(t, out, "4789")
+}
+
+type mockSnapshotOps struct {
+	docker.SnapshotOps
+	snap *docker.SwarmSnapshot
+}
+
+func (m mockSnapshotOps) GetSnapshot() *docker.SwarmSnapshot {
+	return m.snap
+}
+
+func TestGetDiagnosticStatus(t *testing.T) {
+	// 1. Nil snapshot
+	m := New(80, 40)
+	require.Empty(t, m.getDiagnosticStatus())
+
+	// Set up dependencies
+	m.deps = docker.Deps{}
+	
+	// 2. Mock snap with empty nodes
+	mockOps := mockSnapshotOps{
+		snap: &docker.SwarmSnapshot{},
+	}
+	m.deps.Snapshot = mockOps
+	require.Contains(t, m.getDiagnosticStatus(), "No nodes found")
+
+	// Helper to build node entries
+	// 3. Healthy single node manager
+	snap := &docker.SwarmSnapshot{
+		Nodes: []swarm.Node{
+			{
+				ID: "node1",
+				Spec: swarm.NodeSpec{
+					Role: swarm.NodeRoleManager,
+				},
+				Status: swarm.NodeStatus{
+					State: swarm.NodeStateReady,
+				},
+				ManagerStatus: &swarm.ManagerStatus{
+					Leader: true,
+				},
+			},
+		},
+	}
+	mockOps.snap = snap
+	m.deps.Snapshot = mockOps
+	
+	diag := m.getDiagnosticStatus()
+	require.Contains(t, diag, "HEALTHY / ONLINE")
+	require.Contains(t, diag, "TCP 2377")
+	require.Contains(t, diag, "TCP/UDP 7946")
+	require.Contains(t, diag, "UDP 4789")
+
+	// 4. Degraded gossip network (offline worker)
+	snap.Nodes = append(snap.Nodes, swarm.Node{
+		ID: "node2",
+		Spec: swarm.NodeSpec{
+			Role: swarm.NodeRoleWorker,
+		},
+		Status: swarm.NodeStatus{
+			State: swarm.NodeStateDown,
+		},
+	})
+	diag = m.getDiagnosticStatus()
+	require.Contains(t, diag, "DEGRADED / DISRUPTED")
+	require.Contains(t, diag, "offline")
+
+	// 5. Unreachable manager status
+	snap.Nodes = []swarm.Node{
+		{
+			ID: "node1",
+			Spec: swarm.NodeSpec{
+				Role: swarm.NodeRoleManager,
+			},
+			Status: swarm.NodeStatus{
+				State: swarm.NodeStateReady,
+			},
+			ManagerStatus: &swarm.ManagerStatus{
+				Reachability: swarm.ReachabilityUnreachable,
+			},
+		},
+	}
+	diag = m.getDiagnosticStatus()
+	require.Contains(t, diag, "UNREACHABLE / BLOCKED")
+}

--- a/views/ports/register.go
+++ b/views/ports/register.go
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package portsview
+
+import (
+	"swarmcli/docker"
+	"swarmcli/views/view"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func init() {
+	view.RegisterView(ViewName, factory)
+}
+
+func factory(deps docker.Deps, w, h int, _ any) (view.View, tea.Cmd) {
+	model := New(w, h)
+	model.deps = deps
+	return model, model.Init()
+}

--- a/views/ports/update.go
+++ b/views/ports/update.go
@@ -4,7 +4,9 @@
 package portsview
 
 import (
+	"swarmcli/docker"
 	"swarmcli/views/view"
+	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 )
@@ -18,19 +20,38 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 		m.viewport.Height = msg.Height
 		m.ready = true
 		m.updateViewport()
-		return nil
+		// Kick off the first probe round immediately.
+		return tea.Batch(tickCmd(), m.launchProbeCmd())
 
 	case TickMsg:
 		if m.ready {
 			if m.deps.Snapshot != nil {
 				m.deps.Snapshot.TriggerRefreshIfNeeded()
 			}
+			// Launch a new probe round if the last one is old enough.
+			if time.Since(m.lastProbeAt) >= ProbeInterval && !m.probing {
+				m.updateViewport()
+				return tea.Batch(tickCmd(), m.launchProbeCmd())
+			}
 			m.updateViewport()
 		}
 		return tickCmd()
 
+	case ProbeResultMsg:
+		m.setProbeResults(msg.Results)
+		if m.ready {
+			m.updateViewport()
+		}
+		return nil
+
 	case tea.KeyMsg:
 		switch msg.String() {
+		case "r":
+			// Manual re-probe on demand.
+			if !m.probing {
+				return m.launchProbeCmd()
+			}
+			return nil
 		case "esc":
 			return func() tea.Msg {
 				return view.GoBackMsg{}
@@ -41,4 +62,28 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 	var cmd tea.Cmd
 	m.viewport, cmd = m.viewport.Update(msg)
 	return cmd
+}
+
+// launchProbeCmd fans out real TCP/UDP probes to all nodes in a background
+// goroutine and delivers a ProbeResultMsg when done. It is safe to call even
+// when no snapshot is available yet.
+func (m *Model) launchProbeCmd() tea.Cmd {
+	m.probeMu.Lock()
+	m.probing = true
+	m.probeMu.Unlock()
+
+	// Snapshot the node list now (before entering the goroutine) so we don't
+	// hold the model lock during network I/O.
+	var entries []docker.NodeEntry
+	if m.deps.Snapshot != nil {
+		snap := m.deps.Snapshot.GetSnapshot()
+		if snap != nil {
+			entries = snap.ToNodeEntries()
+		}
+	}
+
+	return func() tea.Msg {
+		results := docker.ProbeAllNodes(entries)
+		return ProbeResultMsg{Results: results}
+	}
 }

--- a/views/ports/update.go
+++ b/views/ports/update.go
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package portsview
+
+import (
+	"swarmcli/views/view"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func (m *Model) Update(msg tea.Msg) tea.Cmd {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.width = msg.Width
+		m.height = msg.Height
+		m.viewport.Width = msg.Width
+		m.viewport.Height = msg.Height
+		m.ready = true
+		m.updateViewport()
+		return nil
+
+	case TickMsg:
+		if m.ready {
+			if m.deps.Snapshot != nil {
+				m.deps.Snapshot.TriggerRefreshIfNeeded()
+			}
+			m.updateViewport()
+		}
+		return tickCmd()
+
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "esc":
+			return func() tea.Msg {
+				return view.GoBackMsg{}
+			}
+		}
+	}
+
+	var cmd tea.Cmd
+	m.viewport, cmd = m.viewport.Update(msg)
+	return cmd
+}

--- a/views/ports/view.go
+++ b/views/ports/view.go
@@ -6,7 +6,9 @@ package portsview
 import (
 	"fmt"
 	"strings"
+	"swarmcli/docker"
 	"swarmcli/ui"
+	"time"
 
 	"github.com/charmbracelet/lipgloss"
 )
@@ -43,42 +45,31 @@ func (m *Model) View() string {
 func (m *Model) updateViewport() {
 	var b strings.Builder
 
-	// Style tokens
-	titleStyle := lipgloss.NewStyle().
-		Bold(true).
-		Foreground(lipgloss.Color("81")) // Light blue/cyan
+	// ── Style tokens ──────────────────────────────────────────────────────────
+	titleStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("81"))
+	infoStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("246"))
+	portHeaderStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("208"))
+	labelStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("117")).Width(12)
+	valueStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("255"))
 
-	infoStyle := lipgloss.NewStyle().
-		Foreground(lipgloss.Color("246")) // Gray description text
+	okStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("2"))    // green
+	warnStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("208")) // amber
+	errStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("9"))   // red
+	dimStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("240"))
 
-	portHeaderStyle := lipgloss.NewStyle().
-		Bold(true).
-		Foreground(lipgloss.Color("208")) // Orange/amber for port headings
-
-	labelStyle := lipgloss.NewStyle().
-		Bold(true).
-		Foreground(lipgloss.Color("117")). // Cyan labels
-		Width(12)
-
-	valueStyle := lipgloss.NewStyle().
-		Foreground(lipgloss.Color("255")) // White values
-
-	// Compute card width dynamically
 	cardWidth := m.viewport.Width - 6
 	if cardWidth < 40 {
 		cardWidth = 40
 	}
-
 	borderStyle := lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
-		BorderForeground(lipgloss.Color("63")). // Sleek blue border
+		BorderForeground(lipgloss.Color("63")).
 		Padding(0, 2).
 		MarginBottom(1).
 		Width(cardWidth)
 
-	// Helper to wrap value text to fit the card width and align multi-line values
 	wrapVal := func(val string, labelW int) string {
-		maxValW := cardWidth - labelW - 6 // minus label width, borders, and padding
+		maxValW := cardWidth - labelW - 6
 		if maxValW < 15 {
 			maxValW = 15
 		}
@@ -101,20 +92,13 @@ func (m *Model) updateViewport() {
 		return strings.Join(lines, "\n"+indent)
 	}
 
-	// Intro text
+	// ── Intro ─────────────────────────────────────────────────────────────────
 	b.WriteString(titleStyle.Render("Required Swarm Cluster Ports (node-to-node)"))
 	b.WriteString("\n")
-	b.WriteString(infoStyle.Render("These ports must be open between all Swarm nodes (managers and workers) to ensure cluster coordination, node health state sync, and container overlay networking."))
+	b.WriteString(infoStyle.Render("These ports must be open between all Swarm nodes to ensure cluster coordination, node health state sync, and container overlay networking."))
 	b.WriteString("\n\n")
 
-	// Append Real-time Diagnostics
-	diagnostics := m.getDiagnosticStatus()
-	if diagnostics != "" {
-		b.WriteString(diagnostics)
-		b.WriteString("\n")
-	}
-
-	// Render Port 2377
+	// ── Port reference cards ──────────────────────────────────────────────────
 	port1Content := fmt.Sprintf("%s%s\n%s%s\n%s%s",
 		labelStyle.Render("Protocol:"), valueStyle.Render(wrapVal("TCP", 12)),
 		labelStyle.Render("Used For:"), valueStyle.Render(wrapVal("Swarm control plane (manager election, cluster commands)", 12)),
@@ -123,7 +107,6 @@ func (m *Model) updateViewport() {
 	b.WriteString(borderStyle.Render(fmt.Sprintf("%s\n\n%s", portHeaderStyle.Render("TCP 2377 — Cluster management"), port1Content)))
 	b.WriteString("\n")
 
-	// Render Port 7946
 	port2Content := fmt.Sprintf("%s%s\n%s%s\n%s%s",
 		labelStyle.Render("Protocol:"), valueStyle.Render(wrapVal("TCP / UDP", 12)),
 		labelStyle.Render("Used For:"), valueStyle.Render(wrapVal("Gossip network (node discovery, membership, state sync)", 12)),
@@ -132,16 +115,156 @@ func (m *Model) updateViewport() {
 	b.WriteString(borderStyle.Render(fmt.Sprintf("%s\n\n%s", portHeaderStyle.Render("TCP / UDP 7946 — Node communication"), port2Content)))
 	b.WriteString("\n")
 
-	// Render Port 4789
 	port3Content := fmt.Sprintf("%s%s\n%s%s\n%s%s",
 		labelStyle.Render("Protocol:"), valueStyle.Render(wrapVal("UDP", 12)),
 		labelStyle.Render("Used For:"), valueStyle.Render(wrapVal("Overlay network (VXLAN) container-to-container traffic", 12)),
 		labelStyle.Render("Direction:"), valueStyle.Render(wrapVal("All nodes to all nodes", 12)),
 	)
 	b.WriteString(borderStyle.Render(fmt.Sprintf("%s\n\n%s", portHeaderStyle.Render("UDP 4789 — Overlay network (VXLAN)"), port3Content)))
+	b.WriteString("\n\n")
+
+	// ── Live probe results ────────────────────────────────────────────────────
+	sectionHeader := lipgloss.NewStyle().
+		Bold(true).
+		Foreground(lipgloss.Color("15")).
+		Background(lipgloss.Color("63")).
+		Padding(0, 1)
+
+	m.probeMu.RLock()
+	results := m.probeResults
+	probing := m.probing
+	lastAt := m.lastProbeAt
+	m.probeMu.RUnlock()
+
+	// Header line
+	probeAge := ""
+	if !lastAt.IsZero() {
+		probeAge = fmt.Sprintf("  last probe: %s ago", formatDuration(time.Since(lastAt)))
+	}
+	if probing {
+		b.WriteString(sectionHeader.Render(" LIVE PORT PROBES — probing… "))
+	} else {
+		b.WriteString(sectionHeader.Render(" LIVE PORT PROBES — press r to re-probe"+probeAge+" "))
+	}
+	b.WriteString("\n\n")
+
+	if len(results) == 0 {
+		if probing {
+			b.WriteString(dimStyle.Render("  Probing nodes — please wait…"))
+		} else {
+			b.WriteString(dimStyle.Render("  No probe data yet. Probes run automatically every 10 s, or press r."))
+		}
+		b.WriteString("\n")
+	} else {
+		b.WriteString(m.renderProbeTable(results, okStyle, warnStyle, errStyle, dimStyle, cardWidth))
+	}
+
 	b.WriteString("\n")
 
+	// ── Swarm-state diagnostics (indirect) ────────────────────────────────────
+	diag := m.getDiagnosticStatus()
+	if diag != "" {
+		b.WriteString(diag)
+		b.WriteString("\n")
+	}
+
 	m.viewport.SetContent(b.String())
+}
+
+// renderProbeTable builds a compact per-node, per-port result table.
+func (m *Model) renderProbeTable(
+	results []docker.NodeProbeResult,
+	okStyle, warnStyle, errStyle, dimStyle lipgloss.Style,
+	tableWidth int,
+) string {
+	var b strings.Builder
+
+	// Column widths
+	colHost := 18
+	colAddr := 16
+	colPort := 12
+
+	hdrStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("117"))
+	sep := lipgloss.NewStyle().Foreground(lipgloss.Color("240")).Render("│")
+
+	header := fmt.Sprintf("  %-*s %s %-*s %s %-*s %s %-*s %s %-*s",
+		colHost, hdrStyle.Render("HOSTNAME"),
+		sep,
+		colAddr, hdrStyle.Render("ADDRESS"),
+		sep,
+		colPort, hdrStyle.Render("TCP 2377"),
+		sep,
+		colPort, hdrStyle.Render("TCP 7946"),
+		sep,
+		colPort, hdrStyle.Render("UDP 7946"),
+	)
+	b.WriteString(header)
+	b.WriteString("\n")
+	b.WriteString("  " + strings.Repeat("─", min(tableWidth-4, 80)))
+	b.WriteString("\n")
+
+	for _, r := range results {
+		hostname := truncate(r.Hostname, colHost)
+		addr := r.Addr
+		if addr == "" {
+			addr = "—"
+		}
+		addr = truncate(addr, colAddr)
+
+		// If Docker reports this node as not ready, the probe timeout is caused
+		// by a dead host — not a firewall. Show NODE DOWN across all columns so
+		// users can distinguish a stopped node from a live node with blocked ports.
+		nodeDown := r.NodeState != "" && r.NodeState != "ready"
+		downCell := errStyle.Render("● NODE DOWN")
+
+		var tcp2377, tcp7946, udp7946 string
+		if nodeDown {
+			tcp2377 = downCell
+			tcp7946 = downCell
+			udp7946 = downCell
+		} else {
+			tcp2377 = renderStatus(r.TCP2377, okStyle, warnStyle, errStyle, dimStyle)
+			tcp7946 = renderStatus(r.TCP7946, okStyle, warnStyle, errStyle, dimStyle)
+			udp7946 = renderStatus(r.UDP7946, okStyle, warnStyle, errStyle, dimStyle)
+		}
+
+		row := fmt.Sprintf("  %-*s %s %-*s %s %-*s %s %-*s %s %-*s",
+			colHost, hostname,
+			sep,
+			colAddr, addr,
+			sep,
+			colPort, tcp2377,
+			sep,
+			colPort, tcp7946,
+			sep,
+			colPort, udp7946,
+		)
+		b.WriteString(row)
+		b.WriteString("\n")
+	}
+
+	// UDP 4789 note
+	b.WriteString("\n")
+	note := lipgloss.NewStyle().Foreground(lipgloss.Color("240")).Render(
+		"  UDP 4789 (VXLAN) is handled by the kernel's networking stack and cannot be\n" +
+			"  probed from userspace without raw socket privileges (CAP_NET_RAW).")
+	b.WriteString(note)
+	b.WriteString("\n")
+
+	return b.String()
+}
+
+func renderStatus(s docker.PortStatus, ok, warn, err, dim lipgloss.Style) string {
+	switch s {
+	case docker.PortOpen:
+		return ok.Render("● OPEN    ")
+	case docker.PortRefused:
+		return err.Render("● CLOSED  ")
+	case docker.PortFiltered:
+		return warn.Render("● FILTERED")
+	default:
+		return dim.Render("  UNKNOWN ")
+	}
 }
 
 func (m *Model) getDiagnosticStatus() string {
@@ -172,7 +295,6 @@ func (m *Model) getDiagnosticStatus() string {
 		} else {
 			downNodes++
 		}
-
 		if node.Manager {
 			managers++
 			status := strings.ToLower(node.ManagerStatus)
@@ -185,36 +307,62 @@ func (m *Model) getDiagnosticStatus() string {
 	}
 
 	var sb strings.Builder
-
-	// Style definitions
-	okStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("2")) // Green
-	warnStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("208")) // Yellow/Orange
-	errStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("9")) // Red
+	okStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("2"))
+	warnStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("208"))
+	errStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("9"))
 	headerStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("15")).Background(lipgloss.Color("63")).Padding(0, 1)
 
-	sb.WriteString(headerStyle.Render(" REAL-TIME PORT DIAGNOSTICS (CLIENT-SIDE ANALYSES) ") + "\n\n")
+	sb.WriteString(headerStyle.Render(" SWARM-STATE DIAGNOSTICS (inferred from Docker daemon) ") + "\n\n")
 
-	// 1. Control Plane check (TCP 2377)
+	// TCP 2377
 	sb.WriteString("● TCP 2377 (Swarm Control Plane): ")
 	if unreachableManagers > 0 {
-		sb.WriteString(errStyle.Render("UNREACHABLE / BLOCKED") + fmt.Sprintf(" (Warning: %d managers are unreachable. Verify port TCP 2377 is open inbound!)\n", unreachableManagers))
+		sb.WriteString(errStyle.Render("UNREACHABLE / BLOCKED") + fmt.Sprintf(" (%d managers unreachable — verify TCP 2377 inbound!)\n", unreachableManagers))
 	} else if reachableManagers > 0 || (managers == 1 && readyNodes > 0) {
-		sb.WriteString(okStyle.Render("HEALTHY / ONLINE") + fmt.Sprintf(" (Connected. Reachable managers: %d/%d)\n", reachableManagers, managers))
+		sb.WriteString(okStyle.Render("HEALTHY / ONLINE") + fmt.Sprintf(" (reachable managers: %d/%d)\n", reachableManagers, managers))
 	} else {
-		sb.WriteString(warnStyle.Render("UNKNOWN / SINGLE NODE") + " (Gossip and leader detection status unavailable)\n")
+		sb.WriteString(warnStyle.Render("UNKNOWN / SINGLE NODE") + " (leader detection unavailable)\n")
 	}
 
-	// 2. Gossip network check (TCP/UDP 7946)
+	// TCP/UDP 7946
 	sb.WriteString("● TCP/UDP 7946 (Gossip Node Sync): ")
 	if downNodes == 0 {
-		sb.WriteString(okStyle.Render("HEALTHY") + fmt.Sprintf(" (All %d nodes are Ready. Gossip state sync and node discovery active)\n", totalNodes))
+		sb.WriteString(okStyle.Render("HEALTHY") + fmt.Sprintf(" (all %d nodes ready)\n", totalNodes))
 	} else {
-		sb.WriteString(errStyle.Render("DEGRADED / DISRUPTED") + fmt.Sprintf(" (Warning: %d/%d nodes are down/offline. Verify TCP/UDP 7946 is open between all nodes!)\n", downNodes, totalNodes))
+		sb.WriteString(errStyle.Render("DEGRADED / DISRUPTED") + fmt.Sprintf(" (%d/%d nodes down — verify TCP/UDP 7946 open between all nodes!)\n", downNodes, totalNodes))
 	}
 
-	// 3. Overlay VXLAN check (UDP 4789)
+	// UDP 4789
 	sb.WriteString("● UDP 4789 (Overlay VXLAN Network): ")
-	sb.WriteString(warnStyle.Render("UNVERIFIABLE CLIENT-SIDE") + " (Overlay network communication is only active during container task traffic. Verify UDP 4789 is open to avoid container communication drops across nodes.)\n")
+	sb.WriteString(warnStyle.Render("UNVERIFIABLE CLIENT-SIDE") + " (verify UDP 4789 is open to avoid container communication drops)\n")
 
+	_ = readyNodes // used indirectly through totalNodes and downNodes
 	return sb.String()
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+func truncate(s string, max int) string {
+	if len(s) <= max {
+		return s
+	}
+	if max <= 3 {
+		return s[:max]
+	}
+	return s[:max-1] + "…"
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func formatDuration(d time.Duration) string {
+	d = d.Round(time.Second)
+	if d < time.Minute {
+		return fmt.Sprintf("%ds", int(d.Seconds()))
+	}
+	return fmt.Sprintf("%dm%ds", int(d.Minutes()), int(d.Seconds())%60)
 }

--- a/views/ports/view.go
+++ b/views/ports/view.go
@@ -1,0 +1,220 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package portsview
+
+import (
+	"fmt"
+	"strings"
+	"swarmcli/ui"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+func (m *Model) FrameTitle() string {
+	return "Required Swarm Ports"
+}
+
+func (m *Model) FrameHeader() string {
+	return ui.FrameHeaderStyle.Render("Swarm cluster port requirements (node-to-node)")
+}
+
+func (m *Model) FrameFooter() string {
+	return ""
+}
+
+func (m *Model) FrameContent() string {
+	header := m.FrameHeader()
+	width := m.viewport.Width
+	if width <= 0 {
+		width = 80
+	}
+	frame := ui.ComputeFrameDimensions(width, m.viewport.Height, width, m.height, header, "")
+	return ui.TrimOrPadContentToLines(m.viewport.View(), frame.DesiredContentLines)
+}
+
+func (m *Model) View() string {
+	if !m.ready {
+		return ""
+	}
+	return ui.RenderViewFrame(m.FrameTitle(), m.FrameHeader(), m.FrameContent(), m.FrameFooter(), m.viewport.Width, m.viewport.Height, false)
+}
+
+func (m *Model) updateViewport() {
+	var b strings.Builder
+
+	// Style tokens
+	titleStyle := lipgloss.NewStyle().
+		Bold(true).
+		Foreground(lipgloss.Color("81")) // Light blue/cyan
+
+	infoStyle := lipgloss.NewStyle().
+		Foreground(lipgloss.Color("246")) // Gray description text
+
+	portHeaderStyle := lipgloss.NewStyle().
+		Bold(true).
+		Foreground(lipgloss.Color("208")) // Orange/amber for port headings
+
+	labelStyle := lipgloss.NewStyle().
+		Bold(true).
+		Foreground(lipgloss.Color("117")). // Cyan labels
+		Width(12)
+
+	valueStyle := lipgloss.NewStyle().
+		Foreground(lipgloss.Color("255")) // White values
+
+	// Compute card width dynamically
+	cardWidth := m.viewport.Width - 6
+	if cardWidth < 40 {
+		cardWidth = 40
+	}
+
+	borderStyle := lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(lipgloss.Color("63")). // Sleek blue border
+		Padding(0, 2).
+		MarginBottom(1).
+		Width(cardWidth)
+
+	// Helper to wrap value text to fit the card width and align multi-line values
+	wrapVal := func(val string, labelW int) string {
+		maxValW := cardWidth - labelW - 6 // minus label width, borders, and padding
+		if maxValW < 15 {
+			maxValW = 15
+		}
+		words := strings.Fields(val)
+		if len(words) == 0 {
+			return ""
+		}
+		var lines []string
+		cur := words[0]
+		for _, w := range words[1:] {
+			if len(cur)+1+len(w) > maxValW {
+				lines = append(lines, cur)
+				cur = w
+			} else {
+				cur += " " + w
+			}
+		}
+		lines = append(lines, cur)
+		indent := strings.Repeat(" ", labelW)
+		return strings.Join(lines, "\n"+indent)
+	}
+
+	// Intro text
+	b.WriteString(titleStyle.Render("Required Swarm Cluster Ports (node-to-node)"))
+	b.WriteString("\n")
+	b.WriteString(infoStyle.Render("These ports must be open between all Swarm nodes (managers and workers) to ensure cluster coordination, node health state sync, and container overlay networking."))
+	b.WriteString("\n\n")
+
+	// Append Real-time Diagnostics
+	diagnostics := m.getDiagnosticStatus()
+	if diagnostics != "" {
+		b.WriteString(diagnostics)
+		b.WriteString("\n")
+	}
+
+	// Render Port 2377
+	port1Content := fmt.Sprintf("%s%s\n%s%s\n%s%s",
+		labelStyle.Render("Protocol:"), valueStyle.Render(wrapVal("TCP", 12)),
+		labelStyle.Render("Used For:"), valueStyle.Render(wrapVal("Swarm control plane (manager election, cluster commands)", 12)),
+		labelStyle.Render("Direction:"), valueStyle.Render(wrapVal("Managers only (inbound to managers)", 12)),
+	)
+	b.WriteString(borderStyle.Render(fmt.Sprintf("%s\n\n%s", portHeaderStyle.Render("TCP 2377 — Cluster management"), port1Content)))
+	b.WriteString("\n")
+
+	// Render Port 7946
+	port2Content := fmt.Sprintf("%s%s\n%s%s\n%s%s",
+		labelStyle.Render("Protocol:"), valueStyle.Render(wrapVal("TCP / UDP", 12)),
+		labelStyle.Render("Used For:"), valueStyle.Render(wrapVal("Gossip network (node discovery, membership, state sync)", 12)),
+		labelStyle.Render("Direction:"), valueStyle.Render(wrapVal("All nodes to all nodes", 12)),
+	)
+	b.WriteString(borderStyle.Render(fmt.Sprintf("%s\n\n%s", portHeaderStyle.Render("TCP / UDP 7946 — Node communication"), port2Content)))
+	b.WriteString("\n")
+
+	// Render Port 4789
+	port3Content := fmt.Sprintf("%s%s\n%s%s\n%s%s",
+		labelStyle.Render("Protocol:"), valueStyle.Render(wrapVal("UDP", 12)),
+		labelStyle.Render("Used For:"), valueStyle.Render(wrapVal("Overlay network (VXLAN) container-to-container traffic", 12)),
+		labelStyle.Render("Direction:"), valueStyle.Render(wrapVal("All nodes to all nodes", 12)),
+	)
+	b.WriteString(borderStyle.Render(fmt.Sprintf("%s\n\n%s", portHeaderStyle.Render("UDP 4789 — Overlay network (VXLAN)"), port3Content)))
+	b.WriteString("\n")
+
+	m.viewport.SetContent(b.String())
+}
+
+func (m *Model) getDiagnosticStatus() string {
+	if m.deps.Snapshot == nil {
+		return ""
+	}
+
+	snap := m.deps.Snapshot.GetSnapshot()
+	if snap == nil {
+		return lipgloss.NewStyle().Foreground(lipgloss.Color("240")).Render("Loading real-time swarm diagnostics...")
+	}
+
+	entries := snap.ToNodeEntries()
+	if len(entries) == 0 {
+		return lipgloss.NewStyle().Foreground(lipgloss.Color("240")).Render("No nodes found to analyze port status.")
+	}
+
+	totalNodes := len(entries)
+	readyNodes := 0
+	downNodes := 0
+	managers := 0
+	reachableManagers := 0
+	unreachableManagers := 0
+
+	for _, node := range entries {
+		if node.State == "ready" {
+			readyNodes++
+		} else {
+			downNodes++
+		}
+
+		if node.Manager {
+			managers++
+			status := strings.ToLower(node.ManagerStatus)
+			if status == "leader" || status == "reachable" {
+				reachableManagers++
+			} else if status == "unreachable" {
+				unreachableManagers++
+			}
+		}
+	}
+
+	var sb strings.Builder
+
+	// Style definitions
+	okStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("2")) // Green
+	warnStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("208")) // Yellow/Orange
+	errStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("9")) // Red
+	headerStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("15")).Background(lipgloss.Color("63")).Padding(0, 1)
+
+	sb.WriteString(headerStyle.Render(" REAL-TIME PORT DIAGNOSTICS (CLIENT-SIDE ANALYSES) ") + "\n\n")
+
+	// 1. Control Plane check (TCP 2377)
+	sb.WriteString("● TCP 2377 (Swarm Control Plane): ")
+	if unreachableManagers > 0 {
+		sb.WriteString(errStyle.Render("UNREACHABLE / BLOCKED") + fmt.Sprintf(" (Warning: %d managers are unreachable. Verify port TCP 2377 is open inbound!)\n", unreachableManagers))
+	} else if reachableManagers > 0 || (managers == 1 && readyNodes > 0) {
+		sb.WriteString(okStyle.Render("HEALTHY / ONLINE") + fmt.Sprintf(" (Connected. Reachable managers: %d/%d)\n", reachableManagers, managers))
+	} else {
+		sb.WriteString(warnStyle.Render("UNKNOWN / SINGLE NODE") + " (Gossip and leader detection status unavailable)\n")
+	}
+
+	// 2. Gossip network check (TCP/UDP 7946)
+	sb.WriteString("● TCP/UDP 7946 (Gossip Node Sync): ")
+	if downNodes == 0 {
+		sb.WriteString(okStyle.Render("HEALTHY") + fmt.Sprintf(" (All %d nodes are Ready. Gossip state sync and node discovery active)\n", totalNodes))
+	} else {
+		sb.WriteString(errStyle.Render("DEGRADED / DISRUPTED") + fmt.Sprintf(" (Warning: %d/%d nodes are down/offline. Verify TCP/UDP 7946 is open between all nodes!)\n", downNodes, totalNodes))
+	}
+
+	// 3. Overlay VXLAN check (UDP 4789)
+	sb.WriteString("● UDP 4789 (Overlay VXLAN Network): ")
+	sb.WriteString(warnStyle.Render("UNVERIFIABLE CLIENT-SIDE") + " (Overlay network communication is only active during container task traffic. Verify UDP 4789 is open to avoid container communication drops across nodes.)\n")
+
+	return sb.String()
+}

--- a/views/ports/view.go
+++ b/views/ports/view.go
@@ -52,9 +52,9 @@ func (m *Model) updateViewport() {
 	labelStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("117")).Width(12)
 	valueStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("255"))
 
-	okStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("2"))    // green
+	okStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("2"))     // green
 	warnStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("208")) // amber
-	errStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("9"))   // red
+	errStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("9"))    // red
 	dimStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("240"))
 
 	cardWidth := m.viewport.Width - 6
@@ -144,7 +144,7 @@ func (m *Model) updateViewport() {
 	if probing {
 		b.WriteString(sectionHeader.Render(" LIVE PORT PROBES — probing… "))
 	} else {
-		b.WriteString(sectionHeader.Render(" LIVE PORT PROBES — press r to re-probe"+probeAge+" "))
+		b.WriteString(sectionHeader.Render(" LIVE PORT PROBES — press r to re-probe" + probeAge + " "))
 	}
 	b.WriteString("\n\n")
 

--- a/views/view/constants.go
+++ b/views/view/constants.go
@@ -18,12 +18,14 @@ const (
 	NameLoading  = "loading"
 	NameNetworks = "networks"
 	NameVolumes  = "volumes"
+	NamePorts    = "ports"
 )
 
 var topLevelViews = map[string]bool{
 	NameStacks: true, NameNodes: true, NameConfigs: true,
 	NameSecrets: true, NameNetworks: true, NameVolumes: true,
 	NameContexts: true, NameLoading: true, NameHelp: true,
+	NamePorts: true,
 }
 
 // RegisterTopLevel marks a view name as top-level. Called from init() by

--- a/views/view/constants_test.go
+++ b/views/view/constants_test.go
@@ -13,6 +13,7 @@ func TestIsTopLevel(t *testing.T) {
 	topLevel := []string{
 		NameStacks, NameNodes, NameConfigs, NameSecrets,
 		NameNetworks, NameVolumes, NameContexts, NameLoading, NameHelp,
+		NamePorts,
 	}
 	for _, name := range topLevel {
 		require.True(t, IsTopLevel(name), "expected %q to be top-level", name)


### PR DESCRIPTION
### About Issue Eldara-Tech/swarmcli-be-releases#14 

To test; use the filter `/` then write `ports` or `port`. 

Did smoke sanity tests and tests seem good. TCP and UDP dialing was done with Claude but I'll still do research and try to separate it and send those packets to a VM where I'll block the port using a Firewall. Is it a good approach?

Also, for testing I used a Swarm with containers using [docker:29-dind](https://hub.docker.com/layers/library/docker/29-dind/images/sha256-df7efe7183e533112a8236c5fddb1edf12c96fb2feba3b6b693a285bd7bb993b) and I still haven't run another service in the Swarm, we'll look into it tomorrow.