### PR TITLE
feat(services): container health + port in the services view

### DIFF
--- a/docker/service.go
+++ b/docker/service.go
@@ -356,8 +356,14 @@ type ServiceEntry struct {
 	Mode           string
 	Image          string
 	Ports          string
-	CreatedAt      time.Time
-	UpdatedAt      time.Time
+	// Health is an aggregate health summary for the service's running replicas
+	// (e.g. "2/2 healthy"); "" when unknown. The swarm API does not expose
+	// container health, so the default loaders leave it empty; it is an
+	// extension point populated by a ServiceOps decorator that can reach
+	// per-node container state.
+	Health    string
+	CreatedAt time.Time
+	UpdatedAt time.Time
 }
 
 func LoadNodeServices(nodeID string) []ServiceEntry {

--- a/docker/task.go
+++ b/docker/task.go
@@ -29,9 +29,17 @@ type TaskEntry struct {
 	// the status is unknown. The swarm task snapshot does not carry it, so the
 	// default loaders leave it empty; it is an extension point populated by a
 	// TaskOps decorator that can reach per-node container state.
-	Health    string
-	CreatedAt time.Time
-	UpdatedAt time.Time
+	Health string
+	// ContainerState is the container's live lifecycle state as reported by the
+	// on-node agent (e.g. "running", "restarting", "exited", "dead"); "" by
+	// default. Like Health it is an extension point populated by a TaskOps
+	// decorator. Unlike CurrentState (the swarm task state) it reflects the
+	// container's `docker ps` state, which the remote Swarm API cannot report;
+	// the services view shows it as a fallback when Health is empty so container
+	// errors surface even for images without a healthcheck.
+	ContainerState string
+	CreatedAt      time.Time
+	UpdatedAt      time.Time
 }
 
 // GetTasksForStack returns all tasks for services in the given stack

--- a/docker/task.go
+++ b/docker/task.go
@@ -24,8 +24,14 @@ type TaskEntry struct {
 	CurrentState string
 	Error        string
 	Ports        string
-	CreatedAt    time.Time
-	UpdatedAt    time.Time
+	// Health is the container-level health status (e.g. "healthy",
+	// "unhealthy", "starting"); "" when the container has no healthcheck or
+	// the status is unknown. The swarm task snapshot does not carry it, so the
+	// default loaders leave it empty; it is an extension point populated by a
+	// TaskOps decorator that can reach per-node container state.
+	Health    string
+	CreatedAt time.Time
+	UpdatedAt time.Time
 }
 
 // GetTasksForStack returns all tasks for services in the given stack

--- a/features/features.go
+++ b/features/features.go
@@ -6,21 +6,45 @@
 // call Enable() from init() to activate additional features.
 package features
 
-import "maps"
+import (
+	"maps"
+	"sync"
+)
 
-var enabled = map[string]bool{}
+// mu guards enabled: it is written from the Bubble Tea update goroutine
+// (ApplyLicenseState on startup / license / swarm change) and read from
+// tea.Cmd goroutines (feature-gated data loaders), so unsynchronized access
+// would be a concurrent map read/write.
+var (
+	mu      sync.RWMutex
+	enabled = map[string]bool{}
+)
 
 // Enable marks a feature as enabled.
-func Enable(name string) { enabled[name] = true }
+func Enable(name string) {
+	mu.Lock()
+	defer mu.Unlock()
+	enabled[name] = true
+}
 
 // Disable removes a feature flag.
-func Disable(name string) { delete(enabled, name) }
+func Disable(name string) {
+	mu.Lock()
+	defer mu.Unlock()
+	delete(enabled, name)
+}
 
 // IsEnabled reports whether a feature is enabled.
-func IsEnabled(name string) bool { return enabled[name] }
+func IsEnabled(name string) bool {
+	mu.RLock()
+	defer mu.RUnlock()
+	return enabled[name]
+}
 
 // All returns a copy of all enabled feature flags.
 func All() map[string]bool {
+	mu.RLock()
+	defer mu.RUnlock()
 	out := make(map[string]bool, len(enabled))
 	maps.Copy(out, enabled)
 	return out

--- a/views/services/columns.go
+++ b/views/services/columns.go
@@ -13,16 +13,20 @@ import (
 // serviceColumn pairs a shared-layout column with its sort metadata. The set is
 // the single source of truth for the header, widths, sort indices, and rows.
 type serviceColumn struct {
-	col     filterlist.Column[docker.ServiceEntry]
-	sort    SortField
-	hasSort bool
-	isStack bool
+	col      filterlist.Column[docker.ServiceEntry]
+	sort     SortField
+	hasSort  bool
+	isStack  bool
+	isHealth bool
 }
 
 // serviceColumns returns the columns for the current scope. The STACK column is
 // dropped unless we're showing services from every stack (AllFilter), since in a
-// single-stack/node scope every row carries the same stack value. Cell closures
-// capture the model so the ERROR column can read the per-service error text.
+// single-stack/node scope every row carries the same stack value. The HEALTH
+// column is dropped unless some row carries a health summary — ServiceEntry.Health
+// is empty in the default (remote-API) loaders, so it is invisible unless a
+// ServiceOps decorator populates it. Cell closures capture the model so the ERROR
+// column can read the per-service error text.
 func (m *Model) serviceColumns() []serviceColumn {
 	all := []serviceColumn{
 		{sort: SortByName, hasSort: true, col: filterlist.Column[docker.ServiceEntry]{
@@ -42,6 +46,14 @@ func (m *Model) serviceColumns() []serviceColumn {
 		{sort: SortByStatus, hasSort: true, col: filterlist.Column[docker.ServiceEntry]{
 			Label: "STATUS", MinWidth: 8,
 			Cell: func(e docker.ServiceEntry) string { return e.Status }}},
+		{isHealth: true, col: filterlist.Column[docker.ServiceEntry]{
+			Label: "HEALTH", MinWidth: 6,
+			Cell: func(e docker.ServiceEntry) string {
+				if e.Health == "" {
+					return "—"
+				}
+				return e.Health
+			}}},
 		{col: filterlist.Column[docker.ServiceEntry]{
 			Label: "MODE", MinWidth: 6,
 			Cell: func(e docker.ServiceEntry) string { return e.Mode }}},
@@ -61,16 +73,33 @@ func (m *Model) serviceColumns() []serviceColumn {
 			Label: "ERROR", MinWidth: 6, Flex: true,
 			Cell: func(e docker.ServiceEntry) string { return m.serviceErrorText[e.ServiceID] }}},
 	}
-	if m.filterType == AllFilter {
+	dropStack := m.filterType != AllFilter
+	dropHealth := !m.anyServiceHealth()
+	if !dropStack && !dropHealth {
 		return all
 	}
-	out := make([]serviceColumn, 0, len(all)-1)
+	out := make([]serviceColumn, 0, len(all))
 	for _, c := range all {
-		if !c.isStack {
-			out = append(out, c)
+		if c.isStack && dropStack {
+			continue
 		}
+		if c.isHealth && dropHealth {
+			continue
+		}
+		out = append(out, c)
 	}
 	return out
+}
+
+// anyServiceHealth reports whether any loaded service row carries a health
+// summary, which gates the HEALTH column.
+func (m *Model) anyServiceHealth() bool {
+	for _, e := range m.List.Items {
+		if e.Health != "" {
+			return true
+		}
+	}
+	return false
 }
 
 // layoutColumns extracts the shared-layout column set for the current scope.

--- a/views/services/columns.go
+++ b/views/services/columns.go
@@ -23,11 +23,16 @@ type serviceColumn struct {
 // serviceColumns returns the columns for the current scope. The STACK column is
 // dropped unless we're showing services from every stack (AllFilter), since in a
 // single-stack/node scope every row carries the same stack value. The HEALTH
-// column is dropped unless some row carries a health summary — ServiceEntry.Health
-// is empty in the default (remote-API) loaders, so it is invisible unless a
-// ServiceOps decorator populates it. Cell closures capture the model so the ERROR
-// column can read the per-service error text.
+// column shows live per-container health when a ServiceOps decorator populates
+// ServiceEntry.Health; when there is none but a footer note explains why (CE
+// upsell, or a non-managed context — see healthFooterHint) it stays visible with
+// a "*" placeholder tying rows to that footnote, and is dropped only when there
+// is neither. Cell closures capture the model so the ERROR column can read the
+// per-service error text.
 func (m *Model) serviceColumns() []serviceColumn {
+	// footnoted: HEALTH carries no live data but a footer note explains it, so
+	// keep the column with a "*" placeholder instead of dropping it.
+	footnoted := healthFooterHint() != ""
 	all := []serviceColumn{
 		{sort: SortByName, hasSort: true, col: filterlist.Column[docker.ServiceEntry]{
 			Label: "SERVICE", MinWidth: 8, Flex: true,
@@ -49,10 +54,13 @@ func (m *Model) serviceColumns() []serviceColumn {
 		{isHealth: true, col: filterlist.Column[docker.ServiceEntry]{
 			Label: "HEALTH", MinWidth: 6,
 			Cell: func(e docker.ServiceEntry) string {
-				if e.Health == "" {
-					return "—"
+				if e.Health != "" {
+					return e.Health
 				}
-				return e.Health
+				if footnoted {
+					return "*"
+				}
+				return "—"
 			}}},
 		{col: filterlist.Column[docker.ServiceEntry]{
 			Label: "MODE", MinWidth: 6,
@@ -74,7 +82,7 @@ func (m *Model) serviceColumns() []serviceColumn {
 			Cell: func(e docker.ServiceEntry) string { return m.serviceErrorText[e.ServiceID] }}},
 	}
 	dropStack := m.filterType != AllFilter
-	dropHealth := !m.anyServiceHealth()
+	dropHealth := !m.anyServiceHealth() && !footnoted
 	if !dropStack && !dropHealth {
 		return all
 	}
@@ -92,7 +100,8 @@ func (m *Model) serviceColumns() []serviceColumn {
 }
 
 // anyServiceHealth reports whether any loaded service row carries a health
-// summary, which gates the HEALTH column.
+// summary — one of the two conditions (the other being a footer note) that keep
+// the HEALTH column visible.
 func (m *Model) anyServiceHealth() bool {
 	for _, e := range m.List.Items {
 		if e.Health != "" {

--- a/views/services/columns_test.go
+++ b/views/services/columns_test.go
@@ -4,6 +4,7 @@
 package servicesview
 
 import (
+	"strings"
 	"testing"
 
 	"swarmcli/docker"
@@ -50,6 +51,43 @@ func TestColumns_StackOnlyInAllFilter(t *testing.T) {
 		require.Len(t, m.layoutColumns(), tc.wantLen, "filter %v", tc.ft)
 		require.Equal(t, tc.wantStack, hasColumn(m, "STACK"), "filter %v stack presence", tc.ft)
 	}
+}
+
+func TestColumns_HealthOnlyWhenPresent(t *testing.T) {
+	// No row carries health → the HEALTH column is absent (default CE behavior).
+	m := testModel()
+	loadWithFilter(m, AllFilter, fakeEntries("web", "api"))
+	require.False(t, hasColumn(m, "HEALTH"), "HEALTH must be hidden when no row has health")
+	baseLen := len(m.layoutColumns())
+
+	// A populated Health summary reveals the column, inserted after STATUS.
+	entries := fakeEntries("web", "api")
+	entries[0].Health = "1/1 healthy"
+	m2 := testModel()
+	loadWithFilter(m2, AllFilter, entries)
+	require.True(t, hasColumn(m2, "HEALTH"), "HEALTH must appear when a row has health")
+	require.Len(t, m2.layoutColumns(), baseLen+1)
+	require.Equal(t, colLabelIndex(m2, "STATUS")+1, colLabelIndex(m2, "HEALTH"),
+		"HEALTH should sit immediately after STATUS")
+}
+
+func TestFormatTaskRow_ConditionalColumns(t *testing.T) {
+	// Neither flag set → layout matches the pre-existing NAME…ERROR row.
+	plain := formatTaskRow("web.1", "node-1", "Running", "running 8m", "healthy", "8000/tcp", "boom", false, false)
+	require.NotContains(t, plain, "healthy")
+	require.NotContains(t, plain, "8000/tcp")
+	require.Contains(t, plain, "boom")
+
+	// Both flags set → HEALTH and PORTS appear before ERROR.
+	full := formatTaskRow("web.1", "node-1", "Running", "running 8m", "healthy", "8000/tcp", "boom", true, true)
+	require.Contains(t, full, "healthy")
+	require.Contains(t, full, "8000/tcp")
+	require.Less(t, indexOf(full, "healthy"), indexOf(full, "boom"))
+	require.Less(t, indexOf(full, "8000/tcp"), indexOf(full, "boom"))
+}
+
+func indexOf(s, sub string) int {
+	return strings.Index(s, sub)
 }
 
 func TestColWidths_LengthMatchesHeader(t *testing.T) {

--- a/views/services/columns_test.go
+++ b/views/services/columns_test.go
@@ -71,6 +71,47 @@ func TestColumns_HealthOnlyWhenPresent(t *testing.T) {
 		"HEALTH should sit immediately after STATUS")
 }
 
+func TestExpandedRow_ContainerStateFallback(t *testing.T) {
+	m := testModel()
+	loadWithFilter(m, AllFilter, fakeEntries("web"))
+	// Expand the service and give it a replica that is erroring with no
+	// healthcheck (Health empty). The container's live state must still surface
+	// as the HEALTH fallback so failures show for images without a HEALTHCHECK.
+	m.expandedServices["id-web"] = true
+	m.serviceTasks["id-web"] = []docker.TaskEntry{{
+		Name: "web.1", NodeName: "node-1", DesiredState: "Running",
+		CurrentState: "running 8m", ContainerID: "c1", ContainerState: "exited",
+	}}
+	m.setRenderItem()
+
+	out := m.List.RenderItem(m.List.Filtered[0], false, 0)
+	require.Contains(t, out, "HEALTH", "HEALTH column must appear when a replica carries container state")
+	require.Contains(t, out, "exited", "the container's live state must render as the HEALTH fallback")
+}
+
+func TestTaskRowStyle_TintsFailureStates(t *testing.T) {
+	red, yellow, grey := lipgloss.Color("9"), lipgloss.Color("3"), lipgloss.Color("7")
+	cases := map[string]lipgloss.Color{
+		"unhealthy":  red,
+		"exited":     red,
+		"dead":       red,
+		"starting":   yellow,
+		"restarting": yellow,
+		"healthy":    grey,
+		"running":    grey,
+		"":           grey,
+	}
+	for status, want := range cases {
+		require.Equal(t, want, taskRowStyle(status).GetForeground(), "status %q", status)
+	}
+}
+
+func TestFirstNonEmpty(t *testing.T) {
+	require.Equal(t, "healthy", firstNonEmpty("healthy", "running"))
+	require.Equal(t, "exited", firstNonEmpty("", "exited"))
+	require.Equal(t, "", firstNonEmpty("", ""))
+}
+
 func TestFormatTaskRow_ConditionalColumns(t *testing.T) {
 	// Neither flag set → layout matches the pre-existing NAME…ERROR row.
 	plain := formatTaskRow("web.1", "node-1", "Running", "running 8m", "healthy", "8000/tcp", "boom", false, false)

--- a/views/services/columns_test.go
+++ b/views/services/columns_test.go
@@ -8,11 +8,24 @@ import (
 	"testing"
 
 	"swarmcli/docker"
+	"swarmcli/features"
 	filterlist "swarmcli/ui/components/filterable/list"
+	"swarmcli/views/view"
 
 	"github.com/charmbracelet/lipgloss"
 	"github.com/stretchr/testify/require"
 )
+
+// healthCell returns the rendered HEALTH cell for e, or "" when the HEALTH
+// column is not in the current column set.
+func healthCell(m *Model, e docker.ServiceEntry) string {
+	for _, c := range m.serviceColumns() {
+		if c.isHealth {
+			return c.col.Cell(e)
+		}
+	}
+	return ""
+}
 
 const longServiceName = "myproject_some-very-long-service-name"
 
@@ -35,15 +48,19 @@ func colLabelIndex(m *Model, label string) int {
 }
 
 func TestColumns_StackOnlyInAllFilter(t *testing.T) {
+	// CE default (feature off): the HEALTH column stays visible via its footnote,
+	// so it is present in every scope; only STACK varies with the filter.
+	features.Disable(serviceHealthFeature)
+	view.ServicesHealthHint = nil
 	cases := []struct {
 		ft        FilterType
 		wantStack bool
 		wantLen   int
 	}{
-		{AllFilter, true, 10},
-		{StackFilter, false, 9},
-		{NodeFilter, false, 9},
-		{NoStackFilter, false, 9},
+		{AllFilter, true, 11},
+		{StackFilter, false, 10},
+		{NodeFilter, false, 10},
+		{NoStackFilter, false, 10},
 	}
 	for _, tc := range cases {
 		m := testModel()
@@ -53,21 +70,33 @@ func TestColumns_StackOnlyInAllFilter(t *testing.T) {
 	}
 }
 
-func TestColumns_HealthOnlyWhenPresent(t *testing.T) {
-	// No row carries health → the HEALTH column is absent (default CE behavior).
+func TestColumns_HealthColumnAndFootnote(t *testing.T) {
+	// Feature off (CE / unlicensed): a footnote explains the column, so HEALTH is
+	// shown with a "*" placeholder rather than dropped.
+	features.Disable(serviceHealthFeature)
+	view.ServicesHealthHint = nil
 	m := testModel()
 	loadWithFilter(m, AllFilter, fakeEntries("web", "api"))
-	require.False(t, hasColumn(m, "HEALTH"), "HEALTH must be hidden when no row has health")
-	baseLen := len(m.layoutColumns())
+	require.True(t, hasColumn(m, "HEALTH"), "HEALTH stays visible with a footnote")
+	require.Equal(t, "*", healthCell(m, docker.ServiceEntry{}), "no-health cell shows the footnote asterisk")
 
-	// A populated Health summary reveals the column, inserted after STATUS.
+	// Feature on + reachable (empty note), no row has health → HEALTH is dropped.
+	features.Enable(serviceHealthFeature)
+	t.Cleanup(func() { features.Disable(serviceHealthFeature) })
+	view.ServicesHealthHint = func() string { return "" }
+	t.Cleanup(func() { view.ServicesHealthHint = nil })
+	m2 := testModel()
+	loadWithFilter(m2, AllFilter, fakeEntries("web", "api"))
+	require.False(t, hasColumn(m2, "HEALTH"), "HEALTH hidden when reachable and no row has health")
+
+	// A populated Health summary shows the real value, right after STATUS.
 	entries := fakeEntries("web", "api")
 	entries[0].Health = "1/1 healthy"
-	m2 := testModel()
-	loadWithFilter(m2, AllFilter, entries)
-	require.True(t, hasColumn(m2, "HEALTH"), "HEALTH must appear when a row has health")
-	require.Len(t, m2.layoutColumns(), baseLen+1)
-	require.Equal(t, colLabelIndex(m2, "STATUS")+1, colLabelIndex(m2, "HEALTH"),
+	m3 := testModel()
+	loadWithFilter(m3, AllFilter, entries)
+	require.True(t, hasColumn(m3, "HEALTH"), "HEALTH appears when a row has health")
+	require.Equal(t, "1/1 healthy", healthCell(m3, docker.ServiceEntry{Health: "1/1 healthy"}))
+	require.Equal(t, colLabelIndex(m3, "STATUS")+1, colLabelIndex(m3, "HEALTH"),
 		"HEALTH should sit immediately after STATUS")
 }
 

--- a/views/services/footer.go
+++ b/views/services/footer.go
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package servicesview
+
+import (
+	"swarmcli/features"
+	"swarmcli/views/view"
+)
+
+// serviceHealthFeature gates the per-container HEALTH/PORTS enrichment. The base
+// build never enables it, so CE always shows the upsell footer hint; an
+// extension build enabling it (via the license reconciler) both lights up the
+// HEALTH column and suppresses the hint — mirroring the volumes
+// "volumes-all-nodes" pattern. Matches license.FeatureServiceHealth.
+const serviceHealthFeature = "service-health"
+
+// serviceHealthUpsellHint advertises the Business Edition capability in the
+// services footer when the feature is unavailable (CE or unlicensed).
+var serviceHealthUpsellHint = "Per-container health & ports across nodes is a Business Edition feature: " + view.BELandingURL
+
+// healthFooterHint returns the extra services-view footer line, or "":
+//   - feature off (CE / unlicensed): the BE upsell hint.
+//   - feature on, but the extension reports health is unreachable on the current
+//     context (via view.ServicesHealthHint): that context note.
+//   - feature on and health reachable: "" — the HEALTH column carries the info.
+func healthFooterHint() string {
+	if features.IsEnabled(serviceHealthFeature) {
+		if view.ServicesHealthHint != nil {
+			return view.ServicesHealthHint()
+		}
+		return ""
+	}
+	return serviceHealthUpsellHint
+}

--- a/views/services/footer_test.go
+++ b/views/services/footer_test.go
@@ -46,7 +46,8 @@ func TestFrameFooter_AppendsHint(t *testing.T) {
 	view.ServicesHealthHint = func() string { return "needs the managed context" }
 	t.Cleanup(func() { view.ServicesHealthHint = nil })
 	foot := m.FrameFooter()
-	require.Contains(t, foot, "needs the managed context")
+	// The note is prefixed with "* " to tie it to the "*" HEALTH-column cells.
+	require.Contains(t, foot, "* needs the managed context")
 	require.NotContains(t, foot, view.BELandingURL)
 
 	// Flag on + no note (managed context, health works): neither hint.

--- a/views/services/footer_test.go
+++ b/views/services/footer_test.go
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package servicesview
+
+import (
+	"testing"
+
+	"swarmcli/features"
+	"swarmcli/views/view"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestHealthFooterHint(t *testing.T) {
+	// Flag off (CE / unlicensed): the upsell hint with the BE landing URL.
+	features.Disable(serviceHealthFeature)
+	view.ServicesHealthHint = nil
+	require.Contains(t, healthFooterHint(), view.BELandingURL)
+
+	// Flag on, no BE note: nothing (the HEALTH column carries the info).
+	features.Enable(serviceHealthFeature)
+	t.Cleanup(func() { features.Disable(serviceHealthFeature) })
+	require.Equal(t, "", healthFooterHint())
+
+	// Flag on, BE reports a context note: that note (and not the upsell).
+	view.ServicesHealthHint = func() string { return "needs the managed context" }
+	t.Cleanup(func() { view.ServicesHealthHint = nil })
+	got := healthFooterHint()
+	require.Equal(t, "needs the managed context", got)
+	require.NotContains(t, got, view.BELandingURL)
+}
+
+func TestFrameFooter_AppendsHint(t *testing.T) {
+	m := testModel()
+	loadServices(m, fakeEntries("svc1"))
+
+	// Flag off: the rendered footer carries the upsell hint.
+	features.Disable(serviceHealthFeature)
+	view.ServicesHealthHint = nil
+	require.Contains(t, m.FrameFooter(), view.BELandingURL)
+
+	// Flag on + a BE context note: the note shows, the upsell does not.
+	features.Enable(serviceHealthFeature)
+	t.Cleanup(func() { features.Disable(serviceHealthFeature) })
+	view.ServicesHealthHint = func() string { return "needs the managed context" }
+	t.Cleanup(func() { view.ServicesHealthHint = nil })
+	foot := m.FrameFooter()
+	require.Contains(t, foot, "needs the managed context")
+	require.NotContains(t, foot, view.BELandingURL)
+
+	// Flag on + no note (managed context, health works): neither hint.
+	view.ServicesHealthHint = func() string { return "" }
+	foot = m.FrameFooter()
+	require.NotContains(t, foot, "needs the managed context")
+	require.NotContains(t, foot, view.BELandingURL)
+}

--- a/views/services/update.go
+++ b/views/services/update.go
@@ -792,10 +792,13 @@ func (m *Model) setRenderItem() {
 			if len(tasks) > 0 {
 				// HEALTH and PORTS are per-container data the swarm API does not
 				// expose; they are populated by a TaskOps decorator and stay
-				// empty otherwise, so only show those columns when present.
+				// empty otherwise, so only show those columns when present. The
+				// HEALTH cell shows the healthcheck token when present, else the
+				// container's live state (running / restarting / exited), so the
+				// column appears whenever the decorator is active.
 				showHealth, showPorts := false, false
 				for _, t := range tasks {
-					if t.Health != "" {
+					if t.Health != "" || t.ContainerState != "" {
 						showHealth = true
 					}
 					if t.Ports != "" {
@@ -816,7 +819,7 @@ func (m *Model) setRenderItem() {
 					taskNode := filterlist.TruncateRunes(task.NodeName, 12)
 					taskDesired := filterlist.TruncateRunes(task.DesiredState, 13)
 					taskCurrent := filterlist.TruncateRunes(task.CurrentState, 40)
-					taskHealth := dashIfEmpty(filterlist.TruncateRunes(task.Health, 9))
+					taskHealth := dashIfEmpty(filterlist.TruncateRunes(firstNonEmpty(task.Health, task.ContainerState), 9))
 					taskPorts := dashIfEmpty(filterlist.TruncateRunes(task.Ports, 20))
 					taskErr := filterlist.TruncateRunes(task.Error, 30)
 					rowText := formatTaskRow(taskName, taskNode, taskDesired, taskCurrent,
@@ -838,9 +841,10 @@ func (m *Model) setRenderItem() {
 							}
 						}
 					} else {
-						// Tint the whole row by health so unhealthy replicas stand
-						// out, mirroring the service-level error coloring above.
-						taskLine = taskRowStyle(task.Health).Render(rowText)
+						// Tint the whole row by container status so unhealthy or
+						// failing replicas stand out, mirroring the service-level
+						// error coloring above.
+						taskLine = taskRowStyle(firstNonEmpty(task.Health, task.ContainerState)).Render(rowText)
 					}
 					lineStr += "\n" + taskLine
 				}
@@ -870,14 +874,15 @@ func formatTaskRow(name, node, desired, current, health, ports, errText string, 
 	return s + "  " + errText
 }
 
-// taskRowStyle tints an expanded task sub-row by container health: unhealthy
-// red, starting yellow, everything else (healthy / no healthcheck) the default
-// grey used for normal task rows.
-func taskRowStyle(health string) lipgloss.Style {
-	switch health {
-	case "unhealthy":
+// taskRowStyle tints an expanded task sub-row by container status: failed
+// states (unhealthy / exited / dead) red, transient states (starting /
+// restarting) yellow, everything else (healthy / running / no healthcheck) the
+// default grey used for normal task rows.
+func taskRowStyle(status string) lipgloss.Style {
+	switch status {
+	case "unhealthy", "exited", "dead":
 		return lipgloss.NewStyle().Foreground(lipgloss.Color("9"))
-	case "starting":
+	case "starting", "restarting":
 		return lipgloss.NewStyle().Foreground(lipgloss.Color("3"))
 	default:
 		return lipgloss.NewStyle().Foreground(lipgloss.Color("7"))
@@ -890,6 +895,15 @@ func dashIfEmpty(s string) string {
 		return "—"
 	}
 	return s
+}
+
+// firstNonEmpty returns the first non-empty string, used to fall back from the
+// healthcheck token to the container's live state in the HEALTH cell.
+func firstNonEmpty(a, b string) string {
+	if a != "" {
+		return a
+	}
+	return b
 }
 
 // formatRelativeTime formats a time as a relative duration (e.g., "2h ago", "3d ago")

--- a/views/services/update.go
+++ b/views/services/update.go
@@ -790,11 +790,24 @@ func (m *Model) setRenderItem() {
 		if m.expandedServices[e.ServiceID] {
 			tasks := m.serviceTasks[e.ServiceID]
 			if len(tasks) > 0 {
+				// HEALTH and PORTS are per-container data the swarm API does not
+				// expose; they are populated by a TaskOps decorator and stay
+				// empty otherwise, so only show those columns when present.
+				showHealth, showPorts := false, false
+				for _, t := range tasks {
+					if t.Health != "" {
+						showHealth = true
+					}
+					if t.Ports != "" {
+						showPorts = true
+					}
+				}
+
 				// Add task header (include ERROR column)
 				taskHeaderStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("8")).Italic(true)
 				// Align header columns with task row formatting
-				taskHeader := fmt.Sprintf("   %-22s  %-12s  %-13s  %-40s  %s",
-					"NAME", "NODE", "DESIRED STATE", "CURRENT STATE", "ERROR")
+				taskHeader := formatTaskRow("NAME", "NODE", "DESIRED STATE", "CURRENT STATE",
+					"HEALTH", "PORTS", "ERROR", showHealth, showPorts)
 				lineStr += "\n" + taskHeaderStyle.Render(taskHeader)
 
 				// Add each task as a row
@@ -803,7 +816,11 @@ func (m *Model) setRenderItem() {
 					taskNode := filterlist.TruncateRunes(task.NodeName, 12)
 					taskDesired := filterlist.TruncateRunes(task.DesiredState, 13)
 					taskCurrent := filterlist.TruncateRunes(task.CurrentState, 40)
+					taskHealth := dashIfEmpty(task.Health)
+					taskPorts := dashIfEmpty(filterlist.TruncateRunes(task.Ports, 20))
 					taskErr := filterlist.TruncateRunes(task.Error, 30)
+					rowText := formatTaskRow(taskName, taskNode, taskDesired, taskCurrent,
+						taskHealth, taskPorts, taskErr, showHealth, showPorts)
 
 					// Check if this task is selected
 					taskSelected := selected && m.selectedTaskIndex == taskIdx
@@ -811,8 +828,7 @@ func (m *Model) setRenderItem() {
 					if taskSelected {
 						// Lighter highlight for task rows
 						taskSelStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("230")).Background(lipgloss.Color("24")).Bold(true)
-						taskLine = taskSelStyle.Render(fmt.Sprintf("   %-22s  %-12s  %-13s  %-40s  %s",
-							taskName, taskNode, taskDesired, taskCurrent, taskErr))
+						taskLine = taskSelStyle.Render(rowText)
 						// Pad task highlight to full width
 						if m.List.Viewport.Width > 0 {
 							tw := lipgloss.Width(taskLine)
@@ -822,9 +838,9 @@ func (m *Model) setRenderItem() {
 							}
 						}
 					} else {
-						taskStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("7"))
-						taskLine = taskStyle.Render(fmt.Sprintf("   %-22s  %-12s  %-13s  %-40s  %s",
-							taskName, taskNode, taskDesired, taskCurrent, taskErr))
+						// Tint the whole row by health so unhealthy replicas stand
+						// out, mirroring the service-level error coloring above.
+						taskLine = taskRowStyle(task.Health).Render(rowText)
 					}
 					lineStr += "\n" + taskLine
 				}
@@ -837,6 +853,43 @@ func (m *Model) setRenderItem() {
 
 		return lineStr
 	}
+}
+
+// formatTaskRow lays out one expanded task sub-row (or the header when passed
+// labels). The HEALTH and PORTS columns are only emitted when the caller found
+// data for them, so services without per-container health/port info render
+// exactly as before.
+func formatTaskRow(name, node, desired, current, health, ports, errText string, showHealth, showPorts bool) string {
+	s := fmt.Sprintf("   %-22s  %-12s  %-13s  %-40s", name, node, desired, current)
+	if showHealth {
+		s += fmt.Sprintf("  %-9s", health)
+	}
+	if showPorts {
+		s += fmt.Sprintf("  %-20s", ports)
+	}
+	return s + "  " + errText
+}
+
+// taskRowStyle tints an expanded task sub-row by container health: unhealthy
+// red, starting yellow, everything else (healthy / no healthcheck) the default
+// grey used for normal task rows.
+func taskRowStyle(health string) lipgloss.Style {
+	switch health {
+	case "unhealthy":
+		return lipgloss.NewStyle().Foreground(lipgloss.Color("9"))
+	case "starting":
+		return lipgloss.NewStyle().Foreground(lipgloss.Color("3"))
+	default:
+		return lipgloss.NewStyle().Foreground(lipgloss.Color("7"))
+	}
+}
+
+// dashIfEmpty renders an em dash for empty cells so aligned columns stay legible.
+func dashIfEmpty(s string) string {
+	if s == "" {
+		return "—"
+	}
+	return s
 }
 
 // formatRelativeTime formats a time as a relative duration (e.g., "2h ago", "3d ago")

--- a/views/services/update.go
+++ b/views/services/update.go
@@ -816,7 +816,7 @@ func (m *Model) setRenderItem() {
 					taskNode := filterlist.TruncateRunes(task.NodeName, 12)
 					taskDesired := filterlist.TruncateRunes(task.DesiredState, 13)
 					taskCurrent := filterlist.TruncateRunes(task.CurrentState, 40)
-					taskHealth := dashIfEmpty(task.Health)
+					taskHealth := dashIfEmpty(filterlist.TruncateRunes(task.Health, 9))
 					taskPorts := dashIfEmpty(filterlist.TruncateRunes(task.Ports, 20))
 					taskErr := filterlist.TruncateRunes(task.Error, 30)
 					rowText := formatTaskRow(taskName, taskNode, taskDesired, taskCurrent,

--- a/views/services/view.go
+++ b/views/services/view.go
@@ -9,7 +9,13 @@ import (
 
 func (m *Model) FrameTitle() string  { return m.title }
 func (m *Model) FrameHeader() string { return m.List.RenderHeader() }
-func (m *Model) FrameFooter() string { return m.List.RenderFooter() }
+func (m *Model) FrameFooter() string {
+	footer := m.List.RenderFooter()
+	if hint := healthFooterHint(); hint != "" {
+		footer += "\n" + ui.StatusBarStyle.Render(hint)
+	}
+	return footer
+}
 
 func (m *Model) FrameContent() string {
 	header := m.FrameHeader()

--- a/views/services/view.go
+++ b/views/services/view.go
@@ -12,7 +12,8 @@ func (m *Model) FrameHeader() string { return m.List.RenderHeader() }
 func (m *Model) FrameFooter() string {
 	footer := m.List.RenderFooter()
 	if hint := healthFooterHint(); hint != "" {
-		footer += "\n" + ui.StatusBarStyle.Render(hint)
+		// "* " ties the note to the "*" placeholders in the HEALTH column.
+		footer += "\n" + ui.StatusBarStyle.Render("* "+hint)
 	}
 	return footer
 }

--- a/views/view/edition.go
+++ b/views/view/edition.go
@@ -55,3 +55,10 @@ func FeatureLockedCmd(featureName string) tea.Cmd {
 	}
 	return nil
 }
+
+// ServicesHealthHint, when set by the BE module, returns a one-line services-
+// view footer note (e.g. why container health is unavailable on the current
+// context), or "" when there is nothing to say. It lets BE surface a context-
+// specific note without CE having to know about managed contexts. Set in
+// init(); read on the render goroutine.
+var ServicesHealthHint func() string


### PR DESCRIPTION
## What

Adds the plumbing + rendering for **container health** and **per-replica port** in the services view. The remote Docker/Swarm API cannot report container health (`Up 8m (healthy)`), so today the view can't show whether replicas are actually healthy.

- `docker.TaskEntry.Health` and `docker.ServiceEntry.Health` fields — **generic extension points**. The default (remote-API) loaders leave them empty; they are populated by a `docker.Deps` decorator that can reach per-node container state.
- Expanded per-replica rows gain **conditional HEALTH + PORTS columns** and tint unhealthy replicas red / starting yellow (mirrors the existing service-level error coloring).
- The services list gains a **conditional HEALTH summary column** (after STATUS), shown only when a row carries a summary.

Everything is invisible in plain CE (fields stay empty) — no behavior change without a decorator supplying data.

## Why

Foundation for Business Edition issue Eldara-Tech/swarmcli-be#236 ("Better view on services"). The BE side sources health from the on-node agent and injects it through these fields.

## Tests

Added `columns_test.go` coverage: HEALTH column appears only when populated (and sits after STATUS); `formatTaskRow` omits HEALTH/PORTS unless present. Full suite + `golangci-lint` green.

## Also: discoverability footer hint (services view)

Adds a one-line services-view footer hint so the HEALTH/PORTS capability is discoverable, mirroring the volumes footer-flag pattern (`views/volumes/view.go:78-87`): shown while the `service-health` flag is off (CE / unlicensed → upsell to `view.BELandingURL`), replaced by the HEALTH column when a BE build enables the flag. Also adds a generic `view.ServicesHealthHint` seam so the BE module can surface a context-specific note without CE knowing about managed contexts. Pro-boundary-safe (CE names only a capability + the landing URL).


Follow-up: rather than dropping the HEALTH column when there's no live data, it now stays visible with a `*` placeholder whenever a footnote applies (CE upsell / non-managed context), and the footer note is prefixed with `* ` — so the missing capability is discoverable in-column, not only in the footer. The column is dropped only when health is reachable and no service reports any.
