### PR TITLE
feat(app): add AppInfoMsg neutral-notice modal

### DIFF
--- a/app/appinfo_test.go
+++ b/app/appinfo_test.go
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package app
+
+import (
+	"testing"
+
+	"swarmcli/views/view"
+
+	"github.com/stretchr/testify/require"
+)
+
+// AppInfoMsg must render the shared modal as a neutral notice (InfoMode), not
+// as an error (ErrorMode) — the counterpart to AppErrorMsg.
+func TestAppInfoMsg_ShowsNeutralNotice(t *testing.T) {
+	m := newTestAppModel(&stubView{name: "test"})
+
+	m.Update(view.AppInfoMsg{Message: "all good", FallbackView: ""})
+
+	require.True(t, m.errorDialog.Visible)
+	require.True(t, m.errorDialog.InfoMode)
+	require.False(t, m.errorDialog.ErrorMode)
+	require.Equal(t, "all good", m.errorDialog.Message)
+	require.True(t, m.appErrorDialogActive)
+}
+
+// AppErrorMsg keeps its error styling — guards against a regression where the
+// two cases share state.
+func TestAppErrorMsg_ShowsErrorNotice(t *testing.T) {
+	m := newTestAppModel(&stubView{name: "test"})
+
+	m.Update(view.AppErrorMsg{Error: "boom", FallbackView: ""})
+
+	require.True(t, m.errorDialog.Visible)
+	require.True(t, m.errorDialog.ErrorMode)
+	require.False(t, m.errorDialog.InfoMode)
+	require.Equal(t, "boom", m.errorDialog.Message)
+}

--- a/app/update.go
+++ b/app/update.go
@@ -324,6 +324,10 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.showAppError(msg.Error, msg.FallbackView)
 		return m, nil
 
+	case view.AppInfoMsg:
+		m.showAppInfo(msg.Message, msg.FallbackView)
+		return m, nil
+
 	case confirmdialog.ResultMsg:
 		if m.updateDialogActive {
 			m.updateDialogActive = false

--- a/views/view/navigation.go
+++ b/views/view/navigation.go
@@ -20,6 +20,16 @@ type AppErrorMsg struct {
 	FallbackView string
 }
 
+// AppInfoMsg signals that a view (or the app layer) wants to show an
+// informational notice — the AppErrorMsg counterpart for non-error content.
+// The app shows the same modal styled as a neutral "Info" notice (not an
+// error). On dismiss it navigates to FallbackView (if non-empty) or calls
+// goBack(). Generic extension point: senders decide what warrants a notice.
+type AppInfoMsg struct {
+	Message      string
+	FallbackView string
+}
+
 // GoBackMsg requests the app to pop the current view and return to the previous one.
 type GoBackMsg struct{}
 


### PR DESCRIPTION
## What

Adds `view.AppInfoMsg`, the neutral-notice counterpart to `view.AppErrorMsg`. It routes through the existing `showAppInfo` (`app/model.go`) `InfoMode` path, so the shared modal renders as a neutral **"Info"** notice instead of a red **"Error"** one.

## Why

Generic app-layer extension point (no pro specifics — respects the Pro Feature Boundary). Its first consumer is swarmcli-be's `:bootstrap --check`: today that command returns its report via `AppErrorMsg`, so even an all-green status shows in an "Error"-titled modal. See Eldara-Tech/swarmcli-be#240.

This is the **prerequisite** half of that fix — the BE PR depends on this symbol and must build against it (Deploy order).

## Changes

- `views/view/navigation.go` — new `AppInfoMsg{ Message, FallbackView string }`.
- `app/update.go` — dispatch it via `m.showAppInfo(...)`, beside the `AppErrorMsg` case. Dismissal/fallback reuse the existing shared path; no new wiring.
- `app/appinfo_test.go` — asserts `AppInfoMsg` → `InfoMode` (and `AppErrorMsg` stays `ErrorMode`).

## Test

`go build ./...`, `go test ./...`, `golangci-lint run` — all green.