### PR TITLE
feat(charts): pre-flight external secrets/configs before deploy

### DIFF
--- a/charts/backend_docker.go
+++ b/charts/backend_docker.go
@@ -122,3 +122,15 @@ func (dockerBackend) RemoveOverlayNetwork(ctx context.Context, name string) erro
 	}
 	return nil // already gone
 }
+
+func (dockerBackend) SecretNames(ctx context.Context) (map[string]struct{}, error) {
+	secs, err := docker.ListSecrets(ctx)
+	if err != nil {
+		return nil, err
+	}
+	names := make(map[string]struct{}, len(secs))
+	for _, s := range secs {
+		names[s.Spec.Name] = struct{}{}
+	}
+	return names, nil
+}

--- a/charts/networks.go
+++ b/charts/networks.go
@@ -10,39 +10,55 @@ import (
 )
 
 // externalNetworks returns the real names of the networks a rendered stack
-// manifest declares as external. It understands both compose forms:
-//
-//	networks:
-//	  traefik-public:
-//	    external: true            # real name == map key
-//	  alias:
-//	    external:
-//	      name: actual-network    # real name == external.name
-//
-// Non-external networks are ignored. A manifest without a networks block (or
-// invalid YAML) yields no names and no error — deploy validation handles that.
+// manifest declares as external. Non-external networks are ignored; a manifest
+// without a networks block (or invalid YAML) yields no names and no error —
+// deploy validation handles that.
 func externalNetworks(manifest string) ([]string, error) {
-	var doc struct {
-		Networks map[string]struct {
-			External yaml.Node `yaml:"external"`
-		} `yaml:"networks"`
+	return externalResourceNames(manifest, "networks"), nil
+}
+
+// externalResourceNames returns the real names of the entries under the given
+// top-level compose key (e.g. "networks", "secrets", "configs") that the
+// manifest declares external. It understands both compose forms:
+//
+//	<key>:
+//	  alias:
+//	    external: true            # real name == map key
+//	  other:
+//	    external:
+//	      name: actual-resource   # real name == external.name
+//
+// Non-external entries are ignored. A manifest without that block, or invalid
+// YAML, yields no names. The block is decoded in isolation so unrelated
+// top-level keys (services, volumes, …) of any shape do not interfere.
+func externalResourceNames(manifest, topLevelKey string) []string {
+	var top map[string]yaml.Node
+	if err := yaml.Unmarshal([]byte(manifest), &top); err != nil {
+		return nil
 	}
-	if err := yaml.Unmarshal([]byte(manifest), &doc); err != nil {
-		return nil, nil
+	node, ok := top[topLevelKey]
+	if !ok {
+		return nil
+	}
+	var block map[string]struct {
+		External yaml.Node `yaml:"external"`
+	}
+	if err := node.Decode(&block); err != nil {
+		return nil
 	}
 	var names []string
-	for key, net := range doc.Networks {
-		switch net.External.Kind {
+	for key, res := range block {
+		switch res.External.Kind {
 		case yaml.ScalarNode:
 			var b bool
-			if err := net.External.Decode(&b); err == nil && b {
+			if err := res.External.Decode(&b); err == nil && b {
 				names = append(names, key)
 			}
 		case yaml.MappingNode:
 			var m struct {
 				Name string `yaml:"name"`
 			}
-			if err := net.External.Decode(&m); err == nil {
+			if err := res.External.Decode(&m); err == nil {
 				if m.Name != "" {
 					names = append(names, m.Name)
 				} else {
@@ -52,5 +68,5 @@ func externalNetworks(manifest string) ([]string, error) {
 		}
 	}
 	sort.Strings(names)
-	return names, nil
+	return names
 }

--- a/charts/release.go
+++ b/charts/release.go
@@ -60,6 +60,9 @@ type Backend interface {
 	// RemoveOverlayNetwork removes a network by name, used to roll back networks
 	// auto-created for an install whose deploy then failed. A no-op if absent.
 	RemoveOverlayNetwork(ctx context.Context, name string) error
+	// SecretNames returns the set of existing swarm secret names, used to
+	// pre-flight a chart's external secrets (which cannot be auto-created).
+	SecretNames(ctx context.Context) (map[string]struct{}, error)
 }
 
 // Engine drives release lifecycle operations against a Backend.
@@ -210,6 +213,13 @@ func (e *Engine) deployAndRecord(ctx context.Context, rel *Release, opts Install
 	if opts.DryRun {
 		return rel, nil
 	}
+	// Validate prerequisites that cannot be auto-created (external secrets and
+	// configs) before mutating any swarm state, so a missing one fails fast
+	// without leaving auto-created networks behind.
+	if err := e.ensureExternalSecretsConfigs(ctx, rel.Manifest); err != nil {
+		rel.Status = StatusFailed
+		return rel, err
+	}
 	created, err := e.ensureExternalNetworks(ctx, rel.Manifest)
 	if err != nil {
 		rel.Status = StatusFailed
@@ -291,6 +301,59 @@ func (e *Engine) ensureExternalNetworks(ctx context.Context, manifest string) (c
 		msg += "\ncreate them on a swarm manager, then retry:\n" + strings.TrimRight(cmds.String(), "\n")
 	}
 	return created, fmt.Errorf("%s", msg)
+}
+
+// ensureExternalSecretsConfigs verifies that every secret and config the
+// manifest declares external already exists on the swarm. Unlike networks,
+// these cannot be auto-created — their content is not part of the chart — so a
+// missing one is a hard error that lists the `docker secret/config create`
+// commands needed to resolve it. A manifest with no external secrets/configs is
+// a no-op.
+func (e *Engine) ensureExternalSecretsConfigs(ctx context.Context, manifest string) error {
+	secrets := externalResourceNames(manifest, "secrets")
+	configs := externalResourceNames(manifest, "configs")
+	if len(secrets) == 0 && len(configs) == 0 {
+		return nil
+	}
+
+	var reasons, cmds []string
+
+	if len(secrets) > 0 {
+		have, err := e.Backend.SecretNames(ctx)
+		if err != nil {
+			return fmt.Errorf("checking external secrets: %w", err)
+		}
+		for _, name := range secrets {
+			if _, ok := have[name]; !ok {
+				reasons = append(reasons, fmt.Sprintf("  secret %q does not exist", name))
+				cmds = append(cmds, fmt.Sprintf("  docker secret create %s <file>", name))
+			}
+		}
+	}
+
+	if len(configs) > 0 {
+		metas, err := e.Backend.ListConfigs(ctx)
+		if err != nil {
+			return fmt.Errorf("checking external configs: %w", err)
+		}
+		have := make(map[string]struct{}, len(metas))
+		for _, m := range metas {
+			have[m.Name] = struct{}{}
+		}
+		for _, name := range configs {
+			if _, ok := have[name]; !ok {
+				reasons = append(reasons, fmt.Sprintf("  config %q does not exist", name))
+				cmds = append(cmds, fmt.Sprintf("  docker config create %s <file>", name))
+			}
+		}
+	}
+
+	if len(reasons) == 0 {
+		return nil
+	}
+	return fmt.Errorf("external secret(s)/config(s) required by this chart do not exist:\n%s\n"+
+		"create them on a swarm manager, then retry:\n%s",
+		strings.Join(reasons, "\n"), strings.Join(cmds, "\n"))
 }
 
 // Uninstall removes the release's stack and, unless keepHistory, its recorded

--- a/charts/release_test.go
+++ b/charts/release_test.go
@@ -19,11 +19,13 @@ type fakeBackend struct {
 	deployed      map[string]string // stack name -> manifest
 	volumes       map[string][]string
 	services      map[string][]ServiceState
-	networkScopes map[string]string // network name -> scope
-	createNetErr  map[string]error  // network name -> error to return on create
+	networkScopes map[string]string   // network name -> scope
+	secrets       map[string]struct{} // existing secret names
+	createNetErr  map[string]error    // network name -> error to return on create
 	failNext      bool
 	rmStackErr    error
 	refreshErr    error
+	secretsErr    error                   // error to return from SecretNames
 	onCreate      func(name string) error // hook to simulate concurrent config creation
 }
 
@@ -39,6 +41,7 @@ func newFakeBackend() *fakeBackend {
 		volumes:       map[string][]string{},
 		services:      map[string][]ServiceState{},
 		networkScopes: map[string]string{},
+		secrets:       map[string]struct{}{},
 		createNetErr:  map[string]error{},
 	}
 }
@@ -123,6 +126,16 @@ func (f *fakeBackend) CreateOverlayNetwork(_ context.Context, name string) error
 func (f *fakeBackend) RemoveOverlayNetwork(_ context.Context, name string) error {
 	delete(f.networkScopes, name)
 	return nil
+}
+func (f *fakeBackend) SecretNames(context.Context) (map[string]struct{}, error) {
+	if f.secretsErr != nil {
+		return nil, f.secretsErr
+	}
+	out := make(map[string]struct{}, len(f.secrets))
+	for k := range f.secrets {
+		out[k] = struct{}{}
+	}
+	return out, nil
 }
 
 func testEngine(b Backend) *Engine {

--- a/charts/requirements_test.go
+++ b/charts/requirements_test.go
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package charts
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestExternalResourceNames(t *testing.T) {
+	cases := []struct {
+		name     string
+		manifest string
+		key      string
+		want     []string
+	}{
+		{
+			name:     "external true uses the map key",
+			manifest: "secrets:\n  db:\n    external: true\n",
+			key:      "secrets",
+			want:     []string{"db"},
+		},
+		{
+			name:     "external long form uses the resolved name",
+			manifest: "configs:\n  alias:\n    external:\n      name: real-config\n",
+			key:      "configs",
+			want:     []string{"real-config"},
+		},
+		{
+			name:     "non-external and external:false are ignored",
+			manifest: "secrets:\n  inline:\n    file: ./x\n  off:\n    external: false\n  on:\n    external: true\n",
+			key:      "secrets",
+			want:     []string{"on"},
+		},
+		{
+			name:     "missing block yields nil",
+			manifest: "services:\n  app:\n    image: x\n",
+			key:      "secrets",
+			want:     nil,
+		},
+		{
+			name:     "sorted across multiple",
+			manifest: "configs:\n  b:\n    external: true\n  a:\n    external: true\n",
+			key:      "configs",
+			want:     []string{"a", "b"},
+		},
+		{
+			name:     "unrelated complex top-level keys do not interfere",
+			manifest: "services:\n  app:\n    image: x\n    deploy:\n      replicas: 2\nsecrets:\n  s:\n    external: true\n",
+			key:      "secrets",
+			want:     []string{"s"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, externalResourceNames(tc.manifest, tc.key))
+		})
+	}
+}
+
+func TestEnsureExternalSecretsConfigs(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("no external secrets or configs is a no-op", func(t *testing.T) {
+		e := testEngine(newFakeBackend())
+		require.NoError(t, e.ensureExternalSecretsConfigs(ctx, "services:\n  app:\n    image: x\n"))
+	})
+
+	t.Run("present secret and config pass", func(t *testing.T) {
+		fb := newFakeBackend()
+		fb.secrets["db"] = struct{}{}
+		fb.configs["cfg"] = fakeConfig{}
+		e := testEngine(fb)
+		m := "secrets:\n  db:\n    external: true\nconfigs:\n  cfg:\n    external: true\n"
+		require.NoError(t, e.ensureExternalSecretsConfigs(ctx, m))
+	})
+
+	t.Run("missing secret errors with remediation", func(t *testing.T) {
+		e := testEngine(newFakeBackend())
+		err := e.ensureExternalSecretsConfigs(ctx, "secrets:\n  db:\n    external: true\n")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), `secret "db" does not exist`)
+		require.Contains(t, err.Error(), "docker secret create db <file>")
+	})
+
+	t.Run("missing config errors with remediation", func(t *testing.T) {
+		e := testEngine(newFakeBackend())
+		err := e.ensureExternalSecretsConfigs(ctx, "configs:\n  nginx:\n    external: true\n")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), `config "nginx" does not exist`)
+		require.Contains(t, err.Error(), "docker config create nginx <file>")
+	})
+
+	t.Run("long-form external name is resolved", func(t *testing.T) {
+		fb := newFakeBackend()
+		fb.secrets["real-secret"] = struct{}{}
+		e := testEngine(fb)
+		// alias maps to real-secret, which exists -> passes
+		require.NoError(t, e.ensureExternalSecretsConfigs(ctx,
+			"secrets:\n  alias:\n    external:\n      name: real-secret\n"))
+	})
+
+	t.Run("backend error is surfaced", func(t *testing.T) {
+		fb := newFakeBackend()
+		fb.secretsErr = errors.New("daemon down")
+		e := testEngine(fb)
+		err := e.ensureExternalSecretsConfigs(ctx, "secrets:\n  db:\n    external: true\n")
+		require.ErrorContains(t, err, "checking external secrets")
+	})
+}
+
+// A missing external secret must abort the install before any network is
+// auto-created, leaving no swarm state behind.
+func TestInstallMissingSecretAbortsBeforeNetworkCreate(t *testing.T) {
+	fb := newFakeBackend()
+	e := testEngine(fb)
+	manifest := "services:\n  app:\n    image: x\n" +
+		"networks:\n  pub:\n    external: true\n" +
+		"secrets:\n  db:\n    external: true\n"
+
+	rel, err := e.Install(context.Background(), "demo",
+		ReleaseChart{Name: "demo", Version: "0.1.0"}, nil, manifest, InstallOptions{})
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), `secret "db" does not exist`)
+	require.Equal(t, StatusFailed, rel.Status)
+	require.NotContains(t, fb.networkScopes, "pub", "no network should be created when a prerequisite secret is missing")
+	require.Empty(t, fb.deployed, "nothing should be deployed")
+}
+
+// With the prerequisite secret present, the install proceeds: the external
+// network is created and the stack deploys.
+func TestInstallProceedsWhenSecretPresent(t *testing.T) {
+	fb := newFakeBackend()
+	fb.secrets["db"] = struct{}{}
+	e := testEngine(fb)
+	manifest := "services:\n  app:\n    image: x\n" +
+		"networks:\n  pub:\n    external: true\n" +
+		"secrets:\n  db:\n    external: true\n"
+
+	_, err := e.Install(context.Background(), "demo",
+		ReleaseChart{Name: "demo", Version: "0.1.0"}, nil, manifest, InstallOptions{})
+
+	require.NoError(t, err)
+	require.Contains(t, fb.networkScopes, "pub")
+	require.Contains(t, fb.deployed, "demo")
+}


### PR DESCRIPTION
Implements Eldara-Tech/swarmcli-charts#26.

## Why

External **networks** a stack needs are already auto-created on install (`ensureExternalNetworks`). External **secrets/configs** cannot be auto-created — their content is not part of a chart — so today a missing one surfaces only as a raw `docker stack deploy` failure with no guidance.

## What

A pre-flight check that, before any swarm state is mutated, verifies every secret/config the rendered manifest declares `external` already exists; otherwise it fails with the exact `docker secret/config create` commands to run (mirroring the existing network remediation message).

It runs **before** `ensureExternalNetworks`, so a missing prerequisite aborts the install **without leaving auto-created networks behind**.

- `networks.go`: extract `externalResourceNames(manifest, key)` — networks/secrets/configs share the compose `external` syntax (scalar `true` and long-form `{name: …}`); `externalNetworks` now delegates to it.
- `release.go`: `Backend.SecretNames` + `ensureExternalSecretsConfigs`, wired into `deployAndRecord` ahead of the network step.
- `backend_docker.go`: `SecretNames` via `docker.ListSecrets`; configs reuse the existing `ListConfigs`.

## Tests

Parser cases for secrets/configs (incl. long-form, `external:false`, unrelated complex keys), the pre-flight (present / missing-secret / missing-config / long-form / backend-error), and the **ordering guarantee** (missing secret aborts before any network is created). `go test -race ./charts/` green; gofmt + golangci-lint clean.

## Notes

- No chart in swarmcli-charts uses external secrets/configs yet — this is forward-looking infrastructure, unit-tested via the `Backend` fake (no daemon needed).
- Content is intentionally **not** chart-supplied (security); this is validation/messaging only.