### PR TITLE
feat(charts): release upgrade/rollback/history/diff/get — Phase 2

### DIFF
--- a/charts/README.md
+++ b/charts/README.md
@@ -10,10 +10,10 @@ A Helm-inspired package manager for Docker Swarm. Charts package Docker Stack
 produces a **release** — a Docker stack whose revision history is stored in
 Docker Configs.
 
-This is **Phase 1 (MVP)** of [issue #413]: repository management, discovery,
-templating, and the install/uninstall/list/status release lifecycle. Upgrade,
-history, rollback, diff, and chart-dev tooling (create/lint/dependency) follow
-in later phases.
+Implemented so far ([issue #413]): repository management, discovery, templating,
+and the full release lifecycle — install, upgrade, rollback, uninstall, list,
+status, history, diff, and get. Chart-dev tooling (`create`, `lint`,
+`dependency`) and subchart resolution are the remaining phase.
 
 ## Invocation
 
@@ -29,6 +29,10 @@ swarmcli charts show values eldara/traefik > values.yaml
 swarmcli charts template my-traefik eldara/traefik -f values.yaml
 swarmcli charts install  my-traefik eldara/traefik -f values.yaml
 swarmcli charts status   my-traefik
+swarmcli charts diff upgrade my-traefik eldara/traefik --set replicas=3
+swarmcli charts upgrade  my-traefik eldara/traefik --set replicas=3
+swarmcli charts history  my-traefik
+swarmcli charts rollback my-traefik 1
 swarmcli charts list
 swarmcli charts uninstall my-traefik
 ```

--- a/charts/release.go
+++ b/charts/release.go
@@ -67,10 +67,11 @@ func NewEngineWith(b Backend) *Engine {
 	return &Engine{Backend: b, now: time.Now}
 }
 
-// InstallOptions tune an install.
+// InstallOptions tune an install or upgrade.
 type InstallOptions struct {
 	DryRun     bool
 	Wait       bool
+	Install    bool // upgrade: create the release if it does not exist
 	Timeout    time.Duration
 	HistoryMax int // 0 = keep all
 }
@@ -90,9 +91,97 @@ func (e *Engine) Install(ctx context.Context, release string, chart ReleaseChart
 		return nil, fmt.Errorf("release %q already exists (revision %d); use upgrade", release, cur.Revision)
 	}
 
-	rel := &Release{
+	rel := e.newRevision(release, nextRevision(revs), chart, values, manifest)
+	return e.deployAndRecord(ctx, rel, opts)
+}
+
+// Upgrade deploys a new revision of an existing release. When the release does
+// not exist it errors unless opts.Install is set (the `upgrade --install`
+// behavior). manifest must already be rendered and validated.
+func (e *Engine) Upgrade(ctx context.Context, release string, chart ReleaseChart, values map[string]any, manifest string, opts InstallOptions) (*Release, error) {
+	if err := validateReleaseName(release); err != nil {
+		return nil, err
+	}
+	revs, err := e.revisions(ctx, release)
+	if err != nil {
+		return nil, err
+	}
+	cur := currentRevision(revs)
+	if cur == nil || cur.Status == StatusUninstalled {
+		if !opts.Install {
+			return nil, fmt.Errorf("release %q does not exist; use install or upgrade --install", release)
+		}
+	}
+	rel := e.newRevision(release, nextRevision(revs), chart, values, manifest)
+	return e.deployAndRecord(ctx, rel, opts)
+}
+
+// Rollback deploys a new revision whose content is copied from a previous
+// revision (append-only, mirroring Helm). targetRev must be an existing,
+// non-failed revision.
+func (e *Engine) Rollback(ctx context.Context, release string, targetRev int, opts InstallOptions) (*Release, error) {
+	revs, err := e.revisions(ctx, release)
+	if err != nil {
+		return nil, err
+	}
+	if len(revs) == 0 {
+		return nil, fmt.Errorf("release %q not found", release)
+	}
+	var target *Release
+	for i := range revs {
+		if revs[i].Revision == targetRev {
+			target = &revs[i]
+		}
+	}
+	if target == nil {
+		return nil, fmt.Errorf("release %q has no revision %d", release, targetRev)
+	}
+	if target.Status == StatusFailed {
+		return nil, fmt.Errorf("cannot roll back to failed revision %d", targetRev)
+	}
+	rel := e.newRevision(release, nextRevision(revs), target.Chart, target.Values, target.Manifest)
+	return e.deployAndRecord(ctx, rel, opts)
+}
+
+// History returns every stored revision of a release, ascending, with derived
+// display statuses.
+func (e *Engine) History(ctx context.Context, release string) ([]Release, error) {
+	revs, err := e.revisions(ctx, release)
+	if err != nil {
+		return nil, err
+	}
+	if len(revs) == 0 {
+		return nil, fmt.Errorf("release %q not found", release)
+	}
+	return revs, nil
+}
+
+// GetRevision returns a specific revision of a release, or the current one when
+// rev <= 0.
+func (e *Engine) GetRevision(ctx context.Context, release string, rev int) (*Release, error) {
+	revs, err := e.revisions(ctx, release)
+	if err != nil {
+		return nil, err
+	}
+	if len(revs) == 0 {
+		return nil, fmt.Errorf("release %q not found", release)
+	}
+	if rev <= 0 {
+		return currentRevision(revs), nil
+	}
+	for i := range revs {
+		if revs[i].Revision == rev {
+			return &revs[i], nil
+		}
+	}
+	return nil, fmt.Errorf("release %q has no revision %d", release, rev)
+}
+
+// newRevision builds an unsaved, deployed-status revision.
+func (e *Engine) newRevision(release string, rev int, chart ReleaseChart, values map[string]any, manifest string) *Release {
+	return &Release{
 		Name:      release,
-		Revision:  nextRevision(revs),
+		Revision:  rev,
 		Status:    StatusDeployed,
 		Chart:     chart,
 		Values:    values,
@@ -100,14 +189,17 @@ func (e *Engine) Install(ctx context.Context, release string, chart ReleaseChart
 		Namespace: release,
 		Created:   e.now().UTC().Format(time.RFC3339),
 	}
+}
 
+// deployAndRecord deploys a revision's manifest and records it. On DryRun it
+// returns the prospective revision without touching Docker. On deploy failure
+// it records a failed revision for auditability.
+func (e *Engine) deployAndRecord(ctx context.Context, rel *Release, opts InstallOptions) (*Release, error) {
 	if opts.DryRun {
 		return rel, nil
 	}
-
-	if err := e.Backend.DeployStack(release, manifest); err != nil {
+	if err := e.Backend.DeployStack(rel.Name, rel.Manifest); err != nil {
 		rel.Status = StatusFailed
-		// Best-effort: record the failed revision for auditability.
 		_ = e.record(ctx, rel)
 		return rel, fmt.Errorf("deploy failed: %w", err)
 	}
@@ -115,12 +207,12 @@ func (e *Engine) Install(ctx context.Context, release string, chart ReleaseChart
 		return rel, fmt.Errorf("deployed, but recording release failed: %w", err)
 	}
 	if opts.Wait {
-		if err := e.waitReady(release, opts.Timeout); err != nil {
+		if err := e.waitReady(rel.Name, opts.Timeout); err != nil {
 			return rel, err
 		}
 	}
 	if opts.HistoryMax > 0 {
-		e.pruneHistory(ctx, release, opts.HistoryMax)
+		e.pruneHistory(ctx, rel.Name, opts.HistoryMax)
 	}
 	return rel, nil
 }

--- a/charts/upgrade_test.go
+++ b/charts/upgrade_test.go
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package charts
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func mustInstall(t *testing.T, e *Engine, rel, manifest string) {
+	t.Helper()
+	_, err := e.Install(context.Background(), rel, ReleaseChart{Name: "c", Version: "1"}, map[string]any{"v": 1}, manifest, InstallOptions{})
+	require.NoError(t, err)
+}
+
+func TestUpgradeAddsRevisionAndSupersedes(t *testing.T) {
+	fb := newFakeBackend()
+	e := testEngine(fb)
+	ctx := context.Background()
+	mustInstall(t, e, "demo", "services:\n  s:\n    image: a\n")
+
+	rel, err := e.Upgrade(ctx, "demo", ReleaseChart{Name: "c", Version: "2"}, map[string]any{"v": 2}, "services:\n  s:\n    image: b\n", InstallOptions{})
+	require.NoError(t, err)
+	require.Equal(t, 2, rel.Revision)
+	require.Equal(t, "services:\n  s:\n    image: b\n", fb.deployed["demo"])
+
+	hist, err := e.History(ctx, "demo")
+	require.NoError(t, err)
+	require.Len(t, hist, 2)
+	require.Equal(t, StatusSuperseded, hist[0].Status) // rev1 derived superseded
+	require.Equal(t, StatusDeployed, hist[1].Status)
+}
+
+func TestUpgradeMissingReleaseRequiresInstallFlag(t *testing.T) {
+	e := testEngine(newFakeBackend())
+	ctx := context.Background()
+	_, err := e.Upgrade(ctx, "nope", ReleaseChart{Name: "c", Version: "1"}, nil, "services:\n  s:\n    image: a\n", InstallOptions{})
+	require.Error(t, err)
+
+	rel, err := e.Upgrade(ctx, "nope", ReleaseChart{Name: "c", Version: "1"}, nil, "services:\n  s:\n    image: a\n", InstallOptions{Install: true})
+	require.NoError(t, err)
+	require.Equal(t, 1, rel.Revision)
+}
+
+func TestRollbackCopiesTargetRevision(t *testing.T) {
+	fb := newFakeBackend()
+	e := testEngine(fb)
+	ctx := context.Background()
+	mustInstall(t, e, "demo", "services:\n  s:\n    image: v1\n")
+	_, err := e.Upgrade(ctx, "demo", ReleaseChart{Name: "c", Version: "2"}, map[string]any{"v": 2}, "services:\n  s:\n    image: v2\n", InstallOptions{})
+	require.NoError(t, err)
+
+	rb, err := e.Rollback(ctx, "demo", 1, InstallOptions{})
+	require.NoError(t, err)
+	require.Equal(t, 3, rb.Revision)                                  // append-only
+	require.Equal(t, "services:\n  s:\n    image: v1\n", rb.Manifest) // content from rev1
+	require.Equal(t, "services:\n  s:\n    image: v1\n", fb.deployed["demo"])
+
+	cur, _, err := e.Status(ctx, "demo")
+	require.NoError(t, err)
+	require.Equal(t, 3, cur.Revision)
+}
+
+func TestRollbackUnknownRevision(t *testing.T) {
+	e := testEngine(newFakeBackend())
+	ctx := context.Background()
+	mustInstall(t, e, "demo", "services:\n  s:\n    image: v1\n")
+	_, err := e.Rollback(ctx, "demo", 9, InstallOptions{})
+	require.Error(t, err)
+}
+
+func TestGetRevision(t *testing.T) {
+	fb := newFakeBackend()
+	e := testEngine(fb)
+	ctx := context.Background()
+	mustInstall(t, e, "demo", "services:\n  s:\n    image: v1\n")
+	_, err := e.Upgrade(ctx, "demo", ReleaseChart{Name: "c", Version: "2"}, map[string]any{"v": 2}, "services:\n  s:\n    image: v2\n", InstallOptions{})
+	require.NoError(t, err)
+
+	cur, err := e.GetRevision(ctx, "demo", 0)
+	require.NoError(t, err)
+	require.Equal(t, 2, cur.Revision)
+
+	r1, err := e.GetRevision(ctx, "demo", 1)
+	require.NoError(t, err)
+	require.Contains(t, r1.Manifest, "v1")
+}
+
+func TestHistoryMaxPrunes(t *testing.T) {
+	fb := newFakeBackend()
+	e := testEngine(fb)
+	ctx := context.Background()
+	_, err := e.Install(ctx, "demo", ReleaseChart{Name: "c", Version: "1"}, nil, "services:\n  s:\n    image: v1\n", InstallOptions{HistoryMax: 2})
+	require.NoError(t, err)
+	for i := 2; i <= 4; i++ {
+		_, err := e.Upgrade(ctx, "demo", ReleaseChart{Name: "c", Version: "x"}, nil, "services:\n  s:\n    image: v\n", InstallOptions{HistoryMax: 2})
+		require.NoError(t, err)
+	}
+	hist, err := e.History(ctx, "demo")
+	require.NoError(t, err)
+	require.Len(t, hist, 2) // only the 2 most recent retained
+	require.Equal(t, 3, hist[0].Revision)
+	require.Equal(t, 4, hist[1].Revision)
+}

--- a/cli/args.go
+++ b/cli/args.go
@@ -12,16 +12,18 @@ import (
 // flags holds the parsed flag values shared across charts subcommands. Not
 // every subcommand reads every field.
 type flags struct {
-	values     []string // -f/--values, repeatable
-	sets       []string // --set, repeatable
-	version    string   // --version, chart version selector
-	dryRun     bool
-	wait       bool
-	debug      bool
-	purge      bool          // --purge-volumes
-	install    bool          // --install (upgrade, Phase 2)
-	timeout    time.Duration // --timeout
-	historyMax int           // --history-max
+	values      []string // -f/--values, repeatable
+	sets        []string // --set, repeatable
+	version     string   // --version, chart version selector
+	dryRun      bool
+	wait        bool
+	debug       bool
+	purge       bool          // --purge-volumes
+	install     bool          // --install (upgrade)
+	reuseValues bool          // --reuse-values (upgrade)
+	revision    int           // --revision (get)
+	timeout     time.Duration // --timeout
+	historyMax  int           // --history-max
 }
 
 // parseArgs splits raw args into positionals and flags. It understands the
@@ -93,6 +95,18 @@ func parseArgs(args []string) ([]string, flags, error) {
 				return nil, f, fmt.Errorf("invalid --history-max %q: %w", v, err)
 			}
 			f.historyMax = n
+		case "--revision":
+			v, err := next()
+			if err != nil {
+				return nil, f, err
+			}
+			n, err := parseInt(v)
+			if err != nil {
+				return nil, f, fmt.Errorf("invalid --revision %q: %w", v, err)
+			}
+			f.revision = n
+		case "--reuse-values":
+			f.reuseValues = true
 		case "--dry-run":
 			f.dryRun = true
 		case "--wait":

--- a/cli/charts.go
+++ b/cli/charts.go
@@ -32,7 +32,12 @@ Discovery:
 Releases:
   template <release> <chart>  Render manifest to stdout (no deploy)
   install  <release> <chart>  Install a chart as a release
+  upgrade  <release> <chart>  Upgrade a release to a new revision
   uninstall <release>         Remove a release (keeps volumes)
+  rollback <release> <rev>    Re-deploy the contents of a past revision
+  history <release>           Show a release's revision history
+  get values|manifest <rel>   Show stored values or rendered manifest
+  diff upgrade <rel> <chart>  Preview manifest changes before upgrading
   list                        List releases
   status <release>            Show release status and services
 
@@ -44,6 +49,9 @@ Common options:
       --wait            Wait for services to converge
       --timeout <dur>   Wait timeout, e.g. 10m (default 5m)
       --history-max <n> Max release revisions to retain
+      --install         upgrade: install the release if absent
+      --reuse-values    upgrade/diff: layer overrides on previous values
+      --revision <n>    get: select a specific revision
       --purge-volumes   uninstall: also remove the release's volumes
 `
 
@@ -68,8 +76,18 @@ func chartsMain(args []string) int {
 		return chartsTemplate(rest)
 	case "install":
 		return chartsInstall(rest)
+	case "upgrade":
+		return chartsUpgrade(rest)
 	case "uninstall":
 		return chartsUninstall(rest)
+	case "rollback":
+		return chartsRollback(rest)
+	case "history":
+		return chartsHistory(rest)
+	case "get":
+		return chartsGet(rest)
+	case "diff":
+		return chartsDiff(rest)
 	case "list", "ls":
 		return chartsList(rest)
 	case "status":
@@ -252,7 +270,7 @@ func chartsTemplate(args []string) int {
 		return usageErr("charts template <release> <repo/chart>")
 	}
 	release, ref := pos[0], pos[1]
-	manifest, _, _, code := prepare(release, ref, f)
+	manifest, _, _, code := prepare(release, ref, f, nil)
 	if code >= 0 {
 		return code
 	}
@@ -269,12 +287,11 @@ func chartsInstall(args []string) int {
 		return usageErr("charts install <release> <repo/chart>")
 	}
 	release, ref := pos[0], pos[1]
-	manifest, values, rc, code := prepare(release, ref, f)
+	manifest, values, rc, code := prepare(release, ref, f, nil)
 	if code >= 0 {
 		return code
 	}
-	eng := charts.NewEngine()
-	rel, err := eng.Install(context.Background(), release, rc, values, manifest, charts.InstallOptions{
+	rel, err := charts.NewEngine().Install(context.Background(), release, rc, values, manifest, charts.InstallOptions{
 		DryRun:     f.dryRun,
 		Wait:       f.wait,
 		Timeout:    f.timeout,
@@ -283,7 +300,46 @@ func chartsInstall(args []string) int {
 	if err != nil {
 		return fail(err)
 	}
-	if f.dryRun {
+	return reportRelease(rel, manifest, f.dryRun)
+}
+
+func chartsUpgrade(args []string) int {
+	pos, f, err := parseArgs(args)
+	if err != nil {
+		return usageErr(err.Error())
+	}
+	if len(pos) != 2 {
+		return usageErr("charts upgrade <release> <repo/chart>")
+	}
+	release, ref := pos[0], pos[1]
+
+	var base map[string]any
+	if f.reuseValues {
+		cur, err := charts.NewEngine().GetRevision(context.Background(), release, 0)
+		if err != nil {
+			return fail(err)
+		}
+		base = cur.Values
+	}
+	manifest, values, rc, code := prepare(release, ref, f, base)
+	if code >= 0 {
+		return code
+	}
+	rel, err := charts.NewEngine().Upgrade(context.Background(), release, rc, values, manifest, charts.InstallOptions{
+		DryRun:     f.dryRun,
+		Wait:       f.wait,
+		Install:    f.install,
+		Timeout:    f.timeout,
+		HistoryMax: f.historyMax,
+	})
+	if err != nil {
+		return fail(err)
+	}
+	return reportRelease(rel, manifest, f.dryRun)
+}
+
+func reportRelease(rel *charts.Release, manifest string, dryRun bool) int {
+	if dryRun {
 		outf("NAME: %s\nREVISION: %d\nSTATUS: %s (dry-run, not deployed)\n\n", rel.Name, rel.Revision, rel.Status)
 		outln(manifest)
 		return 0
@@ -292,17 +348,128 @@ func chartsInstall(args []string) int {
 	return 0
 }
 
+func chartsRollback(args []string) int {
+	pos, f, err := parseArgs(args)
+	if err != nil {
+		return usageErr(err.Error())
+	}
+	if len(pos) != 2 {
+		return usageErr("charts rollback <release> <revision>")
+	}
+	rev, err := parseInt(pos[1])
+	if err != nil {
+		return usageErr(fmt.Sprintf("invalid revision %q", pos[1]))
+	}
+	rel, err := charts.NewEngine().Rollback(context.Background(), pos[0], rev, charts.InstallOptions{
+		Wait: f.wait, Timeout: f.timeout, HistoryMax: f.historyMax,
+	})
+	if err != nil {
+		return fail(err)
+	}
+	outf("Rolled back %s to the contents of revision %d (new revision %d)\n", rel.Name, rev, rel.Revision)
+	return 0
+}
+
+func chartsHistory(args []string) int {
+	pos, _, err := parseArgs(args)
+	if err != nil {
+		return usageErr(err.Error())
+	}
+	if len(pos) != 1 {
+		return usageErr("charts history <release>")
+	}
+	hist, err := charts.NewEngine().History(context.Background(), pos[0])
+	if err != nil {
+		return fail(err)
+	}
+	rows := make([][]string, 0, len(hist))
+	for _, r := range hist {
+		rows = append(rows, []string{strconv.Itoa(r.Revision), r.Status, r.Chart.Name + "-" + r.Chart.Version, r.Created})
+	}
+	table([]string{"REVISION", "STATUS", "CHART", "UPDATED"}, rows)
+	return 0
+}
+
+func chartsGet(args []string) int {
+	if len(args) < 2 {
+		return usageErr("charts get <values|manifest> <release> [--revision N]")
+	}
+	what, release := args[0], args[1]
+	_, f, err := parseArgs(args[2:])
+	if err != nil {
+		return usageErr(err.Error())
+	}
+	rel, err := charts.NewEngine().GetRevision(context.Background(), release, f.revision)
+	if err != nil {
+		return fail(err)
+	}
+	switch what {
+	case "values":
+		data, err := yaml.Marshal(rel.Values)
+		if err != nil {
+			return fail(err)
+		}
+		_, _ = stdout.Write(data)
+	case "manifest":
+		outln(rel.Manifest)
+	default:
+		return usageErr(fmt.Sprintf("unknown get target %q (want values|manifest)", what))
+	}
+	return 0
+}
+
+func chartsDiff(args []string) int {
+	if len(args) < 1 {
+		return usageErr("charts diff upgrade <release> <repo/chart>")
+	}
+	if args[0] != "upgrade" {
+		return usageErr(fmt.Sprintf("unknown diff target %q (want upgrade)", args[0]))
+	}
+	pos, f, err := parseArgs(args[1:])
+	if err != nil {
+		return usageErr(err.Error())
+	}
+	if len(pos) != 2 {
+		return usageErr("charts diff upgrade <release> <repo/chart>")
+	}
+	release, ref := pos[0], pos[1]
+
+	cur, err := charts.NewEngine().GetRevision(context.Background(), release, 0)
+	if err != nil {
+		return fail(err)
+	}
+	var base map[string]any
+	if f.reuseValues {
+		base = cur.Values
+	}
+	next, _, _, code := prepare(release, ref, f, base)
+	if code >= 0 {
+		return code
+	}
+	if cur.Manifest == next {
+		outln("No changes.")
+		return 0
+	}
+	out(lineDiff(cur.Manifest, next))
+	return 0
+}
+
 // prepare loads the chart, merges + validates values, and renders the manifest.
-func prepare(release, ref string, f flags) (manifest string, values map[string]any, rc charts.ReleaseChart, code int) {
+// base, when non-nil, replaces the chart defaults as the merge base (used by
+// `upgrade --reuse-values` to layer overrides over the previous release).
+func prepare(release, ref string, f flags, base map[string]any) (manifest string, values map[string]any, rc charts.ReleaseChart, code int) {
 	ch, _, c := loadChart(ref, f.version)
 	if c >= 0 {
 		return "", nil, rc, c
+	}
+	if base == nil {
+		base = ch.Values
 	}
 	files, err := readValuesFiles(f.values)
 	if err != nil {
 		return "", nil, rc, fail(err)
 	}
-	values, err = charts.MergeValues(ch.Values, files, f.sets)
+	values, err = charts.MergeValues(base, files, f.sets)
 	if err != nil {
 		return "", nil, rc, fail(err)
 	}

--- a/cli/diff.go
+++ b/cli/diff.go
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package cli
+
+import "strings"
+
+// lineDiff returns a compact line-oriented diff of a vs b using a longest
+// common subsequence. Removed lines are prefixed "-", added lines "+", and
+// unchanged lines " ". It is intended for human-readable upgrade previews, not
+// machine patching, so it omits hunk headers.
+func lineDiff(a, b string) string {
+	al := splitLines(a)
+	bl := splitLines(b)
+
+	// LCS length table.
+	lcs := make([][]int, len(al)+1)
+	for i := range lcs {
+		lcs[i] = make([]int, len(bl)+1)
+	}
+	for i := len(al) - 1; i >= 0; i-- {
+		for j := len(bl) - 1; j >= 0; j-- {
+			if al[i] == bl[j] {
+				lcs[i][j] = lcs[i+1][j+1] + 1
+			} else if lcs[i+1][j] >= lcs[i][j+1] {
+				lcs[i][j] = lcs[i+1][j]
+			} else {
+				lcs[i][j] = lcs[i][j+1]
+			}
+		}
+	}
+
+	var sb strings.Builder
+	i, j := 0, 0
+	for i < len(al) && j < len(bl) {
+		switch {
+		case al[i] == bl[j]:
+			sb.WriteString("  " + al[i] + "\n")
+			i++
+			j++
+		case lcs[i+1][j] >= lcs[i][j+1]:
+			sb.WriteString("- " + al[i] + "\n")
+			i++
+		default:
+			sb.WriteString("+ " + bl[j] + "\n")
+			j++
+		}
+	}
+	for ; i < len(al); i++ {
+		sb.WriteString("- " + al[i] + "\n")
+	}
+	for ; j < len(bl); j++ {
+		sb.WriteString("+ " + bl[j] + "\n")
+	}
+	return sb.String()
+}
+
+func splitLines(s string) []string {
+	s = strings.TrimRight(s, "\n")
+	if s == "" {
+		return nil
+	}
+	return strings.Split(s, "\n")
+}

--- a/cli/diff_test.go
+++ b/cli/diff_test.go
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package cli
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLineDiff(t *testing.T) {
+	a := "a\nb\nc\n"
+	b := "a\nB\nc\nd\n"
+	d := lineDiff(a, b)
+	lines := strings.Split(strings.TrimRight(d, "\n"), "\n")
+	require.Equal(t, "  a", lines[0])
+	require.Contains(t, d, "- b")
+	require.Contains(t, d, "+ B")
+	require.Contains(t, d, "+ d")
+}
+
+func TestLineDiffIdentical(t *testing.T) {
+	d := lineDiff("x\ny\n", "x\ny\n")
+	require.Equal(t, "  x\n  y\n", d)
+}
+
+func TestUpgradeFlagsParse(t *testing.T) {
+	_, f, err := parseArgs([]string{"rel", "repo/chart", "--install", "--reuse-values", "--revision", "3"})
+	require.NoError(t, err)
+	require.True(t, f.install)
+	require.True(t, f.reuseValues)
+	require.Equal(t, 3, f.revision)
+}

--- a/integration-tests/charts/charts_lifecycle_test.go
+++ b/integration-tests/charts/charts_lifecycle_test.go
@@ -99,6 +99,28 @@ func TestChartsReleaseLifecycle(t *testing.T) {
 	require.Equal(t, charts.StatusDeployed, cur.Status)
 	require.NotEmpty(t, svcs, "status should list services")
 
+	// Upgrade to revision 2 (scale to 1) then roll back to revision 1's content.
+	up, err := charts.MergeValues(ch.Values, nil, []string{"replicas=1"})
+	require.NoError(t, err)
+	upManifest, err := charts.Render(ch, charts.RenderContext{
+		Values:  up,
+		Release: charts.ReleaseMeta{Name: release, Namespace: release, Revision: 2},
+		Chart:   charts.ChartMeta{Name: ch.Metadata.Name, Version: ch.Metadata.Version},
+	})
+	require.NoError(t, err)
+	rel2, err := eng.Upgrade(ctx, release, charts.ReleaseChart{Name: ch.Metadata.Name, Version: ch.Metadata.Version},
+		up, upManifest, charts.InstallOptions{Wait: true, Timeout: 90 * time.Second})
+	require.NoError(t, err)
+	require.Equal(t, 2, rel2.Revision)
+
+	hist, err := eng.History(ctx, release)
+	require.NoError(t, err)
+	require.Len(t, hist, 2)
+
+	rb, err := eng.Rollback(ctx, release, 1, charts.InstallOptions{Wait: true, Timeout: 90 * time.Second})
+	require.NoError(t, err)
+	require.Equal(t, 3, rb.Revision)
+
 	// Uninstall removes the stack and the release Configs.
 	require.NoError(t, eng.Uninstall(ctx, release, true))
 	_, err = docker.InspectConfig(ctx, fmt.Sprintf("swarmcli.release.%s.v1", release))


### PR DESCRIPTION
## What

Phase 2 of **SwarmCLI Charts** (#413), completing the release lifecycle. **Stacked on #415** (base branch is `feat/413-charts-phase1`); review/merge #415 first.

Adds:
- `upgrade <release> <chart> [--install] [--reuse-values]`
- `rollback <release> <revision>` — append-only: deploys a new revision whose content is copied from the target (mirrors Helm)
- `history <release>`
- `get values|manifest <release> [--revision N]`
- `diff upgrade <release> <chart>` — line-oriented manifest preview before upgrading

## Engine

Factored a shared `deployAndRecord` path; `Install`, `Upgrade`, and `Rollback` all flow through it. Statuses stay **derived** from the immutable append-only revision log (highest revision = current; lower deployed = `superseded`), so no Config mutation is needed. New: `Upgrade`, `Rollback`, `History`, `GetRevision`; `InstallOptions.Install` for `upgrade --install`.

## CLI

New subcommands + flags (`--install`, `--reuse-values`, `--revision`) and a small LCS `lineDiff` helper (no new deps). `upgrade --reuse-values` layers `-f`/`--set` over the previous release's values.

## Testing

- `go build ./...`, `go test ./...`, `golangci-lint run ./... --build-tags=integration` all pass.
- Unit tests: upgrade-supersedes, `upgrade --install`, rollback-copies-content, unknown-revision, get-revision, `--history-max` pruning, and the diff helper.
- The integration test now also runs upgrade → history → rollback.

## Follow-ups (Phase 3)

`create`, `lint`, `dependency` (subcharts), an optional read-only `:charts` TUI browser, and seeding `Eldara-Tech/swarmcli-charts` with a published `index.yaml`. Tracking issue to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)