### PR TITLE
feat(help): add SupportContact seam to keybinding cheat-sheet

### DIFF
--- a/views/help/help_test.go
+++ b/views/help/help_test.go
@@ -45,13 +45,34 @@ func TestSupportContact_CheatSheet(t *testing.T) {
 	SupportContact = ""
 	require.NotContains(t, m.buildCategorizedContent(), "SUPPORT")
 
-	// Set: the full address is rendered (no truncation) as the last body line.
+	// Set: the full address is rendered (no truncation), lifted one blank
+	// line off the footer (second-to-last body line, blank spacer below).
 	SupportContact = "be-support@swarmcli.io"
 	out := m.buildCategorizedContent()
 	require.Contains(t, out, "SUPPORT")
 	require.Contains(t, out, "be-support@swarmcli.io")
 	lines := strings.Split(out, "\n")
-	require.Contains(t, lines[len(lines)-1], "be-support@swarmcli.io")
+	require.Equal(t, "", strings.TrimSpace(lines[len(lines)-1]), "blank spacer below SUPPORT")
+	require.Contains(t, lines[len(lines)-2], "be-support@swarmcli.io")
+}
+
+func TestSupportContact_CommandList(t *testing.T) {
+	defer func() { SupportContact = "" }()
+	cmds := []CommandInfo{
+		{Name: "stacks", Description: "List stacks"},
+		{Name: "help", Description: "Show help"},
+	}
+	m := New(80, 24, cmds)
+
+	// Default (empty): OSS shows no support line in the :help command list.
+	SupportContact = ""
+	require.NotContains(t, m.FrameContent(), "SUPPORT")
+
+	// Set: the support line is surfaced in the :help command list too.
+	SupportContact = "be-support@swarmcli.io"
+	out := m.FrameContent()
+	require.Contains(t, out, "SUPPORT")
+	require.Contains(t, out, "be-support@swarmcli.io")
 }
 
 func TestName(t *testing.T) {

--- a/views/help/help_test.go
+++ b/views/help/help_test.go
@@ -34,6 +34,26 @@ func TestNewDetailed_Categories(t *testing.T) {
 	require.Len(t, m.categories, 1)
 }
 
+func TestSupportContact_CheatSheet(t *testing.T) {
+	defer func() { SupportContact = "" }()
+	cats := []HelpCategory{
+		{Title: "General", Items: []HelpItem{{Keys: "<n>", Description: "New"}}},
+	}
+	m := NewDetailed(80, 24, cats)
+
+	// Default (empty): OSS shows no support line.
+	SupportContact = ""
+	require.NotContains(t, m.buildCategorizedContent(), "SUPPORT")
+
+	// Set: the full address is rendered (no truncation) as the last body line.
+	SupportContact = "be-support@swarmcli.io"
+	out := m.buildCategorizedContent()
+	require.Contains(t, out, "SUPPORT")
+	require.Contains(t, out, "be-support@swarmcli.io")
+	lines := strings.Split(out, "\n")
+	require.Contains(t, lines[len(lines)-1], "be-support@swarmcli.io")
+}
+
 func TestName(t *testing.T) {
 	m := New(80, 24, nil)
 	require.Equal(t, "help", m.Name())

--- a/views/help/view.go
+++ b/views/help/view.go
@@ -23,6 +23,11 @@ func (m *Model) FrameHeader() string {
 	return ui.FrameHeaderStyle.Render("Available Commands")
 }
 
+// SupportContact, when non-empty, is rendered as a SUPPORT line at the
+// bottom of the keybinding cheat-sheet. Empty by default so OSS shows
+// nothing; editions set it to their support address at startup.
+var SupportContact string
+
 func (m *Model) FrameFooter() string {
 	return ui.StatusBarStyle.Render("Press <esc> to go back")
 }
@@ -150,6 +155,13 @@ func (m *Model) buildCategorizedContent() string {
 
 	footer := m.FrameFooter()
 	frame := ui.ComputeFrameDimensions(m.Viewable.Width, m.Viewable.Height, m.width, m.height, "", footer)
+	// Pin the edition support line (when set) to the bottom of the body,
+	// flush above the footer, padding the keybinding columns to fill.
+	if SupportContact != "" {
+		body := ui.TrimOrPadContentToLines(fullContent, max(0, frame.DesiredContentLines-1))
+		support := categoryStyle.Render("SUPPORT") + "  " + descStyle.Render(SupportContact)
+		fullContent = body + "\n" + support
+	}
 	return ui.TrimOrPadContentToLines(fullContent, frame.DesiredContentLines)
 }
 

--- a/views/help/view.go
+++ b/views/help/view.go
@@ -39,11 +39,11 @@ func (m *Model) FrameContent() string {
 	if len(m.categories) > 0 {
 		return m.buildCategorizedContent()
 	}
-	// Command help content
+	// Command-list path (`:help`): pin the edition support line at the bottom.
 	header := m.FrameHeader()
 	footer := m.FrameFooter()
 	frame := ui.ComputeFrameDimensions(m.Viewable.Width, m.Viewable.Height, m.width, m.height, header, footer)
-	return ui.TrimOrPadContentToLines(m.Viewable.View(), frame.DesiredContentLines)
+	return appendSupportLine(m.Viewable.View(), frame.DesiredContentLines)
 }
 
 func (m *Model) View() string {
@@ -155,14 +155,23 @@ func (m *Model) buildCategorizedContent() string {
 
 	footer := m.FrameFooter()
 	frame := ui.ComputeFrameDimensions(m.Viewable.Width, m.Viewable.Height, m.width, m.height, "", footer)
-	// Pin the edition support line (when set) to the bottom of the body,
-	// flush above the footer, padding the keybinding columns to fill.
-	if SupportContact != "" {
-		body := ui.TrimOrPadContentToLines(fullContent, max(0, frame.DesiredContentLines-1))
-		support := categoryStyle.Render("SUPPORT") + "  " + descStyle.Render(SupportContact)
-		fullContent = body + "\n" + support
+	return appendSupportLine(fullContent, frame.DesiredContentLines)
+}
+
+// appendSupportLine fits content to total lines, pinning the edition SUPPORT
+// line (when SupportContact is set) one blank line above the footer so it
+// doesn't crowd it. With SupportContact empty (OSS) it just fits content to
+// total, rendering nothing extra.
+func appendSupportLine(content string, total int) string {
+	if SupportContact == "" {
+		return ui.TrimOrPadContentToLines(content, total)
 	}
-	return ui.TrimOrPadContentToLines(fullContent, frame.DesiredContentLines)
+	categoryStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("2"))
+	descStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("252"))
+	// Reserve the SUPPORT line plus one blank spacer above the footer.
+	body := ui.TrimOrPadContentToLines(content, max(0, total-2))
+	support := categoryStyle.Render("SUPPORT") + "  " + descStyle.Render(SupportContact)
+	return ui.TrimOrPadContentToLines(body+"\n"+support, total)
 }
 
 // buildCommandHelpContent renders the per-command help as vertically


### PR DESCRIPTION
## What

Adds a generic, empty-by-default `helpview.SupportContact` extension point. When non-empty, the keybinding cheat-sheet (`?`) renders a `SUPPORT  <address>` line pinned to the bottom of the body, flush above the `Press <esc> to go back` footer.

OSS renders nothing (the var defaults to empty); editions set the address at startup. No edition-specific content lands in OSS — respects the Pro Feature Boundary, mirroring the existing `helpbar.EditionLabel` seam.

This is the CE half of the support-contact feature. The Business Edition sets the value to `be-support@swarmcli.io` in a companion swarmcli-be PR.

## Why

Enables Eldara-Tech/swarmcli-be#191 (surface the BE support email in the help view) without baking BE specifics into OSS.

## Test

- `go test ./views/help/` — new `TestSupportContact_CheatSheet` asserts: empty default renders no SUPPORT line; when set, the full address renders untruncated as the last body line.

## Deploy order

Merge this before the swarmcli-be PR — BE CI builds against remote CE `main` and references `helpview.SupportContact`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)