### PR TITLE
feat(tasks): PullProgress extension point on task and service rows

### DIFF
--- a/docker/service.go
+++ b/docker/service.go
@@ -361,9 +361,16 @@ type ServiceEntry struct {
 	// container health, so the default loaders leave it empty; it is an
 	// extension point populated by a ServiceOps decorator that can reach
 	// per-node container state.
-	Health    string
-	CreatedAt time.Time
-	UpdatedAt time.Time
+	Health string
+	// PullProgress summarizes an image pull in flight for this service's tasks
+	// (e.g. "pulling · 3/12 layers · 412 MB"); "" when nothing is being pulled or
+	// the progress is unavailable. Like Health it is an extension point populated
+	// by a ServiceOps decorator that can reach the nodes performing the pull; the
+	// services view shows it in place of Status while it is set, since a service
+	// whose image is still downloading otherwise reads as a bare "active".
+	PullProgress string
+	CreatedAt    time.Time
+	UpdatedAt    time.Time
 }
 
 func LoadNodeServices(nodeID string) []ServiceEntry {

--- a/docker/task.go
+++ b/docker/task.go
@@ -38,8 +38,26 @@ type TaskEntry struct {
 	// the services view shows it as a fallback when Health is empty so container
 	// errors surface even for images without a healthcheck.
 	ContainerState string
-	CreatedAt      time.Time
-	UpdatedAt      time.Time
+	// PullProgress summarizes the image pull the task's node is currently
+	// performing for it (e.g. "pulling · 3/12 layers · 412 MB"); "" when nothing
+	// is being pulled or the progress is unavailable. A task whose image is still
+	// downloading sits in "preparing" with no further detail — the Swarm API
+	// carries no pull progress at all — so the default loaders leave this empty;
+	// it is an extension point populated by a TaskOps decorator that can reach
+	// the node performing the pull.
+	PullProgress string
+	CreatedAt    time.Time
+	UpdatedAt    time.Time
+}
+
+// StatusText is the task's status cell: the live image-pull summary when a
+// decorator supplied one (a pulling task otherwise shows only a bare
+// "preparing"), else the swarm task state.
+func (t TaskEntry) StatusText() string {
+	if t.PullProgress != "" {
+		return t.PullProgress
+	}
+	return t.CurrentState
 }
 
 // GetTasksForStack returns all tasks for services in the given stack

--- a/docker/task_test.go
+++ b/docker/task_test.go
@@ -67,3 +67,32 @@ func TestSortTasksByServiceAndTime_Empty(t *testing.T) {
 	sortTasksByServiceAndTime(tasks) // should not panic
 	require.Empty(t, tasks)
 }
+
+func TestTaskEntry_StatusText(t *testing.T) {
+	tests := []struct {
+		name string
+		e    TaskEntry
+		want string
+	}{
+		{
+			name: "no pull in flight falls back to the swarm task state",
+			e:    TaskEntry{CurrentState: "running 3 minutes ago"},
+			want: "running 3 minutes ago",
+		},
+		{
+			name: "a pull in flight replaces the bare preparing state",
+			e:    TaskEntry{CurrentState: "preparing 2 minutes ago", PullProgress: "pulling · 3/12 layers · 412 MB"},
+			want: "pulling · 3/12 layers · 412 MB",
+		},
+		{
+			name: "empty entry yields empty status",
+			e:    TaskEntry{},
+			want: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, tt.e.StatusText())
+		})
+	}
+}

--- a/views/services/columns.go
+++ b/views/services/columns.go
@@ -50,7 +50,14 @@ func (m *Model) serviceColumns() []serviceColumn {
 			}}},
 		{sort: SortByStatus, hasSort: true, col: filterlist.Column[docker.ServiceEntry]{
 			Label: "STATUS", MinWidth: 8,
-			Cell: func(e docker.ServiceEntry) string { return e.Status }}},
+			Cell: func(e docker.ServiceEntry) string {
+				// A service still pulling its image reads as a bare "active"; show
+				// the pull instead while one is in flight.
+				if e.PullProgress != "" {
+					return e.PullProgress
+				}
+				return e.Status
+			}}},
 		{isHealth: true, col: filterlist.Column[docker.ServiceEntry]{
 			Label: "HEALTH", MinWidth: 6,
 			Cell: func(e docker.ServiceEntry) string {

--- a/views/services/update.go
+++ b/views/services/update.go
@@ -818,7 +818,7 @@ func (m *Model) setRenderItem() {
 					taskName := filterlist.TruncateRunes(task.Name, 22)
 					taskNode := filterlist.TruncateRunes(task.NodeName, 12)
 					taskDesired := filterlist.TruncateRunes(task.DesiredState, 13)
-					taskCurrent := filterlist.TruncateRunes(task.CurrentState, 40)
+					taskCurrent := filterlist.TruncateRunes(task.StatusText(), 40)
 					taskHealth := dashIfEmpty(filterlist.TruncateRunes(firstNonEmpty(task.Health, task.ContainerState), 9))
 					taskPorts := dashIfEmpty(filterlist.TruncateRunes(task.Ports, 20))
 					taskErr := filterlist.TruncateRunes(task.Error, 30)

--- a/views/stacks/update.go
+++ b/views/stacks/update.go
@@ -1482,7 +1482,7 @@ func (m *Model) setRenderItem() {
 						taskName := truncateWithEllipsis(task.Name, 22)
 						taskNode := truncateWithEllipsis(task.NodeName, 12)
 						taskDesired := truncateWithEllipsis(task.DesiredState, 13)
-						taskCurrent := truncateWithEllipsis(task.CurrentState, 40)
+						taskCurrent := truncateWithEllipsis(task.StatusText(), 40)
 						taskErr := truncateWithEllipsis(task.Error, 30)
 						taskSelected := m.selectedTaskIndex == ti
 						if taskSelected {
@@ -1524,7 +1524,7 @@ func (m *Model) setRenderItem() {
 					taskName := truncateWithEllipsis(task.Name, 22)
 					taskNode := truncateWithEllipsis(task.NodeName, 12)
 					taskDesired := truncateWithEllipsis(task.DesiredState, 13)
-					taskCurrent := truncateWithEllipsis(task.CurrentState, 40)
+					taskCurrent := truncateWithEllipsis(task.StatusText(), 40)
 					taskErr := truncateWithEllipsis(task.Error, 30)
 					taskStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("7"))
 					line += "\n" + taskStyle.Render(fmt.Sprintf("   %-22s  %-12s  %-13s  %-40s  %s", taskName, taskNode, taskDesired, taskCurrent, taskErr))

--- a/views/tasks/view.go
+++ b/views/tasks/view.go
@@ -110,7 +110,7 @@ func (m *Model) renderTasks() string {
 		node := truncate(task.NodeName, colWidths[3])
 		desiredState := truncate(task.DesiredState, colWidths[4])
 
-		status := task.CurrentState
+		status := task.StatusText()
 		if task.Error != "" {
 			status = "Failed: " + task.Error
 		}


### PR DESCRIPTION
## Why

A task whose image is still downloading sits in `preparing` for as long as the pull takes, and the TUI can say nothing more than that. The Swarm API carries **no** image-pull progress at all — the swarm executor consumes the pull's progress stream into a debug log line (moby `daemon/cluster/executor/container/adapter.go`) — so nothing the manager can query knows how far along a multi-gigabyte pull is. Deploying something like `ollama` therefore looks indistinguishable from a hang.

The bytes are only observable on the node doing the pull. This PR adds the CE half: the display seam. The observation itself lives in the agent, and the decorator that fills these fields lives in the BE module.

## What

Two extension-point fields, in the same shape as the existing `Health` / `ContainerState` fields:

- `docker.TaskEntry.PullProgress` — the pull in flight for that task.
- `docker.ServiceEntry.PullProgress` — the same, summarized for the service row.

The default loaders leave both empty, so **base CE behaves exactly as before**. A `TaskOps` / `ServiceOps` decorator that can reach the node performing the pull fills them in.

`TaskEntry.StatusText()` is the accessor the status cell now goes through, so a pulling task shows the pull instead of a bare `preparing`; the services `STATUS` column likewise shows it instead of a bare `active`.

```
SERVICE   REPLICAS  STATUS         IMAGE
ollama    0/1       pulling 41%    ollama/ollama:latest
  \_ ollama.1                      pulling 41% · 1.2 GB / 2.9 GB
```

No new columns, no layout change, no feature flag in CE (the fields are simply empty when nothing fills them).

## Notes for review

- **The tasks view's cell is switched too, but is inert today.** `views/tasks` discards `Deps` (`factory(_ docker.Deps, …)`) and calls the package-level loaders, so no decorator runs there. The same pre-existing gap already leaves `Health` empty in that view. Using `StatusText()` there keeps the three status cells consistent and makes the view correct for free if `Deps` is ever threaded through; it is not a fix for that gap.
- **Sorting by STATUS still sorts on `ServiceEntry.Status`**, not the rendered cell, so a transient pull does not reshuffle the list.
- Pro Feature Boundary respected: the fields are documented as generic extension points, with no pro naming or internals.

Refs Eldara-Tech/swarmcli-be#250

🤖 Generated with [Claude Code](https://claude.com/claude-code)