### PR TITLE
feat(charts): consume requirements.yaml pre-flight + uninstall network summary (#23, #28)

### DIFF
--- a/charts/backend_docker.go
+++ b/charts/backend_docker.go
@@ -105,8 +105,8 @@ func (dockerBackend) NetworkScopes(ctx context.Context) (map[string]string, erro
 	return scopes, nil
 }
 
-func (dockerBackend) CreateOverlayNetwork(ctx context.Context, name string) error {
-	_, _, err := docker.CreateNetwork(ctx, name, network.CreateOptions{Driver: "overlay", Attachable: true})
+func (dockerBackend) CreateOverlayNetwork(ctx context.Context, name, driver string, attachable bool) error {
+	_, _, err := docker.CreateNetwork(ctx, name, network.CreateOptions{Driver: driver, Attachable: attachable})
 	return err
 }
 

--- a/charts/chart.go
+++ b/charts/chart.go
@@ -17,11 +17,12 @@ import (
 )
 
 const (
-	chartfileName = "Chart.yaml"
-	valuesName    = "values.yaml"
-	schemaName    = "values.schema.json"
-	readmeName    = "README.md"
-	templatesDir  = "templates"
+	chartfileName    = "Chart.yaml"
+	valuesName       = "values.yaml"
+	schemaName       = "values.schema.json"
+	readmeName       = "README.md"
+	requirementsName = "requirements.yaml"
+	templatesDir     = "templates"
 )
 
 // maxChartFileSize bounds any single file read from a chart archive to guard
@@ -63,6 +64,14 @@ func LoadChartDir(dir string) (*Chart, error) {
 		ch.Schema = s
 	} else if !os.IsNotExist(err) {
 		return nil, fmt.Errorf("read %s: %w", schemaName, err)
+	}
+
+	if rq, err := os.ReadFile(filepath.Join(dir, requirementsName)); err == nil {
+		if ch.Requirements, err = parseRequirements(rq); err != nil {
+			return nil, err
+		}
+	} else if !os.IsNotExist(err) {
+		return nil, fmt.Errorf("read %s: %w", requirementsName, err)
 	}
 
 	if r, err := os.ReadFile(filepath.Join(dir, readmeName)); err == nil {
@@ -148,6 +157,10 @@ func LoadChartArchive(r io.Reader) (*Chart, error) {
 			}
 		case rel == schemaName:
 			ch.Schema = body
+		case rel == requirementsName:
+			if ch.Requirements, err = parseRequirements(body); err != nil {
+				return nil, err
+			}
 		case rel == readmeName:
 			ch.Readme = string(body)
 		case strings.HasPrefix(rel, templatesDir+"/") && !strings.ContainsRune(rel[len(templatesDir)+1:], '/'):

--- a/charts/chart_test.go
+++ b/charts/chart_test.go
@@ -100,3 +100,54 @@ func TestLoadChartDirNoTemplates(t *testing.T) {
 	require.Error(t, err)
 	require.True(t, strings.Contains(err.Error(), "templates"))
 }
+
+func writeMinimalChart(t *testing.T, dir string) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "templates"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "Chart.yaml"), []byte("name: x\nversion: 1.0.0\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "templates", "stack.yaml"), []byte("services: {}\n"), 0o644))
+}
+
+func TestLoadChartDirParsesRequirements(t *testing.T) {
+	dir := t.TempDir()
+	writeMinimalChart(t, dir)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "requirements.yaml"),
+		[]byte("networks:\n  - name: traefik-public\n    description: shared\n"), 0o644))
+
+	ch, err := LoadChartDir(dir)
+	require.NoError(t, err)
+	require.NotNil(t, ch.Requirements)
+	require.Len(t, ch.Requirements.Networks, 1)
+	require.Equal(t, "traefik-public", ch.Requirements.Networks[0].Name)
+	require.True(t, *ch.Requirements.Networks[0].AutoCreate) // defaulted
+}
+
+func TestLoadChartDirNoRequirementsIsNil(t *testing.T) {
+	dir := t.TempDir()
+	writeMinimalChart(t, dir)
+	ch, err := LoadChartDir(dir)
+	require.NoError(t, err)
+	require.Nil(t, ch.Requirements)
+}
+
+func TestLoadChartArchiveParsesRequirements(t *testing.T) {
+	tgz := packEntries(t, map[string]string{
+		"demo/Chart.yaml":           "name: demo\nversion: 1.0.0\n",
+		"demo/templates/stack.yaml": "services: {}\n",
+		"demo/requirements.yaml":    "networks:\n  - name: traefik-public\n",
+	})
+	ch, err := LoadChartArchive(strings.NewReader(tgz))
+	require.NoError(t, err)
+	require.NotNil(t, ch.Requirements)
+	require.Equal(t, "traefik-public", ch.Requirements.Networks[0].Name)
+}
+
+func TestLoadChartArchiveInvalidRequirements(t *testing.T) {
+	tgz := packEntries(t, map[string]string{
+		"demo/Chart.yaml":           "name: demo\nversion: 1.0.0\n",
+		"demo/templates/stack.yaml": "services: {}\n",
+		"demo/requirements.yaml":    "networks:\n  - description: nameless\n",
+	})
+	_, err := LoadChartArchive(strings.NewReader(tgz))
+	require.ErrorContains(t, err, "networks[0] has no name")
+}

--- a/charts/release.go
+++ b/charts/release.go
@@ -55,8 +55,10 @@ type Backend interface {
 	// NetworkScopes returns existing network names mapped to their scope
 	// (e.g. "swarm", "local"), used to pre-flight a chart's external networks.
 	NetworkScopes(ctx context.Context) (map[string]string, error)
-	// CreateOverlayNetwork creates an attachable, swarm-scoped overlay network.
-	CreateOverlayNetwork(ctx context.Context, name string) error
+	// CreateOverlayNetwork creates a swarm-scoped network with the given driver
+	// and attachability (driver defaults to "overlay" when a chart does not
+	// declare one in requirements.yaml).
+	CreateOverlayNetwork(ctx context.Context, name, driver string, attachable bool) error
 	// RemoveOverlayNetwork removes a network by name, used to roll back networks
 	// auto-created for an install whose deploy then failed. A no-op if absent.
 	RemoveOverlayNetwork(ctx context.Context, name string) error
@@ -89,6 +91,12 @@ type InstallOptions struct {
 	Install    bool // upgrade: create the release if it does not exist
 	Timeout    time.Duration
 	HistoryMax int // 0 = keep all
+	// Requirements is the chart's parsed requirements.yaml, when present. It
+	// drives the external-resource pre-flight (auto-create vs validate-only, the
+	// network driver/attachability, and remediation descriptions) and, when set,
+	// every external resource the manifest references must be declared in it. Nil
+	// falls back to manifest-driven pre-flight (auto-create attachable overlays).
+	Requirements *Requirements
 }
 
 // Install deploys a freshly rendered manifest as revision 1 of a new release and
@@ -216,11 +224,11 @@ func (e *Engine) deployAndRecord(ctx context.Context, rel *Release, opts Install
 	// Validate prerequisites that cannot be auto-created (external secrets and
 	// configs) before mutating any swarm state, so a missing one fails fast
 	// without leaving auto-created networks behind.
-	if err := e.ensureExternalSecretsConfigs(ctx, rel.Manifest); err != nil {
+	if err := e.ensureExternalSecretsConfigs(ctx, rel.Manifest, opts.Requirements); err != nil {
 		rel.Status = StatusFailed
 		return rel, err
 	}
-	created, err := e.ensureExternalNetworks(ctx, rel.Manifest)
+	created, err := e.ensureExternalNetworks(ctx, rel.Manifest, opts.Requirements)
 	if err != nil {
 		rel.Status = StatusFailed
 		for _, n := range created {
@@ -242,6 +250,11 @@ func (e *Engine) deployAndRecord(ctx context.Context, rel *Release, opts Install
 	// The deploy mutated swarm state; invalidate the shared cache so the
 	// convergence poll and any follow-up status read see fresh data.
 	_ = e.Backend.RefreshSnapshot()
+	// Persist the networks we auto-created this revision so uninstall can report
+	// what it leaves behind (see Uninstall). Networks already present from an
+	// earlier revision are not re-created here, so uninstall unions across all
+	// revisions.
+	rel.ManagedNetworks = created
 	if err := e.record(ctx, rel); err != nil {
 		return rel, fmt.Errorf("stack %q was deployed but recording its release history failed: %w; re-run install/upgrade to reconcile", rel.Name, err)
 	}
@@ -257,33 +270,57 @@ func (e *Engine) deployAndRecord(ctx context.Context, rel *Release, opts Install
 }
 
 // ensureExternalNetworks makes sure every network the manifest declares
-// external exists and is swarm-scoped before the stack is deployed. Missing
-// networks are created as attachable swarm overlays; networks that exist with a
-// non-swarm scope, or that cannot be created, are reported with the manual
-// `docker network create` commands needed to resolve them.
-// ensureExternalNetworks returns the names of networks it auto-created, so a
-// caller can roll them back if a later step (the deploy) fails.
-func (e *Engine) ensureExternalNetworks(ctx context.Context, manifest string) (created []string, err error) {
+// external exists and is swarm-scoped before the stack is deployed.
+//
+// When the chart ships a requirements.yaml (req != nil) it is authoritative:
+// every external network the manifest references must be declared there, and the
+// declaration drives behaviour — autoCreate:true networks are created with the
+// declared driver/attachability, autoCreate:false networks are only validated
+// (a missing one is a hard error with the declared description, never created).
+// Without a requirements.yaml (req == nil) it falls back to the historical
+// behaviour: create any missing network as an attachable overlay.
+//
+// Networks that exist with a non-swarm scope, that cannot be created, or that
+// are required-present-but-missing are reported with the manual remediation
+// needed to resolve them. ensureExternalNetworks returns the names of networks
+// it auto-created, so a caller can roll them back if a later step (the deploy)
+// fails.
+func (e *Engine) ensureExternalNetworks(ctx context.Context, manifest string, req *Requirements) (created []string, err error) {
 	names, err := externalNetworks(manifest)
 	if err != nil || len(names) == 0 {
+		return nil, err
+	}
+	// Enforce the requirements.yaml contract first: an undeclared external
+	// resource is a chart-authoring error, distinct from one being unavailable.
+	if err := requireDeclared(req, names, "network", "networks"); err != nil {
 		return nil, err
 	}
 	scopes, err := e.Backend.NetworkScopes(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("checking external networks: %w", err)
 	}
-	var reasons, needCreate []string
+	var reasons, fixes []string
 	for _, name := range names {
-		switch scope, exists := scopes[name]; {
+		nr, declared := req.network(name) // declared == (req != nil), per the contract check above
+		scope, exists := scopes[name]
+		switch {
 		case exists && scope == "swarm":
 			// already usable
 		case exists:
 			reasons = append(reasons,
 				fmt.Sprintf("  %s: a non-swarm (%s) network of this name already exists; remove or rename it", name, scope))
+		case declared && !*nr.AutoCreate:
+			// Validate-only: the chart depends on a network it must not create.
+			reasons = append(reasons, fmt.Sprintf("  %s: does not exist%s", name, describe(nr.Description)))
+			fixes = append(fixes, fmt.Sprintf("  docker network create --driver %s%s %s", networkDriver(nr), attachableFlag(nr), name))
 		default:
-			if cerr := e.Backend.CreateOverlayNetwork(ctx, name); cerr != nil {
+			driver, attachable := "overlay", true
+			if declared {
+				driver, attachable = networkDriver(nr), *nr.Attachable
+			}
+			if cerr := e.Backend.CreateOverlayNetwork(ctx, name, driver, attachable); cerr != nil {
 				reasons = append(reasons, fmt.Sprintf("  %s: auto-create failed: %v", name, cerr))
-				needCreate = append(needCreate, name)
+				fixes = append(fixes, fmt.Sprintf("  docker network create --driver %s%s %s", driver, attachableFlagBool(attachable), name))
 			} else {
 				created = append(created, name)
 			}
@@ -293,14 +330,70 @@ func (e *Engine) ensureExternalNetworks(ctx context.Context, manifest string) (c
 		return created, nil
 	}
 	msg := "external network(s) required by this chart are unavailable:\n" + strings.Join(reasons, "\n")
-	if len(needCreate) > 0 {
-		var cmds strings.Builder
-		for _, name := range needCreate {
-			fmt.Fprintf(&cmds, "  docker network create --driver overlay --attachable %s\n", name)
-		}
-		msg += "\ncreate them on a swarm manager, then retry:\n" + strings.TrimRight(cmds.String(), "\n")
+	if len(fixes) > 0 {
+		msg += "\ncreate them on a swarm manager, then retry:\n" + strings.Join(fixes, "\n")
 	}
 	return created, fmt.Errorf("%s", msg)
+}
+
+// requireDeclared enforces the requirements.yaml contract: when req is non-nil,
+// every external resource name the manifest references must be declared in it.
+// It returns a chart-authoring error listing any undeclared names, or nil when
+// req is nil (no requirements.yaml — manifest-driven fallback) or all declared.
+func requireDeclared(req *Requirements, names []string, kind, key string) error {
+	if req == nil {
+		return nil
+	}
+	var undeclared []string
+	for _, n := range names {
+		var ok bool
+		switch key {
+		case "networks":
+			_, ok = req.network(n)
+		case "secrets":
+			_, ok = req.secret(n)
+		case "configs":
+			_, ok = req.config(n)
+		}
+		if !ok {
+			undeclared = append(undeclared, fmt.Sprintf("  %s", n))
+		}
+	}
+	if len(undeclared) == 0 {
+		return nil
+	}
+	return fmt.Errorf("%s(s) the manifest declares external are not declared in %s:\n%s\n"+
+		"declare them under %s: in %s (it is authoritative when present)",
+		kind, requirementsName, strings.Join(undeclared, "\n"), key, requirementsName)
+}
+
+// networkDriver returns the declared driver, defaulting to overlay (defaults are
+// normally applied at parse time; this guards direct callers/tests).
+func networkDriver(nr *NetworkRequirement) string {
+	if nr.Driver == "" {
+		return "overlay"
+	}
+	return nr.Driver
+}
+
+func attachableFlag(nr *NetworkRequirement) string {
+	return attachableFlagBool(nr.Attachable == nil || *nr.Attachable)
+}
+
+func attachableFlagBool(attachable bool) string {
+	if attachable {
+		return " --attachable"
+	}
+	return ""
+}
+
+// describe renders an optional requirement description as a trailing " (…)"
+// clause for remediation messages, or "" when absent.
+func describe(desc string) string {
+	if desc == "" {
+		return ""
+	}
+	return " (" + desc + ")"
 }
 
 // ensureExternalSecretsConfigs verifies that every secret and config the
@@ -309,11 +402,23 @@ func (e *Engine) ensureExternalNetworks(ctx context.Context, manifest string) (c
 // missing one is a hard error that lists the `docker secret/config create`
 // commands needed to resolve it. A manifest with no external secrets/configs is
 // a no-op.
-func (e *Engine) ensureExternalSecretsConfigs(ctx context.Context, manifest string) error {
+//
+// When the chart ships a requirements.yaml (req != nil) it is authoritative:
+// every external secret/config the manifest references must be declared there
+// (else a hard error), and a declared description enriches the remediation.
+func (e *Engine) ensureExternalSecretsConfigs(ctx context.Context, manifest string, req *Requirements) error {
 	secrets := externalResourceNames(manifest, "secrets")
 	configs := externalResourceNames(manifest, "configs")
 	if len(secrets) == 0 && len(configs) == 0 {
 		return nil
+	}
+	// Enforce the requirements.yaml contract first (chart-authoring error),
+	// separately from the existence check below (operator remediation).
+	if err := requireDeclared(req, secrets, "secret", "secrets"); err != nil {
+		return err
+	}
+	if err := requireDeclared(req, configs, "config", "configs"); err != nil {
+		return err
 	}
 
 	var reasons, cmds []string
@@ -324,8 +429,9 @@ func (e *Engine) ensureExternalSecretsConfigs(ctx context.Context, manifest stri
 			return fmt.Errorf("checking external secrets: %w", err)
 		}
 		for _, name := range secrets {
+			rr, _ := req.secret(name)
 			if _, ok := have[name]; !ok {
-				reasons = append(reasons, fmt.Sprintf("  secret %q does not exist", name))
+				reasons = append(reasons, fmt.Sprintf("  secret %q does not exist%s", name, requirementDescription(rr)))
 				cmds = append(cmds, fmt.Sprintf("  docker secret create %s <file>", name))
 			}
 		}
@@ -341,8 +447,9 @@ func (e *Engine) ensureExternalSecretsConfigs(ctx context.Context, manifest stri
 			have[m.Name] = struct{}{}
 		}
 		for _, name := range configs {
+			rr, _ := req.config(name)
 			if _, ok := have[name]; !ok {
-				reasons = append(reasons, fmt.Sprintf("  config %q does not exist", name))
+				reasons = append(reasons, fmt.Sprintf("  config %q does not exist%s", name, requirementDescription(rr)))
 				cmds = append(cmds, fmt.Sprintf("  docker config create %s <file>", name))
 			}
 		}
@@ -356,15 +463,35 @@ func (e *Engine) ensureExternalSecretsConfigs(ctx context.Context, manifest stri
 		strings.Join(reasons, "\n"), strings.Join(cmds, "\n"))
 }
 
-// Uninstall removes the release's stack and, unless keepHistory, its recorded
-// revisions. Volumes are retained unless purgeVolumes is set.
-func (e *Engine) Uninstall(ctx context.Context, release string, purgeVolumes bool) error {
+// requirementDescription renders a resource requirement's description as a
+// trailing " (…)" clause, or "" when there is no requirement or description.
+func requirementDescription(rr *ResourceRequirement) string {
+	if rr == nil {
+		return ""
+	}
+	return describe(rr.Description)
+}
+
+// UninstallResult reports what an uninstall left behind. OrphanedNetworks are
+// the external networks swarmcli auto-created for the release that still exist
+// after the stack is removed — `docker stack rm` does not remove external
+// networks, and swarmcli deliberately leaves them (they may be shared with other
+// stacks) and reports them instead.
+type UninstallResult struct {
+	OrphanedNetworks []string
+}
+
+// Uninstall removes the release's stack and its recorded revisions, retaining
+// volumes unless purgeVolumes is set. It returns an UninstallResult describing
+// the auto-created external networks left in place so the caller can surface
+// them; the networks themselves are not removed.
+func (e *Engine) Uninstall(ctx context.Context, release string, purgeVolumes bool) (*UninstallResult, error) {
 	revs, err := e.revisions(ctx, release)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	if len(revs) == 0 {
-		return fmt.Errorf("release %q not found", release)
+		return nil, fmt.Errorf("release %q not found", release)
 	}
 
 	// Continue cleanup on partial failure rather than aborting: a stranded
@@ -390,12 +517,50 @@ func (e *Engine) Uninstall(ctx context.Context, release string, purgeVolumes boo
 		}
 	}
 
+	// Collect the networks swarmcli auto-created across all revisions (a network
+	// created in an early revision is not re-created later, so it only appears on
+	// that revision's record — union them), keeping only those that still exist.
+	result := &UninstallResult{OrphanedNetworks: e.orphanedManagedNetworks(ctx, revs)}
+
 	for _, r := range revs {
 		if err := e.Backend.DeleteConfig(ctx, releaseConfigName(release, r.Revision)); err != nil {
 			errs = append(errs, fmt.Errorf("deleting release config: %w", err))
 		}
 	}
-	return errors.Join(errs...)
+	return result, errors.Join(errs...)
+}
+
+// orphanedManagedNetworks returns the sorted, de-duplicated set of networks
+// swarmcli auto-created for the release (recorded per-revision) that still exist
+// on the swarm. A failure to query existing networks degrades to reporting the
+// recorded union (better to over-report a cleanup hint than to hide it).
+func (e *Engine) orphanedManagedNetworks(ctx context.Context, revs []Release) []string {
+	seen := map[string]struct{}{}
+	var managed []string
+	for _, r := range revs {
+		for _, n := range r.ManagedNetworks {
+			if _, ok := seen[n]; !ok {
+				seen[n] = struct{}{}
+				managed = append(managed, n)
+			}
+		}
+	}
+	if len(managed) == 0 {
+		return nil
+	}
+	scopes, err := e.Backend.NetworkScopes(ctx)
+	if err != nil {
+		sort.Strings(managed)
+		return managed
+	}
+	var still []string
+	for _, n := range managed {
+		if _, ok := scopes[n]; ok {
+			still = append(still, n)
+		}
+	}
+	sort.Strings(still)
+	return still
 }
 
 // List returns the current (highest) revision of every release.

--- a/charts/release_test.go
+++ b/charts/release_test.go
@@ -19,9 +19,10 @@ type fakeBackend struct {
 	deployed      map[string]string // stack name -> manifest
 	volumes       map[string][]string
 	services      map[string][]ServiceState
-	networkScopes map[string]string   // network name -> scope
-	secrets       map[string]struct{} // existing secret names
-	createNetErr  map[string]error    // network name -> error to return on create
+	networkScopes map[string]string     // network name -> scope
+	secrets       map[string]struct{}   // existing secret names
+	createNetErr  map[string]error      // network name -> error to return on create
+	createdNets   map[string]createdNet // network name -> driver/attachable used on create
 	failNext      bool
 	rmStackErr    error
 	refreshErr    error
@@ -32,6 +33,11 @@ type fakeBackend struct {
 type fakeConfig struct {
 	data   []byte
 	labels map[string]string
+}
+
+type createdNet struct {
+	driver     string
+	attachable bool
 }
 
 func newFakeBackend() *fakeBackend {
@@ -116,10 +122,14 @@ func (f *fakeBackend) NetworkScopes(context.Context) (map[string]string, error) 
 	}
 	return out, nil
 }
-func (f *fakeBackend) CreateOverlayNetwork(_ context.Context, name string) error {
+func (f *fakeBackend) CreateOverlayNetwork(_ context.Context, name, driver string, attachable bool) error {
 	if err := f.createNetErr[name]; err != nil {
 		return err
 	}
+	if f.createdNets == nil {
+		f.createdNets = map[string]createdNet{}
+	}
+	f.createdNets[name] = createdNet{driver: driver, attachable: attachable}
 	f.networkScopes[name] = "swarm"
 	return nil
 }
@@ -283,12 +293,14 @@ func TestUninstallRemovesStackAndConfigsKeepsVolumes(t *testing.T) {
 	_, err := e.Install(ctx, "demo", ReleaseChart{Name: "demo", Version: "1"}, nil, "services:\n  s:\n    image: x\n", InstallOptions{})
 	require.NoError(t, err)
 
-	require.NoError(t, e.Uninstall(ctx, "demo", false))
+	_, err = e.Uninstall(ctx, "demo", false)
+	require.NoError(t, err)
 	require.Empty(t, fb.deployed)
 	require.Empty(t, fb.configs)
 	require.Equal(t, []string{"demo_data"}, fb.volumes["demo"]) // volume retained
 
-	require.Error(t, e.Uninstall(ctx, "demo", false)) // already gone
+	_, err = e.Uninstall(ctx, "demo", false) // already gone
+	require.Error(t, err)
 }
 
 func TestUninstallPurgeVolumes(t *testing.T) {
@@ -297,7 +309,8 @@ func TestUninstallPurgeVolumes(t *testing.T) {
 	e := testEngine(fb)
 	ctx := context.Background()
 	_, _ = e.Install(ctx, "demo", ReleaseChart{Name: "demo", Version: "1"}, nil, "services:\n  s:\n    image: x\n", InstallOptions{})
-	require.NoError(t, e.Uninstall(ctx, "demo", true))
+	_, err := e.Uninstall(ctx, "demo", true)
+	require.NoError(t, err)
 	require.Empty(t, fb.volumes["demo"])
 }
 
@@ -371,7 +384,7 @@ func TestUninstallContinuesOnPartialFailure(t *testing.T) {
 	require.NoError(t, err)
 
 	fb.rmStackErr = fmt.Errorf("stack gone")
-	err = e.Uninstall(ctx, "demo", false)
+	_, err = e.Uninstall(ctx, "demo", false)
 	require.ErrorContains(t, err, "removing stack")
 	require.Empty(t, fb.configs) // history cleaned up despite the stack-removal failure
 }

--- a/charts/requirements.go
+++ b/charts/requirements.go
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package charts
+
+import (
+	"fmt"
+
+	"gopkg.in/yaml.v3"
+)
+
+// parseRequirements parses and validates a chart's requirements.yaml, applying
+// defaults so the rest of the engine can rely on every field being populated:
+// each network's Driver defaults to "overlay" and its AutoCreate/Attachable
+// default to true. Every entry must carry a non-empty name.
+func parseRequirements(data []byte) (*Requirements, error) {
+	var req Requirements
+	if err := yaml.Unmarshal(data, &req); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", requirementsName, err)
+	}
+	if err := validateRequirements(&req); err != nil {
+		return nil, err
+	}
+	return &req, nil
+}
+
+func validateRequirements(req *Requirements) error {
+	for i := range req.Networks {
+		n := &req.Networks[i]
+		if n.Name == "" {
+			return fmt.Errorf("%s: networks[%d] has no name", requirementsName, i)
+		}
+		if n.Driver == "" {
+			n.Driver = "overlay"
+		}
+		if n.Attachable == nil {
+			n.Attachable = boolPtr(true)
+		}
+		if n.AutoCreate == nil {
+			n.AutoCreate = boolPtr(true)
+		}
+	}
+	for i, s := range req.Secrets {
+		if s.Name == "" {
+			return fmt.Errorf("%s: secrets[%d] has no name", requirementsName, i)
+		}
+	}
+	for i, c := range req.Configs {
+		if c.Name == "" {
+			return fmt.Errorf("%s: configs[%d] has no name", requirementsName, i)
+		}
+	}
+	return nil
+}
+
+func boolPtr(b bool) *bool { return &b }
+
+// network returns the declared requirement for the network of the given real
+// name, if any. After parseRequirements its bool fields are non-nil.
+func (r *Requirements) network(name string) (*NetworkRequirement, bool) {
+	if r == nil {
+		return nil, false
+	}
+	for i := range r.Networks {
+		if r.Networks[i].Name == name {
+			return &r.Networks[i], true
+		}
+	}
+	return nil, false
+}
+
+// secret returns the declared requirement for the secret of the given real
+// name, if any.
+func (r *Requirements) secret(name string) (*ResourceRequirement, bool) {
+	if r == nil {
+		return nil, false
+	}
+	for i := range r.Secrets {
+		if r.Secrets[i].Name == name {
+			return &r.Secrets[i], true
+		}
+	}
+	return nil, false
+}
+
+// config returns the declared requirement for the config of the given real
+// name, if any.
+func (r *Requirements) config(name string) (*ResourceRequirement, bool) {
+	if r == nil {
+		return nil, false
+	}
+	for i := range r.Configs {
+		if r.Configs[i].Name == name {
+			return &r.Configs[i], true
+		}
+	}
+	return nil, false
+}

--- a/charts/requirements_network_test.go
+++ b/charts/requirements_network_test.go
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package charts
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// requirements.yaml drives the network pre-flight: an autoCreate:true network is
+// created with the declared driver and attachability.
+func TestEnsureExternalNetworksAutoCreateHonorsDriver(t *testing.T) {
+	fb := newFakeBackend()
+	e := testEngine(fb)
+	req := &Requirements{Networks: []NetworkRequirement{
+		{Name: "traefik-public", Driver: "overlay", Attachable: boolPtr(false), AutoCreate: boolPtr(true)},
+	}}
+	created, err := e.ensureExternalNetworks(context.Background(), extNetManifest, req)
+	require.NoError(t, err)
+	require.Equal(t, []string{"traefik-public"}, created)
+	require.Equal(t, createdNet{driver: "overlay", attachable: false}, fb.createdNets["traefik-public"])
+}
+
+// An autoCreate:false network is validated, never created: a missing one is a
+// hard error carrying the declared description, and nothing is created.
+func TestEnsureExternalNetworksValidateOnlyMissing(t *testing.T) {
+	fb := newFakeBackend()
+	e := testEngine(fb)
+	req := &Requirements{Networks: []NetworkRequirement{
+		{Name: "traefik-public", Driver: "overlay", Attachable: boolPtr(true), AutoCreate: boolPtr(false), Description: "Traefik ingress"},
+	}}
+	created, err := e.ensureExternalNetworks(context.Background(), extNetManifest, req)
+	require.Error(t, err)
+	require.Empty(t, created)
+	require.NotContains(t, fb.networkScopes, "traefik-public", "validate-only network must not be created")
+	require.Contains(t, err.Error(), "traefik-public: does not exist (Traefik ingress)")
+}
+
+// A pre-existing swarm-scoped network satisfies an autoCreate:false requirement.
+func TestEnsureExternalNetworksValidateOnlyPresent(t *testing.T) {
+	fb := newFakeBackend()
+	fb.networkScopes["traefik-public"] = "swarm"
+	e := testEngine(fb)
+	req := &Requirements{Networks: []NetworkRequirement{
+		{Name: "traefik-public", Driver: "overlay", Attachable: boolPtr(true), AutoCreate: boolPtr(false)},
+	}}
+	created, err := e.ensureExternalNetworks(context.Background(), extNetManifest, req)
+	require.NoError(t, err)
+	require.Empty(t, created)
+}
+
+// When requirements.yaml is present it is authoritative: an external network the
+// manifest references but the file does not declare is a contract error, and no
+// network is created.
+func TestEnsureExternalNetworksUndeclaredIsContractError(t *testing.T) {
+	fb := newFakeBackend()
+	e := testEngine(fb)
+	req := &Requirements{} // present but declares no networks
+	created, err := e.ensureExternalNetworks(context.Background(), extNetManifest, req)
+	require.Error(t, err)
+	require.Empty(t, created)
+	require.NotContains(t, fb.networkScopes, "traefik-public")
+	require.Contains(t, err.Error(), "network(s) the manifest declares external are not declared in requirements.yaml")
+	require.Contains(t, err.Error(), "traefik-public")
+}
+
+// Install records the networks it auto-created on the revision so uninstall can
+// report them, and uninstall returns them as orphaned while leaving them in
+// place.
+func TestInstallRecordsAndUninstallReportsManagedNetworks(t *testing.T) {
+	ctx := context.Background()
+	fb := newFakeBackend()
+	e := testEngine(fb)
+	req := &Requirements{Networks: []NetworkRequirement{
+		{Name: "traefik-public", Driver: "overlay", Attachable: boolPtr(true), AutoCreate: boolPtr(true)},
+	}}
+
+	rel, err := e.Install(ctx, "demo", ReleaseChart{Name: "demo", Version: "1"}, nil, extNetManifest,
+		InstallOptions{Requirements: req})
+	require.NoError(t, err)
+	require.Equal(t, []string{"traefik-public"}, rel.ManagedNetworks)
+
+	res, err := e.Uninstall(ctx, "demo", false)
+	require.NoError(t, err)
+	require.Equal(t, []string{"traefik-public"}, res.OrphanedNetworks)
+	require.Contains(t, fb.networkScopes, "traefik-public", "uninstall must not remove the network")
+}
+
+// A managed network the operator removed out-of-band is not reported as
+// orphaned.
+func TestUninstallSkipsManagedNetworkAlreadyGone(t *testing.T) {
+	ctx := context.Background()
+	fb := newFakeBackend()
+	e := testEngine(fb)
+	req := &Requirements{Networks: []NetworkRequirement{
+		{Name: "traefik-public", Driver: "overlay", Attachable: boolPtr(true), AutoCreate: boolPtr(true)},
+	}}
+	_, err := e.Install(ctx, "demo", ReleaseChart{Name: "demo", Version: "1"}, nil, extNetManifest,
+		InstallOptions{Requirements: req})
+	require.NoError(t, err)
+
+	delete(fb.networkScopes, "traefik-public") // operator removed it themselves
+
+	res, err := e.Uninstall(ctx, "demo", false)
+	require.NoError(t, err)
+	require.Empty(t, res.OrphanedNetworks)
+}
+
+// Without a requirements.yaml the network pre-flight keeps its historical
+// behaviour: a missing external network is auto-created as an attachable
+// overlay.
+func TestEnsureExternalNetworksFallbackWithoutRequirements(t *testing.T) {
+	fb := newFakeBackend()
+	e := testEngine(fb)
+	created, err := e.ensureExternalNetworks(context.Background(), extNetManifest, nil)
+	require.NoError(t, err)
+	require.Equal(t, []string{"traefik-public"}, created)
+	require.Equal(t, createdNet{driver: "overlay", attachable: true}, fb.createdNets["traefik-public"])
+}

--- a/charts/requirements_test.go
+++ b/charts/requirements_test.go
@@ -11,6 +11,31 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestParseRequirementsDefaults(t *testing.T) {
+	// driver, attachable and autoCreate default when omitted.
+	req, err := parseRequirements([]byte("networks:\n  - name: pub\n"))
+	require.NoError(t, err)
+	require.Len(t, req.Networks, 1)
+	require.Equal(t, "overlay", req.Networks[0].Driver)
+	require.NotNil(t, req.Networks[0].Attachable)
+	require.True(t, *req.Networks[0].Attachable)
+	require.NotNil(t, req.Networks[0].AutoCreate)
+	require.True(t, *req.Networks[0].AutoCreate)
+}
+
+func TestParseRequirementsExplicitFalse(t *testing.T) {
+	req, err := parseRequirements([]byte("networks:\n  - name: pub\n    autoCreate: false\n    attachable: false\n"))
+	require.NoError(t, err)
+	require.False(t, *req.Networks[0].AutoCreate)
+	require.False(t, *req.Networks[0].Attachable)
+}
+
+func TestParseRequirementsRejectsNamelessEntry(t *testing.T) {
+	_, err := parseRequirements([]byte("secrets:\n  - description: no name here\n"))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "secrets[0] has no name")
+}
+
 func TestExternalResourceNames(t *testing.T) {
 	cases := []struct {
 		name     string
@@ -67,7 +92,7 @@ func TestEnsureExternalSecretsConfigs(t *testing.T) {
 
 	t.Run("no external secrets or configs is a no-op", func(t *testing.T) {
 		e := testEngine(newFakeBackend())
-		require.NoError(t, e.ensureExternalSecretsConfigs(ctx, "services:\n  app:\n    image: x\n"))
+		require.NoError(t, e.ensureExternalSecretsConfigs(ctx, "services:\n  app:\n    image: x\n", nil))
 	})
 
 	t.Run("present secret and config pass", func(t *testing.T) {
@@ -76,12 +101,12 @@ func TestEnsureExternalSecretsConfigs(t *testing.T) {
 		fb.configs["cfg"] = fakeConfig{}
 		e := testEngine(fb)
 		m := "secrets:\n  db:\n    external: true\nconfigs:\n  cfg:\n    external: true\n"
-		require.NoError(t, e.ensureExternalSecretsConfigs(ctx, m))
+		require.NoError(t, e.ensureExternalSecretsConfigs(ctx, m, nil))
 	})
 
 	t.Run("missing secret errors with remediation", func(t *testing.T) {
 		e := testEngine(newFakeBackend())
-		err := e.ensureExternalSecretsConfigs(ctx, "secrets:\n  db:\n    external: true\n")
+		err := e.ensureExternalSecretsConfigs(ctx, "secrets:\n  db:\n    external: true\n", nil)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), `secret "db" does not exist`)
 		require.Contains(t, err.Error(), "docker secret create db <file>")
@@ -89,7 +114,7 @@ func TestEnsureExternalSecretsConfigs(t *testing.T) {
 
 	t.Run("missing config errors with remediation", func(t *testing.T) {
 		e := testEngine(newFakeBackend())
-		err := e.ensureExternalSecretsConfigs(ctx, "configs:\n  nginx:\n    external: true\n")
+		err := e.ensureExternalSecretsConfigs(ctx, "configs:\n  nginx:\n    external: true\n", nil)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), `config "nginx" does not exist`)
 		require.Contains(t, err.Error(), "docker config create nginx <file>")
@@ -101,15 +126,34 @@ func TestEnsureExternalSecretsConfigs(t *testing.T) {
 		e := testEngine(fb)
 		// alias maps to real-secret, which exists -> passes
 		require.NoError(t, e.ensureExternalSecretsConfigs(ctx,
-			"secrets:\n  alias:\n    external:\n      name: real-secret\n"))
+			"secrets:\n  alias:\n    external:\n      name: real-secret\n", nil))
 	})
 
 	t.Run("backend error is surfaced", func(t *testing.T) {
 		fb := newFakeBackend()
 		fb.secretsErr = errors.New("daemon down")
 		e := testEngine(fb)
-		err := e.ensureExternalSecretsConfigs(ctx, "secrets:\n  db:\n    external: true\n")
+		err := e.ensureExternalSecretsConfigs(ctx, "secrets:\n  db:\n    external: true\n", nil)
 		require.ErrorContains(t, err, "checking external secrets")
+	})
+
+	t.Run("undeclared external secret is a contract error when requirements present", func(t *testing.T) {
+		fb := newFakeBackend()
+		fb.secrets["db"] = struct{}{} // it exists, but is not declared
+		e := testEngine(fb)
+		req := &Requirements{} // present but declares nothing
+		err := e.ensureExternalSecretsConfigs(ctx, "secrets:\n  db:\n    external: true\n", req)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "secret(s) the manifest declares external are not declared in requirements.yaml")
+		require.Contains(t, err.Error(), "db")
+	})
+
+	t.Run("declared description enriches missing-secret remediation", func(t *testing.T) {
+		e := testEngine(newFakeBackend())
+		req := &Requirements{Secrets: []ResourceRequirement{{Name: "db", Description: "Postgres password"}}}
+		err := e.ensureExternalSecretsConfigs(ctx, "secrets:\n  db:\n    external: true\n", req)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), `secret "db" does not exist (Postgres password)`)
 	})
 }
 

--- a/charts/types.go
+++ b/charts/types.go
@@ -63,11 +63,42 @@ type Dependency struct {
 // Chart is a loaded chart: its metadata, default values, optional values
 // schema, and raw template sources keyed by their path under templates/.
 type Chart struct {
-	Metadata  Chartfile
-	Values    map[string]any    // parsed values.yaml (defaults)
-	Schema    []byte            // raw values.schema.json, nil if absent
-	Templates map[string]string // template path -> source, e.g. "templates/stack.yaml"
-	Readme    string            // README.md, empty if absent
+	Metadata     Chartfile
+	Values       map[string]any    // parsed values.yaml (defaults)
+	Schema       []byte            // raw values.schema.json, nil if absent
+	Templates    map[string]string // template path -> source, e.g. "templates/stack.yaml"
+	Readme       string            // README.md, empty if absent
+	Requirements *Requirements     // parsed requirements.yaml, nil if absent
+}
+
+// Requirements is the parsed, defaulted requirements.yaml: the external
+// networks/secrets/configs a chart needs. It is optional — a chart without it
+// falls back to manifest-driven pre-flight. When present it is authoritative:
+// every external resource the rendered manifest references must be declared.
+type Requirements struct {
+	Networks []NetworkRequirement  `yaml:"networks"`
+	Secrets  []ResourceRequirement `yaml:"secrets"`
+	Configs  []ResourceRequirement `yaml:"configs"`
+}
+
+// NetworkRequirement declares one external network a chart needs. AutoCreate and
+// Attachable are pointers so an omitted key defaults to true (preserving the
+// historical auto-create-as-attachable-overlay behaviour) while an explicit
+// false is distinguishable. After parseRequirements they are always non-nil and
+// Driver is non-empty.
+type NetworkRequirement struct {
+	Name        string `yaml:"name"`
+	Driver      string `yaml:"driver"`     // default "overlay"
+	Attachable  *bool  `yaml:"attachable"` // default true
+	AutoCreate  *bool  `yaml:"autoCreate"` // default true; false => validate-only
+	Description string `yaml:"description"`
+}
+
+// ResourceRequirement declares one external secret or config a chart needs.
+// These cannot be auto-created; Description enriches the remediation message.
+type ResourceRequirement struct {
+	Name        string `yaml:"name"`
+	Description string `yaml:"description"`
 }
 
 // RepoEntry is a configured chart repository (name -> index URL).
@@ -104,6 +135,11 @@ type Release struct {
 	Manifest  string         `yaml:"manifest"` // rendered Compose document
 	Created   string         `yaml:"created"`  // RFC3339
 	Namespace string         `yaml:"namespace"`
+	// ManagedNetworks are the external networks swarmcli auto-created for this
+	// revision. Persisted so uninstall can report what it left behind (it does
+	// not remove them — they may be shared). Omitted for revisions that created
+	// none and for records written before this field existed.
+	ManagedNetworks []string `yaml:"managedNetworks,omitempty"`
 }
 
 // ReleaseChart is the chart reference recorded in a Release.

--- a/cli/charts.go
+++ b/cli/charts.go
@@ -41,6 +41,10 @@ Releases:
   list                        List releases
   status <release>            Show release status and services
 
+A chart may declare its external networks/secrets/configs in requirements.yaml:
+install pre-flights them (auto-creating networks marked autoCreate, validating
+the rest) and uninstall reports any auto-created networks it leaves in place.
+
 Common options:
   -f, --values <file>   Values file (repeatable)
       --set k=v         Override a value (repeatable)
@@ -275,7 +279,7 @@ func chartsTemplate(args []string) int {
 		return usageErr("charts template <release> <repo/chart>")
 	}
 	release, ref := pos[0], pos[1]
-	manifest, _, _, code := prepare(release, ref, f, nil)
+	manifest, _, _, _, code := prepare(release, ref, f, nil)
 	if code >= 0 {
 		return code
 	}
@@ -292,15 +296,16 @@ func chartsInstall(args []string) int {
 		return usageErr("charts install <release> <repo/chart>")
 	}
 	release, ref := pos[0], pos[1]
-	manifest, values, rc, code := prepare(release, ref, f, nil)
+	manifest, values, rc, req, code := prepare(release, ref, f, nil)
 	if code >= 0 {
 		return code
 	}
 	rel, err := charts.NewEngine().Install(context.Background(), release, rc, values, manifest, charts.InstallOptions{
-		DryRun:     f.dryRun,
-		Wait:       f.wait,
-		Timeout:    f.timeout,
-		HistoryMax: f.historyMax,
+		DryRun:       f.dryRun,
+		Wait:         f.wait,
+		Timeout:      f.timeout,
+		HistoryMax:   f.historyMax,
+		Requirements: req,
 	})
 	if err != nil {
 		return fail(err)
@@ -331,16 +336,17 @@ func chartsUpgrade(args []string) int {
 			// re-validates the release, so a genuine backend error still surfaces.
 		}
 	}
-	manifest, values, rc, code := prepare(release, ref, f, base)
+	manifest, values, rc, req, code := prepare(release, ref, f, base)
 	if code >= 0 {
 		return code
 	}
 	rel, err := charts.NewEngine().Upgrade(context.Background(), release, rc, values, manifest, charts.InstallOptions{
-		DryRun:     f.dryRun,
-		Wait:       f.wait,
-		Install:    f.install,
-		Timeout:    f.timeout,
-		HistoryMax: f.historyMax,
+		DryRun:       f.dryRun,
+		Wait:         f.wait,
+		Install:      f.install,
+		Timeout:      f.timeout,
+		HistoryMax:   f.historyMax,
+		Requirements: req,
 	})
 	if err != nil {
 		return fail(err)
@@ -452,7 +458,7 @@ func chartsDiff(args []string) int {
 	if f.reuseValues {
 		base = cur.Values
 	}
-	next, _, _, code := prepare(release, ref, f, base)
+	next, _, _, _, code := prepare(release, ref, f, base)
 	if code >= 0 {
 		return code
 	}
@@ -467,24 +473,24 @@ func chartsDiff(args []string) int {
 // prepare loads the chart, merges + validates values, and renders the manifest.
 // base, when non-nil, replaces the chart defaults as the merge base (used by
 // `upgrade --reuse-values` to layer overrides over the previous release).
-func prepare(release, ref string, f flags, base map[string]any) (manifest string, values map[string]any, rc charts.ReleaseChart, code int) {
+func prepare(release, ref string, f flags, base map[string]any) (manifest string, values map[string]any, rc charts.ReleaseChart, req *charts.Requirements, code int) {
 	ch, _, c := loadChart(ref, f.version)
 	if c >= 0 {
-		return "", nil, rc, c
+		return "", nil, rc, nil, c
 	}
 	if base == nil {
 		base = ch.Values
 	}
 	files, err := readValuesFiles(f.values)
 	if err != nil {
-		return "", nil, rc, fail(err)
+		return "", nil, rc, nil, fail(err)
 	}
 	values, err = charts.MergeValues(base, files, f.sets)
 	if err != nil {
-		return "", nil, rc, fail(err)
+		return "", nil, rc, nil, fail(err)
 	}
 	if err := charts.ValidateValues(ch.Schema, values); err != nil {
-		return "", nil, rc, fail(err)
+		return "", nil, rc, nil, fail(err)
 	}
 	manifest, err = charts.Render(ch, charts.RenderContext{
 		Values:  values,
@@ -492,10 +498,10 @@ func prepare(release, ref string, f flags, base map[string]any) (manifest string
 		Chart:   charts.ChartMeta{Name: ch.Metadata.Name, Version: ch.Metadata.Version, AppVersion: ch.Metadata.AppVersion},
 	})
 	if err != nil {
-		return "", nil, rc, fail(err)
+		return "", nil, rc, nil, fail(err)
 	}
 	rc = charts.ReleaseChart{Name: ch.Metadata.Name, Version: ch.Metadata.Version, AppVersion: ch.Metadata.AppVersion}
-	return manifest, values, rc, -1
+	return manifest, values, rc, ch.Requirements, -1
 }
 
 // --- uninstall / list / status ---
@@ -508,10 +514,22 @@ func chartsUninstall(args []string) int {
 	if len(pos) != 1 {
 		return usageErr("charts uninstall <release> [--purge-volumes]")
 	}
-	if err := charts.NewEngine().Uninstall(context.Background(), pos[0], f.purge); err != nil {
+	res, err := charts.NewEngine().Uninstall(context.Background(), pos[0], f.purge)
+	if err != nil {
 		return fail(err)
 	}
 	outf("release %q uninstalled\n", pos[0])
+	if res != nil && len(res.OrphanedNetworks) > 0 {
+		out("\nswarmcli auto-created the following external network(s) on install and left\n" +
+			"them in place (they may be shared with other stacks):\n")
+		for _, n := range res.OrphanedNetworks {
+			outf("  %s\n", n)
+		}
+		out("remove any you no longer need:\n")
+		for _, n := range res.OrphanedNetworks {
+			outf("  docker network rm %s\n", n)
+		}
+	}
 	return 0
 }
 

--- a/integration-tests/charts/charts_lifecycle_test.go
+++ b/integration-tests/charts/charts_lifecycle_test.go
@@ -73,7 +73,7 @@ func TestChartsReleaseLifecycle(t *testing.T) {
 	eng := charts.NewEngine()
 
 	// Ensure teardown even if assertions fail mid-way.
-	defer func() { _ = eng.Uninstall(ctx, release, true) }()
+	defer func() { _, _ = eng.Uninstall(ctx, release, true) }()
 
 	rel, err := eng.Install(ctx, release, charts.ReleaseChart{Name: ch.Metadata.Name, Version: ch.Metadata.Version},
 		values, manifest, charts.InstallOptions{Wait: true, Timeout: 90 * time.Second})
@@ -128,7 +128,8 @@ func TestChartsReleaseLifecycle(t *testing.T) {
 	require.Equal(t, 3, rb.Revision)
 
 	// Uninstall removes the stack and the release Configs.
-	require.NoError(t, eng.Uninstall(ctx, release, true))
+	_, err = eng.Uninstall(ctx, release, true)
+	require.NoError(t, err)
 	_, err = docker.InspectConfig(ctx, fmt.Sprintf("swarmcli.release.%s.v1", release))
 	require.Error(t, err, "release config should be gone after uninstall")
 }
@@ -224,7 +225,7 @@ func TestChartsRepoInstallLifecycle(t *testing.T) {
 	require.NoError(t, err)
 
 	eng := charts.NewEngine()
-	defer func() { _ = eng.Uninstall(ctx, release, true) }()
+	defer func() { _, _ = eng.Uninstall(ctx, release, true) }()
 
 	rel, err := eng.Install(ctx, release, charts.ReleaseChart{Name: ch.Metadata.Name, Version: ch.Metadata.Version},
 		values, manifest, charts.InstallOptions{Wait: true, Timeout: 90 * time.Second})
@@ -235,13 +236,16 @@ func TestChartsRepoInstallLifecycle(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, svcs, "status should list services")
 
-	require.NoError(t, eng.Uninstall(ctx, release, true))
+	_, err = eng.Uninstall(ctx, release, true)
+	require.NoError(t, err)
 	_, err = docker.InspectConfig(ctx, fmt.Sprintf("swarmcli.release.%s.v1", release))
 	require.Error(t, err, "release config should be gone after uninstall")
 }
 
 // writeExtNetChart writes a chart whose stack attaches to (and declares as
-// external) the given network name, returning the chart dir.
+// external) the given network name, returning the chart dir. The network is
+// declared in requirements.yaml with autoCreate:true so the pre-flight creates
+// it.
 func writeExtNetChart(t *testing.T, netName string) string {
 	t.Helper()
 	dir := t.TempDir()
@@ -249,6 +253,8 @@ func writeExtNetChart(t *testing.T, netName string) string {
 		[]byte("apiVersion: v2\nname: itest\nversion: 0.1.0\nappVersion: \"1.0\"\n"), 0o644))
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "values.yaml"),
 		[]byte("replicas: 1\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "requirements.yaml"),
+		[]byte("networks:\n  - name: "+netName+"\n    autoCreate: true\n    description: itest overlay\n"), 0o644))
 	require.NoError(t, os.MkdirAll(filepath.Join(dir, "templates"), 0o755))
 	stack := "version: \"3.9\"\n\n" +
 		"services:\n" +
@@ -284,7 +290,7 @@ func TestChartsExternalNetworkAutoCreate(t *testing.T) {
 
 	eng := charts.NewEngine()
 	defer func() {
-		_ = eng.Uninstall(ctx, release, true)
+		_, _ = eng.Uninstall(ctx, release, true)
 		_ = docker.RemoveNetwork(ctx, netName) // external nets survive stack rm
 	}()
 
@@ -296,9 +302,10 @@ func TestChartsExternalNetworkAutoCreate(t *testing.T) {
 	}
 
 	rel, err := eng.Install(ctx, release, charts.ReleaseChart{Name: ch.Metadata.Name, Version: ch.Metadata.Version},
-		values, manifest, charts.InstallOptions{Wait: true, Timeout: 90 * time.Second})
+		values, manifest, charts.InstallOptions{Wait: true, Timeout: 90 * time.Second, Requirements: ch.Requirements})
 	require.NoError(t, err, "install should auto-create the external network and deploy")
 	require.Equal(t, charts.StatusDeployed, rel.Status)
+	require.Equal(t, []string{netName}, rel.ManagedNetworks, "the auto-created network is recorded on the revision")
 
 	// The external network now exists and is swarm-scoped.
 	nets, err = docker.ListNetworks(ctx)
@@ -311,4 +318,19 @@ func TestChartsExternalNetworkAutoCreate(t *testing.T) {
 		}
 	}
 	require.True(t, found, "external network should have been auto-created")
+
+	// Uninstall leaves the auto-created network in place and reports it as
+	// orphaned so the operator can reclaim it.
+	res, err := eng.Uninstall(ctx, release, true)
+	require.NoError(t, err)
+	require.Equal(t, []string{netName}, res.OrphanedNetworks)
+	nets, err = docker.ListNetworks(ctx)
+	require.NoError(t, err)
+	stillThere := false
+	for _, n := range nets {
+		if n.Name == netName {
+			stillThere = true
+		}
+	}
+	require.True(t, stillThere, "uninstall must not remove the shared external network")
 }


### PR DESCRIPTION
Implements Eldara-Tech/swarmcli-charts#23 (consume `requirements.yaml`) and Eldara-Tech/swarmcli-charts#28 (uninstall summary of auto-created networks). Companion charts PR: Eldara-Tech/swarmcli-charts#30.

## Why
External **networks** are auto-created on install; **secrets/configs** are validated (added in #418). Both were driven purely off the rendered manifest — a chart could not express *how* an external resource should be handled (auto-create vs operator-provisioned), nor give human-meaningful remediation. And on uninstall, auto-created networks were silently left behind (swarmcli could not tell "I created this" from "the user did").

## What

**#23 — requirements.yaml consumption**
- Load + validate `requirements.yaml` in both chart loaders (`chart.go`). Optional: `Chart.Requirements == nil` falls back to today's manifest-driven behaviour. New `Requirements`/`NetworkRequirement`/`ResourceRequirement` types; `*bool` `autoCreate`/`attachable` so an omitted key defaults `true` and an explicit `false` is distinguishable; `driver` defaults to `overlay`.
- The rendered manifest still **detects** the external set (values-aware — handles conditional networks). When `requirements.yaml` is present it is **authoritative**: `requireDeclared` rejects any external resource the manifest references that the file does not declare — a chart-authoring error, kept distinct from operator remediation.
- `autoCreate:true` networks are created with the declared driver/attachability; `autoCreate:false` networks are **validate-only** (a missing one is a hard error carrying the declared `description`, never auto-created). Descriptions also enrich secret/config remediation.
- Threaded via `InstallOptions.Requirements` (set by the CLI from `ch.Requirements`); no public `Install`/`Upgrade` signature change.

**#28 — symmetric uninstall summary** (decision on #28: option 1 — leave in place, write a summary)
- Persist the networks auto-created per revision on `Release.ManagedNetworks` (the previously-ephemeral `created[]`, made durable). Backward compatible — old records simply lack the field.
- `Uninstall` now returns `*UninstallResult{OrphanedNetworks}`: the union across revisions, filtered to those still present. Networks are **not** removed (they may be shared); the CLI reports them with `docker network rm` hints.

`Backend.CreateOverlayNetwork` gains `driver`/`attachable`.

## Tests
Parse/default, autoCreate/validate-only/contract-violation, `ManagedNetworks` persistence, uninstall reporting (+ skip-when-operator-removed), loader (dir/archive), and the no-requirements fallback — all via the `Backend` fake. Integration lifecycle test extended to exercise the requirements-driven auto-create + uninstall summary. `go test -race ./...` green; `go vet -tags=integration`, gofmt, and `golangci-lint run ./... --build-tags=integration` clean.

## Notes
No chart in swarmcli-charts requires changes beyond the docs/CI in the companion PR; the whoami chart already declares `traefik-public`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)