### PR TITLE
chore(security): bump toolchain to go1.26.4 (fix govulncheck stdlib vulns)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module swarmcli
 
 go 1.26
 
-toolchain go1.26.3
+toolchain go1.26.4
 
 require (
 	github.com/briandowns/spinner v1.23.2


### PR DESCRIPTION
## Why
The weekly `govulncheck` workflow is red because the pinned `toolchain go1.26.3` ships three standard-library vulnerabilities, all fixed in **go1.26.4**:

| GO-ID | stdlib pkg |
|---|---|
| GO-2026-5037 | crypto/x509 |
| GO-2026-5038 | mime |
| GO-2026-5039 | net/textproto |

## Change
`go.mod`: `toolchain go1.26.3` → `go1.26.4` (one line). The `go 1.26` directive and `go.sum` are unchanged; the devcontainer tracks major.minor and resolves the patch via `GOTOOLCHAIN=auto`, so no other file changes.

## Verification
`govulncheck v1.3.0` built under go1.26.4 (mirroring the CI step) reports **0 unsuppressed** symbol-level findings — the only remaining ones are the already-suppressed daemon-side docker false-positives `GO-2026-4887` / `GO-2026-4883`. govulncheck runs on schedule, not on PRs, so it will be dispatched on this branch to confirm green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)