### PR TITLE
chore(deps): bump Go toolchain to go1.26.5 (GO-2026-5856)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module swarmcli
 
 go 1.26
 
-toolchain go1.26.4
+toolchain go1.26.5
 
 require (
 	github.com/Masterminds/sprig/v3 v3.3.0


### PR DESCRIPTION
## What

Bump the Go toolchain pin in `go.mod` from `go1.26.4` to `go1.26.5`.

## Why

The weekly `govulncheck` cron flagged [GO-2026-5856](https://pkg.go.dev/vuln/GO-2026-5856) — *Invoking Encrypted Client Hello privacy leak in `crypto/tls`* — reachable from this module. It is a **standard-library** vulnerability (found in `crypto/tls@go1.26.4`, fixed in `crypto/tls@go1.26.5`), not a dependency one, so the fix is a toolchain bump.

Every CI job here resolves its Go via `go-version-file: go.mod`, and `setup-go` runs with `GOTOOLCHAIN=local` — so the `toolchain` line is what actually selects the compiler. Bumping it is the whole fix; no source or dependency changes.

First failure: swarmcli-rbac-proxy [run 29236325176](https://github.com/Eldara-Tech/swarmcli-rbac-proxy/actions/runs/29236325176). All four Go repos pinned `go1.26.4` and are equally affected; the same one-line bump is going out to `swarmcli`, `swarmcli-be`, `swarmcli-agent` and `swarmcli-rbac-proxy`.

## Verification

Ran the repo's own govulncheck gate locally (govulncheck v1.3.0 built with go1.26.5, same as the workflow does) on this branch:

- before: `GO-2026-5856` reported as a symbol-level finding → gate exits 1
- after: no `GO-2026-5856`; gate exits 0

The only remaining findings are the pre-existing `docker`/`moby` daemon false-positives already in the workflow's `SUPPRESSED` set. `go build ./...` passes on go1.26.5.

Dockerfiles need no change: they build `FROM golang:1.26`, which already resolves to 1.26.5.