### PR TITLE
feat(view): FeatureLockedCmdFn seam for rich gated-feature prompts

### DIFF
--- a/views/secrets/update.go
+++ b/views/secrets/update.go
@@ -382,6 +382,9 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 			}
 			action, ok := view.GetAction("reveal-secret")
 			if !ok {
+				if cmd := view.FeatureLockedCmd("Reveal Secret"); cmd != nil {
+					return cmd
+				}
 				m.err = view.BEUnavailableErr("Reveal Secret")
 				m.errorDialogActive = true
 				return nil

--- a/views/services/update.go
+++ b/views/services/update.go
@@ -451,6 +451,9 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 			entry := m.List.Filtered[m.List.Cursor]
 			action, ok := view.GetAction("shell")
 			if !ok {
+				if cmd := view.FeatureLockedCmd("Shell"); cmd != nil {
+					return cmd
+				}
 				m.confirmDialog.Visible = true
 				m.confirmDialog.ErrorMode = true
 				m.confirmDialog.Message = view.BEUnavailableErr("Shell").Error()
@@ -464,6 +467,9 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 			entry := m.List.Filtered[m.List.Cursor]
 			action, ok := view.GetAction("port-forwards")
 			if !ok {
+				if cmd := view.FeatureLockedCmd("Active Forwards"); cmd != nil {
+					return cmd
+				}
 				m.confirmDialog.Visible = true
 				m.confirmDialog.ErrorMode = true
 				m.confirmDialog.Message = view.BEUnavailableErr("Active Forwards").Error()
@@ -477,6 +483,9 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 			entry := m.List.Filtered[m.List.Cursor]
 			action, ok := view.GetAction("port-forward")
 			if !ok {
+				if cmd := view.FeatureLockedCmd("Port Forward"); cmd != nil {
+					return cmd
+				}
 				m.confirmDialog.Visible = true
 				m.confirmDialog.ErrorMode = true
 				m.confirmDialog.Message = view.BEUnavailableErr("Port Forward").Error()

--- a/views/view/edition.go
+++ b/views/view/edition.go
@@ -6,6 +6,8 @@ package view
 import (
 	"errors"
 	"fmt"
+
+	tea "github.com/charmbracelet/bubbletea"
 )
 
 // BEHelpDesc returns desc if the action is registered, or desc+" (BE)" if not.
@@ -35,4 +37,21 @@ func BEUnavailableErr(featureName string) error {
 		return errors.New(BEUnavailableFormatFn(featureName))
 	}
 	return fmt.Errorf(BEUnavailableFormat, featureName)
+}
+
+// FeatureLockedCmdFn, if set by an extension, returns a tea.Cmd to run when a
+// license-gated feature is requested without entitlement. When set it takes
+// precedence over the caller's local error dialog, letting the extension show
+// a richer prompt (e.g. an inline license dialog) instead of the flat
+// BEUnavailableErr text. Override in init().
+var FeatureLockedCmdFn func(featureName string) tea.Cmd
+
+// FeatureLockedCmd returns the extension's rich locked-feature command for
+// featureName, or nil when no extension is registered — in which case callers
+// fall back to surfacing BEUnavailableErr in their own error UI.
+func FeatureLockedCmd(featureName string) tea.Cmd {
+	if FeatureLockedCmdFn != nil {
+		return FeatureLockedCmdFn(featureName)
+	}
+	return nil
 }

--- a/views/view/edition_test.go
+++ b/views/view/edition_test.go
@@ -29,3 +29,20 @@ func TestBEUnavailableErr_ContainsURL(t *testing.T) {
 	err := BEUnavailableErr("Shell")
 	require.Contains(t, err.Error(), "https://swarmcli.io/be")
 }
+
+func TestFeatureLockedCmd_NilWhenUnset(t *testing.T) {
+	require.Nil(t, FeatureLockedCmdFn)
+	require.Nil(t, FeatureLockedCmd("Shell"))
+}
+
+func TestFeatureLockedCmd_ReturnsRegisteredCmd(t *testing.T) {
+	type lockedMsg struct{ feature string }
+	FeatureLockedCmdFn = func(feature string) tea.Cmd {
+		return func() tea.Msg { return lockedMsg{feature: feature} }
+	}
+	defer func() { FeatureLockedCmdFn = nil }()
+
+	cmd := FeatureLockedCmd("Shell")
+	require.NotNil(t, cmd)
+	require.Equal(t, lockedMsg{feature: "Shell"}, cmd())
+}

--- a/views/volumes/update.go
+++ b/views/volumes/update.go
@@ -258,6 +258,9 @@ func (m *Model) selectedVolume() (volumeItem, bool) {
 func (m *Model) dispatchAction(actionName, label, arg string) tea.Cmd {
 	action, ok := view.GetAction(actionName)
 	if !ok {
+		if cmd := view.FeatureLockedCmd(label); cmd != nil {
+			return cmd
+		}
 		m.err = view.BEUnavailableErr(label)
 		m.errorDialogActive = true
 		return nil


### PR DESCRIPTION
## What

Adds a generic extension seam `view.FeatureLockedCmdFn` so an extension (swarmcli-be) can show a richer prompt when a license-gated feature is requested without entitlement, instead of the flat `BEUnavailableErr` text shown today.

- `view.FeatureLockedCmdFn func(featureName string) tea.Cmd` + `view.FeatureLockedCmd(...)` helper, mirroring the adjacent `BEUnavailableFormatFn`.
- All gated-action denial sites prefer the seam and **fall back to the existing local error dialog when it is unset**, so pure-OSS behaviour is unchanged:
  - `views/services/update.go` — shell (`x`), active-forwards (`w`), port-forward (`W`)
  - `views/secrets/update.go` — reveal-secret
  - `views/volumes/update.go` — `dispatchAction` (all volume actions)

## Why

Enables swarmcli-be#174: replace the flat "Shell requires a Business Edition license" error with the same inline license dialog (cluster ID, where-to-get-a-license URL, paste-key input) the `:license` `<s>` flow uses. The BE side (which owns the dialog) lands in a companion PR.

## Test

- `go test ./views/...` — adds `TestFeatureLockedCmd_*` in `views/view/edition_test.go`.
- `go vet` + `golangci-lint run` clean on the changed packages.

Refs Eldara-Tech/swarmcli-be#174

🤖 Generated with [Claude Code](https://claude.com/claude-code)