### PR TITLE
fix(services): stop truncating IMAGE name before column layout

### DIFF
--- a/docker/service_helpers.go
+++ b/docker/service_helpers.go
@@ -30,10 +30,6 @@ func getServiceImage(svc swarm.Service) string {
 	if idx := strings.Index(image, "@sha256:"); idx != -1 {
 		image = image[:idx]
 	}
-	// Optionally truncate very long image names
-	if len(image) > 50 {
-		return image[:47] + "..."
-	}
 	return image
 }
 

--- a/docker/service_helpers_test.go
+++ b/docker/service_helpers_test.go
@@ -60,7 +60,7 @@ func TestGetServiceImage_StripDigest(t *testing.T) {
 	require.Equal(t, "nginx", getServiceImage(svc))
 }
 
-func TestGetServiceImage_LongName(t *testing.T) {
+func TestGetServiceImage_LongNameNotTruncated(t *testing.T) {
 	long := strings.Repeat("a", 60)
 	svc := swarm.Service{
 		Spec: swarm.ServiceSpec{
@@ -69,9 +69,7 @@ func TestGetServiceImage_LongName(t *testing.T) {
 			},
 		},
 	}
-	result := getServiceImage(svc)
-	require.Len(t, result, 50)
-	require.True(t, strings.HasSuffix(result, "..."))
+	require.Equal(t, long, getServiceImage(svc))
 }
 
 func TestGetServiceImage_NilContainerSpec(t *testing.T) {

--- a/views/services/columns_test.go
+++ b/views/services/columns_test.go
@@ -102,6 +102,19 @@ func TestView_FullServiceNameOnWideTerminal(t *testing.T) {
 	require.Contains(t, out, longServiceName, "full name must be visible, not truncated (#392)")
 }
 
+func TestView_FullServiceImageOnWideTerminal(t *testing.T) {
+	const longImage = "registry.example.com/myproject/some-very-long-image-name:v1.2.3"
+	m := testModel()
+	entries := fakeEntries("web")
+	entries[0].Image = longImage
+	loadWithFilter(m, AllFilter, entries)
+	m.List.Viewport.Width = 200
+	m.List.Viewport.Height = 20
+
+	out := m.View()
+	require.Contains(t, out, longImage, "full image must be visible, not truncated")
+}
+
 func TestHeaderRowAlignment(t *testing.T) {
 	// Header and rows must share the same total width across scopes and sort
 	// fields, including the sorted column's " ▲" indicator (the #392 regression).


### PR DESCRIPTION
## Problem
Even after the content-aware column-layout fix (#392 / #394), users still saw **truncated service IMAGE names** in the services view. SERVICE names render in full on wide terminals, but images do not.

## Root cause
`getServiceImage()` (`docker/service_helpers.go`) hard-truncated any image over 50 bytes to `image[:47] + "..."` — clipping the value at the *data source*, before the layout engine ever saw it. The IMAGE column is already `Flex: true`, so the shared layout (`TruncateRunes`/`ScrollWindow`) sizes it to content, shows it in full when space allows, and rune-truncates/scrolls otherwise — but for long images it had nothing to work with. This is the same class of bug #392 fixed for SERVICE names, plus this extra source-level cut.

`Image` has no length-dependent consumer (display + `SortByImage` only), so removing the cap is safe.

## Change
- Remove the manual truncation from `getServiceImage()`; it now strips the `@sha256:` digest and returns the full image. The layout owns width — matching SERVICE-name behavior.
- Repurpose `TestGetServiceImage_LongName` → `TestGetServiceImage_LongNameNotTruncated` (asserts the long name passes through untouched).
- Add `TestView_FullServiceImageOnWideTerminal`, the IMAGE-column analogue of the #392 SERVICE regression test.

OSS-only; `swarmcli-be` inherits the fix via its `replace swarmcli => ../swarmcli` directive.

## Verification
- `go test ./docker/... ./views/services/...` → ok
- `go test ./...` → all pass; `go build` → OK
- `golangci-lint run ./... --build-tags=integration` → 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)