### PR TITLE
fix(contexts): allow switching to a locked swarm + in-app unlock

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -90,3 +90,32 @@ jobs:
         with:
           name: test-report
           path: /tmp/test-report.xml
+
+  # The locked-swarm test autolocks and restarts its own throwaway dind daemon,
+  # so it must stay isolated from the shared multi-node swarm above. It is gated
+  # behind the dedicated `integration_locked` build tag and needs no compose
+  # bring-up, so it runs as its own job for a clean, independent signal.
+  locked-swarm:
+    needs: [changes]
+    if: needs.changes.outputs.integration == 'true'
+    name: Run locked-swarm integration test
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Verify Docker & Go
+        run: |
+          docker version
+          go version
+
+      - name: Run locked-swarm integration test
+        run: go test -tags=integration_locked -count=1 -v -timeout=15m ./integration-tests/...

--- a/app/initialsnapshot.go
+++ b/app/initialsnapshot.go
@@ -5,13 +5,15 @@ package app
 
 import (
 	"swarmcli/docker"
-	stacksview "swarmcli/views/stacks"
-	"swarmcli/views/view"
 
 	tea "github.com/charmbracelet/bubbletea"
 )
 
 // --- Async snapshot loader ---
+// loadSnapshotAsync refreshes the snapshot and reports the outcome via
+// snapshotLoadedMsg, whose handler navigates to the stacks view on success
+// (and surfaces a notice when the swarm is locked). Used on startup, after a
+// context switch, and after an unlock.
 func loadSnapshotAsync() tea.Cmd {
 	return func() tea.Msg {
 		_, err := docker.RefreshSnapshot()
@@ -20,19 +22,3 @@ func loadSnapshotAsync() tea.Cmd {
 }
 
 type snapshotLoadedMsg struct{ Err error }
-
-// loadSnapshotAndNavigateToStacksCmd loads snapshot and then navigates to stacks view
-// Used after context switch to show the stacks for the new context
-func loadSnapshotAndNavigateToStacksCmd() tea.Cmd {
-	return func() tea.Msg {
-		_, err := docker.RefreshSnapshot()
-		if err != nil {
-			return snapshotLoadedMsg{Err: err}
-		}
-		// Navigate to stacks view after snapshot loads
-		return view.NavigateToMsg{
-			ViewName: stacksview.ViewName,
-			Replace:  true, // Replace the loading view
-		}
-	}
-}

--- a/app/model.go
+++ b/app/model.go
@@ -12,6 +12,7 @@ import (
 	loadingview "swarmcli/views/loading"
 	"swarmcli/views/searchinput"
 	systeminfoview "swarmcli/views/systeminfo"
+	"swarmcli/views/unlockdialog"
 
 	"github.com/charmbracelet/lipgloss"
 	"swarmcli/views/view"
@@ -40,6 +41,10 @@ type Model struct {
 	errorDialog          *confirmdialog.Model
 	appErrorDialogActive bool
 	errorFallbackView    string // view to navigate to on dismiss; "" = goBack()
+
+	// App-level swarm unlock-key dialog, shown when the active swarm is locked.
+	unlockDialog       *unlockdialog.Model
+	unlockDialogActive bool
 
 	// Terminal dimensions
 	terminalWidth  int
@@ -95,6 +100,7 @@ func InitialModel() *Model {
 		commandInput:   cmdBar(),
 		searchInput:    searchinput.New(),
 		errorDialog:    confirmdialog.New(terminalWidth, terminalHeight),
+		unlockDialog:   unlockdialog.New(terminalWidth, terminalHeight),
 		terminalWidth:  terminalWidth,
 		terminalHeight: terminalHeight,
 	}
@@ -188,8 +194,19 @@ func cmdBar() *commandinput.Model {
 
 func (m *Model) showAppError(errMsg string, fallbackView string) {
 	m.errorDialog.Visible = true
+	m.errorDialog.InfoMode = false
 	m.errorDialog.ErrorMode = true
 	m.errorDialog.Message = errMsg
+	m.appErrorDialogActive = true
+	m.errorFallbackView = fallbackView
+}
+
+// showAppInfo shows the app-level modal styled as a neutral notice (not an error).
+func (m *Model) showAppInfo(infoMsg string, fallbackView string) {
+	m.errorDialog.Visible = true
+	m.errorDialog.ErrorMode = false
+	m.errorDialog.InfoMode = true
+	m.errorDialog.Message = infoMsg
 	m.appErrorDialogActive = true
 	m.errorFallbackView = fallbackView
 }

--- a/app/update.go
+++ b/app/update.go
@@ -4,6 +4,7 @@
 package app
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"strings"
@@ -18,7 +19,9 @@ import (
 	"swarmcli/views/searchinput"
 	stacksview "swarmcli/views/stacks"
 	systeminfoview "swarmcli/views/systeminfo"
+	"swarmcli/views/unlockdialog"
 	"swarmcli/views/view"
+	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 )
@@ -78,6 +81,15 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.previousContext = ""
 		// Replace loading with stacks view
 		cmd := m.replaceView(stacksview.ViewName, nil)
+		// A locked swarm loads as an empty, flagged snapshot. Tell the user why
+		// the lists are empty and how to unlock — without reverting the switch.
+		if snap := docker.GetSnapshot(); snap != nil && snap.Locked {
+			m.showAppInfo(
+				"Swarm is locked — its resources stay hidden until it is unlocked.\n\n"+
+					"Type :unlock to enter the unlock key, or run `docker swarm unlock` in a terminal.",
+				"",
+			)
+		}
 		return m, cmd
 	case commandinput.SubmitMsg:
 		raw := strings.TrimSpace(msg.Command)
@@ -129,9 +141,9 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case tea.KeyMsg:
-		// If app-level error dialog is active, route all keys to handleKey
+		// If an app-level dialog is active, route all keys to handleKey
 		// which forwards them to the dialog exclusively.
-		if m.appErrorDialogActive {
+		if m.appErrorDialogActive || m.unlockDialogActive {
 			return m.handleKey(msg)
 		}
 
@@ -286,7 +298,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.systemInfo.LoadStatus(),
 			cmd,
 			// Load snapshot and navigate to stacks when ready
-			loadSnapshotAndNavigateToStacksCmd(),
+			loadSnapshotAsync(),
 		)
 
 	case view.AppErrorMsg:
@@ -308,11 +320,40 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		cmd := m.delegateToCurrentView(msg)
 		return m, cmd
 
+	case view.OpenUnlockDialogMsg:
+		m.unlockDialog.Show()
+		m.unlockDialogActive = true
+		return m, m.unlockDialog.Init()
+
+	case unlockdialog.ResultMsg:
+		m.unlockDialogActive = false
+		m.unlockDialog.Hide()
+		if !msg.Confirmed || strings.TrimSpace(msg.Key) == "" {
+			return m, nil
+		}
+		key := msg.Key
+		return m, func() tea.Msg {
+			ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+			defer cancel()
+			return unlockResultMsg{Err: docker.UnlockSwarm(ctx, key)}
+		}
+
+	case unlockResultMsg:
+		if msg.Err != nil {
+			m.showAppError("Failed to unlock swarm: "+msg.Err.Error(), "")
+			return m, nil
+		}
+		docker.InvalidateSnapshot()
+		return m, tea.Batch(loadSnapshotAsync(), m.systemInfo.LoadStatus())
+
 	default:
 		cmd := m.delegateToCurrentView(msg)
 		return m, cmd
 	}
 }
+
+// unlockResultMsg carries the outcome of a docker.UnlockSwarm call.
+type unlockResultMsg struct{ Err error }
 
 func (m *Model) delegateToCurrentView(msg tea.Msg) tea.Cmd {
 	cmd := m.currentView.Update(msg)
@@ -400,6 +441,12 @@ func (m *Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	// If app-level error dialog is active, forward keys to it exclusively
 	if m.appErrorDialogActive {
 		cmd := m.errorDialog.Update(msg)
+		return m, cmd
+	}
+
+	// If the unlock dialog is active, forward keys to it exclusively
+	if m.unlockDialogActive {
+		cmd := m.unlockDialog.Update(msg)
 		return m, cmd
 	}
 

--- a/app/view.go
+++ b/app/view.go
@@ -19,7 +19,7 @@ func (m *Model) View() string {
 		header := m.currentView.FrameHeader()
 		content := m.currentView.FrameContent()
 		out := ui.RenderViewFrame(title, header, content, "", m.terminalWidth, m.terminalHeight, true)
-		return m.overlayStartup(m.overlayAppError(out))
+		return m.overlayStartup(m.overlayUnlock(m.overlayAppError(out)))
 	}
 
 	systemInfo := m.systemInfo.View()
@@ -74,7 +74,7 @@ func (m *Model) View() string {
 			framedView,
 			m.renderStackBar(),
 		)
-		return m.overlayStartup(m.overlayAppError(out))
+		return m.overlayStartup(m.overlayUnlock(m.overlayAppError(out)))
 	}
 
 	if m.searchInput.Visible() {
@@ -95,7 +95,7 @@ func (m *Model) View() string {
 			framedView,
 			m.renderStackBar(),
 		)
-		return m.overlayStartup(m.overlayAppError(out))
+		return m.overlayStartup(m.overlayUnlock(m.overlayAppError(out)))
 	}
 
 	if frameHeight < 1 {
@@ -109,7 +109,7 @@ func (m *Model) View() string {
 		framedView,
 		m.renderStackBar(),
 	)
-	return m.overlayStartup(m.overlayAppError(out))
+	return m.overlayStartup(m.overlayUnlock(m.overlayAppError(out)))
 }
 
 // overlayAppError overlays the app-level error dialog on top of the rendered output.
@@ -118,6 +118,14 @@ func (m *Model) overlayAppError(base string) string {
 		return base
 	}
 	return ui.OverlayCentered(base, m.errorDialog.View(), m.terminalWidth, 0)
+}
+
+// overlayUnlock overlays the swarm unlock-key dialog on top of the rendered output.
+func (m *Model) overlayUnlock(base string) string {
+	if !m.unlockDialog.Visible {
+		return base
+	}
+	return ui.OverlayCentered(base, m.unlockDialog.View(), m.terminalWidth, 0)
 }
 
 // overlayStartup composites the startup overlay on top of the rendered output.

--- a/commands/command/unlock.go
+++ b/commands/command/unlock.go
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package command
+
+import (
+	"swarmcli/args"
+	"swarmcli/registry"
+	"swarmcli/views/view"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+type Unlock struct{}
+
+func (Unlock) Name() string        { return "unlock" }
+func (Unlock) Description() string { return "Unlock a locked Docker Swarm" }
+
+func (Unlock) Spec() registry.CommandSpec {
+	return registry.CommandSpec{
+		Detail: "Opens a prompt to enter the swarm unlock key and decrypt a " +
+			"locked cluster, then reloads its resources. Equivalent to " +
+			"`docker swarm unlock`.",
+		Examples: []string{":unlock"},
+	}
+}
+
+func (Unlock) Execute(ctx any, args args.Args) tea.Cmd {
+	return func() tea.Msg {
+		return view.OpenUnlockDialogMsg{}
+	}
+}
+
+var unlockCmd = Unlock{}
+
+func init() {
+	registry.Register(unlockCmd)
+}

--- a/docker/context.go
+++ b/docker/context.go
@@ -13,8 +13,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
-
-	"github.com/docker/docker/api/types/swarm"
 )
 
 // ContextArchiveExts lists supported Docker context archive extensions.
@@ -179,10 +177,15 @@ func ValidateContext(ctx context.Context, contextName string) error {
 	// Verify the node is part of a Swarm cluster
 	info, err := cli.Info(ctx)
 	if err != nil {
+		// A locked swarm is reachable, just encrypted — allow the switch so the
+		// user can unlock it from within swarmcli (CLI parity with `context use`).
+		if IsSwarmLockedErr(err) {
+			return nil
+		}
 		_ = UseContext(currentCtx)
 		return fmt.Errorf("failed to query info for context %s: %w", contextName, err)
 	}
-	if info.Swarm.LocalNodeState != swarm.LocalNodeStateActive {
+	if !isUsableSwarmState(info.Swarm.LocalNodeState) {
 		_ = UseContext(currentCtx)
 		return fmt.Errorf("context %s is not part of a Docker Swarm cluster", contextName)
 	}

--- a/docker/snapshot.go
+++ b/docker/snapshot.go
@@ -43,6 +43,9 @@ type SwarmSnapshot struct {
 	Tasks     []swarm.Task
 	Fetched   time.Time
 	ClusterID string
+	// Locked is true when the swarm is reachable but encrypted/locked. In that
+	// case the entity lists are empty until the swarm is unlocked.
+	Locked bool
 }
 
 var (
@@ -89,6 +92,14 @@ func RefreshSnapshot() (*SwarmSnapshot, error) {
 
 	nodes, err := c.NodeList(ctx, swarm.NodeListOptions{})
 	if err != nil {
+		// A locked swarm rejects every store-backed call. Surface it as a flagged
+		// empty snapshot instead of a fatal error so the context switch is not
+		// reverted; the app prompts the user to unlock.
+		if IsSwarmLockedErr(err) {
+			snap := &SwarmSnapshot{Locked: true, Fetched: time.Now()}
+			SetSnapshot(snap)
+			return snap, nil
+		}
 		return nil, fmt.Errorf("listing nodes: %w", err)
 	}
 

--- a/docker/swarm_lock.go
+++ b/docker/swarm_lock.go
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package docker
+
+import (
+	"context"
+	"strings"
+
+	"github.com/docker/docker/api/types/swarm"
+)
+
+// IsSwarmLockedErr reports whether err is the Docker daemon's "swarm is locked"
+// error. A locked swarm is reachable (ping/info succeed) but every store-backed
+// call (node/service/task/stack list, ...) fails with this message until the
+// swarm is unlocked. See docs.docker.com/engine/swarm/swarm_manager_locking.
+func IsSwarmLockedErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	s := strings.ToLower(err.Error())
+	return strings.Contains(s, "swarm is encrypted") ||
+		strings.Contains(s, "needs to be unlocked")
+}
+
+// isUsableSwarmState reports whether a node state lets swarmcli switch into the
+// context. Locked is usable: the node IS a swarm member, it just needs unlocking.
+func isUsableSwarmState(s swarm.LocalNodeState) bool {
+	return s == swarm.LocalNodeStateActive || s == swarm.LocalNodeStateLocked
+}
+
+// UnlockSwarm submits the unlock key to the daemon for the current context.
+func UnlockSwarm(ctx context.Context, key string) error {
+	cli, err := GetClient()
+	if err != nil {
+		return err
+	}
+	return cli.SwarmUnlock(ctx, swarm.UnlockRequest{UnlockKey: strings.TrimSpace(key)})
+}

--- a/docker/swarm_lock_test.go
+++ b/docker/swarm_lock_test.go
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package docker
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/docker/docker/api/types/swarm"
+)
+
+func TestIsSwarmLockedErr(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"daemon locked message", errors.New(`Error response from daemon: Swarm is encrypted and needs to be unlocked before it can be used. Please use "docker swarm unlock" to unlock it.`), true},
+		{"encrypted only", errors.New("swarm is encrypted"), true},
+		{"unlock phrase only", errors.New("the cluster needs to be unlocked"), true},
+		{"mixed case", errors.New("SWARM IS ENCRYPTED"), true},
+		{"unrelated", errors.New("connection refused"), false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := IsSwarmLockedErr(c.err); got != c.want {
+				t.Fatalf("IsSwarmLockedErr(%v) = %v, want %v", c.err, got, c.want)
+			}
+		})
+	}
+}
+
+func TestIsUsableSwarmState(t *testing.T) {
+	cases := []struct {
+		state swarm.LocalNodeState
+		want  bool
+	}{
+		{swarm.LocalNodeStateActive, true},
+		{swarm.LocalNodeStateLocked, true},
+		{swarm.LocalNodeStateInactive, false},
+		{swarm.LocalNodeStatePending, false},
+		{swarm.LocalNodeStateError, false},
+		{swarm.LocalNodeState(""), false},
+	}
+	for _, c := range cases {
+		t.Run(string(c.state), func(t *testing.T) {
+			if got := isUsableSwarmState(c.state); got != c.want {
+				t.Fatalf("isUsableSwarmState(%q) = %v, want %v", c.state, got, c.want)
+			}
+		})
+	}
+}

--- a/integration-tests/swarmlock/locked_swarm_test.go
+++ b/integration-tests/swarmlock/locked_swarm_test.go
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+//go:build integration_locked
+
+// Package swarmlock holds the locked-swarm integration test. It is gated behind
+// the dedicated `integration_locked` build tag (not the regular `integration`
+// tag) because it autolocks and restarts its own throwaway Docker daemon, which
+// must stay isolated from the shared multi-node swarm the other integration
+// tests run against. A separate CI job runs only this tag.
+package swarmlock
+
+import (
+	"context"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"swarmcli/docker"
+)
+
+const (
+	dindImage     = "docker:29-dind"
+	containerName = "swarmcli-locked-dind"
+	dindHostPort  = "23375" // distinct from the shared swarm's 22375
+	lockedContext = "swarmcli-locked"
+	contextHost   = "tcp://localhost:" + dindHostPort
+)
+
+// hostDocker runs a docker CLI command against the runner's default daemon
+// (the one hosting the throwaway dind container), regardless of any ambient
+// DOCKER_CONTEXT. It returns combined output for diagnostics.
+func hostDocker(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+	full := append([]string{"--context", "default"}, args...)
+	out, err := exec.Command("docker", full...).CombinedOutput()
+	return string(out), err
+}
+
+// inner runs `docker <args>` *inside* the dind container, i.e. against the
+// daemon under test.
+func inner(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+	return hostDocker(t, append([]string{"exec", containerName, "docker"}, args...)...)
+}
+
+// waitInnerReady polls until the inner daemon answers `docker version`.
+func waitInnerReady(t *testing.T, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if _, err := inner(t, "version"); err == nil {
+			return
+		}
+		time.Sleep(time.Second)
+	}
+	t.Fatalf("inner docker daemon did not become ready within %s", timeout)
+}
+
+func TestLockedSwarm_SwitchSnapshotAndUnlock(t *testing.T) {
+	if _, err := exec.LookPath("docker"); err != nil {
+		t.Skip("docker not available; skipping locked-swarm integration test")
+	}
+
+	// Clean any leftovers from a prior aborted run, then ensure teardown.
+	_, _ = hostDocker(t, "rm", "-f", containerName)
+	_ = exec.Command("docker", "context", "rm", "-f", lockedContext).Run()
+	t.Cleanup(func() {
+		docker.ResetClient()
+		// The context must not be current when we remove it.
+		_ = exec.Command("docker", "context", "use", "default").Run()
+		_ = exec.Command("docker", "context", "rm", "-f", lockedContext).Run()
+		_, _ = hostDocker(t, "rm", "-f", containerName)
+	})
+
+	// 1. Start a throwaway single-node dind daemon with plain-TCP on 2375.
+	if out, err := hostDocker(t, "run", "-d", "--privileged",
+		"-e", "DOCKER_TLS_CERTDIR=",
+		"-p", dindHostPort+":2375",
+		"--name", containerName, dindImage); err != nil {
+		t.Fatalf("starting dind: %v\n%s", err, out)
+	}
+	waitInnerReady(t, 60*time.Second)
+
+	// 2. Init a swarm and turn on autolock, then capture the unlock key.
+	if out, err := inner(t, "swarm", "init", "--advertise-addr", "eth0"); err != nil {
+		t.Fatalf("swarm init: %v\n%s", err, out)
+	}
+	if out, err := inner(t, "swarm", "update", "--autolock=true"); err != nil {
+		t.Fatalf("enabling autolock: %v\n%s", err, out)
+	}
+	keyOut, err := inner(t, "swarm", "unlock-key", "-q")
+	if err != nil {
+		t.Fatalf("reading unlock key: %v\n%s", err, keyOut)
+	}
+	unlockKey := strings.TrimSpace(keyOut)
+	if !strings.HasPrefix(unlockKey, "SWMKEY-") {
+		t.Fatalf("unexpected unlock key %q", unlockKey)
+	}
+
+	// 3. Restart the daemon so it comes back LOCKED.
+	if out, err := hostDocker(t, "restart", containerName); err != nil {
+		t.Fatalf("restarting dind: %v\n%s", err, out)
+	}
+	waitInnerReady(t, 60*time.Second)
+
+	// 4. Point swarmcli's client at the locked daemon via a Docker context.
+	if out, err := hostDocker(t, "context", "create", lockedContext,
+		"--docker", "host="+contextHost); err != nil {
+		t.Fatalf("creating context: %v\n%s", err, out)
+	}
+	t.Setenv("DOCKER_CONTEXT", lockedContext)
+	docker.ResetClient()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// 5. Switching into a locked swarm must succeed (CLI parity).
+	if err := docker.ValidateContext(ctx, lockedContext); err != nil {
+		t.Fatalf("ValidateContext should allow a locked swarm, got: %v", err)
+	}
+
+	// 6. The snapshot must report Locked with no entities (no fatal error).
+	snap, err := docker.RefreshSnapshot()
+	if err != nil {
+		t.Fatalf("RefreshSnapshot on locked swarm returned error: %v", err)
+	}
+	if !snap.Locked {
+		t.Fatalf("expected snapshot.Locked=true on a locked swarm")
+	}
+	if len(snap.Nodes) != 0 {
+		t.Fatalf("expected no nodes while locked, got %d", len(snap.Nodes))
+	}
+
+	// 7. Unlocking with the captured key must succeed and clear the locked state.
+	if err := docker.UnlockSwarm(ctx, unlockKey); err != nil {
+		t.Fatalf("UnlockSwarm failed: %v", err)
+	}
+
+	// 8. After unlocking, the swarm becomes usable; the node list resolves.
+	var after *docker.SwarmSnapshot
+	deadline := time.Now().Add(20 * time.Second)
+	for {
+		docker.InvalidateSnapshot()
+		after, err = docker.RefreshSnapshot()
+		if err == nil && !after.Locked {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("swarm still locked after unlock (err=%v, locked=%v)", err, after != nil && after.Locked)
+		}
+		time.Sleep(time.Second)
+	}
+	if len(after.Nodes) < 1 {
+		t.Fatalf("expected at least one node after unlock, got %d", len(after.Nodes))
+	}
+}

--- a/views/unlockdialog/unlockdialog.go
+++ b/views/unlockdialog/unlockdialog.go
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+// Package unlockdialog provides an app-level modal for entering a Docker Swarm
+// unlock key. It is shown when the active context's swarm is locked.
+package unlockdialog
+
+import (
+	"strings"
+
+	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+// ResultMsg is emitted when the dialog is dismissed. Confirmed is true when the
+// user submitted a key with Enter; Key holds the entered (unmasked) value.
+type ResultMsg struct {
+	Confirmed bool
+	Key       string
+}
+
+type Model struct {
+	Visible bool
+	Width   int
+	Height  int
+	input   textinput.Model
+}
+
+func New(width, height int) *Model {
+	in := textinput.New()
+	in.Placeholder = "SWMKEY-1-..."
+	in.Prompt = "Key: "
+	in.EchoMode = textinput.EchoPassword
+	in.CharLimit = 256
+	in.Width = 50
+	return &Model{Width: width, Height: height, input: in}
+}
+
+func (m *Model) Init() tea.Cmd { return textinput.Blink }
+
+func (m *Model) Update(msg tea.Msg) tea.Cmd {
+	if !m.Visible {
+		return nil
+	}
+	if key, ok := msg.(tea.KeyMsg); ok {
+		switch key.String() {
+		case "enter":
+			m.Visible = false
+			val := m.input.Value()
+			return func() tea.Msg { return ResultMsg{Confirmed: true, Key: val} }
+		case "esc":
+			m.Visible = false
+			return func() tea.Msg { return ResultMsg{Confirmed: false} }
+		}
+	}
+	var cmd tea.Cmd
+	m.input, cmd = m.input.Update(msg)
+	return cmd
+}
+
+func (m *Model) View() string {
+	if !m.Visible {
+		return ""
+	}
+
+	contentWidth := 65
+
+	titleStyle := lipgloss.NewStyle().
+		Bold(true).
+		Foreground(lipgloss.Color("15")).
+		Background(lipgloss.Color("63")).
+		Padding(0, 1).
+		Width(contentWidth)
+
+	messageStyle := lipgloss.NewStyle().
+		Padding(1, 2).
+		Width(contentWidth)
+
+	inputStyle := lipgloss.NewStyle().
+		Padding(0, 2).
+		Width(contentWidth)
+
+	helpStyle := lipgloss.NewStyle().
+		Foreground(lipgloss.Color("240")).
+		Padding(1, 2, 0, 2).
+		Width(contentWidth)
+
+	keyStyle := lipgloss.NewStyle().
+		Foreground(lipgloss.Color("63")).
+		Bold(true)
+
+	borderStyle := lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(lipgloss.Color("63")).
+		Width(contentWidth + 2)
+
+	var lines []string
+	lines = append(lines, titleStyle.Render(" Unlock Swarm "))
+	lines = append(lines, messageStyle.Render("Enter the swarm unlock key to decrypt this cluster."))
+	lines = append(lines, inputStyle.Render(m.input.View()))
+
+	helpText := keyStyle.Render("<Enter>") + " Unlock • " + keyStyle.Render("<Esc>") + " Cancel"
+	lines = append(lines, helpStyle.Render(helpText))
+
+	return borderStyle.Render(strings.Join(lines, "\n"))
+}
+
+// Show makes the dialog visible with a cleared, focused input.
+func (m *Model) Show() *Model {
+	m.input.SetValue("")
+	m.input.Focus()
+	m.Visible = true
+	return m
+}
+
+// Hide makes the dialog invisible and blurs the input.
+func (m *Model) Hide() *Model {
+	m.input.Blur()
+	m.Visible = false
+	return m
+}

--- a/views/unlockdialog/unlockdialog_test.go
+++ b/views/unlockdialog/unlockdialog_test.go
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package unlockdialog
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/stretchr/testify/require"
+)
+
+func key(s string) tea.KeyMsg {
+	switch s {
+	case "enter":
+		return tea.KeyMsg{Type: tea.KeyEnter}
+	case "esc":
+		return tea.KeyMsg{Type: tea.KeyEsc}
+	}
+	return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(s)}
+}
+
+func runCmd(cmd tea.Cmd) tea.Msg {
+	if cmd == nil {
+		return nil
+	}
+	return cmd()
+}
+
+func typeRunes(m *Model, s string) {
+	for _, r := range s {
+		m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+	}
+}
+
+func TestNew(t *testing.T) {
+	m := New(80, 24)
+	require.Equal(t, 80, m.Width)
+	require.Equal(t, 24, m.Height)
+	require.False(t, m.Visible)
+}
+
+func TestShowHide(t *testing.T) {
+	m := New(80, 24)
+	m.Show()
+	require.True(t, m.Visible)
+	m.Hide()
+	require.False(t, m.Visible)
+}
+
+func TestShow_ClearsPreviousValue(t *testing.T) {
+	m := New(80, 24)
+	m.Show()
+	typeRunes(m, "stale")
+	cmd := m.Update(key("esc"))
+	_ = runCmd(cmd)
+	m.Show()
+	cmd = m.Update(key("enter"))
+	msg := runCmd(cmd).(ResultMsg)
+	require.Equal(t, "", msg.Key)
+}
+
+func TestEnter_ConfirmsWithKey(t *testing.T) {
+	m := New(80, 24)
+	m.Show()
+	typeRunes(m, "SWMKEY-1-abc")
+	cmd := m.Update(key("enter"))
+	require.False(t, m.Visible)
+	msg := runCmd(cmd).(ResultMsg)
+	require.True(t, msg.Confirmed)
+	require.Equal(t, "SWMKEY-1-abc", msg.Key)
+}
+
+func TestEsc_Cancels(t *testing.T) {
+	m := New(80, 24)
+	m.Show()
+	cmd := m.Update(key("esc"))
+	require.False(t, m.Visible)
+	msg := runCmd(cmd).(ResultMsg)
+	require.False(t, msg.Confirmed)
+}
+
+func TestNotVisible_IgnoresKeys(t *testing.T) {
+	m := New(80, 24)
+	require.Nil(t, m.Update(key("enter")))
+}
+
+func TestView_NotVisible_Empty(t *testing.T) {
+	require.Equal(t, "", New(80, 24).View())
+}
+
+func TestView_MasksKeyAndShowsTitle(t *testing.T) {
+	m := New(80, 24)
+	m.Show()
+	typeRunes(m, "SECRETKEY")
+	out := m.View()
+	require.Contains(t, out, "Unlock Swarm")
+	require.NotContains(t, out, "SECRETKEY")
+}

--- a/views/view/navigation.go
+++ b/views/view/navigation.go
@@ -22,3 +22,6 @@ type AppErrorMsg struct {
 
 // GoBackMsg requests the app to pop the current view and return to the previous one.
 type GoBackMsg struct{}
+
+// OpenUnlockDialogMsg requests the app to open the swarm unlock-key dialog.
+type OpenUnlockDialogMsg struct{}


### PR DESCRIPTION
## Problem
Resolves #421 ("Swarm is locked"; migrated to CE from Eldara-Tech/swarmcli-be#177). When a context's Swarm is locked (autolock), swarmcli refused to switch into it, even though `docker context use` works from the CLI.

A locked swarm is **reachable** — `/_ping` and `/info` succeed and `docker info` reports `LocalNodeState == "locked"` — but every store-backed call (`node ls`, `service ls`, `stack ls`, …) fails with *"Swarm is encrypted and needs to be unlocked"*. Two places treated that as fatal and reverted the switch:

- `ValidateContext` rejected any state `!= active`.
- `RefreshSnapshot` returned an error on `NodeList`; `app` then reverted to the previous context.

The fix lives in CE; BE consumes it via `replace swarmcli => ../swarmcli` and doesn't override these ops, so it flows to BE on rebuild.

## Changes
- `docker/swarm_lock.go` (new): `IsSwarmLockedErr`, `isUsableSwarmState`, `UnlockSwarm` (wraps `cli.SwarmUnlock`).
- `ValidateContext` accepts the locked state and tolerates a locked `Info` error → the switch succeeds (CLI parity).
- `SwarmSnapshot.Locked` flag; `RefreshSnapshot` returns an empty flagged snapshot instead of erroring → no revert.
- New `views/unlockdialog/` (password-masked text input) + `:unlock` command → calls `SwarmUnlock`, then invalidates and reloads.
- App shows a **neutral info** notice when landing on a locked swarm, explaining `:unlock` / `docker swarm unlock`.
- Unified startup / context-switch / post-unlock snapshot loading through one `snapshotLoadedMsg` path (removed the duplicate `loadSnapshotAndNavigateToStacksCmd`).

## Testing
- `go build`/`go vet` clean; `go test ./...` passes (new `docker/swarm_lock_test.go`, `views/unlockdialog/unlockdialog_test.go`).
- `golangci-lint run ./... --build-tags=integration` → 0 issues.
- `swarmcli-be` builds against the patched CE.
- The locked branches of `ValidateContext`/`RefreshSnapshot` need a live daemon — verify manually: autolock a test swarm, switch in (lands on stacks with the info notice, no revert), `:unlock` with the key (resources reload), wrong key → clear error + retry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)