### PR TITLE
feat(charts): value-aware requirements.yaml pre-flight

### DIFF
--- a/charts/chart.go
+++ b/charts/chart.go
@@ -68,6 +68,7 @@ func LoadChartDir(dir string) (*Chart, error) {
 	}
 
 	if rq, err := os.ReadFile(filepath.Join(dir, requirementsName)); err == nil {
+		ch.RequirementsRaw = rq
 		if ch.Requirements, err = parseRequirements(rq); err != nil {
 			return nil, err
 		}
@@ -160,6 +161,7 @@ func LoadChartArchive(r io.Reader) (*Chart, error) {
 		case rel == schemaName:
 			ch.Schema = body
 		case rel == requirementsName:
+			ch.RequirementsRaw = body
 			if ch.Requirements, err = parseRequirements(body); err != nil {
 				return nil, err
 			}

--- a/charts/render.go
+++ b/charts/render.go
@@ -106,6 +106,52 @@ func renderOne(ch *Chart, name string, ctx RenderContext) (string, error) {
 	return buf.String(), nil
 }
 
+// renderString parses all of the chart's templates into a set (so named
+// helpers / {{ include }} resolve) plus an extra template `src` under `name`,
+// then executes `src` against ctx. Used to render auxiliary files such as
+// requirements.yaml with the same engine, functions, and context as the manifest.
+func renderString(ch *Chart, name, src string, ctx RenderContext) (string, error) {
+	tmpl := template.New(name).Funcs(renderFuncs()).Funcs(extraFuncs())
+	for _, n := range sortedTemplateNames(ch.Templates) {
+		if _, err := tmpl.New(n).Parse(ch.Templates[n]); err != nil {
+			return "", fmt.Errorf("template %s: parse error: %w", n, err)
+		}
+	}
+	if _, err := tmpl.New(name).Parse(src); err != nil {
+		return "", fmt.Errorf("template %s: parse error: %w", name, err)
+	}
+	var buf bytes.Buffer
+	if err := tmpl.ExecuteTemplate(&buf, name, ctx); err != nil {
+		return "", fmt.Errorf("template %s: %w", name, err)
+	}
+	return buf.String(), nil
+}
+
+// RenderRequirements renders the chart's requirements.yaml through the same
+// template engine and context as the manifest, then parses the result. This lets
+// requirements.yaml reference .Values (e.g. an operator-chosen network name) while
+// staying authoritative — the declared names are resolved against the same values
+// that produced the manifest. Returns (nil, nil) when the chart ships no
+// requirements.yaml.
+//
+// Templated values must be quoted (name: "{{ .Values.x }}") so requirements.yaml
+// still parses as YAML at chart-load time; the real value is resolved here, at the
+// install/upgrade pre-flight.
+func RenderRequirements(ch *Chart, ctx RenderContext) (*Requirements, error) {
+	if ch.RequirementsRaw == nil {
+		return nil, nil
+	}
+	rendered, err := renderString(ch, requirementsName, string(ch.RequirementsRaw), ctx)
+	if err != nil {
+		return nil, fmt.Errorf("render %s: %w", requirementsName, err)
+	}
+	req, err := parseRequirements([]byte(rendered))
+	if err != nil {
+		return nil, err
+	}
+	return req, nil
+}
+
 // renderFuncs returns the Sprig function map with host-reaching helpers removed.
 // Charts may come from untrusted repos, so `env`/`expandenv`/`getHostByName`
 // are denied to stop a template from exfiltrating host environment or DNS data

--- a/charts/requirements_render_test.go
+++ b/charts/requirements_render_test.go
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package charts
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// End-to-end: rendering requirements.yaml with the same values as the manifest
+// makes an operator-chosen network name pass the pre-flight, where requirements
+// resolved against defaults (the pre-fix behaviour) would reject it.
+func TestRenderedRequirementsMatchManifestNetwork(t *testing.T) {
+	ch := &Chart{
+		Metadata: Chartfile{Name: "kc", Version: "0.1.0"},
+		Values:   map[string]any{"database": map[string]any{"network": "keycloak-db-net"}},
+		Templates: map[string]string{"templates/stack.yaml": "" +
+			"services:\n" +
+			"  app:\n" +
+			"    image: nginx:1\n" +
+			"    networks:\n" +
+			"      - {{ .Values.database.network }}\n" +
+			"networks:\n" +
+			"  {{ .Values.database.network }}:\n" +
+			"    external: true\n"},
+		RequirementsRaw: []byte("networks:\n  - name: \"{{ .Values.database.network }}\"\n    autoCreate: false\n"),
+	}
+
+	// Operator points the DB at the mariadb chart's overlay.
+	vals, err := MergeValues(ch.Values, nil, []string{"database.network=mariadb-net"})
+	require.NoError(t, err)
+	ctx := RenderContext{Values: vals, Release: ReleaseMeta{Name: "kc", Namespace: "kc", Revision: 1}, Chart: ChartMeta{Name: "kc", Version: "0.1.0"}}
+	manifest, err := Render(ch, ctx)
+	require.NoError(t, err)
+
+	fb := newFakeBackend()
+	fb.networkScopes["mariadb-net"] = "swarm" // the overlay already exists (validate-only)
+	e := testEngine(fb)
+
+	// Fixed: requirements rendered with the same override declare mariadb-net.
+	req, err := RenderRequirements(ch, ctx)
+	require.NoError(t, err)
+	_, err = e.ensureExternalNetworks(context.Background(), manifest, req)
+	require.NoError(t, err, "resolved requirement must match the resolved manifest network")
+
+	// Pre-fix analogue: requirements resolved against defaults still say
+	// keycloak-db-net, so the overridden manifest fails the contract.
+	def, err := RenderRequirements(ch, RenderContext{Values: ch.Values})
+	require.NoError(t, err)
+	_, err = e.ensureExternalNetworks(context.Background(), manifest, def)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not declared in requirements.yaml")
+	require.Contains(t, err.Error(), "mariadb-net")
+}
+
+// A templated, quoted requirement value is resolved against the same values that
+// produce the manifest, so an operator-chosen network name is what the pre-flight
+// validates against. Non-name fields (autoCreate) and sibling resources survive.
+func TestRenderRequirementsResolvesValues(t *testing.T) {
+	ch := &Chart{
+		Templates: map[string]string{},
+		RequirementsRaw: []byte(
+			"networks:\n" +
+				"  - name: \"{{ .Values.database.network }}\"\n" +
+				"    autoCreate: false\n" +
+				"secrets:\n" +
+				"  - name: app_pw\n"),
+	}
+	ctx := RenderContext{Values: map[string]any{
+		"database": map[string]any{"network": "shared-db-net"},
+	}}
+
+	req, err := RenderRequirements(ch, ctx)
+	require.NoError(t, err)
+	require.NotNil(t, req)
+	require.Len(t, req.Networks, 1)
+	require.Equal(t, "shared-db-net", req.Networks[0].Name)
+	require.False(t, *req.Networks[0].AutoCreate) // preserved through render+parse
+	require.Len(t, req.Secrets, 1)
+	require.Equal(t, "app_pw", req.Secrets[0].Name)
+}
+
+// A chart without requirements.yaml yields (nil, nil) — the manifest-driven
+// fallback, unchanged.
+func TestRenderRequirementsNilWhenAbsent(t *testing.T) {
+	ch := &Chart{Templates: map[string]string{}}
+	req, err := RenderRequirements(ch, RenderContext{})
+	require.NoError(t, err)
+	require.Nil(t, req)
+}
+
+// A requirements.yaml with no template directives renders byte-identically, so
+// existing charts are unaffected.
+func TestRenderRequirementsStaticUnchanged(t *testing.T) {
+	ch := &Chart{
+		Templates:       map[string]string{},
+		RequirementsRaw: []byte("networks:\n  - name: fixed-net\n"),
+	}
+	req, err := RenderRequirements(ch, RenderContext{Values: map[string]any{}})
+	require.NoError(t, err)
+	require.Len(t, req.Networks, 1)
+	require.Equal(t, "fixed-net", req.Networks[0].Name)
+}
+
+// A template error in requirements.yaml surfaces as an error, not a silent miss.
+func TestRenderRequirementsBadTemplate(t *testing.T) {
+	ch := &Chart{
+		Templates:       map[string]string{},
+		RequirementsRaw: []byte("networks:\n  - name: \"{{ .Values.missing | \"\n"),
+	}
+	_, err := RenderRequirements(ch, RenderContext{Values: map[string]any{}})
+	require.Error(t, err)
+}

--- a/charts/types.go
+++ b/charts/types.go
@@ -63,13 +63,14 @@ type Dependency struct {
 // Chart is a loaded chart: its metadata, default values, optional values
 // schema, and raw template sources keyed by their path under templates/.
 type Chart struct {
-	Metadata     Chartfile
-	Values       map[string]any    // parsed values.yaml (defaults)
-	ValuesRaw    []byte            // raw values.yaml bytes, nil if absent (preserves comments/order)
-	Schema       []byte            // raw values.schema.json, nil if absent
-	Templates    map[string]string // template path -> source, e.g. "templates/stack.yaml"
-	Readme       string            // README.md, empty if absent
-	Requirements *Requirements     // parsed requirements.yaml, nil if absent
+	Metadata        Chartfile
+	Values          map[string]any    // parsed values.yaml (defaults)
+	ValuesRaw       []byte            // raw values.yaml bytes, nil if absent (preserves comments/order)
+	Schema          []byte            // raw values.schema.json, nil if absent
+	Templates       map[string]string // template path -> source, e.g. "templates/stack.yaml"
+	Readme          string            // README.md, empty if absent
+	Requirements    *Requirements     // parsed requirements.yaml (raw, unrendered), nil if absent
+	RequirementsRaw []byte            // raw requirements.yaml bytes, nil if absent; re-rendered with values at pre-flight
 }
 
 // Requirements is the parsed, defaulted requirements.yaml: the external

--- a/cli/args.go
+++ b/cli/args.go
@@ -13,18 +13,19 @@ import (
 // flags holds the parsed flag values shared across charts subcommands. Not
 // every subcommand reads every field.
 type flags struct {
-	values      []string // -f/--values, repeatable
-	sets        []string // --set, repeatable
-	version     string   // --version, chart version selector
-	dryRun      bool
-	wait        bool
-	debug       bool
-	purge       bool          // --purge-volumes
-	install     bool          // --install (upgrade)
-	reuseValues bool          // --reuse-values (upgrade)
-	revision    int           // --revision (get)
-	timeout     time.Duration // --timeout
-	historyMax  int           // --history-max
+	values       []string // -f/--values, repeatable
+	sets         []string // --set, repeatable
+	version      string   // --version, chart version selector
+	dryRun       bool
+	wait         bool
+	debug        bool
+	requirements bool          // --requirements (template): emit rendered requirements.yaml
+	purge        bool          // --purge-volumes
+	install      bool          // --install (upgrade)
+	reuseValues  bool          // --reuse-values (upgrade)
+	revision     int           // --revision (get)
+	timeout      time.Duration // --timeout
+	historyMax   int           // --history-max
 }
 
 // parseArgs splits raw args into positionals and flags. It understands the
@@ -112,6 +113,8 @@ func parseArgs(args []string) ([]string, flags, error) {
 			f.dryRun = true
 		case "--wait":
 			f.wait = true
+		case "--requirements":
+			f.requirements = true
 		case "--debug":
 			f.debug = true
 		case "--purge-volumes":

--- a/cli/charts.go
+++ b/cli/charts.go
@@ -51,6 +51,7 @@ Common options:
       --set k=v         Override a value (repeatable)
       --version <ver>   Chart version (default: latest)
       --dry-run         Render and validate without deploying
+      --requirements    template: emit rendered requirements.yaml, not the manifest
       --wait            Wait for services to converge
       --timeout <dur>   Wait timeout, e.g. 10m (default 5m)
       --history-max <n> Max release revisions to retain
@@ -289,9 +290,23 @@ func chartsTemplate(args []string) int {
 		return usageErr("charts template <release> <repo/chart>")
 	}
 	release, ref := pos[0], pos[1]
-	manifest, _, _, _, code := prepare(release, ref, f, nil)
+	manifest, _, _, req, code := prepare(release, ref, f, nil)
 	if code >= 0 {
 		return code
+	}
+	// --requirements emits the chart's requirements.yaml rendered with the same
+	// values as the manifest (the resolved external-resource contract), instead of
+	// the manifest. A chart with no requirements.yaml emits nothing.
+	if f.requirements {
+		if req == nil {
+			return 0
+		}
+		out, err := yaml.Marshal(req)
+		if err != nil {
+			return fail(err)
+		}
+		outln(strings.TrimRight(string(out), "\n"))
+		return 0
 	}
 	outln(manifest)
 	return 0
@@ -555,16 +570,24 @@ func prepare(release, ref string, f flags, base map[string]any) (manifest string
 	if err := charts.ValidateValues(ch.Schema, values); err != nil {
 		return "", nil, rc, nil, fail(err)
 	}
-	manifest, err = charts.Render(ch, charts.RenderContext{
+	ctx := charts.RenderContext{
 		Values:  values,
 		Release: charts.ReleaseMeta{Name: release, Namespace: release, Revision: 1},
 		Chart:   charts.ChartMeta{Name: ch.Metadata.Name, Version: ch.Metadata.Version, AppVersion: ch.Metadata.AppVersion},
-	})
+	}
+	manifest, err = charts.Render(ch, ctx)
+	if err != nil {
+		return "", nil, rc, nil, fail(err)
+	}
+	// requirements.yaml is rendered with the same values as the manifest, so an
+	// operator-chosen network/secret name (e.g. database.network) is validated
+	// against the name the manifest actually references.
+	req, err = charts.RenderRequirements(ch, ctx)
 	if err != nil {
 		return "", nil, rc, nil, fail(err)
 	}
 	rc = charts.ReleaseChart{Name: ch.Metadata.Name, Version: ch.Metadata.Version, AppVersion: ch.Metadata.AppVersion}
-	return manifest, values, rc, ch.Requirements, -1
+	return manifest, values, rc, req, -1
 }
 
 // --- uninstall / list / status ---

--- a/cli/charts_test.go
+++ b/cli/charts_test.go
@@ -127,6 +127,13 @@ func TestParseArgsInlineValue(t *testing.T) {
 	require.Equal(t, "2.0.0", f.version)
 }
 
+func TestParseArgsRequirements(t *testing.T) {
+	pos, f, err := parseArgs([]string{"rel", "repo/chart", "--requirements"})
+	require.NoError(t, err)
+	require.Equal(t, []string{"rel", "repo/chart"}, pos)
+	require.True(t, f.requirements)
+}
+
 func TestParseIntRejectsGarbage(t *testing.T) {
 	n, err := parseInt("3")
 	require.NoError(t, err)


### PR DESCRIPTION
## What

Render `requirements.yaml` through the chart template engine with the **same values** as the manifest, at the install/upgrade pre-flight, so an operator-chosen external-resource name is validated against the name the manifest actually references.

## Why

`requirements.yaml` is authoritative — every external network/secret/config the rendered manifest references must be declared there — but it was parsed as **static YAML at chart-load, before values exist** (`charts/chart.go` → `parseRequirements`). So a chart with an operator-configurable network (e.g. keycloak `database.network`, mariadb `network.name`) failed its **own** pre-flight the moment an operator changed the knob:

```
network(s) the manifest declares external are not declared in requirements.yaml:
  mariadb-net
```

Reported on the swarmcli-charts keycloak PR (operator pointing Keycloak at the MariaDB chart’s overlay).

## How

- `Chart.RequirementsRaw` holds the raw bytes; `charts.RenderRequirements(ch, ctx)` renders them through the same engine/funcs/context as the manifest, then parses. `prepare()` returns the **rendered** requirements, so install/upgrade/rollback pre-flight against resolved names.
- Templated values must be **quoted** (`name: "{{ .Values.x }}"`) so `requirements.yaml` still parses as YAML at load time; the real value resolves at pre-flight.
- `swarmcli charts template --requirements` emits the rendered requirements (the resolved contract) for tooling/CI.

## Compatibility

Non-templated `requirements.yaml` renders **byte-identically** — every existing chart is unaffected (`C0-breaks-nothing`).

## Tests

- Unit: templated value resolves; nil when absent; static unchanged; bad template errors.
- End-to-end: rendering manifest + requirements with an override (`database.network=mariadb-net`) **passes** `ensureExternalNetworks`, while requirements resolved against defaults reject the overridden manifest with the exact contract error.
- `go test ./...`, `go vet`, `golangci-lint` all green.

## Companion

The chart-side change (template the network names in `keycloak`/`mariadb` `requirements.yaml`, update the CI `requirements-check.sh` to compare against `charts template --requirements`) lands in **swarmcli-charts** and depends on this being on `main` (its CI builds swarmcli from `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)