### PR TITLE
ci(release): silence release-drafter deprecation + commitish warnings

### DIFF
--- a/.github/release_template.yml
+++ b/.github/release_template.yml
@@ -1,28 +1,38 @@
 name-template: 'v$RESOLVED_VERSION'
 tag-template: 'v$RESOLVED_VERSION'
-exclude-labels:
-  - 'E0-silent'
 # Categories key off the mutually-exclusive A-type (and D0) labels only.
 # B (urgency) and C (breaking) are orthogonal axes: release-drafter places
 # a PR in *every* matching category (by design, no per-category exclude),
 # so keeping B2/C1 categories duplicated those PRs into their type section.
 # Breaking-ness is conveyed by the version/RC itself.
+# The leading pre-exclude category replaces the deprecated top-level
+# exclude-labels (release-drafter PR #1558); 'when:' wrappers replace the
+# deprecated per-category 'labels:' field.
 categories:
+  - type: 'pre-exclude'
+    when:
+      labels:
+        - 'E0-silent'
   - title: '[UI]'
-    labels:
-      - 'A0-ui'
+    when:
+      labels:
+        - 'A0-ui'
   - title: ' [Feature] '
-    labels:
-      - 'A1-feature'
+    when:
+      labels:
+        - 'A1-feature'
   - title: ' [Bug Fixes] '
-    labels:
-      - 'A2-bugfix'
+    when:
+      labels:
+        - 'A2-bugfix'
   - title: ' [Technical] '
-    labels:
-      - 'A3-technical'
+    when:
+      labels:
+        - 'A3-technical'
   - title: ' [Dependencies] '
-    labels:
-      - 'D0-dependency'
+    when:
+      labels:
+        - 'D0-dependency'
 change-template: '- $TITLE (#$NUMBER) @$AUTHOR '
 change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
 template: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,11 @@ jobs:
           config-name: release_template.yml
           tag: ${{ github.ref_name }}
           name: ${{ github.ref_name }}
+          # On a tag push, release-drafter defaults the release target_commitish
+          # to the tag ref, which GitHub rejects ("not supported as release
+          # target, falling back to default branch"). Point it at the default
+          # branch explicitly — the same value the fallback already used.
+          commitish: ${{ github.event.repository.default_branch }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
Clears all seven actionable warnings from the `Release` workflow ([run 28182318316](https://github.com/Eldara-Tech/swarmcli/actions/runs/28182318316), `v1.10.0-rc1`).

### release-drafter config (`.github/release_template.yml`)
v7.4.0 deprecated the per-category `labels:` field and the top-level `exclude-labels` field ([release-drafter#1558](https://github.com/release-drafter/release-drafter/pull/1558)):
- each categorys `labels:` is now nested under a `when:` block
- `exclude-labels: [E0-silent]` becomes a leading `type: pre-exclude` category with the same `when: labels:`

Semantics are unchanged. Verified the pinned `v7.4.0` already supports the new syntax — #1558 merged 2026-05-27, v7.4.0 published 2026-06-16 (6 commits ahead of the merge), so the migrated config runs on the same action version with no warning.

### commitish (`.github/workflows/release.yml`)
On a tag push, release-drafter defaulted the draft `target_commitish` to the tag ref, which GitHub rejects: `refs/tags/v1.10.0-rc1 is not supported as release target (commitish), falling back to default branch`. Setting `commitish: ${{ github.event.repository.default_branch }}` makes the existing fallback explicit and removes the warning. No behavioural change.

### Not touched
The remaining `goreleaser`-job log lines are benign and expected: `pipe skipped … prerelease detected` / `release is prerelease` (no Homebrew publish for an RC), `cosign not found … skipping signature verification`, the internal `tar --warning=no-unknown-keyword` flag, and a git `hint:` during checkout.

### Validation
Both YAML files parse and structurally validate (1 pre-exclude category, 5 titled categories all using `when.labels`, no legacy `labels:` keys, `commitish` set) via `gopkg.in/yaml.v3`.

> [!NOTE]
> `release.yml` only runs on tag pushes, so this PRs CI will not exercise the changed files; the next RC/GA tag is the real validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)