### PR TITLE
feat: list all services with :service / :svc (#377)

### DIFF
--- a/commands/autoload.go
+++ b/commands/autoload.go
@@ -10,5 +10,6 @@ import (
 	_ "swarmcli/commands/command/docker/network"
 	_ "swarmcli/commands/command/docker/node"
 	_ "swarmcli/commands/command/docker/secret"
+	_ "swarmcli/commands/command/docker/service"
 	_ "swarmcli/commands/command/docker/volume"
 )

--- a/commands/command/docker/service/ls.go
+++ b/commands/command/docker/service/ls.go
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package service
+
+import (
+	"swarmcli/args"
+	"swarmcli/registry"
+	servicesview "swarmcli/views/services"
+	"swarmcli/views/view"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+type DockerServiceLs struct{}
+
+func (DockerServiceLs) Name() string        { return "service" }
+func (DockerServiceLs) Description() string { return "docker service ls" }
+
+func (DockerServiceLs) Spec() registry.CommandSpec {
+	return registry.CommandSpec{
+		Detail: "Opens the Services list across all stacks (docker service ls), " +
+			"where you can browse, scale, restart and inspect every service in " +
+			"the swarm.",
+		Examples: []string{":service", ":svc"},
+	}
+}
+
+func (DockerServiceLs) Execute(ctx any, args args.Args) tea.Cmd {
+	return func() tea.Msg {
+		return view.NavigateToMsg{
+			ViewName: servicesview.ViewName,
+			Payload:  nil,
+		}
+	}
+}
+
+// svcAlias is the ":svc" alias for ":service". It inherits Description, Execute
+// and Spec from the embedded primary; AliasOf folds it under "service" in the
+// command list and help.
+type svcAlias struct{ DockerServiceLs }
+
+func (svcAlias) Name() string    { return "svc" }
+func (svcAlias) AliasOf() string { return "service" }
+
+var lsCmd = DockerServiceLs{}
+
+func init() {
+	registry.Register(lsCmd)
+	registry.Register(svcAlias{})
+}

--- a/commands/command/docker/service/ls_test.go
+++ b/commands/command/docker/service/ls_test.go
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package service
+
+import (
+	"testing"
+
+	"swarmcli/args"
+	"swarmcli/registry"
+	servicesview "swarmcli/views/services"
+	"swarmcli/views/view"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestServiceLs_Name(t *testing.T) {
+	require.Equal(t, "service", lsCmd.Name())
+}
+
+func TestServiceLs_Description(t *testing.T) {
+	require.NotEmpty(t, lsCmd.Description())
+}
+
+func TestServiceLs_ExecuteNavigatesToAllServices(t *testing.T) {
+	cmd := lsCmd.Execute(nil, args.Args{})
+	require.NotNil(t, cmd)
+
+	nav, ok := cmd().(view.NavigateToMsg)
+	require.True(t, ok, "expected a NavigateToMsg")
+	require.Equal(t, servicesview.ViewName, nav.ViewName)
+	// A nil payload makes the services factory default to AllFilter (all stacks).
+	require.Nil(t, nav.Payload)
+}
+
+func TestServiceLs_RegisteredWithSvcAlias(t *testing.T) {
+	_, ok := registry.Get("service")
+	require.True(t, ok)
+
+	alias, ok := registry.Get("svc")
+	require.True(t, ok)
+	a, ok := alias.(registry.Aliaser)
+	require.True(t, ok)
+	require.Equal(t, "service", a.AliasOf())
+}

--- a/docker/service.go
+++ b/docker/service.go
@@ -436,6 +436,43 @@ func LoadStackServices(stackName string) []ServiceEntry {
 	return entries
 }
 
+// LoadAllServices returns every service in the swarm, across all stacks
+// (including services with no stack, shown as "-"). Equivalent to
+// `docker service ls`.
+func LoadAllServices() []ServiceEntry {
+	snap, err := GetOrRefreshSnapshot()
+	if err != nil {
+		l().Warnf("failed to get snapshot: %v", err)
+		return nil
+	}
+
+	var entries []ServiceEntry
+
+	for _, svc := range snap.Services {
+		stack, desired := getServiceStackAndDesired(svc, snap)
+
+		// Count tasks on all nodes
+		onNode := countTasksForNode(svc.ID, "", snap)
+
+		entries = append(entries, ServiceEntry{
+			StackName:      stack,
+			ServiceName:    svc.Spec.Name,
+			ServiceID:      svc.ID,
+			ReplicasOnNode: onNode,
+			ReplicasTotal:  desired,
+			Status:         getServiceStatus(svc),
+			Mode:           getServiceMode(svc),
+			Image:          getServiceImage(svc),
+			Ports:          getServicePorts(svc),
+			CreatedAt:      svc.CreatedAt,
+			UpdatedAt:      svc.UpdatedAt,
+		})
+	}
+
+	sortEntries(entries)
+	return entries
+}
+
 // --- Helpers ---
 
 // getServiceStackAndDesired returns the stack name and desired replicas for a service

--- a/docker/service_ops.go
+++ b/docker/service_ops.go
@@ -20,6 +20,7 @@ type ServiceOps interface {
 	RestartServiceWithProgress(ctx context.Context, serviceName string, progressCh chan<- ProgressUpdate) error
 	LoadNodeServices(nodeID string) []ServiceEntry
 	LoadStackServices(stackName string) []ServiceEntry
+	LoadAllServices() []ServiceEntry
 	GetServiceLogs(ctx context.Context, serviceID string) (string, error)
 	GetServiceTaskDiagnostics(ctx context.Context, serviceID string) (string, error)
 	CreateService(ctx context.Context, spec swarm.ServiceSpec) (string, error)
@@ -53,6 +54,9 @@ func (defaultServiceOps) LoadNodeServices(nodeID string) []ServiceEntry {
 }
 func (defaultServiceOps) LoadStackServices(stackName string) []ServiceEntry {
 	return LoadStackServices(stackName)
+}
+func (defaultServiceOps) LoadAllServices() []ServiceEntry {
+	return LoadAllServices()
 }
 func (defaultServiceOps) GetServiceLogs(ctx context.Context, serviceID string) (string, error) {
 	return GetServiceLogs(ctx, serviceID)

--- a/integration-tests/docker/service/list_all_test.go
+++ b/integration-tests/docker/service/list_all_test.go
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+//go:build integration
+
+package service
+
+import (
+	"testing"
+
+	"swarmcli/docker"
+)
+
+// TestLoadAllServicesListsEveryService verifies that LoadAllServices returns
+// every service in the swarm across all stacks (the data backing :service /
+// :svc), not just the services of a single stack.
+func TestLoadAllServicesListsEveryService(t *testing.T) {
+	if _, err := docker.RefreshSnapshot(); err != nil {
+		t.Fatalf("failed to refresh snapshot: %v", err)
+	}
+
+	all := docker.LoadAllServices()
+	if len(all) == 0 {
+		t.Fatal("LoadAllServices returned no services; expected the demo stack services")
+	}
+
+	got := make(map[string]bool, len(all))
+	for _, e := range all {
+		got[e.ServiceName] = true
+	}
+
+	// Services deployed by test-setup/test-stack.yml under the "demo" stack.
+	for _, name := range []string{
+		"demo_whoami",
+		"demo_whoami_single",
+		"demo_default_net_probe",
+		"demo_log_ticker",
+	} {
+		if !got[name] {
+			t.Errorf("expected service %q in LoadAllServices result", name)
+		}
+	}
+
+	// "All" must cover at least everything a single-stack scope returns.
+	stackOnly := docker.LoadStackServices("demo")
+	if len(all) < len(stackOnly) {
+		t.Errorf("LoadAllServices returned %d services, fewer than the demo stack's %d",
+			len(all), len(stackOnly))
+	}
+}

--- a/views/services/model_test.go
+++ b/views/services/model_test.go
@@ -28,6 +28,7 @@ type mockServiceOps struct {
 	rollbackServiceFn   func(ctx context.Context, serviceName string) error
 	loadNodeServicesFn  func(nodeID string) []docker.ServiceEntry
 	loadStackServicesFn func(stackName string) []docker.ServiceEntry
+	loadAllServicesFn   func() []docker.ServiceEntry
 	getServiceLogsFn    func(ctx context.Context, serviceID string) (string, error)
 	createServiceFn     func(ctx context.Context, spec swarm.ServiceSpec) (string, error)
 }
@@ -58,6 +59,9 @@ func (m *mockServiceOps) LoadNodeServices(nodeID string) []docker.ServiceEntry {
 }
 func (m *mockServiceOps) LoadStackServices(stackName string) []docker.ServiceEntry {
 	return m.loadStackServicesFn(stackName)
+}
+func (m *mockServiceOps) LoadAllServices() []docker.ServiceEntry {
+	return m.loadAllServicesFn()
 }
 func (m *mockServiceOps) GetServiceLogs(ctx context.Context, serviceID string) (string, error) {
 	if m.getServiceLogsFn != nil {
@@ -166,6 +170,7 @@ func noopServiceOps() *mockServiceOps {
 		rollbackServiceFn:   func(_ context.Context, _ string) error { return nil },
 		loadNodeServicesFn:  func(_ string) []docker.ServiceEntry { return nil },
 		loadStackServicesFn: func(_ string) []docker.ServiceEntry { return nil },
+		loadAllServicesFn:   func() []docker.ServiceEntry { return nil },
 	}
 }
 
@@ -438,6 +443,7 @@ func TestConfirmRestart_Success(t *testing.T) {
 			rollbackServiceFn:   func(_ context.Context, _ string) error { return nil },
 			loadNodeServicesFn:  func(_ string) []docker.ServiceEntry { return nil },
 			loadStackServicesFn: func(_ string) []docker.ServiceEntry { return nil },
+			loadAllServicesFn:   func() []docker.ServiceEntry { return nil },
 		}
 	})
 	loadServices(m, fakeEntries("web"))
@@ -459,6 +465,7 @@ func TestConfirmRemove_Success(t *testing.T) {
 			rollbackServiceFn:   func(_ context.Context, _ string) error { return nil },
 			loadNodeServicesFn:  func(_ string) []docker.ServiceEntry { return nil },
 			loadStackServicesFn: func(_ string) []docker.ServiceEntry { return nil },
+			loadAllServicesFn:   func() []docker.ServiceEntry { return nil },
 		}
 	})
 	loadServices(m, fakeEntries("web"))
@@ -480,6 +487,7 @@ func TestConfirmRollback_Success(t *testing.T) {
 			rollbackServiceFn:   func(_ context.Context, name string) error { rolledBack = name; return nil },
 			loadNodeServicesFn:  func(_ string) []docker.ServiceEntry { return nil },
 			loadStackServicesFn: func(_ string) []docker.ServiceEntry { return nil },
+			loadAllServicesFn:   func() []docker.ServiceEntry { return nil },
 		}
 	})
 	loadServices(m, fakeEntries("web"))
@@ -527,6 +535,7 @@ func TestScaleDialogResult_Confirmed(t *testing.T) {
 			rollbackServiceFn:   func(_ context.Context, _ string) error { return nil },
 			loadNodeServicesFn:  func(_ string) []docker.ServiceEntry { return nil },
 			loadStackServicesFn: func(_ string) []docker.ServiceEntry { return nil },
+			loadAllServicesFn:   func() []docker.ServiceEntry { return nil },
 		}
 	})
 	loadServices(m, fakeEntries("web"))
@@ -657,13 +666,16 @@ func TestGetServicesHelpContent(t *testing.T) {
 
 func TestLoadServicesForView_AllFilter(t *testing.T) {
 	mock := noopServiceOps()
-	mock.loadStackServicesFn = func(stackName string) []docker.ServiceEntry {
-		require.Equal(t, "", stackName)
-		return fakeEntries("web")
+	mock.loadStackServicesFn = func(string) []docker.ServiceEntry {
+		t.Fatal("AllFilter must not call LoadStackServices")
+		return nil
+	}
+	mock.loadAllServicesFn = func() []docker.ServiceEntry {
+		return fakeEntries("web", "db")
 	}
 	m := testModel(func(m *Model) { m.deps.Services = mock })
 	entries, title := m.loadServicesForView(AllFilter, "", "")
-	require.Len(t, entries, 1)
+	require.Len(t, entries, 2)
 	require.Contains(t, title, "All Services")
 }
 

--- a/views/services/service.go
+++ b/views/services/service.go
@@ -49,7 +49,7 @@ func loadServicesForViewWith(serviceOps docker.ServiceOps, filterType FilterType
 		entries = serviceOps.LoadStackServices("-")
 		title = "Services (no stack)"
 	default: // All services
-		entries = serviceOps.LoadStackServices("")
+		entries = serviceOps.LoadAllServices()
 		title = "All Services"
 	}
 	return


### PR DESCRIPTION
## What

Adds a top-level command `:service` (alias `:svc`) that lists **all** swarm services across the cluster — the equivalent of `docker service ls` — instead of only the services scoped to a single stack.

Closes #377.

## Why it's small

The services view already had a dormant `AllFilter` mode (with a conditional STACK column shown only in that mode), and the factory already defaults to it for an empty payload. Two gaps prevented it from working:

1. **No command opened it** — the view was only reachable by drilling into a stack.
2. **The data layer returned empty** — the `AllFilter` path called `LoadStackServices("")`, which matches nothing because every service's stack is normalised to a real label or `"-"`, never `""`.

This PR activates the existing UI rather than adding a new view.

## Changes

- `docker/service.go` — new `LoadAllServices()` (snapshot iteration, no stack filter).
- `docker/service_ops.go` — `LoadAllServices()` on the `ServiceOps` interface + default impl.
- `views/services/service.go` — `AllFilter` case now calls `LoadAllServices()`.
- `commands/command/docker/service/ls.go` — `:service` command + `:svc` alias; registered via `commands/autoload.go`.

## Tests

- Command unit test (name, navigation message, `svc`→`service` alias).
- Rewrote `TestLoadServicesForView_AllFilter` to assert routing to `LoadAllServices`.
- New integration test asserting `LoadAllServices()` lists every `demo_*` service.
- `go build`, `go test ./...`, and `golangci-lint run --build-tags=integration` all pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)