### PR TITLE
feat(volumes): flexible content-aware columns like the other list views (#400)

### DIFF
--- a/views/volumes/columns_test.go
+++ b/views/volumes/columns_test.go
@@ -10,29 +10,62 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestColWidths_SumToWidth(t *testing.T) {
-	for _, w := range []int{60, 80, 100, 120, 200} {
-		widths := (&Model{}).volumeColWidths(w)
-		require.Len(t, widths, 6)
-		sum := 0
-		for _, cw := range widths {
-			require.Greater(t, cw, 0)
-			sum += cw
+// longVolName is wide enough to overflow the NAME column on a narrow terminal
+// and to verify full visibility on a wide one.
+const longVolName = "volume_with_a_fairly_long_descriptive_name"
+
+// longVolume returns the loaded item whose name overflows, for scroll tests.
+func longVolume(m *Model) volumeItem {
+	for _, v := range m.volumesList.Filtered {
+		if v.Name == longVolName {
+			return v
 		}
-		// columns + 5 two-space separators reconstruct the effective width.
-		require.LessOrEqual(t, sum+5*2, w+1, "columns must fit within the available width at w=%d", w)
 	}
+	return volumeItem{}
 }
 
 func TestHeaderAndRow_Aligned(t *testing.T) {
-	for _, w := range []int{80, 120} {
+	for _, w := range []int{60, 120, 220} {
 		m := testModel()
 		m.volumesList.Viewport.Width = w
-		loadVolumes(m, fakeVolumes("alpha"))
+		loadVolumes(m, fakeVolumes(longVolName, "z2"))
 
-		header := m.renderVolumesHeader()
+		header := m.volumesList.RenderHeader()
 		row := m.volumesList.RenderItem(m.volumesList.Filtered[0], false, 0)
 		require.Equal(t, lipgloss.Width(header), lipgloss.Width(row),
 			"header and row widths must match at width %d", w)
 	}
+}
+
+func TestContentAwareName_WideTerminal(t *testing.T) {
+	m := testModel()
+	m.volumesList.Viewport.Width = 220
+	loadVolumes(m, fakeVolumes(longVolName, "z2"))
+	row := m.volumesList.RenderItem(longVolume(m), false, 0)
+	require.Contains(t, row, longVolName, "full name must be visible on a wide terminal")
+}
+
+func TestArrowScrollMovesWindow(t *testing.T) {
+	m := testModel()
+	m.volumesList.Viewport.Width = 70 // narrow → flex columns overflow
+	loadVolumes(m, fakeVolumes(longVolName, "z2"))
+	before := m.volumesList.RenderItem(longVolume(m), true, 0)
+	m.Update(key("right"))
+	after := m.volumesList.RenderItem(longVolume(m), true, 0)
+	require.NotEqual(t, before, after, "right arrow should shift the truncated cell window")
+}
+
+func TestResetScrollOnCursorMove(t *testing.T) {
+	m := testModel()
+	m.volumesList.Viewport.Width = 70
+	loadVolumes(m, fakeVolumes(longVolName, "z2"))
+	m.Update(key("right"))
+	m.Update(key("right"))
+	scrolled := m.volumesList.RenderItem(longVolume(m), true, 0)
+
+	m.Update(key("down"))
+	m.Update(key("up"))
+
+	require.NotEqual(t, scrolled, m.volumesList.RenderItem(longVolume(m), true, 0),
+		"scroll offset must reset when the cursor moves")
 }

--- a/views/volumes/model.go
+++ b/views/volumes/model.go
@@ -77,6 +77,7 @@ func New(width, height int) *Model {
 		sortAscending: true,
 	}
 
+	cols := m.buildColumns()
 	list := filterlist.FilterableList[volumeItem]{
 		Viewport: vp,
 		Match: func(v volumeItem, query string) bool {
@@ -87,13 +88,11 @@ func New(width, height int) *Model {
 				strings.Contains(strings.ToLower(v.Mountpoint), q) ||
 				strings.Contains(strings.ToLower(v.Host), q)
 		},
+		Columns: cols,
 		Header: &filterlist.HeaderConfig{
-			Columns: []filterlist.ColumnDef{
-				{Label: "NAME"}, {Label: "STACK"}, {Label: "DRIVER"},
-				{Label: "MOUNT POINT"}, {Label: "CREATED"}, {Label: "HOST"},
-			},
-			ColWidthsFunc: func(w int) []int {
-				return m.volumeColWidths(w)
+			Columns: filterlist.ColumnDefs(cols),
+			SortIndicator: func() (int, bool) {
+				return m.sortColumnIndex(), m.sortAscending
 			},
 		},
 		Footer: &filterlist.FooterConfig{

--- a/views/volumes/model_test.go
+++ b/views/volumes/model_test.go
@@ -54,6 +54,10 @@ func key(s string) tea.KeyMsg {
 		return tea.KeyMsg{Type: tea.KeyUp}
 	case "down":
 		return tea.KeyMsg{Type: tea.KeyDown}
+	case "left":
+		return tea.KeyMsg{Type: tea.KeyLeft}
+	case "right":
+		return tea.KeyMsg{Type: tea.KeyRight}
 	}
 	return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(s)}
 }

--- a/views/volumes/update.go
+++ b/views/volumes/update.go
@@ -4,35 +4,18 @@
 package volumesview
 
 import (
-	"fmt"
 	"sort"
 	"strings"
 	"time"
 
 	"swarmcli/core/primitives/hash"
 	"swarmcli/ui"
+	filterlist "swarmcli/ui/components/filterable/list"
 	helpview "swarmcli/views/help"
 	view "swarmcli/views/view"
 
 	tea "github.com/charmbracelet/bubbletea"
-	"github.com/charmbracelet/lipgloss"
 )
-
-func truncateWithEllipsis(s string, maxWidth int) string {
-	if maxWidth <= 0 {
-		return ""
-	}
-	if maxWidth <= 1 {
-		return "…"
-	}
-	if lipgloss.Width(s) <= maxWidth {
-		return s
-	}
-	if maxWidth == 2 {
-		return s[:1] + "…"
-	}
-	return s[:maxWidth-1] + "…"
-}
 
 func formatCreated(t time.Time) string {
 	if t.IsZero() {
@@ -41,54 +24,37 @@ func formatCreated(t time.Time) string {
 	return t.Format("2006-01-02 15:04")
 }
 
-// volumeColWidths allocates the six column widths as percentages of the
-// available width, with the MOUNT POINT column absorbing rounding remainder.
-func (m *Model) volumeColWidths(totalWidth int) []int {
-	if totalWidth <= 0 {
-		totalWidth = 80
+// buildColumns declares the volumes table columns for the shared content-aware
+// layout. NAME, MOUNT POINT, and HOST flex (absorb slack and horizontally
+// scroll when truncated on the selected row); the rest size to content.
+func (m *Model) buildColumns() []filterlist.Column[volumeItem] {
+	return []filterlist.Column[volumeItem]{
+		{Label: "NAME", MinWidth: 4, Flex: true, Cell: func(v volumeItem) string { return v.Name }},
+		{Label: "STACK", MinWidth: 5, Cell: func(v volumeItem) string { return displayOrDash(v.Stack) }},
+		{Label: "DRIVER", MinWidth: 6, Cell: func(v volumeItem) string { return v.Driver }},
+		{Label: "MOUNT POINT", MinWidth: 10, Flex: true, Cell: func(v volumeItem) string { return v.Mountpoint }},
+		{Label: "CREATED", MinWidth: 16, Cell: func(v volumeItem) string { return formatCreated(v.Created) }},
+		{Label: "HOST", MinWidth: 4, Flex: true, Cell: func(v volumeItem) string { return displayOrDash(v.Host) }},
 	}
-	const (
-		sepLen  = 2
-		numCols = 6
-		flexCol = 3 // MOUNT POINT
-	)
-	effWidth := totalWidth - (numCols-1)*sepLen
-	if effWidth < 30 {
-		effWidth = totalWidth
-	}
+}
 
-	weights := []int{20, 12, 9, 21, 24, 14} // NAME STACK DRIVER MOUNT CREATED HOST
-	mins := []int{8, 5, 5, 10, 12, 5}
-
-	widths := make([]int, numCols)
-	sum := 0
-	for i := 0; i < numCols; i++ {
-		w := (effWidth * weights[i]) / 100
-		if w < 1 {
-			w = 1
-		}
-		widths[i] = w
-		sum += w
+// sortColumnIndex maps the active sort field to its column index for the header
+// sort arrow. The mapping is not 1:1 because MOUNT POINT (column 3) is
+// unsortable, so CREATED and HOST sit one column past their sort-field ordinal.
+func (m *Model) sortColumnIndex() int {
+	switch m.sortField {
+	case SortByName:
+		return 0
+	case SortByStack:
+		return 1
+	case SortByDriver:
+		return 2
+	case SortByCreated:
+		return 4
+	case SortByHost:
+		return 5
 	}
-	widths[flexCol] += effWidth - sum
-
-	for i := range widths {
-		if widths[i] < mins[i] {
-			widths[i] = mins[i]
-		}
-	}
-
-	sum = 0
-	for _, w := range widths {
-		sum += w
-	}
-	if sum != effWidth {
-		widths[flexCol] += effWidth - sum
-		if widths[flexCol] < mins[flexCol] {
-			widths[flexCol] = mins[flexCol]
-		}
-	}
-	return widths
+	return 0
 }
 
 func (m *Model) Update(msg tea.Msg) tea.Cmd {
@@ -212,14 +178,22 @@ func (m *Model) handleNormalKeys(msg tea.KeyMsg) tea.Cmd {
 	case "H":
 		m.toggleSort(SortByHost)
 		return nil
+	case "left":
+		m.volumesList.ScrollLeft()
+		m.volumesList.Viewport.SetContent(m.volumesList.View())
+	case "right":
+		m.volumesList.ScrollRight()
+		m.volumesList.Viewport.SetContent(m.volumesList.View())
 	case "up", "k":
 		if m.volumesList.Cursor > 0 {
 			m.volumesList.Cursor--
+			m.volumesList.ResetColumnScroll()
 			m.volumesList.Viewport.SetContent(m.volumesList.View())
 		}
 	case "down", "j":
 		if m.volumesList.Cursor < len(m.volumesList.Filtered)-1 {
 			m.volumesList.Cursor++
+			m.volumesList.ResetColumnScroll()
 			m.volumesList.Viewport.SetContent(m.volumesList.View())
 		}
 	case "pgup":
@@ -231,6 +205,7 @@ func (m *Model) handleNormalKeys(msg tea.KeyMsg) tea.Cmd {
 		if m.volumesList.Cursor < 0 {
 			m.volumesList.Cursor = 0
 		}
+		m.volumesList.ResetColumnScroll()
 		m.volumesList.Viewport.SetContent(m.volumesList.View())
 	case "pgdown":
 		page := m.volumesList.Viewport.Height
@@ -241,6 +216,7 @@ func (m *Model) handleNormalKeys(msg tea.KeyMsg) tea.Cmd {
 		if m.volumesList.Cursor >= len(m.volumesList.Filtered) {
 			m.volumesList.Cursor = len(m.volumesList.Filtered) - 1
 		}
+		m.volumesList.ResetColumnScroll()
 		m.volumesList.Viewport.SetContent(m.volumesList.View())
 	case "i", "enter":
 		if len(m.volumesList.Filtered) == 0 {
@@ -358,40 +334,12 @@ func (m *Model) applySorting() {
 }
 
 func (m *Model) setRenderItem() {
-	m.volumesList.RenderItem = func(item volumeItem, selected bool, colWidth int) string {
-		style := ui.ListItemStyle
+	m.volumesList.RenderItem = func(item volumeItem, selected bool, _ int) string {
+		row := m.volumesList.RenderRow(item, selected)
 		if selected {
-			style = ui.ListSelectedStyle
+			return ui.ListSelectedStyle.Render(row)
 		}
-
-		widths := m.volumesList.ColWidths()
-		if len(widths) < 6 {
-			return item.Name
-		}
-		nameW, stackW, driverW := widths[0], widths[1], widths[2]
-		mountW, createdW, hostW := widths[3], widths[4], widths[5]
-
-		innerNameW := nameW
-		if innerNameW > 1 {
-			innerNameW--
-		}
-		name := " " + truncateWithEllipsis(item.Name, innerNameW)
-		stack := truncateWithEllipsis(displayOrDash(item.Stack), stackW)
-		driver := truncateWithEllipsis(item.Driver, driverW)
-		mount := truncateWithEllipsis(item.Mountpoint, mountW)
-		created := truncateWithEllipsis(formatCreated(item.Created), createdW)
-		host := truncateWithEllipsis(displayOrDash(item.Host), hostW)
-
-		sep := strings.Repeat(" ", 2)
-		line := fmt.Sprintf("%-*s%s%-*s%s%-*s%s%-*s%s%-*s%s%-*s",
-			nameW, name, sep,
-			stackW, stack, sep,
-			driverW, driver, sep,
-			mountW, mount, sep,
-			createdW, created, sep,
-			hostW, host,
-		)
-		return style.Render(line)
+		return ui.ListItemStyle.Render(row)
 	}
 	m.volumesList.Viewport.SetContent(m.volumesList.View())
 }

--- a/views/volumes/view.go
+++ b/views/volumes/view.go
@@ -11,7 +11,6 @@ import (
 	"swarmcli/features"
 	"swarmcli/ui"
 	"swarmcli/ui/components/errordialog"
-	"swarmcli/ui/components/sorting"
 	"swarmcli/views/view"
 )
 
@@ -24,7 +23,7 @@ func (m *Model) FrameTitle() string {
 }
 
 func (m *Model) FrameHeader() string {
-	return m.renderVolumesHeader()
+	return m.volumesList.RenderHeader()
 }
 
 func (m *Model) FrameFooter() string {
@@ -74,45 +73,6 @@ func (m *Model) buildMainContent() string {
 		content = ui.OverlayCentered(content, errorDialog, width, 0)
 	}
 	return content
-}
-
-func (m *Model) renderVolumesHeader() string {
-	widths := m.volumesList.ColWidths()
-	if len(widths) < 6 {
-		return ""
-	}
-
-	labels := []string{" NAME", "STACK", "DRIVER", "MOUNT POINT", "CREATED", "HOST"}
-
-	arrow := func() string {
-		if m.sortAscending {
-			return sorting.SortArrow(sorting.Ascending)
-		}
-		return sorting.SortArrow(sorting.Descending)
-	}
-	switch m.sortField {
-	case SortByName:
-		labels[0] = " NAME " + arrow()
-	case SortByStack:
-		labels[1] = "STACK " + arrow()
-	case SortByDriver:
-		labels[2] = "DRIVER " + arrow()
-	case SortByCreated:
-		labels[4] = "CREATED " + arrow()
-	case SortByHost:
-		labels[5] = "HOST " + arrow()
-	}
-
-	sep := strings.Repeat(" ", 2)
-	line := fmt.Sprintf("%-*s%s%-*s%s%-*s%s%-*s%s%-*s%s%-*s",
-		widths[0], labels[0], sep,
-		widths[1], labels[1], sep,
-		widths[2], labels[2], sep,
-		widths[3], labels[3], sep,
-		widths[4], labels[4], sep,
-		widths[5], labels[5],
-	)
-	return ui.FrameHeaderStyle.Render(line)
 }
 
 func (m *Model) renderVolumesFooter() string {

--- a/views/volumes/view_test.go
+++ b/views/volumes/view_test.go
@@ -33,7 +33,8 @@ func TestView_ReadyState_ShowsVolumes(t *testing.T) {
 func TestHeader_ShowsAllColumns(t *testing.T) {
 	m := testModel()
 	m.volumesList.Viewport.Width = 120
-	header := m.renderVolumesHeader()
+	loadVolumes(m, fakeVolumes("alpha"))
+	header := m.volumesList.RenderHeader()
 	for _, col := range []string{"NAME", "STACK", "DRIVER", "MOUNT POINT", "CREATED", "HOST"} {
 		require.Contains(t, header, col)
 	}


### PR DESCRIPTION
Closes #400.

## What

Migrates the **volumes** view onto the shared content-aware column layout (`ui/components/filterable/list/layout.go`) that **secrets, configs, nodes, services** adopted in #394/#395. Volumes was the last list view still on the legacy engine.

Before, volumes used:
- `volumeColWidths` — fixed percentage-weighted widths (not content-aware)
- `truncateWithEllipsis` — byte-based slicing (splits multibyte runes)
- a hand-rolled header + row formatter kept in sync manually
- no horizontal scrolling of truncated cells

Now it gets, for free and consistently with its siblings: content-sized columns (no dead space on wide terminals, no premature truncation on narrow ones), a guaranteed inter-column gap, one column set driving both header and rows (can't drift), and unified rune-aware left/right scrolling of truncated flex cells.

**Flex columns:** NAME, MOUNT POINT, HOST (the unbounded-length ones). STACK, DRIVER, CREATED size to content.

## Changes

- **`model.go`** — declare `Columns` via `buildColumns()`; header switches to `ColumnDefs(cols)` + a `SortIndicator`. Drops the bespoke `ColumnDef` literal and `ColWidthsFunc`.
- **`update.go`** — delete `volumeColWidths` and `truncateWithEllipsis`; add `buildColumns`, `sortColumnIndex` (maps sort field → column index; **not 1:1**, since MOUNT POINT is unsortable so CREATED/HOST sit one column past their ordinal), a one-line `RenderRow` delegation, and `left`/`right` scroll keys with scroll-reset on cursor move.
- **`view.go`** — `FrameHeader` delegates to the shared `RenderHeader`; removes the hand-rolled `renderVolumesHeader` and the now-unused `sorting` import.
- **tests** — replace the `volumeColWidths`/`renderVolumesHeader` tests with shared-API equivalents; add content-aware + scroll regression tests mirroring the nodes view.

## Note (non-breaking)

The inter-column gap narrows from 2 spaces to 1 (`ColGap=1`) — a deliberate, intended consequence of adopting the shared layer, identical to what the sibling views did in #395. Purely visual; no API or data-model change.

## Verification

- `go build -v -o swarmcli .` — clean
- `go test ./views/... ./ui/...` — all pass (incl. new regression tests)
- `golangci-lint run ./views/volumes/...` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)