### PR TITLE
fix(charts): preserve comments in `charts show values`

### DIFF
--- a/charts/chart.go
+++ b/charts/chart.go
@@ -53,6 +53,7 @@ func LoadChartDir(dir string) (*Chart, error) {
 		if err := yaml.Unmarshal(v, &ch.Values); err != nil {
 			return nil, fmt.Errorf("parse %s: %w", valuesName, err)
 		}
+		ch.ValuesRaw = v
 	} else if !os.IsNotExist(err) {
 		return nil, fmt.Errorf("read %s: %w", valuesName, err)
 	}
@@ -155,6 +156,7 @@ func LoadChartArchive(r io.Reader) (*Chart, error) {
 			if err := yaml.Unmarshal(body, &ch.Values); err != nil {
 				return nil, fmt.Errorf("parse %s: %w", valuesName, err)
 			}
+			ch.ValuesRaw = body
 		case rel == schemaName:
 			ch.Schema = body
 		case rel == requirementsName:

--- a/charts/chart_test.go
+++ b/charts/chart_test.go
@@ -130,6 +130,39 @@ func TestLoadChartDirNoRequirementsIsNil(t *testing.T) {
 	require.Nil(t, ch.Requirements)
 }
 
+func TestLoadChartDirRetainsValuesRaw(t *testing.T) {
+	dir := t.TempDir()
+	writeMinimalChart(t, dir)
+	raw := "# a comment\nfoo: bar  # inline\n"
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "values.yaml"), []byte(raw), 0o644))
+
+	ch, err := LoadChartDir(dir)
+	require.NoError(t, err)
+	require.Equal(t, raw, string(ch.ValuesRaw)) // verbatim: comments + order preserved
+	require.Equal(t, "bar", ch.Values["foo"])   // still parsed
+}
+
+func TestLoadChartDirNoValuesRawIsNil(t *testing.T) {
+	dir := t.TempDir()
+	writeMinimalChart(t, dir)
+	ch, err := LoadChartDir(dir)
+	require.NoError(t, err)
+	require.Nil(t, ch.ValuesRaw)
+}
+
+func TestLoadChartArchiveRetainsValuesRaw(t *testing.T) {
+	raw := "# a comment\nfoo: bar\n"
+	tgz := packEntries(t, map[string]string{
+		"demo/Chart.yaml":           "name: demo\nversion: 1.0.0\n",
+		"demo/templates/stack.yaml": "services: {}\n",
+		"demo/values.yaml":          raw,
+	})
+	ch, err := LoadChartArchive(strings.NewReader(tgz))
+	require.NoError(t, err)
+	require.Equal(t, raw, string(ch.ValuesRaw))
+	require.Equal(t, "bar", ch.Values["foo"])
+}
+
 func TestLoadChartArchiveParsesRequirements(t *testing.T) {
 	tgz := packEntries(t, map[string]string{
 		"demo/Chart.yaml":           "name: demo\nversion: 1.0.0\n",

--- a/charts/types.go
+++ b/charts/types.go
@@ -65,6 +65,7 @@ type Dependency struct {
 type Chart struct {
 	Metadata     Chartfile
 	Values       map[string]any    // parsed values.yaml (defaults)
+	ValuesRaw    []byte            // raw values.yaml bytes, nil if absent (preserves comments/order)
 	Schema       []byte            // raw values.schema.json, nil if absent
 	Templates    map[string]string // template path -> source, e.g. "templates/stack.yaml"
 	Readme       string            // README.md, empty if absent

--- a/cli/charts.go
+++ b/cli/charts.go
@@ -235,6 +235,13 @@ func chartsShow(args []string) int {
 	case "chart":
 		printChartMeta(ch)
 	case "values":
+		// Print the chart's values.yaml verbatim so its comments and key order
+		// survive (re-marshalling the parsed map would drop both). Fall back to
+		// marshalling for a chart that ships no values.yaml.
+		if len(ch.ValuesRaw) > 0 {
+			_, _ = stdout.Write(ch.ValuesRaw)
+			break
+		}
 		data, err := yaml.Marshal(ch.Values)
 		if err != nil {
 			return fail(err)

--- a/cli/charts_test.go
+++ b/cli/charts_test.go
@@ -5,6 +5,8 @@ package cli
 
 import (
 	"bytes"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -88,6 +90,24 @@ func TestChartsShowValues(t *testing.T) {
 	})
 	require.Equal(t, 0, code)
 	require.Contains(t, o, "replicas: 1")
+}
+
+// show values must print values.yaml verbatim — its comments and key order are
+// documentation and must survive (re-marshalling the parsed map would drop both).
+func TestChartsShowValuesPreservesComments(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "templates"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "Chart.yaml"), []byte("name: demo\nversion: 1.0.0\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "templates", "stack.yaml"), []byte("services: {}\n"), 0o644))
+	raw := "# leading comment\nreplicas: 1  # inline comment\n"
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "values.yaml"), []byte(raw), 0o644))
+
+	var code int
+	o, _ := capture(t, func() {
+		code = Dispatch([]string{"charts", "show", "values", dir}, "dev")
+	})
+	require.Equal(t, 0, code)
+	require.Equal(t, raw, o)
 }
 
 func TestParseArgs(t *testing.T) {


### PR DESCRIPTION
## What

`charts show values <repo/chart>` re-marshalled the parsed values map, so it dropped the **comments** and original **key order** from the chart's `values.yaml`. Those comments are the chart's inline docs (defaults, required fields, gotchas), so losing them hurts.

## Fix

Retain the raw `values.yaml` bytes at load time (`Chart.ValuesRaw`, populated in both `LoadChartDir` and `LoadChartArchive`) and print them **verbatim** in `charts show values` — mirroring how `show schema` already emits raw `Schema` bytes. Falls back to marshalling the parsed map when a chart ships no `values.yaml`.

## Before / after (traefik chart)

```
# before: sorted keys, no comments
configs: []
deploy:
    placement:
        ...

# after: verbatim
# traefik chart default values.
#
# Deploys Traefik v3 as the Swarm edge proxy: ...
image:
  repository: traefik
  tag: ""  # defaults to appVersion from Chart.yaml
```

## Tests

- `charts`: `TestLoadChartDirRetainsValuesRaw`, `TestLoadChartDirNoValuesRawIsNil`, `TestLoadChartArchiveRetainsValuesRaw`
- `cli`: `TestChartsShowValuesPreservesComments` (verbatim output incl. comments)

`go test ./...`, `go vet`, `gofmt`, and `golangci-lint run` all clean.

Reported on Eldara-Tech/swarmcli-charts#37.

🤖 Generated with [Claude Code](https://claude.com/claude-code)