### PR TITLE
fix(docker): retry node spec updates on "update out of sequence"

### DIFF
--- a/docker/node.go
+++ b/docker/node.go
@@ -6,9 +6,58 @@ package docker
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/docker/docker/api/types/swarm"
 )
+
+// nodeUpdateMaxAttempts bounds how many times a spec update is retried when the
+// daemon rejects it with "update out of sequence". Swarm bumps a node's version
+// index on background status/heartbeat writes as well as spec changes, so a
+// fetch-then-update can race a concurrent bump and submit a stale version index;
+// re-fetching and retrying resolves it.
+const nodeUpdateMaxAttempts = 5
+
+// nodeUpdater is the subset of the Docker client used to mutate a node's spec.
+// *client.Client satisfies it; it exists so updateNodeSpec is unit-testable
+// without a live daemon.
+type nodeUpdater interface {
+	NodeInspectWithRaw(ctx context.Context, nodeID string) (swarm.Node, []byte, error)
+	NodeUpdate(ctx context.Context, nodeID string, version swarm.Version, spec swarm.NodeSpec) error
+}
+
+// isUpdateOutOfSequence reports whether err is the daemon's optimistic-concurrency
+// rejection ("update out of sequence"), raised when NodeUpdate is given a version
+// index that no longer matches the store.
+func isUpdateOutOfSequence(err error) bool {
+	return err != nil && strings.Contains(strings.ToLower(err.Error()), "update out of sequence")
+}
+
+// updateNodeSpec fetches the node, applies mutate to a copy of its spec, and
+// submits the update using the node's current version index. On an "update out
+// of sequence" rejection it re-fetches and retries, up to nodeUpdateMaxAttempts.
+func updateNodeSpec(ctx context.Context, c nodeUpdater, nodeID string, mutate func(*swarm.NodeSpec)) error {
+	var lastErr error
+	for attempt := 0; attempt < nodeUpdateMaxAttempts; attempt++ {
+		node, _, err := c.NodeInspectWithRaw(ctx, nodeID)
+		if err != nil {
+			return fmt.Errorf("inspect node: %w", err)
+		}
+
+		spec := node.Spec
+		mutate(&spec)
+
+		err = c.NodeUpdate(ctx, nodeID, node.Version, spec)
+		if err == nil {
+			return nil
+		}
+		if !isUpdateOutOfSequence(err) {
+			return err
+		}
+		lastErr = err
+	}
+	return fmt.Errorf("after %d attempts: %w", nodeUpdateMaxAttempts, lastErr)
+}
 
 // GetLocalNodeID returns the swarm node ID of the daemon the active Docker
 // client is connected to, or "" if it is not an active swarm node.
@@ -50,18 +99,9 @@ func DemoteNode(ctx context.Context, nodeID string) error {
 		return err
 	}
 
-	// Fetch current node to get the version and current spec
-	node, _, err := c.NodeInspectWithRaw(ctx, nodeID)
-	if err != nil {
-		return fmt.Errorf("inspect node: %w", err)
-	}
-
-	// Modify spec to set worker role
-	spec := node.Spec
-	spec.Role = swarm.NodeRoleWorker
-
-	// Perform update using the node's current version index
-	if err := c.NodeUpdate(ctx, nodeID, node.Version, spec); err != nil {
+	if err := updateNodeSpec(ctx, c, nodeID, func(spec *swarm.NodeSpec) {
+		spec.Role = swarm.NodeRoleWorker
+	}); err != nil {
 		return fmt.Errorf("demote node: %w", err)
 	}
 	return nil
@@ -74,18 +114,9 @@ func PromoteNode(ctx context.Context, nodeID string) error {
 		return err
 	}
 
-	// Fetch current node to get the version and current spec
-	node, _, err := c.NodeInspectWithRaw(ctx, nodeID)
-	if err != nil {
-		return fmt.Errorf("inspect node: %w", err)
-	}
-
-	// Modify spec to set manager role
-	spec := node.Spec
-	spec.Role = swarm.NodeRoleManager
-
-	// Perform update using the node's current version index
-	if err := c.NodeUpdate(ctx, nodeID, node.Version, spec); err != nil {
+	if err := updateNodeSpec(ctx, c, nodeID, func(spec *swarm.NodeSpec) {
+		spec.Role = swarm.NodeRoleManager
+	}); err != nil {
 		return fmt.Errorf("promote node: %w", err)
 	}
 	return nil
@@ -98,18 +129,9 @@ func SetNodeAvailability(ctx context.Context, nodeID string, availability swarm.
 		return err
 	}
 
-	// Fetch current node to get the version and current spec
-	node, _, err := c.NodeInspectWithRaw(ctx, nodeID)
-	if err != nil {
-		return fmt.Errorf("inspect node: %w", err)
-	}
-
-	// Modify spec to set availability
-	spec := node.Spec
-	spec.Availability = availability
-
-	// Perform update using the node's current version index
-	if err := c.NodeUpdate(ctx, nodeID, node.Version, spec); err != nil {
+	if err := updateNodeSpec(ctx, c, nodeID, func(spec *swarm.NodeSpec) {
+		spec.Availability = availability
+	}); err != nil {
 		return fmt.Errorf("set node availability: %w", err)
 	}
 	return nil
@@ -122,21 +144,12 @@ func AddNodeLabel(ctx context.Context, nodeID string, key string, value string) 
 		return err
 	}
 
-	// Fetch current node to get the version and current spec
-	node, _, err := c.NodeInspectWithRaw(ctx, nodeID)
-	if err != nil {
-		return fmt.Errorf("inspect node: %w", err)
-	}
-
-	// Modify spec to add/update label
-	spec := node.Spec
-	if spec.Labels == nil {
-		spec.Labels = make(map[string]string)
-	}
-	spec.Labels[key] = value
-
-	// Perform update using the node's current version index
-	if err := c.NodeUpdate(ctx, nodeID, node.Version, spec); err != nil {
+	if err := updateNodeSpec(ctx, c, nodeID, func(spec *swarm.NodeSpec) {
+		if spec.Labels == nil {
+			spec.Labels = make(map[string]string)
+		}
+		spec.Labels[key] = value
+	}); err != nil {
 		return fmt.Errorf("add node label: %w", err)
 	}
 	return nil
@@ -149,20 +162,11 @@ func RemoveNodeLabel(ctx context.Context, nodeID string, key string) error {
 		return err
 	}
 
-	// Fetch current node to get the version and current spec
-	node, _, err := c.NodeInspectWithRaw(ctx, nodeID)
-	if err != nil {
-		return fmt.Errorf("inspect node: %w", err)
-	}
-
-	// Modify spec to remove label
-	spec := node.Spec
-	if spec.Labels != nil {
-		delete(spec.Labels, key)
-	}
-
-	// Perform update using the node's current version index
-	if err := c.NodeUpdate(ctx, nodeID, node.Version, spec); err != nil {
+	if err := updateNodeSpec(ctx, c, nodeID, func(spec *swarm.NodeSpec) {
+		if spec.Labels != nil {
+			delete(spec.Labels, key)
+		}
+	}); err != nil {
 		return fmt.Errorf("remove node label: %w", err)
 	}
 	return nil

--- a/docker/node_test.go
+++ b/docker/node_test.go
@@ -1,0 +1,164 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package docker
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/docker/docker/api/types/swarm"
+)
+
+func TestIsUpdateOutOfSequence(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"daemon message", errors.New("Error response from daemon: rpc error: code = Unknown desc = update out of sequence"), true},
+		{"mixed case", errors.New("Update Out Of Sequence"), true},
+		{"unrelated", errors.New("connection refused"), false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := isUpdateOutOfSequence(c.err); got != c.want {
+				t.Fatalf("isUpdateOutOfSequence(%v) = %v, want %v", c.err, got, c.want)
+			}
+		})
+	}
+}
+
+// fakeNodeUpdater satisfies nodeUpdater. Each NodeUpdate that fails bumps the
+// stored version, so the next NodeInspectWithRaw returns a fresh index —
+// modelling the concurrent status writes that cause "update out of sequence".
+type fakeNodeUpdater struct {
+	curVersion uint64
+	spec       swarm.NodeSpec
+	inspectErr error
+	updateErr  error // returned by NodeUpdate while failsLeft > 0
+	failsLeft  int
+
+	inspects int
+	updates  int
+	lastSpec swarm.NodeSpec
+	lastVer  swarm.Version
+}
+
+func (f *fakeNodeUpdater) NodeInspectWithRaw(_ context.Context, _ string) (swarm.Node, []byte, error) {
+	f.inspects++
+	if f.inspectErr != nil {
+		return swarm.Node{}, nil, f.inspectErr
+	}
+	return swarm.Node{
+		Meta: swarm.Meta{Version: swarm.Version{Index: f.curVersion}},
+		Spec: f.spec,
+	}, nil, nil
+}
+
+func (f *fakeNodeUpdater) NodeUpdate(_ context.Context, _ string, version swarm.Version, spec swarm.NodeSpec) error {
+	f.updates++
+	f.lastVer = version
+	f.lastSpec = spec
+	if f.failsLeft > 0 {
+		f.failsLeft--
+		f.curVersion++ // a concurrent write moved the index forward
+		return f.updateErr
+	}
+	return nil
+}
+
+func TestUpdateNodeSpec_SucceedsFirstTry(t *testing.T) {
+	f := &fakeNodeUpdater{curVersion: 7, spec: swarm.NodeSpec{}}
+
+	err := updateNodeSpec(context.Background(), f, "n1", func(spec *swarm.NodeSpec) {
+		if spec.Labels == nil {
+			spec.Labels = map[string]string{}
+		}
+		spec.Labels["k"] = "v"
+	})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if f.inspects != 1 || f.updates != 1 {
+		t.Fatalf("inspects=%d updates=%d, want 1/1", f.inspects, f.updates)
+	}
+	if f.lastVer.Index != 7 {
+		t.Fatalf("update used version %d, want 7", f.lastVer.Index)
+	}
+	if f.lastSpec.Labels["k"] != "v" {
+		t.Fatalf("mutate not applied to submitted spec: %#v", f.lastSpec.Labels)
+	}
+}
+
+func TestUpdateNodeSpec_RetriesThenSucceeds(t *testing.T) {
+	f := &fakeNodeUpdater{
+		curVersion: 3,
+		updateErr:  errors.New("Error response from daemon: update out of sequence"),
+		failsLeft:  2,
+	}
+
+	err := updateNodeSpec(context.Background(), f, "n1", func(*swarm.NodeSpec) {})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if f.inspects != 3 || f.updates != 3 {
+		t.Fatalf("inspects=%d updates=%d, want 3/3", f.inspects, f.updates)
+	}
+	if f.lastVer.Index != 5 { // 3 + two concurrent bumps; proves it re-inspected
+		t.Fatalf("final update used version %d, want 5 (re-fetched)", f.lastVer.Index)
+	}
+}
+
+func TestUpdateNodeSpec_GivesUpAfterMaxAttempts(t *testing.T) {
+	f := &fakeNodeUpdater{
+		updateErr: errors.New("update out of sequence"),
+		failsLeft: nodeUpdateMaxAttempts + 1,
+	}
+
+	err := updateNodeSpec(context.Background(), f, "n1", func(*swarm.NodeSpec) {})
+
+	if err == nil {
+		t.Fatal("expected error after exhausting retries")
+	}
+	if !strings.Contains(err.Error(), "update out of sequence") {
+		t.Fatalf("error should wrap the daemon message: %v", err)
+	}
+	if f.updates != nodeUpdateMaxAttempts {
+		t.Fatalf("updates=%d, want %d", f.updates, nodeUpdateMaxAttempts)
+	}
+}
+
+func TestUpdateNodeSpec_NonRetryableErrorReturnsImmediately(t *testing.T) {
+	f := &fakeNodeUpdater{
+		updateErr: errors.New("node not found"),
+		failsLeft: 1,
+	}
+
+	err := updateNodeSpec(context.Background(), f, "n1", func(*swarm.NodeSpec) {})
+
+	if err == nil || !strings.Contains(err.Error(), "node not found") {
+		t.Fatalf("want non-retryable error returned verbatim, got %v", err)
+	}
+	if f.updates != 1 {
+		t.Fatalf("updates=%d, want 1 (no retry on non-conflict error)", f.updates)
+	}
+}
+
+func TestUpdateNodeSpec_InspectErrorIsWrapped(t *testing.T) {
+	f := &fakeNodeUpdater{inspectErr: errors.New("boom")}
+
+	err := updateNodeSpec(context.Background(), f, "n1", func(*swarm.NodeSpec) {})
+
+	if err == nil || !strings.Contains(err.Error(), "inspect node") {
+		t.Fatalf("want inspect-node wrapped error, got %v", err)
+	}
+	if f.updates != 0 {
+		t.Fatalf("updates=%d, want 0 (no update after inspect failure)", f.updates)
+	}
+}


### PR DESCRIPTION
## Problem
`TestAddAndRemoveNodeLabel` failed on `main` after #410 merged, with:

```
remove node label: Error response from daemon: rpc error: code = Unknown desc = update out of sequence
```

This is **not** a regression from #410 (that merge touched only swarm-lock/context/snapshot/unlock files — never `docker/node.go`). It is a pre-existing latent race that surfaced for the first time.

**Root cause.** Each node mutator does `NodeInspectWithRaw` → read `node.Version` → `NodeUpdate(version, spec)`. Swarm bumps a node's `Meta.Version.Index` on *background* status/heartbeat writes as well as spec changes, so a concurrent bump landing in the inspect→update window makes the submitted version index stale, and the daemon rejects it with *"update out of sequence."* Small window, probabilistic — hence it passed until now. All five mutators (`Demote`/`PromoteNode`, `SetNodeAvailability`, `Add`/`RemoveNodeLabel`) shared the flaw; none retried.

## Changes
- `docker/node.go`: new `updateNodeSpec` helper — re-inspect + re-submit, retrying up to `nodeUpdateMaxAttempts` (5) on the optimistic-concurrency rejection only; all other errors propagate immediately. All five mutators now route through it. `isUpdateOutOfSequence` mirrors the existing `IsSwarmLockedErr` daemon-message detection style.
- Helper sits behind a small `nodeUpdater` interface (satisfied by `*client.Client`) so the retry logic is unit-testable without a live daemon.
- `RemoveNode` is untouched — it calls `NodeRemove`, which is not version-checked.

## Testing
- New `docker/node_test.go`: covers success-first-try (correct version + mutation submitted), retry-then-succeed (re-fetches a fresh index each attempt), give-up-after-max-attempts (wraps the daemon message), non-retryable error returns immediately, and inspect-error wrapping.
- `go test ./...` green; `go vet ./...` clean; `golangci-lint run ./docker/ --build-tags=integration` → 0 issues.
- The live-daemon path is exercised by the existing `TestAddAndRemoveNodeLabel` integration test (now retry-hardened).

🤖 Generated with [Claude Code](https://claude.com/claude-code)