### PR TITLE
fix(logs): align node-selector overlay over special-char log lines

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/charmbracelet/bubbles v1.0.0
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0
+	github.com/charmbracelet/x/ansi v0.11.6
 	github.com/docker/docker v28.5.2+incompatible
 	github.com/mitchellh/hashstructure/v2 v2.0.2
 	github.com/muesli/reflow v0.3.0
@@ -25,7 +26,6 @@ require (
 	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/charmbracelet/colorprofile v0.4.1 // indirect
-	github.com/charmbracelet/x/ansi v0.11.6 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.15 // indirect
 	github.com/charmbracelet/x/term v0.2.2 // indirect
 	github.com/clipperhouse/displaywidth v0.9.0 // indirect

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
 )
 
 // Styles (you can override these per-view if desired)
@@ -418,6 +419,12 @@ func OverlayCentered(base, overlay string, width, height int) string {
 		} else {
 			// Overlay dialog in the middle using width-aware truncation
 			leftPart := TruncateANSI(baseLine, startCol)
+			// A wide grapheme straddling startCol leaves leftPart one cell
+			// short; pad so the dialog's left border is column-aligned on
+			// every row (otherwise borders jitter on wide-char lines).
+			if pad := startCol - lipgloss.Width(leftPart); pad > 0 {
+				leftPart += strings.Repeat(" ", pad)
+			}
 			rightStart := startCol + dialogWidth
 			rightPart := ""
 			if rightStart < baseWidth {
@@ -436,71 +443,22 @@ func OverlayCentered(base, overlay string, width, height int) string {
 	return strings.Join(baseLines, "\n")
 }
 
-// TruncateANSI truncates a string with ANSI codes to a specific visual width.
+// TruncateANSI truncates a string with ANSI codes to a specific visual (cell)
+// width. It is grapheme/display-width aware (wide East-Asian chars and emoji
+// count as 2 cells) and never splits an escape sequence.
 func TruncateANSI(s string, width int) string {
 	if width <= 0 {
 		return ""
 	}
-	var result strings.Builder
-	var currentWidth int
-	inEscape := false
-
-	for _, r := range s {
-		if r == '\x1b' {
-			inEscape = true
-		}
-
-		if inEscape {
-			result.WriteRune(r)
-			if r == 'm' {
-				inEscape = false
-			}
-			continue
-		}
-
-		if currentWidth >= width {
-			break
-		}
-
-		result.WriteRune(r)
-		currentWidth++
-	}
-
-	return result.String()
+	return ansi.Truncate(s, width, "")
 }
 
-// TruncateANSIAfter skips characters up to a visual width and returns the rest.
+// TruncateANSIAfter skips skipWidth visual cells and returns the rest,
+// re-emitting the active SGR state at the cut so colors survive. It is
+// grapheme/display-width aware and never splits an escape sequence.
 func TruncateANSIAfter(s string, skipWidth int) string {
 	if skipWidth <= 0 {
 		return s
 	}
-	var result strings.Builder
-	var currentWidth int
-	inEscape := false
-	var escapeBuffer strings.Builder
-
-	for _, r := range s {
-		if r == '\x1b' {
-			inEscape = true
-			escapeBuffer.Reset()
-		}
-
-		if inEscape {
-			escapeBuffer.WriteRune(r)
-			if r == 'm' {
-				inEscape = false
-				if currentWidth >= skipWidth {
-					result.WriteString(escapeBuffer.String())
-				}
-			}
-			continue
-		}
-
-		if currentWidth >= skipWidth {
-			result.WriteRune(r)
-		}
-		currentWidth++
-	}
-
-	return result.String()
+	return ansi.TruncateLeft(s, skipWidth, "")
 }

--- a/ui/ui_test.go
+++ b/ui/ui_test.go
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTruncateANSI_WidthAware(t *testing.T) {
+	tests := []struct {
+		name  string
+		in    string
+		width int
+	}{
+		{"ascii", "hello world", 5},
+		{"sgr colored", "\x1b[31mhello\x1b[0m world", 4},
+		{"wide cjk", "你好世界ab", 3},
+		{"emoji", "ab😀cd", 3},
+		{"over budget", "hi", 10},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := TruncateANSI(tc.in, tc.width)
+			// Never exceeds the requested cell width (lipgloss == x/ansi width model).
+			require.LessOrEqual(t, lipgloss.Width(got), tc.width)
+			// Never emits a dangling escape introducer.
+			require.False(t, strings.HasSuffix(got, "\x1b"))
+		})
+	}
+	require.Equal(t, "", TruncateANSI("anything", 0))
+}
+
+func TestTruncateANSIAfter_WidthAware(t *testing.T) {
+	// Skipping N non-straddling cells leaves width-N cells behind.
+	require.Equal(t, 6, lipgloss.Width(TruncateANSIAfter("hello world", 5))) // " world"
+	require.Equal(t, 4, lipgloss.Width(TruncateANSIAfter("你好世界", 4)))        // 4 wide = 8 cells, skip 4 -> 4 cells
+	require.Equal(t, "hello", TruncateANSIAfter("hello", 0))                 // skip<=0 returns input
+	// Skipping past content yields nothing.
+	require.Equal(t, "", TruncateANSIAfter("hi", 10))
+}
+
+// Regression for issue #369: the centered overlay must keep its left border on
+// the same display column for every row, even when the background log lines
+// contain wide characters at differing positions. The old rune-counting
+// truncation cut at the wrong display column per row, so the box zig-zagged and
+// background text bled through.
+func TestOverlayCentered_AlignsWithWideChars(t *testing.T) {
+	const w = 40
+	// Two backgrounds of equal display width (40) but different rune layouts:
+	// one front-loads wide CJK chars, the other is plain ASCII. Rune-counting
+	// truncation diverges between them; cell-aware truncation does not.
+	wideRow := "你你你你你" + strings.Repeat(" ", w-10) // 5 wide = 10 cells + 30 spaces
+	asciiRow := strings.Repeat("x", 10) + strings.Repeat(" ", w-10)
+	require.Equal(t, w, lipgloss.Width(wideRow))
+	require.Equal(t, w, lipgloss.Width(asciiRow))
+
+	var base []string
+	for i := 0; i < 11; i++ {
+		if i%2 == 0 {
+			base = append(base, wideRow)
+		} else {
+			base = append(base, asciiRow)
+		}
+	}
+
+	overlay := lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		Width(18).
+		Render("Select Node to Filter\nnode-1\nnode-2")
+
+	out := OverlayCentered(strings.Join(base, "\n"), overlay, w, 0)
+
+	// The left vertical border '│' must sit at one constant display column.
+	var leftCols []int
+	for _, line := range strings.Split(out, "\n") {
+		if idx := strings.Index(line, "│"); idx >= 0 {
+			leftCols = append(leftCols, lipgloss.Width(line[:idx]))
+		}
+	}
+	require.GreaterOrEqual(t, len(leftCols), 2, "overlay border rows should be present")
+	for _, c := range leftCols[1:] {
+		require.Equal(t, leftCols[0], c, "dialog left border must be column-aligned on every row")
+	}
+}


### PR DESCRIPTION
## Problem

Fixes #369. While tailing logs, opening the **Select Node to Filter** overlay rendered a broken box — zig-zag borders with background log text bleeding through — but only when a log line behind the overlay contained a "special character" (wide CJK/emoji or an embedded escape sequence).

## Root cause

`ui.OverlayCentered` positioned the dialog using `lipgloss.Width` (grapheme/cell-width and full-ANSI aware) but *sliced* the background lines with the hand-rolled `TruncateANSI`/`TruncateANSIAfter`, which counted every rune as 1 cell and only recognised SGR escapes ending in `m`. On lines with wide chars or non-SGR escapes the two width models disagreed, so each dialog row spliced at a different column.

## Fix

- Reimplement `TruncateANSI`/`TruncateANSIAfter` over `charmbracelet/x/ansi` (`ansi.Truncate`/`ansi.TruncateLeft`) — the same engine `lipgloss.Width` uses — so slicing and measuring share one cell-width model. Signatures unchanged; no call-site changes. This also fixes the logs horizontal-scroll path that shares these helpers.
- Pad the overlay's left part to the start column so the box stays aligned when a wide grapheme straddles the cut.
- Promote `x/ansi` to a direct dependency (`go mod tidy`).
- Add the previously-missing unit tests for both helpers plus a #369 regression test for `OverlayCentered`.

## Verification

- `go build`, `go test ./...`, `golangci-lint run ./...` all pass.
- The regression test fails against the pre-fix code (dialog border lands at column 10 on some rows, 15 on others — the exact bug) and passes after the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)