### PR TITLE
feat: startup "update available" popup with per-version dismissal (#423)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,7 +64,7 @@ views/
   viewstack/               Navigation stack (push/pop)
 commands/
   api/                     Command context & arg parsing
-  command/                 Top-level built-in commands (help.go, contexts.go, quit.go, alias.go, bootstrap.go); docker-entity commands live under command/docker/<entity>/ls.go (service, node, network, volume, secret, config)
+  command/                 Top-level built-in commands (help.go, contexts.go, quit.go, alias.go, bootstrap.go, devupdate.go); docker-entity commands live under command/docker/<entity>/ls.go (service, node, network, volume, secret, config). devupdate.go registers `:dev-update` only when SWARMCLI_ENV=dev (force-shows the update-available notice for previewing)
   autoload.go              Blank import triggers init() registration
 docker/
   client.go                Context-aware Docker client factory
@@ -100,7 +100,7 @@ utils/log/
 
 | Variable | Purpose | Default |
 |---|---|---|
-| `SWARMCLI_ENV` | `dev` (console logs) or `prod` (JSON logs) | `prod` |
+| `SWARMCLI_ENV` | `dev` (console logs) or `prod` (JSON logs); also registers the dev-only `:dev-update` command (force-shows the update-available notice for previewing) | `prod` |
 | `LOG_LEVEL` | `debug`/`info`/`warn`/`error` | `debug` (dev), `info` (prod) |
 | `DOCKER_CONTEXT` | Override Docker context | `docker context show` |
 | `TEST_LOG` | Enable logging in tests | unset |

--- a/app/model.go
+++ b/app/model.go
@@ -46,6 +46,13 @@ type Model struct {
 	unlockDialog       *unlockdialog.Model
 	unlockDialogActive bool
 
+	// App-level "update available" notice, raised once per new release at
+	// startup (and on demand via :dev-update). Driven by the systeminfo
+	// version check; dismissal opt-out persists via the settings package.
+	updateDialog         *confirmdialog.Model
+	updateDialogActive   bool
+	pendingUpdateVersion string // version to persist if the opt-out box is ticked
+
 	// Terminal dimensions
 	terminalWidth  int
 	terminalHeight int
@@ -101,6 +108,7 @@ func InitialModel() *Model {
 		searchInput:    searchinput.New(),
 		errorDialog:    confirmdialog.New(terminalWidth, terminalHeight),
 		unlockDialog:   unlockdialog.New(terminalWidth, terminalHeight),
+		updateDialog:   confirmdialog.New(terminalWidth, terminalHeight),
 		terminalWidth:  terminalWidth,
 		terminalHeight: terminalHeight,
 	}

--- a/app/update.go
+++ b/app/update.go
@@ -11,6 +11,8 @@ import (
 	"swarmcli/commands/api"
 	cmdpkg "swarmcli/commands/command"
 	"swarmcli/docker"
+	"swarmcli/settings"
+	swarmlog "swarmcli/utils/log"
 	"swarmcli/views/commandinput"
 	"swarmcli/views/confirmdialog"
 	contextsview "swarmcli/views/contexts"
@@ -143,7 +145,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.KeyMsg:
 		// If an app-level dialog is active, route all keys to handleKey
 		// which forwards them to the dialog exclusively.
-		if m.appErrorDialogActive || m.unlockDialogActive {
+		if m.appErrorDialogActive || m.unlockDialogActive || m.updateDialogActive {
 			return m.handleKey(msg)
 		}
 
@@ -279,6 +281,23 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tickMsg:
 		return m.handleTick(msg)
 
+	case systeminfoview.LatestVersionMsg:
+		// Keep the header badge in sync first, then raise the one-time startup
+		// notice — unless a startup overlay (e.g. a BE proactive nudge) already
+		// owns the screen, another app dialog is up, or the user opted out of
+		// this version.
+		cmd := m.systemInfo.Update(msg)
+		if startupOverlay != nil && startupOverlay.Active() {
+			return m, cmd
+		}
+		if m.appErrorDialogActive || m.unlockDialogActive || m.updateDialogActive {
+			return m, cmd
+		}
+		if msg.LatestVersion != settings.Load().DismissedUpdateVersion {
+			m.showUpdateNotice(msg.LatestVersion)
+		}
+		return m, cmd
+
 	case systeminfoview.SystemInfoMsg:
 		return m, m.systemInfo.Update(msg)
 
@@ -306,6 +325,17 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case confirmdialog.ResultMsg:
+		if m.updateDialogActive {
+			m.updateDialogActive = false
+			m.updateDialog.Visible = false
+			if msg.CheckboxChecked && m.pendingUpdateVersion != "" {
+				if err := (settings.Settings{DismissedUpdateVersion: m.pendingUpdateVersion}).Save(); err != nil {
+					swarmlog.L().Infow("failed to persist update-notice dismissal", "error", err)
+				}
+			}
+			m.pendingUpdateVersion = ""
+			return m, nil
+		}
 		if m.appErrorDialogActive {
 			m.appErrorDialogActive = false
 			m.errorDialog.Visible = false
@@ -324,6 +354,18 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.unlockDialog.Show()
 		m.unlockDialogActive = true
 		return m, m.unlockDialog.Init()
+
+	case view.OpenUpdateDialogMsg:
+		// On-demand (dev-only) preview: force-show regardless of dismissal.
+		latest := strings.TrimSpace(msg.Version)
+		if latest == "" {
+			latest = m.systemInfo.Latest()
+		}
+		if latest == "" {
+			latest = version + " (preview)"
+		}
+		m.showUpdateNotice(latest)
+		return m, nil
 
 	case unlockdialog.ResultMsg:
 		m.unlockDialogActive = false
@@ -447,6 +489,12 @@ func (m *Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	// If the unlock dialog is active, forward keys to it exclusively
 	if m.unlockDialogActive {
 		cmd := m.unlockDialog.Update(msg)
+		return m, cmd
+	}
+
+	// If the update notice is active, forward keys to it exclusively
+	if m.updateDialogActive {
+		cmd := m.updateDialog.Update(msg)
 		return m, cmd
 	}
 

--- a/app/updatenotice.go
+++ b/app/updatenotice.go
@@ -14,6 +14,15 @@ const (
 	updateNoticeCheckbox    = "Do not show this again for this version"
 )
 
+// BusinessEditionActive reports whether Business Edition is effectively active.
+// The update notice uses it to choose the install link and whether to show the
+// "try Business Edition" hint. It defaults to the static build edition flag, so
+// the CE binary always reports false (and shows the hint). BE overrides it from
+// its live license state — so an unlicensed BE binary, which already presents
+// as Community Edition throughout the UI, also shows the hint, while a licensed
+// one suppresses it.
+var BusinessEditionActive = func() bool { return edition == "be" }
+
 // showUpdateNotice raises the app-level "update available" dialog for the given
 // latest release. Edition selects the install link and whether the CE→BE hint
 // is shown. The dialog is an info-mode confirmdialog carrying an opt-out
@@ -29,14 +38,15 @@ func (m *Model) showUpdateNotice(latest string) {
 	m.pendingUpdateVersion = latest
 }
 
-// updateNoticeMessage builds the notice body. BE shows only the BE install
-// link; CE shows the CE link plus a subtle one-line BE upsell.
+// updateNoticeMessage builds the notice body. An active Business Edition shows
+// only the BE install link; otherwise (CE, or unlicensed BE presenting as
+// Community Edition) it shows the CE link plus a subtle one-line BE upsell.
 func updateNoticeMessage(latest string) string {
 	current := strings.TrimSpace(version)
 	if current == "" {
 		current = "unknown"
 	}
-	if edition == "be" {
+	if BusinessEditionActive() {
 		return fmt.Sprintf(
 			"A new version of SwarmCLI Business Edition is available: %s (you have %s).\n\n"+
 				"Update: %s",

--- a/app/updatenotice.go
+++ b/app/updatenotice.go
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package app
+
+import (
+	"fmt"
+	"strings"
+)
+
+const (
+	installDocsURLCommunity = "https://swarmcli.io/docs/cli#installation"
+	installDocsURLBusiness  = "https://swarmcli.io/docs/cli#installation-business"
+	updateNoticeCheckbox    = "Do not show this again for this version"
+)
+
+// showUpdateNotice raises the app-level "update available" dialog for the given
+// latest release. Edition selects the install link and whether the CE→BE hint
+// is shown. The dialog is an info-mode confirmdialog carrying an opt-out
+// checkbox; ResultMsg handling persists the dismissal when it is ticked.
+func (m *Model) showUpdateNotice(latest string) {
+	m.updateDialog.Visible = true
+	m.updateDialog.ErrorMode = false
+	m.updateDialog.InfoMode = true
+	m.updateDialog.CheckboxLabel = updateNoticeCheckbox
+	m.updateDialog.CheckboxChecked = false
+	m.updateDialog.Message = updateNoticeMessage(latest)
+	m.updateDialogActive = true
+	m.pendingUpdateVersion = latest
+}
+
+// updateNoticeMessage builds the notice body. BE shows only the BE install
+// link; CE shows the CE link plus a subtle one-line BE upsell.
+func updateNoticeMessage(latest string) string {
+	current := strings.TrimSpace(version)
+	if current == "" {
+		current = "unknown"
+	}
+	if edition == "be" {
+		return fmt.Sprintf(
+			"A new version of SwarmCLI Business Edition is available: %s (you have %s).\n\n"+
+				"Update: %s",
+			latest, current, installDocsURLBusiness)
+	}
+	return fmt.Sprintf(
+		"A new version of SwarmCLI is available: %s (you have %s).\n\n"+
+			"Update: %s\n\n"+
+			"Need RBAC, SSO & port-forwarding? Try Business Edition →\n%s",
+		latest, current, installDocsURLCommunity, installDocsURLBusiness)
+}

--- a/app/updatenotice_test.go
+++ b/app/updatenotice_test.go
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package app
+
+import (
+	"testing"
+
+	"swarmcli/settings"
+	"swarmcli/views/confirmdialog"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestUpdateNoticeMessage_CE(t *testing.T) {
+	origV, origE := version, edition
+	defer func() { version, edition = origV, origE }()
+	version, edition = "v1.8.0", "ce"
+
+	msg := updateNoticeMessage("v1.9.0")
+	require.Contains(t, msg, "v1.9.0")
+	require.Contains(t, msg, "v1.8.0")
+	require.Contains(t, msg, installDocsURLCommunity)
+	require.Contains(t, msg, installDocsURLBusiness) // CE → BE upsell present
+	require.Contains(t, msg, "Business Edition")
+}
+
+func TestUpdateNoticeMessage_BE(t *testing.T) {
+	origV, origE := version, edition
+	defer func() { version, edition = origV, origE }()
+	version, edition = "v1.8.0", "be"
+
+	msg := updateNoticeMessage("v1.9.0")
+	require.Contains(t, msg, installDocsURLBusiness)
+	require.Contains(t, msg, "Business Edition")
+	require.NotContains(t, msg, "Try Business Edition") // no CE→BE upsell line for BE
+}
+
+func TestShowUpdateNotice_SetsInfoDialogWithCheckbox(t *testing.T) {
+	m := newTestAppModel(&stubView{name: "test"})
+	m.updateDialog = confirmdialog.New(200, 50)
+
+	m.showUpdateNotice("v1.9.0")
+
+	require.True(t, m.updateDialogActive)
+	require.True(t, m.updateDialog.Visible)
+	require.True(t, m.updateDialog.InfoMode)
+	require.Equal(t, updateNoticeCheckbox, m.updateDialog.CheckboxLabel)
+	require.False(t, m.updateDialog.CheckboxChecked)
+	require.Equal(t, "v1.9.0", m.pendingUpdateVersion)
+}
+
+func TestUpdateDialogDismiss_PersistsWhenChecked(t *testing.T) {
+	t.Setenv("HOME", t.TempDir()) // redirect settings file location
+
+	m := newTestAppModel(&stubView{name: "test"})
+	m.updateDialog = confirmdialog.New(200, 50)
+	m.showUpdateNotice("v1.9.0")
+
+	m.Update(confirmdialog.ResultMsg{CheckboxChecked: true})
+
+	require.False(t, m.updateDialogActive)
+	require.Equal(t, "v1.9.0", settings.Load().DismissedUpdateVersion)
+}
+
+func TestUpdateDialogDismiss_NotPersistedWhenUnchecked(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	m := newTestAppModel(&stubView{name: "test"})
+	m.updateDialog = confirmdialog.New(200, 50)
+	m.showUpdateNotice("v1.9.0")
+
+	m.Update(confirmdialog.ResultMsg{CheckboxChecked: false})
+
+	require.False(t, m.updateDialogActive)
+	require.Equal(t, "", settings.Load().DismissedUpdateVersion)
+}

--- a/app/updatenotice_test.go
+++ b/app/updatenotice_test.go
@@ -36,6 +36,32 @@ func TestUpdateNoticeMessage_BE(t *testing.T) {
 	require.NotContains(t, msg, "Try Business Edition") // no CE→BE upsell line for BE
 }
 
+// Unlicensed BE: the build flag is "be" but BusinessEditionActive is overridden
+// to report false (no valid license), so the notice shows the CE copy + upsell,
+// matching the Community Edition presentation the rest of the UI uses.
+func TestUpdateNoticeMessage_UnlicensedBE_ShowsUpsell(t *testing.T) {
+	origV, origE, origP := version, edition, BusinessEditionActive
+	defer func() { version, edition, BusinessEditionActive = origV, origE, origP }()
+	version, edition = "v1.8.0", "be"
+	BusinessEditionActive = func() bool { return false }
+
+	msg := updateNoticeMessage("v1.9.0")
+	require.Contains(t, msg, installDocsURLCommunity)
+	require.Contains(t, msg, "Try Business Edition")
+}
+
+// Licensed BE: predicate true → BE copy, no upsell, regardless of build flag.
+func TestUpdateNoticeMessage_LicensedBE_NoUpsell(t *testing.T) {
+	origV, origE, origP := version, edition, BusinessEditionActive
+	defer func() { version, edition, BusinessEditionActive = origV, origE, origP }()
+	version, edition = "v1.8.0", "ce" // build flag deliberately not "be"
+	BusinessEditionActive = func() bool { return true }
+
+	msg := updateNoticeMessage("v1.9.0")
+	require.Contains(t, msg, installDocsURLBusiness)
+	require.NotContains(t, msg, "Try Business Edition")
+}
+
 func TestShowUpdateNotice_SetsInfoDialogWithCheckbox(t *testing.T) {
 	m := newTestAppModel(&stubView{name: "test"})
 	m.updateDialog = confirmdialog.New(200, 50)

--- a/app/view.go
+++ b/app/view.go
@@ -19,7 +19,7 @@ func (m *Model) View() string {
 		header := m.currentView.FrameHeader()
 		content := m.currentView.FrameContent()
 		out := ui.RenderViewFrame(title, header, content, "", m.terminalWidth, m.terminalHeight, true)
-		return m.overlayStartup(m.overlayUnlock(m.overlayAppError(out)))
+		return m.overlayStartup(m.overlayUnlock(m.overlayAppError(m.overlayUpdate(out))))
 	}
 
 	systemInfo := m.systemInfo.View()
@@ -74,7 +74,7 @@ func (m *Model) View() string {
 			framedView,
 			m.renderStackBar(),
 		)
-		return m.overlayStartup(m.overlayUnlock(m.overlayAppError(out)))
+		return m.overlayStartup(m.overlayUnlock(m.overlayAppError(m.overlayUpdate(out))))
 	}
 
 	if m.searchInput.Visible() {
@@ -95,7 +95,7 @@ func (m *Model) View() string {
 			framedView,
 			m.renderStackBar(),
 		)
-		return m.overlayStartup(m.overlayUnlock(m.overlayAppError(out)))
+		return m.overlayStartup(m.overlayUnlock(m.overlayAppError(m.overlayUpdate(out))))
 	}
 
 	if frameHeight < 1 {
@@ -109,7 +109,7 @@ func (m *Model) View() string {
 		framedView,
 		m.renderStackBar(),
 	)
-	return m.overlayStartup(m.overlayUnlock(m.overlayAppError(out)))
+	return m.overlayStartup(m.overlayUnlock(m.overlayAppError(m.overlayUpdate(out))))
 }
 
 // overlayAppError overlays the app-level error dialog on top of the rendered output.
@@ -126,6 +126,14 @@ func (m *Model) overlayUnlock(base string) string {
 		return base
 	}
 	return ui.OverlayCentered(base, m.unlockDialog.View(), m.terminalWidth, 0)
+}
+
+// overlayUpdate overlays the "update available" notice on top of the output.
+func (m *Model) overlayUpdate(base string) string {
+	if !m.updateDialog.Visible {
+		return base
+	}
+	return ui.OverlayCentered(base, m.updateDialog.View(), m.terminalWidth, 0)
 }
 
 // overlayStartup composites the startup overlay on top of the rendered output.

--- a/commands/command/devupdate.go
+++ b/commands/command/devupdate.go
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package command
+
+import (
+	"os"
+	"strings"
+
+	"swarmcli/args"
+	"swarmcli/registry"
+	"swarmcli/views/view"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// DevUpdate is the dev-only :dev-update command. It force-shows the startup
+// "update available" notice on demand for previewing, bypassing the per-version
+// dismissal. Registered only under SWARMCLI_ENV=dev (see init), so it does not
+// exist in production builds.
+type DevUpdate struct{}
+
+func (DevUpdate) Name() string        { return "dev-update" }
+func (DevUpdate) Description() string { return "Dev only: preview the update-available notice" }
+
+func (DevUpdate) Spec() registry.CommandSpec {
+	return registry.CommandSpec{
+		Usage: "[version]",
+		Detail: "Dev-only preview of the startup \"update available\" notice. " +
+			"Force-shows the dialog on demand (optionally for a given version), " +
+			"bypassing the per-version dismissal. Registered only under " +
+			"SWARMCLI_ENV=dev.",
+		Examples: []string{":dev-update", ":dev-update v9.9.9"},
+	}
+}
+
+func (DevUpdate) Execute(_ any, a args.Args) tea.Cmd {
+	var ver string
+	if len(a.Positionals) > 0 {
+		ver = strings.TrimSpace(a.Positionals[0])
+	}
+	return func() tea.Msg {
+		return view.OpenUpdateDialogMsg{Version: ver}
+	}
+}
+
+// devUpdateEnabled reports whether the dev-only command should register.
+func devUpdateEnabled() bool { return os.Getenv("SWARMCLI_ENV") == "dev" }
+
+func init() {
+	if devUpdateEnabled() {
+		registry.Register(DevUpdate{})
+	}
+}

--- a/commands/command/devupdate_test.go
+++ b/commands/command/devupdate_test.go
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package command
+
+import (
+	"testing"
+
+	"swarmcli/args"
+	"swarmcli/views/view"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDevUpdateEnabledGate(t *testing.T) {
+	t.Setenv("SWARMCLI_ENV", "dev")
+	require.True(t, devUpdateEnabled())
+
+	t.Setenv("SWARMCLI_ENV", "prod")
+	require.False(t, devUpdateEnabled())
+
+	t.Setenv("SWARMCLI_ENV", "")
+	require.False(t, devUpdateEnabled())
+}
+
+func TestDevUpdateExecuteEmitsOpenMsg(t *testing.T) {
+	msg := DevUpdate{}.Execute(nil, args.Args{})()
+	open, ok := msg.(view.OpenUpdateDialogMsg)
+	require.True(t, ok)
+	require.Equal(t, "", open.Version)
+
+	msg = DevUpdate{}.Execute(nil, args.Args{Positionals: []string{"v9.9.9"}})()
+	open, ok = msg.(view.OpenUpdateDialogMsg)
+	require.True(t, ok)
+	require.Equal(t, "v9.9.9", open.Version)
+}

--- a/settings/settings.go
+++ b/settings/settings.go
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+// Package settings persists small, single-purpose CLI preferences to the user
+// config dir (~/.config/swarmcli). Today it records only the version at which
+// the user dismissed the startup update notice.
+package settings
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+)
+
+// Overridable for tests (mirrors the seams in swarmcli-be's nudge throttle).
+var (
+	userHomeDirFn = os.UserHomeDir
+	readFileFn    = os.ReadFile
+	writeFileFn   = os.WriteFile
+	mkdirAllFn    = os.MkdirAll
+)
+
+// relPath is the per-user preferences file, beside the license key under
+// ~/.config/swarmcli.
+const relPath = ".config/swarmcli/update-notice.json"
+
+// Settings is the persisted CLI preference state.
+type Settings struct {
+	// DismissedUpdateVersion is the latest-release version at which the user
+	// ticked "do not show again for this version" in the startup update
+	// notice. A different latest version re-shows the notice.
+	DismissedUpdateVersion string `json:"dismissedUpdateVersion,omitempty"`
+}
+
+func path() (string, error) {
+	home, err := userHomeDirFn()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, relPath), nil
+}
+
+// Load reads the settings file. A missing or unreadable/corrupt file is not an
+// error — it yields the zero value.
+func Load() Settings {
+	var s Settings
+	p, err := path()
+	if err != nil {
+		return s
+	}
+	data, err := readFileFn(p)
+	if err != nil {
+		return s
+	}
+	if err := json.Unmarshal(data, &s); err != nil {
+		return Settings{}
+	}
+	return s
+}
+
+// Save writes the settings file (0644), creating ~/.config/swarmcli if needed.
+func (s Settings) Save() error {
+	p, err := path()
+	if err != nil {
+		return err
+	}
+	if err := mkdirAllFn(filepath.Dir(p), 0o755); err != nil {
+		return err
+	}
+	data, err := json.Marshal(s)
+	if err != nil {
+		return err
+	}
+	return writeFileFn(p, data, 0o644)
+}

--- a/settings/settings_test.go
+++ b/settings/settings_test.go
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package settings
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// withHome points the package's home-dir seam at a temp dir for the test and
+// restores it afterwards.
+func withHome(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	orig := userHomeDirFn
+	userHomeDirFn = func() (string, error) { return home, nil }
+	t.Cleanup(func() { userHomeDirFn = orig })
+	return home
+}
+
+func TestSaveLoadRoundTrip(t *testing.T) {
+	home := withHome(t)
+
+	require.NoError(t, Settings{DismissedUpdateVersion: "v1.9.0"}.Save())
+
+	// File lands at ~/.config/swarmcli/update-notice.json.
+	_, err := os.Stat(filepath.Join(home, relPath))
+	require.NoError(t, err)
+
+	require.Equal(t, "v1.9.0", Load().DismissedUpdateVersion)
+}
+
+func TestLoadMissingFileIsZeroValue(t *testing.T) {
+	withHome(t)
+	require.Equal(t, Settings{}, Load())
+}
+
+func TestLoadCorruptFileIsZeroValue(t *testing.T) {
+	home := withHome(t)
+	p := filepath.Join(home, relPath)
+	require.NoError(t, os.MkdirAll(filepath.Dir(p), 0o755))
+	require.NoError(t, os.WriteFile(p, []byte("{not json"), 0o644))
+
+	require.Equal(t, Settings{}, Load())
+}
+
+func TestLoadHonorsHomeDirSeam(t *testing.T) {
+	home := withHome(t)
+	require.NoError(t, Settings{DismissedUpdateVersion: "v2.0.0"}.Save())
+
+	// A second home with no file yields the zero value, proving Load reads
+	// from the seam rather than a fixed path.
+	other := t.TempDir()
+	userHomeDirFn = func() (string, error) { return other, nil }
+	require.Equal(t, Settings{}, Load())
+
+	userHomeDirFn = func() (string, error) { return home, nil }
+	require.Equal(t, "v2.0.0", Load().DismissedUpdateVersion)
+}

--- a/views/confirmdialog/confirmdialog.go
+++ b/views/confirmdialog/confirmdialog.go
@@ -43,6 +43,13 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 			return func() tea.Msg { return ResultMsg{Confirmed: false, CheckboxChecked: m.CheckboxChecked} }
 		}
 		if m.ErrorMode || m.InfoMode {
+			// Info mode with a checkbox: Space toggles it instead of closing,
+			// so a notice can carry a "do not show again" opt-out. Enter/Esc
+			// still close and report the checkbox state.
+			if m.InfoMode && m.CheckboxLabel != "" && msg.String() == " " {
+				m.CheckboxChecked = !m.CheckboxChecked
+				return nil
+			}
 			// In error/info mode, any key closes the dialog
 			switch msg.String() {
 			case "enter", "esc", " ":
@@ -148,8 +155,8 @@ func (m *Model) View() string {
 	}
 	lines = append(lines, messageStyle.Render(wrappedMessage))
 
-	// Add checkbox if label is provided
-	if m.CheckboxLabel != "" && !m.ErrorMode && !m.InfoMode {
+	// Add checkbox if label is provided (confirm or info mode; never error mode)
+	if m.CheckboxLabel != "" && !m.ErrorMode {
 		checkboxStyle := lipgloss.NewStyle().
 			Padding(0, 2).
 			Width(contentWidth)
@@ -165,19 +172,22 @@ func (m *Model) View() string {
 	}
 
 	var helpText string
-	if m.ErrorMode || m.InfoMode {
+	switch {
+	case m.InfoMode && m.CheckboxLabel != "":
+		helpText = fmt.Sprintf("%s Toggle • %s Close",
+			keyStyle.Render("<Space>"),
+			keyStyle.Render("<Enter/Esc>"))
+	case m.ErrorMode || m.InfoMode:
 		helpText = fmt.Sprintf("%s Close", keyStyle.Render("<Enter/Esc>"))
-	} else {
-		if m.CheckboxLabel != "" {
-			helpText = fmt.Sprintf("%s Yes • %s No • %s Toggle",
-				keyStyle.Render("<y>"),
-				keyStyle.Render("<n/Esc>"),
-				keyStyle.Render("<Space>"))
-		} else {
-			helpText = fmt.Sprintf("%s Yes • %s No",
-				keyStyle.Render("<y>"),
-				keyStyle.Render("<n/Esc>"))
-		}
+	case m.CheckboxLabel != "":
+		helpText = fmt.Sprintf("%s Yes • %s No • %s Toggle",
+			keyStyle.Render("<y>"),
+			keyStyle.Render("<n/Esc>"),
+			keyStyle.Render("<Space>"))
+	default:
+		helpText = fmt.Sprintf("%s Yes • %s No",
+			keyStyle.Render("<y>"),
+			keyStyle.Render("<n/Esc>"))
 	}
 	lines = append(lines, helpStyle.Render(helpText))
 

--- a/views/confirmdialog/confirmdialog_test.go
+++ b/views/confirmdialog/confirmdialog_test.go
@@ -151,6 +151,48 @@ func TestErrorMode_SpaceCloses(t *testing.T) {
 	require.False(t, msg.Confirmed)
 }
 
+func TestInfoMode_Checkbox_SpaceToggles_EnterCloses(t *testing.T) {
+	m := New(80, 24)
+	m.InfoMode = true
+	m.CheckboxLabel = "Do not show again"
+	m.Show("update available")
+
+	// Space toggles the checkbox instead of closing the notice.
+	require.False(t, m.CheckboxChecked)
+	cmd := m.Update(key(" "))
+	require.Nil(t, cmd)
+	require.True(t, m.Visible)
+	require.True(t, m.CheckboxChecked)
+
+	// Enter closes and reports the checkbox state.
+	cmd = m.Update(key("enter"))
+	require.False(t, m.Visible)
+	msg := runCmd(cmd).(ResultMsg)
+	require.False(t, msg.Confirmed)
+	require.True(t, msg.CheckboxChecked)
+}
+
+func TestInfoMode_NoCheckbox_SpaceCloses(t *testing.T) {
+	m := New(80, 24)
+	m.InfoMode = true
+	m.Show("notice")
+	cmd := m.Update(key(" "))
+	require.False(t, m.Visible)
+	msg := runCmd(cmd).(ResultMsg)
+	require.False(t, msg.Confirmed)
+}
+
+func TestView_InfoMode_Checkbox_ShowsLabelAndHelp(t *testing.T) {
+	m := New(80, 24)
+	m.InfoMode = true
+	m.CheckboxLabel = "Do not show again"
+	m.Show("update available")
+	out := m.View()
+	require.Contains(t, out, "Do not show again")
+	require.Contains(t, out, "Toggle")
+	require.Contains(t, out, "Info")
+}
+
 func TestView_NotVisible_Empty(t *testing.T) {
 	m := New(80, 24)
 	require.Equal(t, "", m.View())

--- a/views/systeminfo/messages.go
+++ b/views/systeminfo/messages.go
@@ -37,8 +37,11 @@ type TickMsg time.Time
 
 type SpinnerTickMsg time.Time
 
+// LatestVersionMsg reports that the version API returned a newer release than
+// the running build. The app layer reads LatestVersion to raise the startup
+// update notice, so the field is exported.
 type LatestVersionMsg struct {
-	latestVersion string
+	LatestVersion string
 }
 
 type NoVersionUpdateMsg struct{}

--- a/views/systeminfo/model.go
+++ b/views/systeminfo/model.go
@@ -97,6 +97,11 @@ func New(deps docker.Deps, version, edition string) *Model {
 	}
 }
 
+// Latest returns the newest release reported by the version check, or "" if
+// none has been observed yet. The app reads it to populate the on-demand
+// update notice (the proactive notice is driven by LatestVersionMsg directly).
+func (m *Model) Latest() string { return m.latest }
+
 func (m *Model) Init() tea.Cmd {
 	cmds := []tea.Cmd{m.tickCmd(), m.spinnerTickCmd()}
 	if cmd := m.CheckLatestVersion(); cmd != nil {
@@ -131,7 +136,7 @@ func (m *Model) CheckLatestVersion() tea.Cmd {
 		}
 
 		return LatestVersionMsg{
-			latestVersion: latestVersion,
+			LatestVersion: latestVersion,
 		}
 	}
 }

--- a/views/systeminfo/systeminfo_test.go
+++ b/views/systeminfo/systeminfo_test.go
@@ -200,7 +200,7 @@ func TestCheckLatestVersion_SendsVersionAndEdition(t *testing.T) {
 
 	latestMsg, ok := msg.(LatestVersionMsg)
 	require.True(t, ok)
-	require.Equal(t, "1.3.3", latestMsg.latestVersion)
+	require.Equal(t, "1.3.3", latestMsg.LatestVersion)
 	require.Equal(t, "1.2.2", received.Version)
 	require.Equal(t, "ce", received.Edition)
 }
@@ -274,7 +274,7 @@ func TestIsNewerVersion(t *testing.T) {
 
 func TestUpdate_LatestVersionMsg(t *testing.T) {
 	m := New(testDeps(), "1.2.2", "ce")
-	cmd := m.Update(LatestVersionMsg{latestVersion: "1.3.3"})
+	cmd := m.Update(LatestVersionMsg{LatestVersion: "1.3.3"})
 	require.Nil(t, cmd)
 	require.Equal(t, "1.3.3", m.latest)
 	require.Contains(t, m.content, "1.2.2")
@@ -297,7 +297,7 @@ func TestView_VersionLineDoesNotWrap_LongVersions(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			m := New(testDeps(), tc.version, "ce")
-			m.Update(LatestVersionMsg{latestVersion: tc.latest})
+			m.Update(LatestVersionMsg{LatestVersion: tc.latest})
 
 			rendered := m.View()
 			lines := strings.Split(strings.TrimRight(rendered, "\n"), "\n")

--- a/views/systeminfo/update.go
+++ b/views/systeminfo/update.go
@@ -20,7 +20,7 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 		return m.LoadSlowStatus()
 
 	case LatestVersionMsg:
-		m.latest = msg.latestVersion
+		m.latest = msg.LatestVersion
 		m.content = m.buildContent()
 		return nil
 

--- a/views/view/navigation.go
+++ b/views/view/navigation.go
@@ -25,3 +25,11 @@ type GoBackMsg struct{}
 
 // OpenUnlockDialogMsg requests the app to open the swarm unlock-key dialog.
 type OpenUnlockDialogMsg struct{}
+
+// OpenUpdateDialogMsg requests the app to force-show the "update available"
+// notice on demand (the dev-only :dev-update command), bypassing the
+// per-version dismissal. Version overrides the displayed latest version when
+// set; otherwise the app falls back to the last checked version or a stub.
+type OpenUpdateDialogMsg struct {
+	Version string
+}


### PR DESCRIPTION
Closes #423.

## What

On startup, when a newer release exists, show a blocking notice with the install-doc link, plus a "do not show again for this version" opt-out. CE shows a subtle "try Business Edition" hint; BE shows only the BE link.

## How

- **Reuse the existing check.** `views/systeminfo` already POSTs `{version, edition}` to `swarmcli.io/api/v1/version` and emits `LatestVersionMsg`. This PR surfaces that result as a popup — no new network call, no new comparison logic. The field `LatestVersionMsg.LatestVersion` is exported (+ `Model.Latest()`) so the app layer can read it; the passive `⚡` header badge is untouched.
- **Dialog.** Reuses `confirmdialog`, extended so `InfoMode` can carry a toggle-able checkbox (backward-compatible — nothing else sets a checkbox on an info dialog).
- **Persistence.** New `settings` package writes the dismissed version to `~/.config/swarmcli/update-notice.json` (config dir, matching BE's dismissal-file convention). Exact-match per version: a newer release re-notifies.
- **Coexistence with BE.** Implemented as an app-level dialog (like `errorDialog`/`unlockDialog`), **not** the single `StartupOverlay` slot that BE's infranudge composite owns — so they don't collide. The popup defers while a startup overlay is active, so BE users don't see two notices. BE's `RemediationUpdateCLI` (compat-staleness) and this (upstream release) remain independent signals.
- **Dev preview.** `:dev-update` (registered only under `SWARMCLI_ENV=dev`) force-shows the notice for previewing; documented in `CLAUDE.md`.

## Gating (unchanged, inherited)

No popup for `dev` builds or when `SWARMCLI_DISABLE_VERSION_CHECK=true`.

## Tests

- `settings`: round-trip, missing/corrupt → zero value, home-dir seam.
- `confirmdialog`: InfoMode checkbox toggles on space / closes on enter; info-without-checkbox still closes on space (regression).
- `app`: CE vs BE copy, `showUpdateNotice`, dismissal persists only when ticked.
- `commands`: `:dev-update` env gate + emits `OpenUpdateDialogMsg`.
- Full `go test ./...`, `go vet`, and `golangci-lint` (0 issues) green.

## Note for BE

The CE/BE branch reads the shared `app` edition var; verify the BE build injects `edition=be`. Double-notify avoidance is best-effort (overlay-active defer); a hard suppression flag can be a BE follow-up if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)