### PR TITLE
feat(charts): `charts prune` command + --history-max UX polish

### DIFF
--- a/charts/README.md
+++ b/charts/README.md
@@ -85,6 +85,37 @@ external database.
 docker config ls --filter label=com.swarmcli.release=my-traefik
 ```
 
+## Pruning release history
+
+Because every revision is its own Config, history grows without bound. Trim it
+with the retention window — keep only the newest `N` revisions:
+
+```bash
+# Apply a window inline, after the deploy:
+swarmcli charts install my-traefik eldara/traefik --history-max 20
+swarmcli charts upgrade my-traefik eldara/traefik --history-max 20
+
+# Or prune existing history on demand:
+swarmcli charts prune my-traefik --history-max 20   # one release
+swarmcli charts prune --history-max 20              # every release
+swarmcli charts prune my-traefik --history-max 20 --dry-run  # preview only
+```
+
+`prune` deletes the oldest revisions beyond the window and **always keeps the
+current (highest) revision**, so the live release and rollback targets inside the
+window are preserved. Without `--history-max` (or with `0`) it keeps everything
+and reports that no window was given. `--dry-run` prints the keep/delete decision
+without touching Docker.
+
+> **Use `swarmcli charts prune`, not raw Docker.** `docker config prune`,
+> `docker system prune` and `docker config rm swarmcli.release.*` are not
+> SwarmCLI-aware and will corrupt release history, rollback targets and audit
+> lineage. SwarmCLI is the only sanctioned way to delete a release's resources.
+
+Per-revision protection labels (`com.swarmcli.keep`, `com.swarmcli.protected`)
+are a planned Phase-3 addition; today the current revision plus the newest-`N`
+window are the protections.
+
 ## Notes & limitations
 
 - **`install --dry-run`** renders, validates, and computes the next revision

--- a/charts/prune_test.go
+++ b/charts/prune_test.go
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package charts
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// seedRevisions installs a release and upgrades it to `count` total revisions
+// using a fresh engine that does not auto-prune.
+func seedRevisions(t *testing.T, e *Engine, release string, count int) {
+	t.Helper()
+	ctx := context.Background()
+	_, err := e.Install(ctx, release, ReleaseChart{Name: "c", Version: "1"}, nil,
+		"services:\n  s:\n    image: v1\n", InstallOptions{})
+	require.NoError(t, err)
+	for i := 2; i <= count; i++ {
+		_, err := e.Upgrade(ctx, release, ReleaseChart{Name: "c", Version: "1"}, nil,
+			fmt.Sprintf("services:\n  s:\n    image: v%d\n", i), InstallOptions{})
+		require.NoError(t, err)
+	}
+}
+
+func revs(n int) []Release {
+	out := make([]Release, n)
+	for i := range out {
+		out[i] = Release{Revision: i + 1}
+	}
+	return out
+}
+
+func deleted(actions []PruneAction) []int {
+	var out []int
+	for _, a := range actions {
+		if a.Delete {
+			out = append(out, a.Revision)
+		}
+	}
+	return out
+}
+
+func TestPlanPrune(t *testing.T) {
+	cases := []struct {
+		name string
+		n    int
+		keep int
+		want []int // revisions deleted
+	}{
+		{"keep zero keeps all", 4, 0, nil},
+		{"negative keeps all", 4, -3, nil},
+		{"keep ge len keeps all", 4, 4, nil},
+		{"keep gt len keeps all", 4, 9, nil},
+		{"keep two deletes oldest two", 4, 2, []int{1, 2}},
+		{"keep one deletes all but current", 4, 1, []int{1, 2, 3}},
+		{"single revision never deleted", 1, 1, nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			actions := planPrune(revs(tc.n), tc.keep)
+			require.Len(t, actions, tc.n)
+			require.Equal(t, tc.want, deleted(actions))
+			// The highest revision is always the current one and never deleted.
+			top := actions[len(actions)-1]
+			require.True(t, top.Current)
+			require.False(t, top.Delete)
+		})
+	}
+}
+
+func TestPruneDeletesOldestKeepsCurrent(t *testing.T) {
+	fb := newFakeBackend()
+	e := testEngine(fb)
+	seedRevisions(t, e, "demo", 4)
+
+	res, err := e.Prune(context.Background(), "demo", 2, false)
+	require.NoError(t, err)
+	require.Equal(t, []int{1, 2}, res.Deleted())
+
+	_, ok1 := fb.configs[releaseConfigName("demo", 1)]
+	_, ok2 := fb.configs[releaseConfigName("demo", 2)]
+	_, ok3 := fb.configs[releaseConfigName("demo", 3)]
+	_, ok4 := fb.configs[releaseConfigName("demo", 4)]
+	require.False(t, ok1)
+	require.False(t, ok2)
+	require.True(t, ok3)
+	require.True(t, ok4) // current revision retained
+}
+
+func TestPruneDryRunMutatesNothing(t *testing.T) {
+	fb := newFakeBackend()
+	e := testEngine(fb)
+	seedRevisions(t, e, "demo", 4)
+
+	res, err := e.Prune(context.Background(), "demo", 2, true)
+	require.NoError(t, err)
+	require.Equal(t, []int{1, 2}, res.Deleted())
+	require.Len(t, fb.configs, 4) // nothing actually deleted
+}
+
+func TestPruneKeepZeroIsNoOp(t *testing.T) {
+	fb := newFakeBackend()
+	e := testEngine(fb)
+	seedRevisions(t, e, "demo", 3)
+
+	res, err := e.Prune(context.Background(), "demo", 0, false)
+	require.NoError(t, err)
+	require.Empty(t, res.Deleted())
+	require.Len(t, fb.configs, 3)
+}
+
+func TestPruneNotFound(t *testing.T) {
+	e := testEngine(newFakeBackend())
+	_, err := e.Prune(context.Background(), "ghost", 1, false)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not found")
+}
+
+func TestPruneAllPerReleaseIsolation(t *testing.T) {
+	fb := newFakeBackend()
+	e := testEngine(fb)
+	seedRevisions(t, e, "alpha", 3)
+	seedRevisions(t, e, "beta", 2)
+
+	results, err := e.PruneAll(context.Background(), 1, false)
+	require.NoError(t, err)
+	require.Len(t, results, 2)
+	require.Equal(t, "alpha", results[0].Release) // sorted by name
+	require.Equal(t, "beta", results[1].Release)
+
+	// Each release keeps only its current revision.
+	require.Equal(t, []int{1, 2}, results[0].Deleted())
+	require.Equal(t, []int{1}, results[1].Deleted())
+	require.Len(t, fb.configs, 2)
+	require.Contains(t, fb.configs, releaseConfigName("alpha", 3))
+	require.Contains(t, fb.configs, releaseConfigName("beta", 2))
+}
+
+func TestPruneAggregatesDeleteErrors(t *testing.T) {
+	fb := newFakeBackend()
+	e := testEngine(fb)
+	seedRevisions(t, e, "demo", 3)
+	fb.deleteCfgErr = map[string]error{releaseConfigName("demo", 1): fmt.Errorf("boom")}
+
+	_, err := e.Prune(context.Background(), "demo", 1, false)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "boom")
+	// The non-failing revision was still deleted; the failing one remains.
+	require.Contains(t, fb.configs, releaseConfigName("demo", 1))
+	require.NotContains(t, fb.configs, releaseConfigName("demo", 2))
+	require.Contains(t, fb.configs, releaseConfigName("demo", 3)) // current
+}

--- a/charts/release.go
+++ b/charts/release.go
@@ -553,14 +553,111 @@ func (e *Engine) storeRevision(ctx context.Context, rel *Release) error {
 	return e.Backend.CreateConfig(ctx, releaseConfigName(rel.Name, rel.Revision), gz, labels)
 }
 
-// pruneHistory deletes the oldest revisions beyond keep (best-effort).
+// PruneAction is the keep/delete decision for one revision in a prune.
+type PruneAction struct {
+	Revision int
+	Delete   bool
+	Current  bool // the live (highest) revision; never deleted
+}
+
+// PruneResult reports what a prune did (or, for a dry run, would do) for one
+// release. Actions are ascending by revision.
+type PruneResult struct {
+	Release string
+	Actions []PruneAction
+}
+
+// Deleted returns the revision numbers Prune removed (or would remove).
+func (r PruneResult) Deleted() []int {
+	var out []int
+	for _, a := range r.Actions {
+		if a.Delete {
+			out = append(out, a.Revision)
+		}
+	}
+	return out
+}
+
+// planPrune decides, for revisions sorted ascending, which to delete to retain
+// the newest keep. keep <= 0 keeps everything. The highest (current) revision is
+// always retained regardless of keep, so the live release is never destroyed.
+func planPrune(revs []Release, keep int) []PruneAction {
+	actions := make([]PruneAction, len(revs))
+	top := len(revs) - 1
+	for i, r := range revs {
+		current := i == top
+		del := keep > 0 && i < len(revs)-keep && !current
+		actions[i] = PruneAction{Revision: r.Revision, Delete: del, Current: current}
+	}
+	return actions
+}
+
+// Prune deletes superseded revisions of one release beyond the keep window,
+// always retaining the current (highest) revision. keep <= 0 keeps everything.
+// On a dry run no Config is touched. Deletion failures are aggregated and
+// returned, but pruning of the remaining revisions continues.
+func (e *Engine) Prune(ctx context.Context, release string, keep int, dryRun bool) (PruneResult, error) {
+	revs, err := e.revisions(ctx, release)
+	if err != nil {
+		return PruneResult{}, err
+	}
+	if len(revs) == 0 {
+		return PruneResult{}, fmt.Errorf("release %q not found", release)
+	}
+	res := PruneResult{Release: release, Actions: planPrune(revs, keep)}
+	if dryRun {
+		return res, nil
+	}
+	var errs []error
+	for _, a := range res.Actions {
+		if !a.Delete {
+			continue
+		}
+		if derr := e.Backend.DeleteConfig(ctx, releaseConfigName(release, a.Revision)); derr != nil {
+			errs = append(errs, fmt.Errorf("deleting %s: %w", releaseConfigName(release, a.Revision), derr))
+		}
+	}
+	return res, errors.Join(errs...)
+}
+
+// PruneAll prunes every release to the keep window, returning one result per
+// release (sorted by name). Per-release errors are aggregated; a failing release
+// does not stop the others.
+func (e *Engine) PruneAll(ctx context.Context, keep int, dryRun bool) ([]PruneResult, error) {
+	byRelease, err := e.allRevisions(ctx)
+	if err != nil {
+		return nil, err
+	}
+	names := make([]string, 0, len(byRelease))
+	for name := range byRelease {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	var results []PruneResult
+	var errs []error
+	for _, name := range names {
+		res, perr := e.Prune(ctx, name, keep, dryRun)
+		if perr != nil {
+			errs = append(errs, perr)
+		}
+		results = append(results, res)
+	}
+	return results, errors.Join(errs...)
+}
+
+// pruneHistory trims a release's history to keep revisions after a successful
+// deploy. It is best-effort: deletion errors are ignored because the deploy
+// itself already succeeded and recorded. Retention logic is shared with Prune
+// via planPrune, so the keep <= 0 / current-revision guarantees hold here too.
 func (e *Engine) pruneHistory(ctx context.Context, release string, keep int) {
 	revs, err := e.revisions(ctx, release)
-	if err != nil || len(revs) <= keep {
+	if err != nil {
 		return
 	}
-	for _, r := range revs[:len(revs)-keep] {
-		_ = e.Backend.DeleteConfig(ctx, releaseConfigName(release, r.Revision))
+	for _, a := range planPrune(revs, keep) {
+		if a.Delete {
+			_ = e.Backend.DeleteConfig(ctx, releaseConfigName(release, a.Revision))
+		}
 	}
 }
 

--- a/charts/release.go
+++ b/charts/release.go
@@ -604,6 +604,13 @@ func (e *Engine) Prune(ctx context.Context, release string, keep int, dryRun boo
 	if len(revs) == 0 {
 		return PruneResult{}, fmt.Errorf("release %q not found", release)
 	}
+	return e.pruneRevs(ctx, release, revs, keep, dryRun)
+}
+
+// pruneRevs applies the retention plan to a release whose revisions are already
+// loaded (ascending, non-empty). Splitting this out lets PruneAll prune from the
+// single allRevisions load instead of re-reading every config per release.
+func (e *Engine) pruneRevs(ctx context.Context, release string, revs []Release, keep int, dryRun bool) (PruneResult, error) {
 	res := PruneResult{Release: release, Actions: planPrune(revs, keep)}
 	if dryRun {
 		return res, nil
@@ -636,7 +643,7 @@ func (e *Engine) PruneAll(ctx context.Context, keep int, dryRun bool) ([]PruneRe
 	var results []PruneResult
 	var errs []error
 	for _, name := range names {
-		res, perr := e.Prune(ctx, name, keep, dryRun)
+		res, perr := e.pruneRevs(ctx, name, byRelease[name], keep, dryRun)
 		if perr != nil {
 			errs = append(errs, perr)
 		}

--- a/charts/release_test.go
+++ b/charts/release_test.go
@@ -27,6 +27,7 @@ type fakeBackend struct {
 	refreshErr    error
 	secretsErr    error                   // error to return from SecretNames
 	onCreate      func(name string) error // hook to simulate concurrent config creation
+	deleteCfgErr  map[string]error        // config name -> error to return on delete
 }
 
 type fakeConfig struct {
@@ -89,6 +90,9 @@ func (f *fakeBackend) InspectConfig(_ context.Context, name string) ([]byte, err
 	return c.data, nil
 }
 func (f *fakeBackend) DeleteConfig(_ context.Context, name string) error {
+	if err := f.deleteCfgErr[name]; err != nil {
+		return err
+	}
 	delete(f.configs, name)
 	return nil
 }

--- a/cli/charts.go
+++ b/cli/charts.go
@@ -36,6 +36,7 @@ Releases:
   uninstall <release>         Remove a release (keeps volumes)
   rollback <release> <rev>    Re-deploy the contents of a past revision
   history <release>           Show a release's revision history
+  prune [release]             Delete old revisions beyond --history-max
   get values|manifest <rel>   Show stored values or rendered manifest
   diff upgrade <rel> <chart>  Preview manifest changes before upgrading
   list                        List releases
@@ -84,6 +85,8 @@ func chartsMain(args []string) int {
 		return chartsRollback(rest)
 	case "history":
 		return chartsHistory(rest)
+	case "prune":
+		return chartsPrune(rest)
 	case "get":
 		return chartsGet(rest)
 	case "diff":
@@ -397,6 +400,58 @@ func chartsHistory(args []string) int {
 		rows = append(rows, []string{strconv.Itoa(r.Revision), r.Status, r.Chart.Name + "-" + r.Chart.Version, r.Created})
 	}
 	table([]string{"REVISION", "STATUS", "CHART", "UPDATED"}, rows)
+	return 0
+}
+
+func chartsPrune(args []string) int {
+	pos, f, err := parseArgs(args)
+	if err != nil {
+		return usageErr(err.Error())
+	}
+	if len(pos) > 1 {
+		return usageErr("charts prune [release] [--history-max <n>] [--dry-run]")
+	}
+	e := charts.NewEngine()
+	ctx := context.Background()
+
+	var results []charts.PruneResult
+	if len(pos) == 1 {
+		var res charts.PruneResult
+		res, err = e.Prune(ctx, pos[0], f.historyMax, f.dryRun)
+		results = []charts.PruneResult{res}
+	} else {
+		results, err = e.PruneAll(ctx, f.historyMax, f.dryRun)
+	}
+	if err != nil {
+		return fail(err)
+	}
+
+	rows := make([][]string, 0)
+	deleted := 0
+	for _, res := range results {
+		for _, a := range res.Actions {
+			action := "keep"
+			switch {
+			case a.Delete:
+				action = "delete"
+				deleted++
+			case a.Current:
+				action = "keep (current)"
+			}
+			rows = append(rows, []string{res.Release, strconv.Itoa(a.Revision), action})
+		}
+	}
+	table([]string{"RELEASE", "REVISION", "ACTION"}, rows)
+
+	if f.historyMax <= 0 {
+		errf("no --history-max retention window given; all revisions kept (pass --history-max <n> to prune)\n")
+		return 0
+	}
+	if f.dryRun {
+		outf("dry-run: %d revision(s) would be pruned\n", deleted)
+	} else {
+		outf("pruned %d revision(s)\n", deleted)
+	}
 	return 0
 }
 

--- a/cli/charts.go
+++ b/cli/charts.go
@@ -426,6 +426,11 @@ func chartsPrune(args []string) int {
 		return fail(err)
 	}
 
+	if f.historyMax <= 0 {
+		errf("no --history-max retention window given; all revisions kept (pass --history-max <n> to prune)\n")
+		return 0
+	}
+
 	rows := make([][]string, 0)
 	deleted := 0
 	for _, res := range results {
@@ -443,10 +448,6 @@ func chartsPrune(args []string) int {
 	}
 	table([]string{"RELEASE", "REVISION", "ACTION"}, rows)
 
-	if f.historyMax <= 0 {
-		errf("no --history-max retention window given; all revisions kept (pass --history-max <n> to prune)\n")
-		return 0
-	}
 	if f.dryRun {
 		outf("dry-run: %d revision(s) would be pruned\n", deleted)
 	} else {

--- a/cli/charts_test.go
+++ b/cli/charts_test.go
@@ -64,6 +64,23 @@ func TestChartsTemplateUnknownFlag(t *testing.T) {
 	require.Equal(t, 2, code)
 }
 
+func TestChartsPruneTooManyArgs(t *testing.T) {
+	var code int
+	_, errOut := capture(t, func() {
+		code = Dispatch([]string{"charts", "prune", "rel-a", "rel-b"}, "dev")
+	})
+	require.Equal(t, 2, code)
+	require.Contains(t, errOut, "charts prune [release]")
+}
+
+func TestChartsPruneUnknownFlag(t *testing.T) {
+	var code int
+	capture(t, func() {
+		code = Dispatch([]string{"charts", "prune", "--bogus"}, "dev")
+	})
+	require.Equal(t, 2, code)
+}
+
 func TestChartsShowValues(t *testing.T) {
 	var code int
 	o, _ := capture(t, func() {


### PR DESCRIPTION
## What

Adds `swarmcli charts prune` — the sanctioned way to reclaim chart release history — and polishes the `--history-max` retention path. Implements #414 and the related Phase-2 follow-up from #415.

```
swarmcli charts prune [release] [--history-max N] [--dry-run]
```
- no `release` → all releases; one positional → that release
- `--history-max N` keeps the newest N revisions (reuses the existing flag)
- no `--history-max` (or `0`) → keeps everything and says so (no silent no-op)
- the **current (highest) revision is never deleted**, regardless of N
- `--dry-run` previews the keep/delete decision without touching Docker

## Why / design

Release history is an append-only log of immutable, gzipped Docker Configs (`swarmcli.release.<rel>.v<N>`). It grows unbounded, and the only prior trimming was a private, silent, best-effort `pruneHistory` that was unsafe at `keep=0` (would delete the live revision).

- **`charts/release.go`**: extracted a pure `planPrune` as the single source of truth for retention; added public `Prune`/`PruneAll` returning a reportable `PruneResult`; rewired the inline `pruneHistory` through `planPrune`. This fixes the `keep=0` footgun and surfaces deletion failures via `errors.Join` instead of swallowing them.
- **`cli/charts.go`**: the `prune` subcommand, reusing the existing `table()`/flag plumbing.
- **`charts/README.md`**: pruning section carrying the #414 safety guidance (never use raw `docker config prune`/`rm` on `swarmcli.release.*`).

### Design decisions (confirmed with maintainer)
- **Retention is a stateless flag**, not persisted — matches the existing per-command model; no new persistence in immutable per-revision configs.
- **keep/protected labels deferred to Phase 3.** Every recorded config stores `status=deployed` ("superseded" is *derived* at read-time), so a literal `status=deployed` protection rule would protect everything and is redundant with "keep newest N≥1"; and release configs are immutable with no in-place label-update helper, so toggling a protection label would mean rewriting an immutable audit record.
- **Scope:** prune + `--history-max` polish + docs only; richer `diff`/`get` output (the other half of the #415 bullet) is out of scope.

## Testing
- `go build ./...`, `go test ./...`, `golangci-lint run ./... --build-tags=integration` all pass; `gofmt` clean.
- New `charts/prune_test.go`: `planPrune` table tests, deletes-oldest/keeps-current, dry-run no-op, `keep=0` no-op, not-found, `PruneAll` per-release isolation, delete-error aggregation.
- CLI arg-validation tests; existing `TestHistoryMaxPrunes` stays green (inline behavior unchanged).

## Follow-ups
- Phase 3: `com.swarmcli.keep` / `com.swarmcli.protected` protection labels + protect/unprotect.
- Optional: an `integration-tests/charts/` install→upgrade×K→prune→history case (needs the DinD swarm).

Closes #414.

🤖 Generated with [Claude Code](https://claude.com/claude-code)