### PR TITLE
ci(govulncheck): suppress daemon-side docker cp/archive false-positives

### DIFF
--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -39,11 +39,15 @@ jobs:
         # Fixed in: N/A — docker/docker@v28.5.2 is the latest release with no
         # upstream fix available. govulncheck has no native ignore flag, so the
         # JSON output is filtered to suppress only these known false-positives.
+        # GO-2026-5746/5668/5617 are likewise daemon-side docker cp/archive
+        # false-positives (the container-archive exec and two docker cp races);
+        # this client never invokes those paths and they share the N/A fix state.
         run: |
           python3 - <<'PYEOF'
           import subprocess, sys, json
 
-          SUPPRESSED = {"GO-2026-4887", "GO-2026-4883"}
+          SUPPRESSED = {"GO-2026-4883", "GO-2026-4887",
+                        "GO-2026-5617", "GO-2026-5668", "GO-2026-5746"}
 
           # -format json exits 0 and streams JSON; vulnerability data is in the stream.
           proc = subprocess.run(


### PR DESCRIPTION
## What

Three new Docker advisories were published this week against `github.com/docker/docker` (vendored as `moby/moby`):

- **GO-2026-5746** — `PUT /containers/{id}/archive` executes container binary on the host
- **GO-2026-5668** — `docker cp` symlink-swap race → arbitrary empty files on host
- **GO-2026-5617** — `docker cp` race → bind-mount redirection to host path

These broke the weekly `govulncheck` job.

## Why suppress

All three are **daemon-side** (`dockerd` archive / `docker cp` handling). This binary is a Docker API **client**, not the daemon, and makes no `CopyTo/FromContainer` (docker cp) calls — the vulnerable code paths are never invoked. govulncheck flags them at whole-module granularity because the OSV has no symbol list and **no fix on the `+incompatible` line** (only `moby/moby/v2 ≥ 2.0.0-beta.14`, a breaking beta migration — not viable). Same class as the already-suppressed GO-2026-4887 / GO-2026-4883.

Added the three IDs to the existing `SUPPRESSED` set; the loud-fail guard for any *other* / future vuln is unchanged.

Companion PRs (same change): swarmcli-agent, swarmcli, swarmcli-be — all three share this dependency and suppression mechanism. swarmcli-rbac-proxy has no docker dependency and is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)