### PR TITLE
fix(inspect): surface service logging driver in inspect/edit (#428)

### DIFF
--- a/docker/stack_inspect.go
+++ b/docker/stack_inspect.go
@@ -38,6 +38,7 @@ type ServiceSummary struct {
 	Configs     []string          `json:"configs,omitempty"`
 	Labels      map[string]string `json:"labels,omitempty"`
 	Healthcheck *Healthcheck      `json:"healthcheck,omitempty"`
+	Logging     *Logging          `json:"logging,omitempty"`
 	CreatedAt   time.Time         `json:"created_at"`
 	UpdatedAt   time.Time         `json:"updated_at"`
 }
@@ -170,6 +171,12 @@ func GetStackInspection(stackName string) (string, error) {
 		sort.Strings(svcSecrets)
 		sort.Strings(svcConfigs)
 
+		// Logging driver — TaskTemplate.LogDriver → `logging:`
+		var logging *Logging
+		if ld := svc.Spec.TaskTemplate.LogDriver; ld != nil {
+			logging = composeLogging(ld.Name, ld.Options)
+		}
+
 		// Add service summary
 		desc.Services = append(desc.Services, ServiceSummary{
 			Name:        svc.Spec.Name,
@@ -182,6 +189,7 @@ func GetStackInspection(stackName string) (string, error) {
 			Configs:     svcConfigs,
 			Labels:      svc.Spec.Labels,
 			Healthcheck: healthcheck,
+			Logging:     logging,
 			CreatedAt:   svc.CreatedAt,
 			UpdatedAt:   svc.UpdatedAt,
 		})

--- a/docker/stack_to_compose.go
+++ b/docker/stack_to_compose.go
@@ -42,7 +42,17 @@ type ComposeService struct {
 	Configs     []map[string]any  `yaml:"configs,omitempty"`
 	Deploy      map[string]any    `yaml:"deploy,omitempty"`
 	Healthcheck *Healthcheck      `yaml:"healthcheck,omitempty"`
+	Logging     *Logging          `yaml:"logging,omitempty"`
 	Extra       map[string]any    `yaml:",inline,omitempty"` // fallback
+}
+
+// Logging is the compose-shaped view of a service's log driver, mirroring the
+// Swarm `TaskTemplate.LogDriver` (`*swarm.Driver`). It is used both in
+// reconstructed Compose YAML and in stack-inspect JSON. The compose `logging:`
+// block carries a `driver:` name and an `options:` map.
+type Logging struct {
+	Driver  string            `json:"driver,omitempty" yaml:"driver,omitempty"`
+	Options map[string]string `json:"options,omitempty" yaml:"options,omitempty"`
 }
 
 // Healthcheck is the compose-shaped view of a service healthcheck, used both
@@ -89,7 +99,15 @@ type TaskTemplate struct {
 	Placement     *Placement     `json:"Placement,omitempty"`
 	Networks      []NetRef       `json:"Networks,omitempty"`
 	ForceUpdate   uint64         `json:"ForceUpdate,omitempty"`
-	LogDriver     any            `json:"LogDriver,omitempty"`
+	LogDriver     *LogDriver     `json:"LogDriver,omitempty"`
+}
+
+// LogDriver represents the Swarm `TaskTemplate.LogDriver` (`*swarm.Driver`):
+// the logging driver name plus its options. It is nil when the service does
+// not pin a log driver (the daemon default is used).
+type LogDriver struct {
+	Name    string            `json:"Name,omitempty"`
+	Options map[string]string `json:"Options,omitempty"`
 }
 
 // ContainerSpec represents the container specification
@@ -404,6 +422,11 @@ func ReconstructStackCompose(stackName string) (string, error) {
 			}
 		}
 
+		// Logging driver — TaskTemplate.LogDriver → compose `logging:`
+		if ld := si.Spec.TaskTemplate.LogDriver; ld != nil {
+			cs.Logging = composeLogging(ld.Name, ld.Options)
+		}
+
 		// Ports
 		if si.Spec.EndpointSpec != nil {
 			for _, p := range si.Spec.EndpointSpec.Ports {
@@ -675,6 +698,21 @@ func composeHealthcheck(test []string, intervalNs, timeoutNs, startPeriodNs,
 	}
 	hc.Retries = retries
 	return hc
+}
+
+// composeLogging builds the compose-shaped Logging block from a service's log
+// driver name and options. Returns nil when the service pins no log driver
+// (Swarm reports LogDriver: nil / empty), so the daemon default is used and no
+// `logging:` block is emitted. A driver with no name but with options still
+// round-trips its options.
+func composeLogging(name string, options map[string]string) *Logging {
+	if name == "" && len(options) == 0 {
+		return nil
+	}
+	return &Logging{
+		Driver:  name,
+		Options: options,
+	}
 }
 
 // escapeComposeArgs applies escapeComposeInterpolation to each element.

--- a/docker/stack_to_compose_test.go
+++ b/docker/stack_to_compose_test.go
@@ -4,6 +4,7 @@
 package docker
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 	"time"
@@ -378,4 +379,87 @@ func TestComposeService_HealthcheckOmittedWhenNil(t *testing.T) {
 	out, err := yaml.Marshal(&cs)
 	require.NoError(t, err)
 	require.NotContains(t, string(out), "healthcheck")
+}
+
+// Issue #428: a service deployed with a logging driver+options must round-trip
+// into the compose `logging:` block.
+func TestComposeLogging_DriverAndOptions(t *testing.T) {
+	lg := composeLogging("loki:latest", map[string]string{
+		"loki-url": "http://loki:3100/loki/api/v1/push",
+	})
+	require.NotNil(t, lg)
+	require.Equal(t, "loki:latest", lg.Driver)
+	require.Equal(t, "http://loki:3100/loki/api/v1/push", lg.Options["loki-url"])
+}
+
+func TestComposeLogging_DriverOnly(t *testing.T) {
+	lg := composeLogging("json-file", nil)
+	require.NotNil(t, lg)
+	require.Equal(t, "json-file", lg.Driver)
+	require.Empty(t, lg.Options)
+}
+
+func TestComposeLogging_OptionsOnly(t *testing.T) {
+	lg := composeLogging("", map[string]string{"max-size": "10m"})
+	require.NotNil(t, lg)
+	require.Empty(t, lg.Driver)
+	require.Equal(t, "10m", lg.Options["max-size"])
+}
+
+func TestComposeLogging_NoDriverReturnsNil(t *testing.T) {
+	require.Nil(t, composeLogging("", nil))
+	require.Nil(t, composeLogging("", map[string]string{}))
+}
+
+func TestComposeService_LoggingYAML(t *testing.T) {
+	cs := ComposeService{
+		Image: "nginx:latest",
+		Logging: &Logging{
+			Driver:  "loki:latest",
+			Options: map[string]string{"loki-url": "http://loki:3100/loki/api/v1/push"},
+		},
+	}
+	out, err := yaml.Marshal(&cs)
+	require.NoError(t, err)
+	yamlStr := string(out)
+	require.Contains(t, yamlStr, "logging:")
+	require.Contains(t, yamlStr, "driver: loki:latest")
+	require.Contains(t, yamlStr, "options:")
+	require.Contains(t, yamlStr, "loki-url: http://loki:3100/loki/api/v1/push")
+}
+
+func TestComposeService_LoggingOmittedWhenNil(t *testing.T) {
+	cs := ComposeService{Image: "nginx:latest"}
+	out, err := yaml.Marshal(&cs)
+	require.NoError(t, err)
+	require.NotContains(t, string(out), "logging")
+}
+
+// Capture side: the `docker service inspect` JSON LogDriver block must
+// unmarshal into TaskTemplate.LogDriver (issue #428).
+func TestServiceInspect_CapturesLogDriver(t *testing.T) {
+	raw := []byte(`{
+		"Spec": {
+			"Name": "web",
+			"TaskTemplate": {
+				"LogDriver": {
+					"Name": "loki:latest",
+					"Options": {"loki-url": "http://loki:3100/loki/api/v1/push"}
+				}
+			}
+		}
+	}`)
+	var si ServiceInspect
+	require.NoError(t, json.Unmarshal(raw, &si))
+	require.NotNil(t, si.Spec.TaskTemplate.LogDriver)
+	require.Equal(t, "loki:latest", si.Spec.TaskTemplate.LogDriver.Name)
+	require.Equal(t, "http://loki:3100/loki/api/v1/push",
+		si.Spec.TaskTemplate.LogDriver.Options["loki-url"])
+}
+
+func TestServiceInspect_NoLogDriverIsNil(t *testing.T) {
+	raw := []byte(`{"Spec":{"Name":"web","TaskTemplate":{}}}`)
+	var si ServiceInspect
+	require.NoError(t, json.Unmarshal(raw, &si))
+	require.Nil(t, si.Spec.TaskTemplate.LogDriver)
 }

--- a/integration-tests/docker/stack_inspect_test.go
+++ b/integration-tests/docker/stack_inspect_test.go
@@ -149,6 +149,22 @@ func TestInspectStack(t *testing.T) {
 		} else if svc.Healthcheck != nil {
 			t.Errorf("Service %q: expected no healthcheck, got %+v", svc.Name, svc.Healthcheck)
 		}
+
+		// Issue #428: whoami_single declares a logging driver; others do not.
+		if strings.HasSuffix(svc.Name, "whoami_single") {
+			if svc.Logging == nil {
+				t.Errorf("Service %q: expected a logging driver, got nil", svc.Name)
+			} else {
+				if svc.Logging.Driver != "json-file" {
+					t.Errorf("Service %q: logging driver = %q, want \"json-file\"", svc.Name, svc.Logging.Driver)
+				}
+				if svc.Logging.Options["max-size"] != "10m" {
+					t.Errorf("Service %q: logging option max-size = %q, want \"10m\"", svc.Name, svc.Logging.Options["max-size"])
+				}
+			}
+		} else if svc.Logging != nil {
+			t.Errorf("Service %q: expected no logging driver, got %+v", svc.Name, svc.Logging)
+		}
 	}
 
 	t.Logf("Successfully inspected stack: %d services, %d tasks", inspection.ServiceCount, inspection.TaskCount)

--- a/integration-tests/docker/stack_to_compose_test.go
+++ b/integration-tests/docker/stack_to_compose_test.go
@@ -121,6 +121,22 @@ func TestReconstructStackCompose(t *testing.T) {
 		}
 	}
 
+	// Issue #428: whoami_single declares a logging driver — it must round-trip
+	// through reconstruction rather than being silently dropped.
+	if !strings.Contains(yaml, "logging:") {
+		t.Error("Issue #428: reconstructed YAML missing 'logging:' section")
+	}
+	if single.Logging == nil {
+		t.Error("Issue #428: 'whoami_single' lost its logging driver during reconstruction")
+	} else {
+		if single.Logging.Driver != "json-file" {
+			t.Errorf("Issue #428: logging driver = %q, want \"json-file\"", single.Logging.Driver)
+		}
+		if single.Logging.Options["max-size"] != "10m" {
+			t.Errorf("Issue #428: logging option max-size = %q, want \"10m\"", single.Logging.Options["max-size"])
+		}
+	}
+
 	t.Logf("Successfully reconstructed stack YAML (%d bytes)", len(yaml))
 }
 

--- a/test-setup/test-stack.yml
+++ b/test-setup/test-stack.yml
@@ -61,6 +61,14 @@ services:
       timeout: 5s
       retries: 3
       start_period: 5s
+    # Issue #428 fixture: a service with a logging driver + options. Both
+    # inspect and compose reconstruction must surface the logging block. Uses
+    # the always-available json-file driver so the stack deploys without plugins.
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
     command: >
       sh -c '
         apk add --no-cache netcat-openbsd;


### PR DESCRIPTION
## What

Fixes #428 — a service deployed with a logging driver (e.g. Loki) lost its `logging:` block in both `stack inspect` and the `edit` (compose reconstruction) flows.

## Root cause

The Swarm `TaskTemplate.LogDriver` (`*swarm.Driver`: name + options) was dropped on the **render** side of both paths:
- `stack_to_compose.go` typed `TaskTemplate.LogDriver` as `any` (parsed but never read) and `ComposeService` had no logging field, so the `edit` reconstruction never emitted it.
- `stack_inspect.go` `ServiceSummary` had no logging field, so the inspect JSON never surfaced it.

## Fix

- New `Logging` (compose `driver:`/`options:`) and `LogDriver` (typed JSON capture) structs.
- `ReconstructStackCompose` and `GetStackInspection` now read `TaskTemplate.LogDriver` and emit `logging` via a shared `composeLogging()` helper — mirroring the existing `composeHealthcheck` pattern.
- Unset driver (`LogDriver: nil`, Swarm’s representation when none is pinned) emits **no** `logging:` block, so the daemon default is preserved — same "inherit ⇒ omit" behaviour as healthcheck.

## Tests

- Unit (`docker/stack_to_compose_test.go`): `composeLogging` variants, YAML emit/omit, and capture-side JSON unmarshal of `LogDriver` (both ends of the path).
- Integration: `logging:` assertions on `whoami_single` + a `json-file` driver fixture in `test-setup/test-stack.yml` (json-file so it deploys with no plugin), mirroring the #379 healthcheck integration pattern.

`go build` (both tags), `go test ./...`, `go vet`, `gofmt`, `golangci-lint` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)