### PR TITLE
fix(logs): show starting-container logs in hide-stopped filter (#388)

### DIFF
--- a/views/logs/logs_test.go
+++ b/views/logs/logs_test.go
@@ -691,14 +691,15 @@ func TestShouldFallbackToRawFromStdCopy(t *testing.T) {
 
 // --- hide-stopped (issue #388) tests ---
 
-// hideStoppedModel returns a model whose snapshot has one running and one
-// stopped task for the model's service (svc-123).
+// hideStoppedModel returns a model whose snapshot has one running, one starting
+// and one stopped (terminal) task for the model's service (svc-123).
 func hideStoppedModel() *Model {
 	m := testModel()
 	m.deps.Snapshot = &mockSnapshotOps{snap: &docker.SwarmSnapshot{
 		Tasks: []swarm.Task{
-			{ID: "task-run", ServiceID: "svc-123", DesiredState: swarm.TaskStateRunning},
-			{ID: "task-stop", ServiceID: "svc-123", DesiredState: swarm.TaskStateShutdown},
+			{ID: "task-run", ServiceID: "svc-123", Status: swarm.TaskStatus{State: swarm.TaskStateRunning}},
+			{ID: "task-start", ServiceID: "svc-123", Status: swarm.TaskStatus{State: swarm.TaskStateStarting}},
+			{ID: "task-stop", ServiceID: "svc-123", Status: swarm.TaskStatus{State: swarm.TaskStateShutdown}},
 		},
 	}}
 	return m
@@ -739,6 +740,24 @@ func TestBuildContent_HidesStoppedTasks(t *testing.T) {
 	require.Contains(t, content, "running line")
 	require.NotContains(t, content, "stopped line")
 	require.Contains(t, content, "system line") // empty task ID => always visible
+}
+
+// TestBuildContent_ShowsStartingAndUnknownTasks is the regression guard for
+// issue #388 comment 4644247107: starting containers (non-terminal state) and
+// tasks not yet present in the snapshot must remain visible while hide-stopped
+// is on.
+func TestBuildContent_ShowsStartingAndUnknownTasks(t *testing.T) {
+	m := hideStoppedModel()
+	require.True(t, m.getHideStopped())
+	m.mu.Lock()
+	m.lines = []string{"starting line", "unknown line", "stopped line"}
+	m.lineTasks = []string{"task-start", "task-not-in-snapshot", "task-stop"}
+	m.lineNodes = []string{"n", "n", "n"}
+	m.mu.Unlock()
+	content := m.buildContent()
+	require.Contains(t, content, "starting line")    // starting => not terminal => visible
+	require.Contains(t, content, "unknown line")      // not in snapshot => fail open => visible
+	require.NotContains(t, content, "stopped line")   // terminal => hidden
 }
 
 func TestBuildContent_ShowAllWhenHideStoppedOff(t *testing.T) {

--- a/views/logs/logs_test.go
+++ b/views/logs/logs_test.go
@@ -755,9 +755,9 @@ func TestBuildContent_ShowsStartingAndUnknownTasks(t *testing.T) {
 	m.lineNodes = []string{"n", "n", "n"}
 	m.mu.Unlock()
 	content := m.buildContent()
-	require.Contains(t, content, "starting line")    // starting => not terminal => visible
-	require.Contains(t, content, "unknown line")      // not in snapshot => fail open => visible
-	require.NotContains(t, content, "stopped line")   // terminal => hidden
+	require.Contains(t, content, "starting line")   // starting => not terminal => visible
+	require.Contains(t, content, "unknown line")    // not in snapshot => fail open => visible
+	require.NotContains(t, content, "stopped line") // terminal => hidden
 }
 
 func TestBuildContent_ShowAllWhenHideStoppedOff(t *testing.T) {

--- a/views/logs/model.go
+++ b/views/logs/model.go
@@ -254,27 +254,43 @@ func (m *Model) HasErrors() bool {
 	return false
 }
 
-// runningTaskIDs returns the set of full task IDs for this service whose desired
-// state is running. Returns nil when no snapshot is available (callers treat nil
-// as "show all" — fail open). Does not take m.mu; callers already hold it.
-func (m *Model) runningTaskIDs() map[string]bool {
+// isTerminalTaskState reports whether a task's current state means its container
+// has exited — i.e. the task is "stopped" and its logs are old history. Starting
+// states (new/pending/…/preparing/ready/starting) and running are NOT terminal.
+func isTerminalTaskState(state swarm.TaskState) bool {
+	switch state {
+	case swarm.TaskStateComplete, swarm.TaskStateShutdown, swarm.TaskStateFailed,
+		swarm.TaskStateRejected, swarm.TaskStateOrphaned, swarm.TaskStateRemove:
+		return true
+	default:
+		return false
+	}
+}
+
+// stoppedTaskIDs returns the set of full task IDs for this service whose current
+// state is terminal (container has exited). Returns nil when no snapshot is
+// available (callers treat nil as "hide nothing" — fail open). The hide-stopped
+// filter is a denylist over this set: lines from running, starting, and unknown
+// (not-yet-in-snapshot) tasks stay visible. Does not take m.mu; callers already
+// hold it.
+func (m *Model) stoppedTaskIDs() map[string]bool {
 	snap := m.deps.Snapshot.GetSnapshot()
 	if snap == nil {
 		return nil
 	}
-	running := make(map[string]bool)
+	stopped := make(map[string]bool)
 	for _, task := range snap.Tasks {
-		if task.ServiceID == m.ServiceEntry.ServiceID && task.DesiredState == swarm.TaskStateRunning {
-			running[task.ID] = true
+		if task.ServiceID == m.ServiceEntry.ServiceID && isTerminalTaskState(task.Status.State) {
+			stopped[task.ID] = true
 		}
 	}
-	return running
+	return stopped
 }
 
 // lineVisible reports whether the line at index i passes all active filters
 // (node filter, "/" text filter, hide-stopped). Callers must hold m.mu and pass
-// the precomputed running-task set (nil = don't apply the hide-stopped filter).
-func (m *Model) lineVisible(i int, running map[string]bool) bool {
+// the precomputed stopped-task set (nil = don't apply the hide-stopped filter).
+func (m *Model) lineVisible(i int, stopped map[string]bool) bool {
 	// node filter
 	if m.nodeFilter != "" && (i >= len(m.lineNodes) || m.lineNodes[i] != m.nodeFilter) {
 		return false
@@ -283,14 +299,16 @@ func (m *Model) lineVisible(i int, running map[string]bool) bool {
 	if m.filterQuery != "" && !strings.Contains(strings.ToLower(m.lines[i]), strings.ToLower(m.filterQuery)) {
 		return false
 	}
-	// hide-stopped filter
-	if m.hideStopped && running != nil {
+	// hide-stopped filter: hide only lines from tasks known to be terminal.
+	// Unknown task IDs (not yet in the snapshot — e.g. a starting container)
+	// fail open and stay visible.
+	if m.hideStopped && stopped != nil {
 		taskID := ""
 		if i < len(m.lineTasks) {
 			taskID = m.lineTasks[i]
 		}
 		// empty task ID => always visible (can't determine task state)
-		if taskID != "" && !running[taskID] {
+		if taskID != "" && stopped[taskID] {
 			return false
 		}
 	}

--- a/views/logs/update.go
+++ b/views/logs/update.go
@@ -309,15 +309,15 @@ func (m *Model) highlightContent() {
 		m.searchMatches = []int{}
 		lower := strings.ToLower(m.searchTerm)
 		m.mu.Lock()
-		var running map[string]bool
+		var stopped map[string]bool
 		if m.hideStopped {
-			running = m.runningTaskIDs()
+			stopped = m.stoppedTaskIDs()
 		}
 		visibleIdx := 0
 		for i, L := range m.lines {
 			// Skip lines hidden by any active filter (must match buildContent
 			// exactly so search-match indices line up with the rendered output).
-			if !m.lineVisible(i, running) {
+			if !m.lineVisible(i, stopped) {
 				continue
 			}
 			if strings.Contains(strings.ToLower(L), lower) {
@@ -346,13 +346,13 @@ func (m *Model) buildContent() string {
 
 	// Apply all active filters (node, "/" text, hide-stopped) in a single pass
 	// via the shared predicate so the visible set matches highlightContent.
-	var running map[string]bool
+	var stopped map[string]bool
 	if m.hideStopped {
-		running = m.runningTaskIDs()
+		stopped = m.stoppedTaskIDs()
 	}
 	var filteredLines []string
 	for i, line := range m.lines {
-		if m.lineVisible(i, running) {
+		if m.lineVisible(i, stopped) {
 			filteredLines = append(filteredLines, line)
 		}
 	}


### PR DESCRIPTION
## Problem

Closes #388 (follow-up to [comment 4644247107](https://github.com/Eldara-Tech/swarmcli/issues/388#issuecomment-4644247107)).

PR #390 added the hide-stopped log filter but it had a regression: **starting containers' logs were not shown.**

The filter was an *allowlist that fails closed* — a line was shown only if its task's `DesiredState == Running` (`runningTaskIDs` + `lineVisible`). Any task not provably desired-running was hidden, so a starting container's logs disappeared because:

1. The task is not in the 3s-TTL snapshot yet (scale-up / crash-restart / deploy).
2. It is transiently in a non-`Running` desired state during start-first rolling updates.

## Fix

Invert to a *denylist that fails open*:

- `model.go`: `runningTaskIDs` → `stoppedTaskIDs`, collecting tasks whose **current `Status.State` is terminal** (complete/shutdown/failed/rejected/orphaned/remove) via new `isTerminalTaskState` helper. `lineVisible` now hides a line only if its task ID is in that stopped set.
- `update.go`: both call sites (`highlightContent`, `buildContent`) updated.
- Fail-open preserved: nil snapshot hides nothing; a task ID absent from the snapshot (starting/new) stays visible.

Net behavior: genuinely stopped/old containers stay hidden (original #388 still fixed); running, starting, and not-yet-tracked containers show.

## Tests

- Fixture switched from `DesiredState` to `Status.State`, added a starting task.
- New `TestBuildContent_ShowsStartingAndUnknownTasks` regression guard for the comment.
- `go test ./views/logs/` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)