### PR TITLE
test(infra): drop apk-on-restart from whoami services to fix restart flake

### DIFF
--- a/test-setup/test-stack.yml
+++ b/test-setup/test-stack.yml
@@ -33,13 +33,18 @@ services:
         target: /etc/whoami/config
     deploy:
       replicas: 2
+    # Uses alpine's built-in busybox `nc` (no `apk add`) so a task restart does
+    # NOT depend on network access to the package CDN. Re-installing
+    # netcat-openbsd on every container start made multi-replica restarts flake
+    # under slow-network windows (TestRestartServiceWithProgress). The `|| sleep`
+    # guard keeps the container up even if a connection attempt errors — no test
+    # exercises the HTTP endpoint, only that tasks stay running.
     command: >
       sh -c '
-        apk add --no-cache netcat-openbsd;
         echo "Starting whoami service...";
         while true; do
           printf "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\n\r\nService: whoami\nConfig:\n%s\n\n" "$$(cat /etc/whoami/config)" \
-          | nc -l -p 80 -q 1;
+          | nc -l -p 80 2>/dev/null || sleep 1;
         done
       '
 
@@ -69,13 +74,13 @@ services:
       options:
         max-size: "10m"
         max-file: "3"
+    # See whoami above: built-in busybox `nc`, no `apk add` on restart.
     command: >
       sh -c '
-        apk add --no-cache netcat-openbsd;
         echo "Starting whoami_single service...";
         while true; do
           printf "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\n\r\nService: whoami_single\nConfig:\n%s\n\n" "$$(cat /etc/whoami/config)" \
-          | nc -l -p 80 -q 1;
+          | nc -l -p 80 2>/dev/null || sleep 1;
         done
       '
     ports:


### PR DESCRIPTION
## What

The `whoami` / `whoami_single` integration test services ran `apk add --no-cache netcat-openbsd` **on every container start**, so each task restart had to reach the Alpine package CDN over the network.

## Why

Under a slow-network window, the 2-replica rolling restart in `TestRestartServiceWithProgress/multi_replica` exceeded its 120s deadline because each replacement task re-downloaded netcat before becoming healthy. This is a pre-existing flake — it failed on `main` (Integration run for `2e774e15`) and blocked #431 across multiple runs, even though everything those PRs changed was green.

Telling detail: in the same runs, `TestRestartServiceAndWait/multi_replica (demo_whoami)` restarted both replicas fine in ~33s — so `demo_whoami` is healthy; only the tighter-deadline `WithProgress` variant tipped over when an `apk` fetch was slow.

## Fix

Use alpine's **built-in busybox `nc`** (no `apk add`) and guard the listener with `|| sleep 1` so the container stays up regardless of busybox nc flag support. A restarted task now just starts the already-cached alpine image and listens — no network.

No integration test connects to the whoami HTTP endpoint (they only assert task/replica state), so suite-relevant behaviour is unchanged; the services still best-effort-serve HTTP via busybox nc for manual/demo use.

## Test

Single-file change to `test-setup/test-stack.yml`. The integration suite — including `TestRestartServiceWithProgress/multi_replica` — should now pass reliably (the restart no longer depends on the package CDN).

🤖 Generated with [Claude Code](https://claude.com/claude-code)