### PR TITLE
docs: fix view-registration docs and document the charts CLI

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -4,7 +4,7 @@ This document gives focused, actionable knowledge to help an AI coding agent be 
 
 High-level architecture
 - **CLI app entry:** [main.go](main.go) creates a Bubble Tea `Program` and calls `app.Init()`.
-- **App bootstrap & view registry:** [app/app.go](app/app.go) initializes logging, command autoload (`import "swarmcli/commands"`), and registers views via `registerView(name, factory)`. Views are built with the `view.Factory` pattern.
+- **App bootstrap:** [app/app.go](app/app.go) initializes logging and triggers autoload via blank imports — commands (`_ "swarmcli/commands"`) and views (`_ "swarmcli/views"`). Views self-register with the `view.Factory` pattern; the registry lives in [views/view/registry.go](views/view/registry.go).
 - **Views & UI:** UI components live under `views/` and `ui/`. Each view is a Bubble Tea model; common patterns: `Init()` returns a `tea.Cmd`, views expose `SetSize`, `View()`, and handle messages in `update.go`.
 - **Docker integration:** The `docker/` package wraps Docker CLI + SDK. `docker.GetClient()` respects `DOCKER_CONTEXT` (or `docker context show`) and TLS cert layout. See [docker/client.go](docker/client.go) and [docker/context.go](docker/context.go).
 - **Commands registry:** The `commands` package uses autoloading to register CLI commands with `registry`. See [app/app.go](app/app.go) and `commands/` for patterns.
@@ -16,7 +16,7 @@ Key developer workflows
 - Docker contexts for tests: The project creates a Docker context pointing at a local DinD manager; `DOCKER_CONTEXT` environment variable is honored by `docker.GetClient()` and tests (see `integration-tests/*` and `test-setup/testenv.sh`).
 
 Project-specific conventions & patterns
-- Bubble Tea / view factory: Views are registered centrally in `app.Init()` and must return `(view.View, tea.Cmd)`. Prefer returning a ready-to-run `tea.Cmd` (often `model.Init()` or `tea.Batch(...)`). Example registration: services, nodes, contexts in [app/app.go](app/app.go).
+- Bubble Tea / view factory: Each view self-registers from its own `register.go` `init()` via `view.RegisterView(name, factory)`; the factory signature is `func(deps docker.Deps, width, height int, payload any) (view.View, tea.Cmd)`. Prefer returning a ready-to-run `tea.Cmd` (often `model.Init()` or `tea.Batch(...)`). The package must be blank-imported in [views/autoload.go](views/autoload.go). Example: [views/nodes/register.go](views/nodes/register.go).
 - UI composition: Shared UI helpers are under `ui/` (framed boxes, overlays, status bar). Prefer these helpers for consistent look/feel (examples in `views/configs/view.go` and `views/stacks/*`).
 - Filterable lists: Use the `ui/components/filterable` package for lists (cursor, search modes). Items implement `FilterValue()`, `Title()`, `Description()` — see `views/configs/view.go` for concrete types.
 - Error & dialogs: Reuse `ui/components/errordialog` and `ui.RenderConfirmDialog` for modal flows; views typically toggle `...DialogActive` booleans and overlay rendered content with `ui.OverlayCentered()`.
@@ -27,7 +27,7 @@ Integration points & external dependencies
 - Test harness: `test-setup` uses Docker Compose to spin up a small Swarm cluster (DinD). The integration test harness relies on `docker context create` and `docker --context ... stack deploy` flow.
 
 Helpful code pointers (quick examples)
-- Registering views: [app/app.go](app/app.go) — follow its `registerView` usage.
+- Registering views: [views/view/registry.go](views/view/registry.go) and each view's `register.go` — follow the `view.RegisterView` + autoload pattern.
 - Docker client: [docker/client.go](docker/client.go) — honor `DOCKER_CONTEXT` and TLS cert layout; use `GetClient()` for network calls.
 - Filterable item example: `views/configs/view.go` defines `configItem` (methods `FilterValue`, `Title`, `Description`).
 - Test runner: `test-setup/testenv.sh` and `integration-tests/` — run the full integration environment from the repo root.
@@ -41,6 +41,7 @@ Coding agent DOs and DON'Ts (repo-specific)
 
 If unsure, inspect these files first
 - [app/app.go](app/app.go)
+- [views/view/registry.go](views/view/registry.go) and a view's `register.go` (e.g. [views/nodes/register.go](views/nodes/register.go))
 - [main.go](main.go)
 - [docker/client.go](docker/client.go)
 - [test-setup/testenv.sh](test-setup/testenv.sh)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,9 +33,11 @@ tail -f ~/.local/state/swarmcli/app.log          # prod mode (JSON)
 ## Architecture
 
 ```
-main.go                    Entry point; version injection via ldflags, tea.NewProgram()
+main.go                    Entry point; version injection via ldflags. With args, dispatches non-interactive CLI subcommands via cli.Dispatch(); bare invocation launches the TUI (tea.NewProgram())
+cli/                       Arg-based CLI dispatch (cli.Dispatch): `charts`, `version`, `help`
+charts/                    Helm-like package manager (repos, chart rendering, releases)
 app/
-  app.go                   View factory registry, Init(), command autoload via _ "swarmcli/commands"
+  app.go                   Init(); triggers command autoload via _ "swarmcli/commands" and view autoload via _ "swarmcli/views" (view factory registry lives in views/view/registry.go)
   hooks.go                 PreUpdateHook registration; StartupOverlay; RegisterShutdownHook / RunShutdownHooks (BE port-forward manager registers CloseAll here)
   model.go                 Central state: Model struct (viewport, currentView, viewStack, commandInput, searchInput, systemInfo)
   update.go                Main message router: navigation, resize, events, key dispatch
@@ -62,7 +64,7 @@ views/
   viewstack/               Navigation stack (push/pop)
 commands/
   api/                     Command context & arg parsing
-  command/                 Built-in commands (help, contexts, stacks, services, etc.)
+  command/                 Top-level built-in commands (help.go, contexts.go, quit.go, alias.go, bootstrap.go); docker-entity commands live under command/docker/<entity>/ls.go (service, node, network, volume, secret, config)
   autoload.go              Blank import triggers init() registration
 docker/
   client.go                Context-aware Docker client factory
@@ -82,7 +84,7 @@ utils/log/
 
 - **Bubble Tea MVC**: Input → Update() → tea.Cmd → View(). All state changes via `tea.Msg` types.
 - **View Stack**: `viewStack.Push(old)` / `Pop()` for breadcrumb navigation.
-- **View Factory**: `viewRegistry[name]` maps view names to constructor functions, registered in `app.Init()`.
+- **View Factory**: Views auto-register via `init()` + `view.RegisterView(name, factory)` in each view's `register.go` (registry in `views/view/registry.go`, looked up with `GetFactory`). `app/app.go`'s blank import `_ "swarmcli/views"` pulls `views/autoload.go`, which blank-imports every view — exactly mirroring the command autoload pattern.
 - **Command Registry**: Commands in `commands/command/` auto-register via `init()` + `registry.Register()`. Accessed via `:` input.
 - **Command Spec**: Commands optionally implement `registry.CommandWithSpec` (`Spec() registry.CommandSpec`, discovered by type assertion like `Aliaser`). The spec declares `Usage`, `Flags` (the allow-list), and `Examples`. `api.ParseInput` is the single chokepoint that, in order: short-circuits `Passthrough` specs, intercepts `--help`/`-h`/`-help` (and `:help <cmd>`) into a per-command help screen reusing the detailed help view, then rejects any undeclared flag (**global strict**, with a `did you mean --x?` suggestion). Unknown-flag rejection means every registered command MUST declare a spec — a missing/empty spec rejects all flags. `Passthrough:true` is the narrow escape-hatch for delegating/unavailable stubs (e.g. the OSS `bootstrap` stub): it skips both help interception and validation so every arg reaches `Execute` unchanged and the command keeps its own messaging (and no Pro flag internals leak into OSS — see Pro Feature Boundary).
 - **Snapshot Cache**: `docker.GetSnapshot()` / `docker.RefreshSnapshot()` — 3s TTL, background event-driven invalidation.
@@ -92,7 +94,7 @@ utils/log/
 
 **New command**: Create `commands/command/mycommand.go`, implement `registry.Command` (Name/Description/Execute), call `registry.Register()` in `init()`. Also implement `Spec() registry.CommandSpec` — declare every flag the command reads (`a.Has`/`a.Get`) plus `Usage`/`Examples`, or `:cmd --help` shows only a fallback and strict validation rejects the command's own flags. Aliases (`Aliaser`) inherit the primary's spec; do not add a spec to the alias. See `commands/command/docker/node/ls.go` for a zero-flag spec and `swarmcli-be/commands/pro/bootstrap.go` for the full worked example.
 
-**New view**: Create `views/myview/`, implement `view.View` interface, register factory in `app/app.go` `Init()`.
+**New view**: Create `views/myview/`, implement `view.View` interface, and add a `register.go` whose `init()` calls `view.RegisterView(name, factory)`. Add its blank import to `views/autoload.go` so the package is loaded. See `views/nodes/register.go`.
 
 ## Environment Variables
 

--- a/README.md
+++ b/README.md
@@ -62,8 +62,40 @@ swarmcli
 - **Instant Logs**: No more `docker service logs -f`. Just press `l` on any service.
 - **Secrets & Configs**: Manage, rotate, and — with [Business Edition](#business-edition) — **reveal** secrets for debugging.
 - **Management Actions**: Scale, restart, remove, and update services with single keystrokes.
+- **Chart Package Manager**: Helm-like packaging for Swarm — install, upgrade, roll back, and diff releases from chart repositories via `swarmcli charts`.
 - **Zero Config**: Works out-of-the-box with your local Docker engine or remote via SSH/Contexts.
 - **Lightweight**: Built with Go. Single static binary (< 20MB). Zero dependencies.
+
+## Charts (CLI)
+
+A bare `swarmcli` launches the TUI, but a few commands run non-interactively
+when arguments are supplied: `swarmcli version`, `swarmcli help`, and the
+Helm-like chart package manager `swarmcli charts <command>`:
+
+```bash
+# Repositories
+swarmcli charts repo add <name> <url>     # add a repo and download its index
+swarmcli charts repo list                 # list configured repos
+swarmcli charts repo update [name]        # refresh indexes (all, or one)
+swarmcli charts repo remove <name>        # remove a repo
+
+# Discovery
+swarmcli charts search [keyword]          # search charts across repos
+swarmcli charts show chart  <repo/chart>  # chart metadata (also: values, schema)
+
+# Releases
+swarmcli charts template <release> <repo/chart>   # render manifest (no deploy)
+swarmcli charts install  <release> <repo/chart>   # install a chart as a release
+swarmcli charts upgrade  <release> <repo/chart>   # upgrade to a new revision
+swarmcli charts diff upgrade <release> <repo/chart>  # preview upgrade changes
+swarmcli charts rollback <release> <revision>     # re-deploy a past revision
+swarmcli charts uninstall <release>               # remove a release
+swarmcli charts history <release>                 # revision history
+swarmcli charts list                              # list releases
+swarmcli charts status <release>                  # release status and services
+```
+
+Run `swarmcli charts --help` for the full command and option reference.
 
 ## Business Edition
 
@@ -173,7 +205,6 @@ TEST_LOG=1 ./test-setup/testenv.sh test
 | `:secret`  | Navigate to Secret    |
 | `:network` | Navigate to Networks  |
 | `:volume`  | Navigate to Volumes   |
-| `:node`  | Navigate to Nodes       |
 | `l`      | View Logs               |
 | `s`      | Scale Service           |
 | `r`      | Restart Service         |


### PR DESCRIPTION
Documentation-only. No code changes. Found during a cross-repo doc-freshness audit.

**View registration was documented wrong** (would misguide anyone adding a view). CLAUDE.md and `.github/copilot-instructions.md` said views are "registered in `app.Init()`" via `registerView` — that symbol doesn't exist. Views self-register via `view.RegisterView` in each view's `register.go`, pulled in by autoload (`views/autoload.go`); the registry lives in `views/view/registry.go`. Also corrected the factory signature in copilot-instructions.

**Charts CLI was undocumented.** The `swarmcli charts …` Helm-like package manager (merged via #415/#418) plus `swarmcli version`/`help` now have a README section. CLAUDE.md architecture updated to note the `cli.Dispatch` entry path, the new `cli/` and `charts/` packages, and the `commands/command/docker/<entity>/` reorg.

**Minor:** removed a duplicate `:node` key-binding row in README.

The commented-out `ghcr.io/...` Docker-run block in README was deliberately left untouched — see the cross-repo summary; the published image is `eldaratech/swarmcli` (Docker Hub) and re-enabling that block is a separate editorial call.
