### PR TITLE
feat(charts): declarative release manifests (charts apply) + charts outdated

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,8 +34,8 @@ tail -f ~/.local/state/swarmcli/app.log          # prod mode (JSON)
 
 ```
 main.go                    Entry point; version injection via ldflags. With args, dispatches non-interactive CLI subcommands via cli.Dispatch(); bare invocation launches the TUI (tea.NewProgram())
-cli/                       Arg-based CLI dispatch (cli.Dispatch): `charts`, `version`, `help`
-charts/                    Helm-like package manager (repos, chart rendering, releases)
+cli/                       Arg-based CLI dispatch (cli.Dispatch): `charts`, `version`, `help`; cli/apply.go holds the GitOps subcommands (`charts apply`, `charts outdated`)
+charts/                    Helm-like package manager (repos, chart rendering, releases) + declarative releases (releasefile.go, apply.go, outdated.go). charts.ChartSource (source.go) is the seam that resolves a chart ref — repo or local path — so release planning is testable without Docker, a network or a filesystem
 app/
   app.go                   Init(); triggers command autoload via _ "swarmcli/commands" and view autoload via _ "swarmcli/views" (view factory registry lives in views/view/registry.go)
   hooks.go                 PreUpdateHook registration; StartupOverlay; RegisterShutdownHook / RunShutdownHooks (BE port-forward manager registers CloseAll here)
@@ -95,6 +95,8 @@ utils/log/
 **New command**: Create `commands/command/mycommand.go`, implement `registry.Command` (Name/Description/Execute), call `registry.Register()` in `init()`. Also implement `Spec() registry.CommandSpec` — declare every flag the command reads (`a.Has`/`a.Get`) plus `Usage`/`Examples`, or `:cmd --help` shows only a fallback and strict validation rejects the command's own flags. Aliases (`Aliaser`) inherit the primary's spec; do not add a spec to the alias. See `commands/command/docker/node/ls.go` for a zero-flag spec and `swarmcli-be/commands/pro/bootstrap.go` for the full worked example.
 
 **New view**: Create `views/myview/`, implement `view.View` interface, and add a `register.go` whose `init()` calls `view.RegisterView(name, factory)`. Add its blank import to `views/autoload.go` so the package is loaded. See `views/nodes/register.go`.
+
+**New `swarmcli charts <sub>` CLI subcommand** (this is *not* the TUI `:` registry — it's the arg-based dispatcher): add a `case` to the switch in `cli/charts.go` `chartsMain`, put the logic in `charts/` and keep the `cli/` half thin (the `charts` package is where the coverage bar applies). Any new flag goes in the single **global** `flags` struct in `cli/args.go` — note that every subcommand therefore parses every flag and *silently ignores* what it does not read, so if a flag would be a lie for your subcommand, reject it explicitly (see `rejectUnsupported` in `cli/apply.go`). Then update **all three** places the command list is duplicated, or they drift: `chartsUsage` in `cli/charts.go`, `README.md`, and `charts/README.md`.
 
 ## Environment Variables
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ swarmcli
 - **Instant Logs**: No more `docker service logs -f`. Just press `l` on any service.
 - **Secrets & Configs**: Manage, rotate, and — with [Business Edition](#business-edition) — **reveal** secrets for debugging.
 - **Management Actions**: Scale, restart, remove, and update services with single keystrokes.
-- **Chart Package Manager**: Helm-like packaging for Swarm — install, upgrade, roll back, and diff releases from chart repositories via `swarmcli charts`.
+- **Chart Package Manager**: Helm-like packaging for Swarm — install, upgrade, roll back, and diff releases from chart repositories via `swarmcli charts`, or converge the swarm to a committed release file with `swarmcli charts apply`.
 - **Zero Config**: Works out-of-the-box with your local Docker engine or remote via SSH/Contexts.
 - **Lightweight**: Built with Go. Single static binary (< 20MB). Zero dependencies.
 
@@ -93,7 +93,17 @@ swarmcli charts uninstall <release>               # remove a release
 swarmcli charts history <release>                 # revision history
 swarmcli charts list                              # list releases
 swarmcli charts status <release>                  # release status and services
+
+# GitOps — converge the swarm to a file you commit
+swarmcli charts apply -f swarmcli-release.yaml    # install/upgrade/skip to match the file
+swarmcli charts apply -f swarmcli-release.yaml --diff   # preview, never deploys
+swarmcli charts outdated                          # releases with a newer chart available
 ```
+
+`apply` reads a release file pinning each release to a chart version, so the
+deployed state is reproducible and an automated updater (e.g. Renovate) has
+something concrete to bump. It never removes a release the file does not mention —
+it reports those instead. See [charts/README.md](charts/README.md#declarative-releases-gitops).
 
 Run `swarmcli charts --help` for the full command and option reference.
 

--- a/charts/README.md
+++ b/charts/README.md
@@ -11,9 +11,10 @@ produces a **release** — a Docker stack whose revision history is stored in
 Docker Configs.
 
 Implemented so far ([issue #413]): repository management, discovery, templating,
-and the full release lifecycle — install, upgrade, rollback, uninstall, list,
-status, history, diff, and get. Chart-dev tooling (`create`, `lint`,
-`dependency`) and subchart resolution are the remaining phase.
+the full release lifecycle — install, upgrade, rollback, uninstall, list, status,
+history, diff, get, and prune — and declarative releases (`apply`, `outdated`).
+Chart-dev tooling (`create`, `lint`, `dependency`) and subchart resolution are the
+remaining phase.
 
 ## Invocation
 
@@ -37,8 +38,94 @@ swarmcli charts list
 swarmcli charts uninstall my-traefik
 ```
 
-A chart reference is either a configured `repo/chart` (optionally `--version`)
-or a local path to a chart directory or packaged `.tgz`.
+A chart reference is either a configured `repo/chart` or a local path to a chart
+directory or packaged `.tgz`. **`--version` selects a version from a repository
+index, so it applies only to a `repo/chart` reference** — a local chart carries its
+version in its own `Chart.yaml`, and passing `--version` with one is an error
+rather than being silently ignored.
+
+## Declarative releases (GitOps)
+
+The commands above are imperative, and release state lives in the swarm — so
+nothing in git says what *should* be running. `charts apply` closes that gap: it
+converges the swarm to a file you commit.
+
+```yaml
+# swarmcli-release.yaml
+apiVersion: v1
+repositories:
+  - name: swarmcli-charts
+    url: https://eldara-tech.github.io/swarmcli-charts
+releases:
+  - name: edge
+    chart: swarmcli-charts/traefik
+    version: "0.1.1"
+    values: [./traefik.yaml]     # relative to THIS FILE, not the working directory
+  - name: hello
+    chart: swarmcli-charts/whoami
+    version: "0.1.8"
+```
+
+```bash
+swarmcli charts apply -f swarmcli-release.yaml --dry-run   # plan
+swarmcli charts apply -f swarmcli-release.yaml --diff      # plan + manifest diffs
+swarmcli charts apply -f swarmcli-release.yaml             # converge
+swarmcli charts outdated                                   # what has a newer chart?
+```
+
+| Behaviour | |
+|---|---|
+| Missing release | installed |
+| Changed chart version, values, or rendered manifest | upgraded |
+| Identical | **skipped — no new revision** |
+| On the swarm but not in the file | **reported, never removed** |
+
+Two of those deserve the emphasis. Releases are **never deleted**: a release
+records nothing about which file produced it, so a prune could not tell one owned
+by another manifest, or installed by hand, from a genuinely obsolete one — it
+prints the `uninstall` command instead and leaves the decision to you. And an
+unchanged release is skipped **entirely**: history is one Docker Config per
+revision, so re-applying on every CI push would otherwise grow the swarm's config
+store without bound.
+
+For a `repo/chart`, **`version` is required** — a floating pin would silently
+upgrade production on the next `apply`. For a **local** chart path (`chart:
+./charts/mine`, resolved against the file) it must be **omitted**: the chart's own
+`Chart.yaml` sets the version, so there is nothing to select.
+
+Unknown keys are rejected, so a typo fails loudly instead of quietly doing nothing.
+Releases are applied in file order; add `--wait` if a later release needs an
+earlier one live.
+
+`apply` honours `--wait`, `--timeout` and `--history-max`. It **rejects** `--set`,
+`--version`, `--reuse-values`, `--install`, `--purge-volumes`, `--requirements` and
+`--revision` rather than ignoring them — the file is the only source of truth, so a
+value passed on the command line would be a lie. `--diff` implies `--dry-run` and
+never deploys.
+
+### Keeping it up to date automatically
+
+If your charts come from [swarmcli-charts], extend its Renovate preset — that is
+the whole configuration:
+
+```json
+{ "extends": ["github>Eldara-Tech/swarmcli-charts"] }
+```
+
+For any other chart repository, one line does the same job:
+
+```json
+{ "helmfile": { "managerFilePatterns": ["/(^|/)swarmcli-release\\.ya?ml$/"] } }
+```
+
+Both work because the file's key names match [Helmfile](https://helmfile.readthedocs.io/)'s,
+so [Renovate](https://docs.renovatebot.com/)'s **built-in** `helmfile` manager reads
+it — no custom regex to maintain. Renovate resolves each chart against the
+`repositories` you declared and opens a PR bumping `version:` when a new chart
+version is published, with the chart's release notes attached. Merge it, and
+`swarmcli charts apply` in CI rolls it out.
+
+[swarmcli-charts]: https://github.com/Eldara-Tech/swarmcli-charts
 
 ## Chart format
 

--- a/charts/apply.go
+++ b/charts/apply.go
@@ -1,0 +1,276 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package charts
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Action is what apply will do to one release.
+type Action string
+
+const (
+	ActionInstall   Action = "install"
+	ActionUpgrade   Action = "upgrade"
+	ActionUnchanged Action = "unchanged"
+)
+
+// ReleasePlan is the computed desired state of one release.
+type ReleasePlan struct {
+	Name   string
+	Ref    string
+	Action Action
+	// FromVersion is the currently deployed chart version, empty for an install.
+	FromVersion string
+	ToVersion   string
+
+	Chart        ReleaseChart
+	Values       map[string]any
+	Manifest     string
+	Requirements *Requirements
+	// CurrentManifest is the deployed manifest, for diffing. Empty for an install.
+	CurrentManifest string
+}
+
+// Plan is what apply would do to the whole swarm.
+type Plan struct {
+	// Releases, in file order.
+	Releases []ReleasePlan
+	// Unmanaged names releases that exist on the swarm but are absent from the
+	// file. Apply never touches them — see Engine.Apply.
+	Unmanaged []string
+}
+
+// Counts summarises a plan.
+func (p *Plan) Counts() (install, upgrade, unchanged int) {
+	for _, r := range p.Releases {
+		switch r.Action {
+		case ActionInstall:
+			install++
+		case ActionUpgrade:
+			upgrade++
+		case ActionUnchanged:
+			unchanged++
+		}
+	}
+	return install, upgrade, unchanged
+}
+
+// PlanApply computes what Apply would do, without writing anything.
+//
+// Every release is resolved, merged, schema-validated and rendered BEFORE any of
+// them is deployed. A bad value in the third release therefore aborts the whole
+// apply instead of leaving the swarm half-converged — and `--dry-run` is just
+// "stop after planning".
+func (e *Engine) PlanApply(ctx context.Context, rf *ReleaseFile, src ChartSource) (*Plan, error) {
+	current, err := e.List(ctx)
+	if err != nil {
+		return nil, err
+	}
+	deployed := make(map[string]Release, len(current))
+	for _, rel := range current {
+		deployed[rel.Name] = rel
+	}
+
+	plan := &Plan{}
+	managed := map[string]bool{}
+
+	for _, spec := range rf.Releases {
+		managed[spec.Name] = true
+
+		rp, err := e.planRelease(rf, spec, src, deployed)
+		if err != nil {
+			return nil, err
+		}
+		plan.Releases = append(plan.Releases, rp)
+	}
+
+	for _, rel := range current {
+		if !managed[rel.Name] {
+			plan.Unmanaged = append(plan.Unmanaged, rel.Name)
+		}
+	}
+	return plan, nil
+}
+
+func (e *Engine) planRelease(rf *ReleaseFile, spec ReleaseSpec, src ChartSource, deployed map[string]Release) (ReleasePlan, error) {
+	ref := rf.ChartRef(spec)
+
+	ch, err := src.Load(ref, spec.Version)
+	if err != nil {
+		return ReleasePlan{}, fmt.Errorf("%s: release %q: %w", rf.Path, spec.Name, err)
+	}
+
+	files, err := readFiles(rf.ValuesPaths(spec))
+	if err != nil {
+		return ReleasePlan{}, fmt.Errorf("%s: release %q: %w", rf.Path, spec.Name, err)
+	}
+	// No --set equivalent: the file is the only source of truth, so a value that
+	// is not in it cannot influence what gets deployed.
+	values, err := MergeValues(ch.Values, files, nil)
+	if err != nil {
+		return ReleasePlan{}, fmt.Errorf("%s: release %q: %w", rf.Path, spec.Name, err)
+	}
+	if err := ValidateValues(ch.Schema, values); err != nil {
+		return ReleasePlan{}, fmt.Errorf("%s: release %q: %w", rf.Path, spec.Name, err)
+	}
+
+	rc := ReleaseChartOf(ch)
+	rctx := RenderContext{
+		Values:  values,
+		Release: ReleaseMeta{Name: spec.Name, Namespace: spec.Name, Revision: 1},
+		Chart:   ChartMeta{Name: rc.Name, Version: rc.Version, AppVersion: rc.AppVersion},
+	}
+	manifest, err := Render(ch, rctx)
+	if err != nil {
+		return ReleasePlan{}, fmt.Errorf("%s: release %q: %w", rf.Path, spec.Name, err)
+	}
+	req, err := RenderRequirements(ch, rctx)
+	if err != nil {
+		return ReleasePlan{}, fmt.Errorf("%s: release %q: %w", rf.Path, spec.Name, err)
+	}
+
+	rp := ReleasePlan{
+		Name:         spec.Name,
+		Ref:          spec.Chart,
+		ToVersion:    rc.Version,
+		Chart:        rc,
+		Values:       values,
+		Manifest:     manifest,
+		Requirements: req,
+	}
+
+	cur, ok := deployed[spec.Name]
+	switch {
+	case !ok:
+		rp.Action = ActionInstall
+	default:
+		rp.FromVersion = cur.Chart.Version
+		rp.CurrentManifest = cur.Manifest
+		same, err := unchanged(&cur, rc, values, manifest)
+		if err != nil {
+			return ReleasePlan{}, fmt.Errorf("%s: release %q: %w", rf.Path, spec.Name, err)
+		}
+		if same {
+			rp.Action = ActionUnchanged
+		} else {
+			rp.Action = ActionUpgrade
+		}
+	}
+	return rp, nil
+}
+
+// ApplyResult is what Apply actually did to one release.
+type ApplyResult struct {
+	Name     string
+	Action   Action
+	Revision int // 0 when unchanged (nothing was recorded)
+}
+
+// Apply converges the swarm to a plan, in file order.
+//
+// It never deletes. A release on the swarm that is absent from the file is
+// reported (Plan.Unmanaged) and left alone: a Release carries no marker saying
+// which manifest produced it, so a prune could not distinguish a release owned by
+// a second manifest, or one installed by hand, from a genuinely obsolete one.
+//
+// Unchanged releases are skipped entirely. That is not an optimisation but a
+// requirement: history is one Docker Config per revision, so an apply that
+// recorded a revision even when nothing changed would grow the swarm's config
+// store on every CI run, forever.
+//
+// It stops at the first failure and returns the results completed so far
+// alongside the error, so a partial apply still reports what it did. Re-running
+// is safe: the successful releases become no-ops.
+func (e *Engine) Apply(ctx context.Context, plan *Plan, opts InstallOptions) ([]ApplyResult, error) {
+	var results []ApplyResult
+	for _, rp := range plan.Releases {
+		if rp.Action == ActionUnchanged {
+			results = append(results, ApplyResult{Name: rp.Name, Action: ActionUnchanged})
+			continue
+		}
+		o := opts
+		o.Requirements = rp.Requirements
+		// Always Upgrade with Install set, never Install: a release that appeared
+		// between planning and applying then upgrades cleanly instead of failing
+		// with "already exists".
+		o.Install = true
+		rel, err := e.Upgrade(ctx, rp.Name, rp.Chart, rp.Values, rp.Manifest, o)
+		if err != nil {
+			return results, fmt.Errorf("release %q: %w", rp.Name, err)
+		}
+		results = append(results, ApplyResult{Name: rp.Name, Action: rp.Action, Revision: rel.Revision})
+	}
+	return results, nil
+}
+
+// unchanged reports whether the current revision already encodes the desired
+// state: same chart, same rendered manifest, same values.
+func unchanged(cur *Release, chart ReleaseChart, values map[string]any, manifest string) (bool, error) {
+	if cur == nil || cur.Status == StatusUninstalled {
+		return false, nil
+	}
+	if cur.Chart.Name != chart.Name || cur.Chart.Version != chart.Version {
+		return false, nil
+	}
+	if cur.Manifest != manifest {
+		return false, nil
+	}
+	return sameValues(cur.Values, values)
+}
+
+// sameValues compares a freshly merged values map against one decoded from a
+// stored release.
+//
+// reflect.DeepEqual is wrong here. The stored map came back through YAML, so a
+// value written as 1.0 may decode as int(1) where the in-memory merge holds
+// float64(1.0). DeepEqual would call those different, every release would look
+// changed, and apply would write a new revision on every single run — the exact
+// failure this function exists to prevent. Round-tripping both through the same
+// encoder erases the type skew, and yaml.Marshal sorts map keys, so the result is
+// canonical and order-independent. It is also precisely the encoding that gets
+// persisted, so this compares what is actually stored.
+func sameValues(a, b map[string]any) (bool, error) {
+	ca, err := canonicalValues(a)
+	if err != nil {
+		return false, err
+	}
+	cb, err := canonicalValues(b)
+	if err != nil {
+		return false, err
+	}
+	return ca == cb, nil
+}
+
+func canonicalValues(v map[string]any) (string, error) {
+	first, err := yaml.Marshal(v)
+	if err != nil {
+		return "", err
+	}
+	var back map[string]any
+	if err := yaml.Unmarshal(first, &back); err != nil {
+		return "", err
+	}
+	second, err := yaml.Marshal(back)
+	if err != nil {
+		return "", err
+	}
+	return string(second), nil
+}
+
+func readFiles(paths []string) ([][]byte, error) {
+	var out [][]byte
+	for _, p := range paths {
+		b, err := os.ReadFile(p)
+		if err != nil {
+			return nil, fmt.Errorf("read values file %q: %w", p, err)
+		}
+		out = append(out, b)
+	}
+	return out, nil
+}

--- a/charts/apply_test.go
+++ b/charts/apply_test.go
@@ -294,3 +294,158 @@ func TestPlanCounts(t *testing.T) {
 	require.Equal(t, 1, u)
 	require.Equal(t, 2, n)
 }
+
+// The repository path of apply — repositories: -> EnsureRepos -> Resolve -> Pull
+// -> render -> plan — was covered by NOTHING at any tier: the unit tests use a
+// fakeChartSource that never touches RepoStore, and the integration test passes a
+// nil store with a local chart dir. This is the only test that would catch a break
+// anywhere along the chain a downstream user actually runs.
+func TestPlanApplyAgainstARealRepository(t *testing.T) {
+	store := serveRepo(t, "0.1.0", "0.2.0")
+	repos, err := store.List()
+	require.NoError(t, err)
+	url := repos[0].URL
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "swarmcli-release.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(
+		"repositories:\n  - name: eldara\n    url: "+url+"\n"+
+			"releases:\n  - name: hello\n    chart: eldara/demo\n    version: \"0.1.0\"\n"), 0o600))
+
+	rf, err := LoadReleaseFile(path)
+	require.NoError(t, err)
+
+	// A fresh store, so EnsureRepos genuinely has to add the repository — exactly
+	// what `charts apply -f` does on a CI runner that has never seen it.
+	fresh := NewRepoStoreAt(t.TempDir())
+	require.NoError(t, fresh.EnsureRepos(rf.Repositories))
+
+	e := NewEngineWith(newFakeBackend())
+	plan, err := e.PlanApply(context.Background(), rf, NewChartSource(fresh))
+	require.NoError(t, err)
+	require.Len(t, plan.Releases, 1)
+	require.Equal(t, ActionInstall, plan.Releases[0].Action)
+	require.Equal(t, "0.1.0", plan.Releases[0].ToVersion, "the PINNED version must win, not the latest")
+	require.NotEmpty(t, plan.Releases[0].Manifest)
+
+	res, err := e.Apply(context.Background(), plan, InstallOptions{})
+	require.NoError(t, err)
+	require.Equal(t, 1, res[0].Revision)
+}
+
+// A release row left in StatusUninstalled must plan as an install, not silently
+// no-op as "unchanged".
+func TestPlanApplyReinstallsAnUninstalledRelease(t *testing.T) {
+	e, fb, src, rf := applyEnv(t, oneRelease, "0.1.0")
+	ctx := context.Background()
+
+	plan, err := e.PlanApply(ctx, rf, src)
+	require.NoError(t, err)
+	_, err = e.Apply(ctx, plan, InstallOptions{})
+	require.NoError(t, err)
+
+	_, err = e.Uninstall(ctx, "hello", false)
+	require.NoError(t, err)
+	require.NotContains(t, fb.deployed, "hello")
+
+	plan2, err := e.PlanApply(ctx, rf, src)
+	require.NoError(t, err)
+	require.Equal(t, ActionInstall, plan2.Releases[0].Action,
+		"an uninstalled release must be reinstalled, not reported unchanged")
+
+	_, err = e.Apply(ctx, plan2, InstallOptions{})
+	require.NoError(t, err)
+	require.Contains(t, fb.deployed, "hello")
+}
+
+// Same chart version and same values, but the chart's template changed: the
+// rendered manifest differs, so it is an upgrade. Nothing exercised the manifest
+// half of the comparison on its own.
+func TestPlanApplyDetectsManifestOnlyChange(t *testing.T) {
+	e, _, src, rf := applyEnv(t, oneRelease, "0.1.0")
+	ctx := context.Background()
+
+	plan, err := e.PlanApply(ctx, rf, src)
+	require.NoError(t, err)
+	_, err = e.Apply(ctx, plan, InstallOptions{})
+	require.NoError(t, err)
+
+	// Re-publish the SAME chart version with a different template body. The edit
+	// has to survive rendering: Render deep-merges and re-marshals the Compose
+	// document, so an added comment would be dropped and the manifest would come
+	// out byte-identical.
+	edited := demoChart(t, "0.1.0")
+	edited.Templates["stack.yaml"] += "    stop_grace_period: 42s\n"
+	src.charts["swarmcli-charts/demo@0.1.0"] = edited
+
+	plan2, err := e.PlanApply(ctx, rf, src)
+	require.NoError(t, err)
+	require.Equal(t, ActionUpgrade, plan2.Releases[0].Action)
+}
+
+// A missing values file must abort planning, before anything deploys, naming the
+// path.
+func TestPlanApplyMissingValuesFileFailsBeforeDeploying(t *testing.T) {
+	body := `releases:
+  - name: hello
+    chart: swarmcli-charts/demo
+    version: "0.1.0"
+    values: [./absent.yaml]
+`
+	e, fb, src, rf := applyEnv(t, body, "0.1.0")
+
+	_, err := e.PlanApply(context.Background(), rf, src)
+	require.ErrorContains(t, err, "absent.yaml")
+	require.ErrorContains(t, err, "hello")
+	require.Empty(t, fb.deployed)
+}
+
+// The file path and release name in the error are the whole ergonomic point of the
+// planRelease wrappers.
+func TestPlanApplyErrorsNameTheFileAndRelease(t *testing.T) {
+	e, _, src, rf := applyEnv(t, oneRelease, "0.1.0")
+
+	// A chart version the source cannot serve.
+	rf.Releases[0].Version = "9.9.9"
+	_, err := e.PlanApply(context.Background(), rf, src)
+	require.ErrorContains(t, err, rf.Path)
+	require.ErrorContains(t, err, `release "hello"`)
+}
+
+// A values file that violates the chart's schema must abort planning — before any
+// release deploys — with the file and release named. This is the wrapper that
+// makes a bad value in one release safe for all the others.
+func TestPlanApplyRejectsSchemaViolationBeforeDeploying(t *testing.T) {
+	e, fb, src, rf := applyEnv(t, oneRelease, "0.1.0")
+
+	bad := filepath.Join(rf.Dir, "bad.yaml")
+	require.NoError(t, os.WriteFile(bad, []byte("replicas: 0\n"), 0o600)) // schema: minimum 1
+	rf.Releases[0].Values = []string{"./bad.yaml"}
+
+	_, err := e.PlanApply(context.Background(), rf, src)
+	require.Error(t, err)
+	require.ErrorContains(t, err, rf.Path)
+	require.ErrorContains(t, err, `release "hello"`)
+	require.Empty(t, fb.deployed, "a schema violation must abort before anything deploys")
+}
+
+// Pointing a release at a different chart entirely (not just a new version) is an
+// upgrade, not "unchanged".
+func TestPlanApplyDetectsChartNameChange(t *testing.T) {
+	e, _, src, rf := applyEnv(t, oneRelease, "0.1.0")
+	ctx := context.Background()
+
+	plan, err := e.PlanApply(ctx, rf, src)
+	require.NoError(t, err)
+	_, err = e.Apply(ctx, plan, InstallOptions{})
+	require.NoError(t, err)
+
+	other := demoChart(t, "0.1.0")
+	other.Metadata.Name = "different"
+	src.charts["swarmcli-charts/other@0.1.0"] = other
+	rf.Releases[0].Chart = "swarmcli-charts/other"
+
+	plan2, err := e.PlanApply(ctx, rf, src)
+	require.NoError(t, err)
+	require.Equal(t, ActionUpgrade, plan2.Releases[0].Action)
+}

--- a/charts/apply_test.go
+++ b/charts/apply_test.go
@@ -1,0 +1,296 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package charts
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// fakeChartSource serves charts from testdata without a repository, a network or
+// a filesystem lookup, which is the whole point of the ChartSource seam.
+type fakeChartSource struct {
+	charts map[string]*Chart // "<repo>/<chart>@<version>" -> chart
+	loads  int
+}
+
+func (f *fakeChartSource) Load(ref, version string) (*Chart, error) {
+	f.loads++
+	if ch, ok := f.charts[ref+"@"+version]; ok {
+		return ch, nil
+	}
+	return nil, fmt.Errorf("chart %q version %q not found", ref, version)
+}
+
+// demoChart loads testdata/demo and stamps it with a version, so a plan can move
+// a release from one chart version to another.
+func demoChart(t *testing.T, version string) *Chart {
+	t.Helper()
+	ch, err := LoadChartDir("testdata/demo")
+	require.NoError(t, err)
+	ch.Metadata.Version = version
+	return ch
+}
+
+// applyEnv wires an Engine over the fake backend with a fake chart source and
+// writes the release file to a temp dir.
+func applyEnv(t *testing.T, body string, versions ...string) (*Engine, *fakeBackend, *fakeChartSource, *ReleaseFile) {
+	t.Helper()
+	fb := newFakeBackend()
+	e := NewEngineWith(fb)
+
+	src := &fakeChartSource{charts: map[string]*Chart{}}
+	for _, v := range versions {
+		src.charts["swarmcli-charts/demo@"+v] = demoChart(t, v)
+	}
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "swarmcli-release.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(body), 0o600))
+	rf, err := LoadReleaseFile(path)
+	require.NoError(t, err)
+	return e, fb, src, rf
+}
+
+const oneRelease = `repositories:
+  - name: swarmcli-charts
+    url: https://eldara-tech.github.io/swarmcli-charts
+releases:
+  - name: hello
+    chart: swarmcli-charts/demo
+    version: "0.1.0"
+`
+
+func TestApplyInstallsThenIsIdempotent(t *testing.T) {
+	e, fb, src, rf := applyEnv(t, oneRelease, "0.1.0")
+	ctx := context.Background()
+
+	plan, err := e.PlanApply(ctx, rf, src)
+	require.NoError(t, err)
+	require.Len(t, plan.Releases, 1)
+	require.Equal(t, ActionInstall, plan.Releases[0].Action)
+
+	res, err := e.Apply(ctx, plan, InstallOptions{})
+	require.NoError(t, err)
+	require.Equal(t, 1, res[0].Revision)
+	require.Contains(t, fb.deployed, "hello")
+
+	// THE NO-CHURN GUARANTEE. History is one Docker Config per revision, so an
+	// apply that recorded a revision when nothing changed would grow the swarm's
+	// config store on every CI run, forever. Re-applying an unchanged file must
+	// write nothing at all. Do not delete this test.
+	before := len(fb.configs)
+
+	plan2, err := e.PlanApply(ctx, rf, src)
+	require.NoError(t, err)
+	require.Equal(t, ActionUnchanged, plan2.Releases[0].Action)
+
+	res2, err := e.Apply(ctx, plan2, InstallOptions{})
+	require.NoError(t, err)
+	require.Equal(t, ActionUnchanged, res2[0].Action)
+	require.Zero(t, res2[0].Revision)
+	require.Len(t, fb.configs, before, "an unchanged apply must not record a revision")
+}
+
+func TestApplyUpgradesOnVersionBump(t *testing.T) {
+	e, _, src, rf := applyEnv(t, oneRelease, "0.1.0")
+	ctx := context.Background()
+
+	plan, err := e.PlanApply(ctx, rf, src)
+	require.NoError(t, err)
+	_, err = e.Apply(ctx, plan, InstallOptions{})
+	require.NoError(t, err)
+
+	// This is exactly what Renovate does to the file: bump the pinned version.
+	bumped := &ReleaseFile{
+		Path: rf.Path, Dir: rf.Dir,
+		Releases: []ReleaseSpec{{Name: "hello", Chart: "swarmcli-charts/demo", Version: "0.2.0"}},
+	}
+	src.charts["swarmcli-charts/demo@0.2.0"] = demoChart(t, "0.2.0")
+
+	plan2, err := e.PlanApply(ctx, bumped, src)
+	require.NoError(t, err)
+	require.Equal(t, ActionUpgrade, plan2.Releases[0].Action)
+	require.Equal(t, "0.1.0", plan2.Releases[0].FromVersion)
+	require.Equal(t, "0.2.0", plan2.Releases[0].ToVersion)
+
+	res, err := e.Apply(ctx, plan2, InstallOptions{})
+	require.NoError(t, err)
+	require.Equal(t, 2, res[0].Revision)
+
+	cur, err := e.GetRevision(ctx, "hello", 0)
+	require.NoError(t, err)
+	require.Equal(t, "0.2.0", cur.Chart.Version)
+}
+
+// A values change that the template does not read still changes the release's
+// recorded values, so it must still be an upgrade. This proves the values half of
+// the comparison is live rather than decorative.
+func TestApplyDetectsValuesOnlyChange(t *testing.T) {
+	e, _, src, rf := applyEnv(t, oneRelease, "0.1.0")
+	ctx := context.Background()
+
+	plan, err := e.PlanApply(ctx, rf, src)
+	require.NoError(t, err)
+	_, err = e.Apply(ctx, plan, InstallOptions{})
+	require.NoError(t, err)
+
+	vals := filepath.Join(rf.Dir, "extra.yaml")
+	require.NoError(t, os.WriteFile(vals, []byte("unreadByTemplate: 1\n"), 0o600))
+	withValues := &ReleaseFile{
+		Path: rf.Path, Dir: rf.Dir,
+		Releases: []ReleaseSpec{{
+			Name: "hello", Chart: "swarmcli-charts/demo", Version: "0.1.0",
+			Values: []string{"./extra.yaml"},
+		}},
+	}
+
+	plan2, err := e.PlanApply(ctx, withValues, src)
+	require.NoError(t, err)
+	require.Equal(t, ActionUpgrade, plan2.Releases[0].Action)
+}
+
+// The stored values come back through YAML, so a value merged in memory as
+// float64(1.0) may be decoded as int(1). reflect.DeepEqual would call those
+// different and every apply would churn a revision. Canonicalising both through
+// the same encoder must make them compare equal.
+func TestSameValuesIgnoresYAMLTypeSkew(t *testing.T) {
+	stored := map[string]any{"replicas": int(1), "ratio": float64(0.5)}
+	merged := map[string]any{"replicas": float64(1.0), "ratio": float64(0.5)}
+
+	same, err := sameValues(stored, merged)
+	require.NoError(t, err)
+	require.True(t, same, "int(1) and float64(1.0) must not look like a change")
+
+	diff, err := sameValues(stored, map[string]any{"replicas": 2})
+	require.NoError(t, err)
+	require.False(t, diff)
+}
+
+// Key order must not matter either.
+func TestSameValuesIsOrderIndependent(t *testing.T) {
+	same, err := sameValues(
+		map[string]any{"a": 1, "b": map[string]any{"x": 1, "y": 2}},
+		map[string]any{"b": map[string]any{"y": 2, "x": 1}, "a": 1},
+	)
+	require.NoError(t, err)
+	require.True(t, same)
+}
+
+// apply never deletes. A release on the swarm that the file does not mention is
+// reported and left running.
+func TestApplyNeverRemovesUnmanagedReleases(t *testing.T) {
+	e, fb, src, rf := applyEnv(t, oneRelease, "0.1.0")
+	ctx := context.Background()
+
+	// A release installed by hand, or by a second manifest.
+	ch := demoChart(t, "0.1.0")
+	_, err := e.Install(ctx, "legacy", ReleaseChartOf(ch), ch.Values, "services: {}\n", InstallOptions{})
+	require.NoError(t, err)
+
+	plan, err := e.PlanApply(ctx, rf, src)
+	require.NoError(t, err)
+	require.Equal(t, []string{"legacy"}, plan.Unmanaged)
+
+	_, err = e.Apply(ctx, plan, InstallOptions{})
+	require.NoError(t, err)
+	require.Contains(t, fb.deployed, "legacy", "apply must not remove a release it does not manage")
+	require.Contains(t, fb.deployed, "hello")
+}
+
+// Everything is rendered and validated before anything is deployed, so a bad
+// release cannot leave the swarm half-converged.
+func TestPlanApplyValidatesEverythingBeforeDeployingAnything(t *testing.T) {
+	body := `releases:
+  - name: good
+    chart: swarmcli-charts/demo
+    version: "0.1.0"
+  - name: bad
+    chart: swarmcli-charts/demo
+    version: "9.9.9"
+`
+	e, fb, src, rf := applyEnv(t, body, "0.1.0")
+
+	_, err := e.PlanApply(context.Background(), rf, src)
+	require.ErrorContains(t, err, "bad")
+	require.Empty(t, fb.deployed, "the first release must not deploy when a later one fails to plan")
+}
+
+// A failure mid-apply stops immediately and still reports what was done.
+func TestApplyFailsFastAndReportsPartialProgress(t *testing.T) {
+	body := `releases:
+  - name: first
+    chart: swarmcli-charts/demo
+    version: "0.1.0"
+  - name: second
+    chart: swarmcli-charts/demo
+    version: "0.1.0"
+`
+	e, fb, src, rf := applyEnv(t, body, "0.1.0")
+	ctx := context.Background()
+
+	plan, err := e.PlanApply(ctx, rf, src)
+	require.NoError(t, err)
+
+	fb.failNext = true // first DeployStack fails
+	res, err := e.Apply(ctx, plan, InstallOptions{})
+	require.Error(t, err)
+	require.ErrorContains(t, err, "first")
+	require.Empty(t, res, "nothing completed")
+	require.NotContains(t, fb.deployed, "second", "apply must stop at the first failure")
+}
+
+// A release that appears between planning and applying must upgrade cleanly
+// rather than colliding with "already exists".
+func TestApplyToleratesReleaseAppearingAfterPlan(t *testing.T) {
+	e, fb, src, rf := applyEnv(t, oneRelease, "0.1.0")
+	ctx := context.Background()
+
+	plan, err := e.PlanApply(ctx, rf, src)
+	require.NoError(t, err)
+	require.Equal(t, ActionInstall, plan.Releases[0].Action)
+
+	// Someone else installs it in the gap.
+	ch := demoChart(t, "0.1.0")
+	_, err = e.Install(ctx, "hello", ReleaseChartOf(ch), ch.Values, "services: {}\n", InstallOptions{})
+	require.NoError(t, err)
+
+	_, err = e.Apply(ctx, plan, InstallOptions{})
+	require.NoError(t, err, "apply upgrades over a release that appeared after planning")
+	require.Contains(t, fb.deployed, "hello")
+}
+
+// Render must be byte-stable for identical inputs: the no-op detection compares
+// rendered manifests, and `charts diff upgrade` already relies on it.
+func TestRenderIsDeterministic(t *testing.T) {
+	ch := demoChart(t, "0.1.0")
+	ctx := RenderContext{
+		Values:  ch.Values,
+		Release: ReleaseMeta{Name: "hello", Namespace: "hello", Revision: 1},
+		Chart:   ChartMeta{Name: ch.Metadata.Name, Version: "0.1.0"},
+	}
+	first, err := Render(ch, ctx)
+	require.NoError(t, err)
+	for range 20 {
+		again, err := Render(ch, ctx)
+		require.NoError(t, err)
+		require.Equal(t, first, again, "Render must be byte-stable or every apply churns a revision")
+	}
+}
+
+func TestPlanCounts(t *testing.T) {
+	p := &Plan{Releases: []ReleasePlan{
+		{Action: ActionInstall}, {Action: ActionUpgrade},
+		{Action: ActionUnchanged}, {Action: ActionUnchanged},
+	}}
+	i, u, n := p.Counts()
+	require.Equal(t, 1, i)
+	require.Equal(t, 1, u)
+	require.Equal(t, 2, n)
+}

--- a/charts/outdated.go
+++ b/charts/outdated.go
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package charts
+
+import "sort"
+
+// OutdatedEntry is one installed release with a newer chart version available.
+type OutdatedEntry struct {
+	Release   string
+	Chart     string
+	Repo      string
+	Installed string
+	Latest    string
+}
+
+// Outdated joins installed releases against the newest version of their chart in
+// any configured repository index. Releases already at the newest version, and
+// those whose chart appears in no index (a local chart), are omitted.
+//
+// A Release does not record which repository it came from, so a chart present in
+// two repositories resolves to the highest version across them, reporting the
+// repository that supplied it. That ambiguity is documented rather than designed
+// away: recording the source repository is a change to persisted release state,
+// which is not worth making for a case most users never hit.
+func Outdated(rels []Release, indexes map[string]*Index) []OutdatedEntry {
+	var out []OutdatedEntry
+	for _, rel := range rels {
+		var (
+			bestVer  string
+			bestRepo string
+		)
+		for repo, idx := range indexes {
+			versions := idx.Entries[rel.Chart.Name]
+			if len(versions) == 0 {
+				continue
+			}
+			latest := latestVersion(versions)
+			if bestVer == "" || compareVersions(latest.Version, bestVer) > 0 {
+				bestVer, bestRepo = latest.Version, repo
+			}
+		}
+		if bestVer == "" || compareVersions(bestVer, rel.Chart.Version) <= 0 {
+			continue
+		}
+		out = append(out, OutdatedEntry{
+			Release:   rel.Name,
+			Chart:     rel.Chart.Name,
+			Repo:      bestRepo,
+			Installed: rel.Chart.Version,
+			Latest:    bestVer,
+		})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Release < out[j].Release })
+	return out
+}

--- a/charts/outdated_test.go
+++ b/charts/outdated_test.go
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package charts
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func idx(chart string, versions ...string) *Index {
+	entries := make([]IndexEntry, 0, len(versions))
+	for _, v := range versions {
+		entries = append(entries, IndexEntry{Name: chart, Version: v})
+	}
+	return &Index{APIVersion: "v1", Entries: map[string][]IndexEntry{chart: entries}}
+}
+
+func rel(name, chart, version string) Release {
+	return Release{Name: name, Chart: ReleaseChart{Name: chart, Version: version}}
+}
+
+func TestOutdated(t *testing.T) {
+	got := Outdated(
+		[]Release{rel("hello", "whoami", "0.1.6")},
+		map[string]*Index{"swarmcli-charts": idx("whoami", "0.1.6", "0.1.8", "0.1.7")},
+	)
+	require.Len(t, got, 1)
+	require.Equal(t, OutdatedEntry{
+		Release: "hello", Chart: "whoami", Repo: "swarmcli-charts",
+		Installed: "0.1.6", Latest: "0.1.8",
+	}, got[0])
+}
+
+func TestOutdatedSkipsCurrentReleases(t *testing.T) {
+	got := Outdated(
+		[]Release{rel("hello", "whoami", "0.1.8")},
+		map[string]*Index{"swarmcli-charts": idx("whoami", "0.1.8")},
+	)
+	require.Empty(t, got)
+}
+
+// A local chart is in no index; that is not an error, it is just not reportable.
+func TestOutdatedSkipsChartsInNoIndex(t *testing.T) {
+	got := Outdated(
+		[]Release{rel("hello", "mine", "0.1.0")},
+		map[string]*Index{"swarmcli-charts": idx("whoami", "0.1.8")},
+	)
+	require.Empty(t, got)
+}
+
+// Someone running a version newer than any index offers is not "outdated".
+func TestOutdatedIgnoresReleasesAheadOfTheIndex(t *testing.T) {
+	got := Outdated(
+		[]Release{rel("hello", "whoami", "0.2.0")},
+		map[string]*Index{"swarmcli-charts": idx("whoami", "0.1.8")},
+	)
+	require.Empty(t, got)
+}
+
+// A Release does not record which repository it came from, so the highest version
+// across all of them wins and the reported repo is the one that supplied it.
+func TestOutdatedPicksHighestAcrossRepos(t *testing.T) {
+	got := Outdated(
+		[]Release{rel("hello", "whoami", "0.1.0")},
+		map[string]*Index{
+			"stable": idx("whoami", "0.1.2"),
+			"edge":   idx("whoami", "0.2.0"),
+		},
+	)
+	require.Len(t, got, 1)
+	require.Equal(t, "0.2.0", got[0].Latest)
+	require.Equal(t, "edge", got[0].Repo)
+}
+
+func TestOutdatedSortsByRelease(t *testing.T) {
+	got := Outdated(
+		[]Release{rel("zeta", "whoami", "0.1.0"), rel("alpha", "whoami", "0.1.0")},
+		map[string]*Index{"r": idx("whoami", "0.1.8")},
+	)
+	require.Len(t, got, 2)
+	require.Equal(t, "alpha", got[0].Release)
+	require.Equal(t, "zeta", got[1].Release)
+}

--- a/charts/releasefile.go
+++ b/charts/releasefile.go
@@ -1,0 +1,190 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package charts
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+)
+
+// ReleaseFile is a declarative release manifest: the desired set of releases on a
+// swarm, plus the repositories their charts come from. It is the GitOps entry
+// point — `charts install` and `charts upgrade` are imperative and release state
+// lives in the swarm, so without this file there is nothing in git for an
+// automated updater (Renovate, Dependabot, a bot of your own) to edit.
+//
+// The key names deliberately mirror Helmfile's. Renovate ships a `helmfile`
+// manager that reads exactly `repositories[].{name,url}` and
+// `releases[].{name,chart,version}`, so pointing it at this file needs one line
+// of config and no hand-written regex:
+//
+//	{"helmfile": {"managerFilePatterns": ["/(^|/)swarmcli-release\\.ya?ml$/"]}}
+//
+// Unknown keys are a hard error (see ParseReleaseFile), which also contains the
+// obvious hazard of borrowing another tool's vocabulary: pasting real Helmfile
+// syntax fails loudly and names the key, rather than silently doing half of what
+// was meant.
+type ReleaseFile struct {
+	APIVersion   string        `yaml:"apiVersion,omitempty"`
+	Repositories []RepoSpec    `yaml:"repositories,omitempty"`
+	Releases     []ReleaseSpec `yaml:"releases"`
+
+	// Dir is the directory containing the file. Values files and local chart
+	// paths resolve against it, never the process working directory, so the
+	// manifest is relocatable: a CI job gets the same result no matter where it
+	// invoked swarmcli from.
+	Dir string `yaml:"-"`
+	// Path is the file as given, used to prefix error messages.
+	Path string `yaml:"-"`
+}
+
+// RepoSpec is a chart repository the file depends on.
+type RepoSpec struct {
+	Name string `yaml:"name"`
+	URL  string `yaml:"url"`
+}
+
+// ReleaseSpec is one desired release.
+type ReleaseSpec struct {
+	Name    string   `yaml:"name"`
+	Chart   string   `yaml:"chart"`
+	Version string   `yaml:"version,omitempty"`
+	Values  []string `yaml:"values,omitempty"`
+}
+
+// LoadReleaseFile reads and validates a release manifest.
+func LoadReleaseFile(path string) (*ReleaseFile, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	return ParseReleaseFile(data, path)
+}
+
+// ParseReleaseFile decodes and validates a release manifest. Unknown keys are
+// rejected: this is a file an automated updater rewrites, so a misspelled
+// `version:` must fail loudly rather than silently leave the release floating.
+func ParseReleaseFile(data []byte, path string) (*ReleaseFile, error) {
+	rf := &ReleaseFile{Path: path, Dir: filepath.Dir(path)}
+
+	dec := yaml.NewDecoder(bytes.NewReader(data))
+	dec.KnownFields(true)
+	if err := dec.Decode(rf); err != nil {
+		return nil, fmt.Errorf("%s: %w", path, err)
+	}
+	if err := rf.validate(); err != nil {
+		return nil, err
+	}
+	return rf, nil
+}
+
+func (rf *ReleaseFile) validate() error {
+	if rf.APIVersion != "" && rf.APIVersion != "v1" {
+		return rf.errf("unsupported apiVersion %q (expected v1)", rf.APIVersion)
+	}
+	if len(rf.Releases) == 0 {
+		return rf.errf("no releases declared")
+	}
+
+	seenRepo := map[string]bool{}
+	for i, r := range rf.Repositories {
+		switch {
+		case r.Name == "":
+			return rf.errf("repositories[%d]: name is required", i)
+		case r.URL == "":
+			return rf.errf("repositories[%d] (%s): url is required", i, r.Name)
+		case seenRepo[r.Name]:
+			return rf.errf("repositories[%d]: duplicate repository %q", i, r.Name)
+		}
+		seenRepo[r.Name] = true
+	}
+
+	seenRelease := map[string]bool{}
+	for i, r := range rf.Releases {
+		where := fmt.Sprintf("releases[%d]", i)
+		if r.Name != "" {
+			where = fmt.Sprintf("releases[%d] (%s)", i, r.Name)
+		}
+		if r.Name == "" {
+			return rf.errf("%s: name is required", where)
+		}
+		if err := validateReleaseName(r.Name); err != nil {
+			return rf.errf("%s: %v", where, err)
+		}
+		if seenRelease[r.Name] {
+			return rf.errf("%s: duplicate release %q", where, r.Name)
+		}
+		seenRelease[r.Name] = true
+
+		if r.Chart == "" {
+			return rf.errf("%s: chart is required", where)
+		}
+		if IsPathRef(r.Chart) {
+			// A local chart carries its version in its own Chart.yaml; there is
+			// nothing for `version:` to select, so accepting it would be a lie.
+			if r.Version != "" {
+				return rf.errf("%s: version must be omitted for the local chart %q (its Chart.yaml sets the version)", where, r.Chart)
+			}
+			continue
+		}
+		// The entire point of this file is to be reproducible and to give an
+		// updater something concrete to bump. A floating version would silently
+		// upgrade a swarm the next time upstream published.
+		if r.Version == "" {
+			return rf.errf("%s: version is required — a release manifest must be reproducible; run `swarmcli charts search %s` and pin one", where, chartNameOf(r.Chart))
+		}
+	}
+	return nil
+}
+
+func (rf *ReleaseFile) errf(format string, a ...any) error {
+	return fmt.Errorf("%s: %s", rf.Path, fmt.Sprintf(format, a...))
+}
+
+// ValuesPaths resolves a release's values files against the manifest's directory.
+func (rf *ReleaseFile) ValuesPaths(r ReleaseSpec) []string {
+	out := make([]string, 0, len(r.Values))
+	for _, p := range r.Values {
+		out = append(out, rf.resolve(p))
+	}
+	return out
+}
+
+// ChartRef resolves a release's chart reference, joining local paths against the
+// manifest's directory and passing "<repo>/<chart>" references through.
+func (rf *ReleaseFile) ChartRef(r ReleaseSpec) string {
+	if IsPathRef(r.Chart) {
+		return rf.resolve(r.Chart)
+	}
+	return r.Chart
+}
+
+func (rf *ReleaseFile) resolve(p string) string {
+	if filepath.IsAbs(p) {
+		return p
+	}
+	return filepath.Join(rf.Dir, p)
+}
+
+// chartNameOf returns the chart part of a "<repo>/<chart>" reference, for error
+// messages that suggest a follow-up command.
+func chartNameOf(ref string) string {
+	if _, name, ok := cutLast(ref, "/"); ok {
+		return name
+	}
+	return ref
+}
+
+func cutLast(s, sep string) (before, after string, found bool) {
+	for i := len(s) - len(sep); i >= 0; i-- {
+		if s[i:i+len(sep)] == sep {
+			return s[:i], s[i+len(sep):], true
+		}
+	}
+	return s, "", false
+}

--- a/charts/releasefile_test.go
+++ b/charts/releasefile_test.go
@@ -100,6 +100,7 @@ func TestParseValidationErrors(t *testing.T) {
 		"dup release":    {"releases:\n  - {name: a, chart: r/c, version: \"1\"}\n  - {name: a, chart: r/d, version: \"1\"}\n", "duplicate release"},
 		"dup repo":       {"repositories:\n  - {name: r, url: http://x}\n  - {name: r, url: http://y}\nreleases:\n  - {name: a, chart: r/c, version: \"1\"}\n", "duplicate repository"},
 		"repo no url":    {"repositories:\n  - {name: r}\nreleases:\n  - {name: a, chart: r/c, version: \"1\"}\n", "url is required"},
+		"repo no name":   {"repositories:\n  - {url: http://x}\nreleases:\n  - {name: a, chart: r/c, version: \"1\"}\n", "name is required"},
 		"bad apiVersion": {"apiVersion: v2\nreleases:\n  - {name: a, chart: r/c, version: \"1\"}\n", "unsupported apiVersion"},
 		"bad rel name":   {"releases:\n  - {name: \"Bad Name\", chart: r/c, version: \"1\"}\n", "Bad Name"},
 	} {
@@ -147,4 +148,12 @@ func TestIsPathRefIsSyntactic(t *testing.T) {
 	for _, ref := range []string{"repo/chart", "chart", "swarmcli-charts/whoami"} {
 		require.False(t, IsPathRef(ref), ref)
 	}
+}
+
+// chartNameOf backs the "run `charts search <chart>`" hint in the version-required
+// error; a reference with no separator must fall back to the whole string.
+func TestChartNameOf(t *testing.T) {
+	require.Equal(t, "whoami", chartNameOf("swarmcli-charts/whoami"))
+	require.Equal(t, "whoami", chartNameOf("whoami"))
+	require.Equal(t, "c", chartNameOf("a/b/c"))
 }

--- a/charts/releasefile_test.go
+++ b/charts/releasefile_test.go
@@ -1,0 +1,150 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package charts
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func parse(t *testing.T, body string) (*ReleaseFile, error) {
+	t.Helper()
+	return ParseReleaseFile([]byte(body), "/wd/deploy/swarmcli-release.yaml")
+}
+
+func TestParseReleaseFile(t *testing.T) {
+	rf, err := parse(t, `apiVersion: v1
+repositories:
+  - name: swarmcli-charts
+    url: https://eldara-tech.github.io/swarmcli-charts
+releases:
+  - name: edge
+    chart: swarmcli-charts/traefik
+    version: "0.1.1"
+    values: [./traefik.yaml]
+  - name: hello
+    chart: swarmcli-charts/whoami
+    version: "0.1.8"
+`)
+	require.NoError(t, err)
+	require.Len(t, rf.Releases, 2)
+	require.Equal(t, "swarmcli-charts", rf.Repositories[0].Name)
+	require.Equal(t, "0.1.1", rf.Releases[0].Version)
+}
+
+// A file an automated updater rewrites must fail loudly on a typo, not silently
+// leave the release floating.
+//
+//nolint:misspell // "verison" is a deliberate typo — it is what the test rejects.
+func TestParseRejectsUnknownKeys(t *testing.T) {
+	_, err := parse(t, `releases:
+  - name: hello
+    chart: swarmcli-charts/whoami
+    verison: "0.1.8"
+`)
+	require.ErrorContains(t, err, "verison")
+}
+
+// Borrowing Helmfile's key names means people will paste Helmfile syntax. Strict
+// decoding turns that into a clear error naming the key rather than silent
+// half-behaviour.
+func TestParseRejectsHelmfileOnlyKeys(t *testing.T) {
+	_, err := parse(t, `environments:
+  default: {}
+releases:
+  - name: hello
+    chart: swarmcli-charts/whoami
+    version: "0.1.8"
+`)
+	require.ErrorContains(t, err, "environments")
+}
+
+func TestParseRequiresVersionForRepoCharts(t *testing.T) {
+	_, err := parse(t, `releases:
+  - name: hello
+    chart: swarmcli-charts/whoami
+`)
+	require.ErrorContains(t, err, "version is required")
+	require.ErrorContains(t, err, "hello")
+	// The message should point at the fix.
+	require.ErrorContains(t, err, "charts search whoami")
+}
+
+// A local chart carries its version in its own Chart.yaml, so `version:` selects
+// nothing. Accepting it would be a lie — the pre-existing `--version` bug in
+// imperative install, surfaced here as an explicit error.
+func TestParseRejectsVersionOnLocalChart(t *testing.T) {
+	_, err := parse(t, `releases:
+  - name: hello
+    chart: ./charts/mine
+    version: "0.1.8"
+`)
+	require.ErrorContains(t, err, "version must be omitted")
+
+	ok, err := parse(t, `releases:
+  - name: hello
+    chart: ./charts/mine
+`)
+	require.NoError(t, err)
+	require.Equal(t, "./charts/mine", ok.Releases[0].Chart)
+}
+
+func TestParseValidationErrors(t *testing.T) {
+	for name, tc := range map[string]struct{ body, want string }{
+		"no releases":    {"releases: []\n", "no releases"},
+		"missing name":   {"releases:\n  - chart: r/c\n    version: \"1\"\n", "name is required"},
+		"missing chart":  {"releases:\n  - name: a\n", "chart is required"},
+		"dup release":    {"releases:\n  - {name: a, chart: r/c, version: \"1\"}\n  - {name: a, chart: r/d, version: \"1\"}\n", "duplicate release"},
+		"dup repo":       {"repositories:\n  - {name: r, url: http://x}\n  - {name: r, url: http://y}\nreleases:\n  - {name: a, chart: r/c, version: \"1\"}\n", "duplicate repository"},
+		"repo no url":    {"repositories:\n  - {name: r}\nreleases:\n  - {name: a, chart: r/c, version: \"1\"}\n", "url is required"},
+		"bad apiVersion": {"apiVersion: v2\nreleases:\n  - {name: a, chart: r/c, version: \"1\"}\n", "unsupported apiVersion"},
+		"bad rel name":   {"releases:\n  - {name: \"Bad Name\", chart: r/c, version: \"1\"}\n", "Bad Name"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			_, err := parse(t, tc.body)
+			require.ErrorContains(t, err, tc.want)
+		})
+	}
+}
+
+// Values and local chart paths resolve against the FILE's directory, never the
+// process working directory: the file is committed to git and must produce the
+// same result no matter where CI invoked swarmcli from.
+func TestPathsResolveAgainstTheManifestNotTheCWD(t *testing.T) {
+	rf, err := parse(t, `releases:
+  - name: a
+    chart: ./charts/mine
+    values: [./v.yaml, ../shared.yaml, /abs/v.yaml]
+`)
+	require.NoError(t, err)
+
+	got := rf.ValuesPaths(rf.Releases[0])
+	require.Equal(t, []string{
+		filepath.FromSlash("/wd/deploy/v.yaml"),
+		filepath.FromSlash("/wd/shared.yaml"),
+		filepath.FromSlash("/abs/v.yaml"),
+	}, got)
+
+	require.Equal(t, filepath.FromSlash("/wd/deploy/charts/mine"), rf.ChartRef(rf.Releases[0]))
+}
+
+// A "<repo>/<chart>" reference is passed through untouched.
+func TestChartRefPassesThroughRepoReferences(t *testing.T) {
+	rf, err := parse(t, "releases:\n  - {name: a, chart: swarmcli-charts/whoami, version: \"0.1.8\"}\n")
+	require.NoError(t, err)
+	require.Equal(t, "swarmcli-charts/whoami", rf.ChartRef(rf.Releases[0]))
+}
+
+// Whether a reference is a path must not depend on what happens to exist on the
+// disk of whichever machine runs the file.
+func TestIsPathRefIsSyntactic(t *testing.T) {
+	for _, ref := range []string{"./x", "../x", "/x", "~/x"} {
+		require.True(t, IsPathRef(ref), ref)
+	}
+	for _, ref := range []string{"repo/chart", "chart", "swarmcli-charts/whoami"} {
+		require.False(t, IsPathRef(ref), ref)
+	}
+}

--- a/charts/repo.go
+++ b/charts/repo.go
@@ -30,6 +30,18 @@ const maxIndexSize = 16 << 20 // 16 MiB
 type RepoStore struct {
 	dir    string
 	client *http.Client
+
+	// Warnf, when set, receives non-fatal diagnostics — e.g. a repository whose
+	// index could not be refreshed, so a cached one is being used. charts is a
+	// library with no output of its own; nil is silent, and cli wires this to
+	// stderr.
+	Warnf func(format string, a ...any)
+}
+
+func (s *RepoStore) warnf(format string, a ...any) {
+	if s.Warnf != nil {
+		s.Warnf(format, a...)
+	}
 }
 
 // NewRepoStore returns a store rooted at the standard charts state directory.
@@ -191,6 +203,69 @@ func (s *RepoStore) LoadIndex(name string) (*Index, error) {
 		return nil, fmt.Errorf("parse index for %q: %w", name, err)
 	}
 	return &idx, nil
+}
+
+// Indexes returns the cached index of every configured repository, keyed by
+// repository name. Repositories with no cached index are skipped, as in Search.
+func (s *RepoStore) Indexes() (map[string]*Index, error) {
+	repos, err := s.List()
+	if err != nil {
+		return nil, err
+	}
+	out := make(map[string]*Index, len(repos))
+	for _, r := range repos {
+		idx, err := s.LoadIndex(r.Name)
+		if err != nil {
+			continue
+		}
+		out[r.Name] = idx
+	}
+	return out, nil
+}
+
+// EnsureRepos makes the repositories a release manifest declares available,
+// adding those that are absent and refreshing the rest. It exists so that
+// `charts apply -f file` is the only command a CI job needs to run.
+//
+// What it writes is a name-to-URL mapping plus a cached index — a cache, not user
+// data. The one thing it will not do is silently repoint an existing repository
+// at a different origin.
+func (s *RepoStore) EnsureRepos(specs []RepoSpec) error {
+	if len(specs) == 0 {
+		return nil
+	}
+	repos, err := s.List()
+	if err != nil {
+		return err
+	}
+	existing := make(map[string]string, len(repos))
+	for _, r := range repos {
+		existing[r.Name] = r.URL
+	}
+
+	for _, spec := range specs {
+		want := strings.TrimRight(spec.URL, "/")
+		have, ok := existing[spec.Name]
+		switch {
+		case !ok:
+			if err := s.Add(spec.Name, want); err != nil {
+				return err
+			}
+		case have != want:
+			return fmt.Errorf("repository %q is already configured with a different URL (%s); "+
+				"refusing to repoint it — run `swarmcli charts repo remove %s` first if that is intended",
+				spec.Name, have, spec.Name)
+		default:
+			// Refreshing is best-effort. Every version in the manifest is pinned,
+			// so a stale cache can only fail to resolve a chart — it can never
+			// resolve one to the wrong version. Failing the whole apply because
+			// the network blipped would be worse than proceeding offline.
+			if _, _, err := s.Update(spec.Name); err != nil {
+				s.warnf("could not refresh repository %q (%v); using the cached index\n", spec.Name, err)
+			}
+		}
+	}
+	return nil
 }
 
 // ChartHit is a search result: one chart version in a repository.

--- a/charts/repo_test.go
+++ b/charts/repo_test.go
@@ -4,6 +4,7 @@
 package charts
 
 import (
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -261,4 +262,148 @@ func TestCompareVersions(t *testing.T) {
 	require.Equal(t, 1, compareVersions("0.2.0", "0.1.0"))
 	require.Equal(t, -1, compareVersions("1.0.0", "1.0.1"))
 	require.Equal(t, 1, compareVersions("v3.5.0", "3.4.0"))
+}
+
+// --- EnsureRepos: the gate every `charts apply` passes through ---
+
+// newIndexServer serves a mutable index and reports whether it is currently up.
+func newIndexServer(t *testing.T, body *string, up *bool) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if *up && strings.HasSuffix(r.URL.Path, "/index.yaml") {
+			_, _ = w.Write([]byte(*body))
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func TestEnsureReposAddsAbsentRepository(t *testing.T) {
+	body := "apiVersion: v1\nentries:\n  demo:\n    - {name: demo, version: 0.1.0, urls: [\"d.tgz\"]}\n"
+	up := true
+	srv := newIndexServer(t, &body, &up)
+
+	s := NewRepoStoreAt(t.TempDir())
+	require.NoError(t, s.EnsureRepos([]RepoSpec{{Name: "eldara", URL: srv.URL}}))
+
+	repos, err := s.List()
+	require.NoError(t, err)
+	require.Len(t, repos, 1)
+	// The index must actually be cached, not merely the name recorded — apply
+	// resolves against the cache immediately afterwards.
+	idx, err := s.LoadIndex("eldara")
+	require.NoError(t, err)
+	require.Contains(t, idx.Entries, "demo")
+}
+
+// A trailing slash in the manifest's URL must take the refresh branch, not the
+// "different URL" hard error. Add normalises with TrimRight, so without this the
+// refusal would fire on every manifest whose url ends in "/".
+func TestEnsureReposRefreshesSameRepositoryAndToleratesTrailingSlash(t *testing.T) {
+	body := "apiVersion: v1\nentries:\n  demo:\n    - {name: demo, version: 0.1.0, urls: [\"d.tgz\"]}\n"
+	up := true
+	srv := newIndexServer(t, &body, &up)
+
+	s := NewRepoStoreAt(t.TempDir())
+	require.NoError(t, s.Add("eldara", srv.URL))
+
+	body = "apiVersion: v1\nentries:\n  demo:\n    - {name: demo, version: 0.2.0, urls: [\"d.tgz\"]}\n"
+	require.NoError(t, s.EnsureRepos([]RepoSpec{{Name: "eldara", URL: srv.URL + "/"}}))
+
+	idx, err := s.LoadIndex("eldara")
+	require.NoError(t, err)
+	require.Equal(t, "0.2.0", idx.Entries["demo"][0].Version, "the index must have been refreshed")
+}
+
+// Never silently repoint an existing repository at a different origin: that would
+// let a manifest swap out where every one of its charts comes from.
+func TestEnsureReposRefusesToRepointADifferentURL(t *testing.T) {
+	body := "apiVersion: v1\nentries: {}\n"
+	up := true
+	srvA := newIndexServer(t, &body, &up)
+	srvB := newIndexServer(t, &body, &up)
+
+	s := NewRepoStoreAt(t.TempDir())
+	require.NoError(t, s.Add("eldara", srvA.URL))
+
+	err := s.EnsureRepos([]RepoSpec{{Name: "eldara", URL: srvB.URL}})
+	require.ErrorContains(t, err, "different URL")
+
+	// The refusal is the point: assert the store was not repointed.
+	repos, lerr := s.List()
+	require.NoError(t, lerr)
+	require.Equal(t, srvA.URL, repos[0].URL)
+}
+
+// A network blip must not fail the apply. Every version in a manifest is pinned,
+// so a stale cache can only fail to resolve a chart — never resolve it to the
+// wrong one. This is the "CI keeps working when the network wobbles" contract.
+func TestEnsureReposWarnsAndUsesCacheWhenRefreshFails(t *testing.T) {
+	body := "apiVersion: v1\nentries:\n  demo:\n    - {name: demo, version: 0.1.0, urls: [\"d.tgz\"]}\n"
+	up := true
+	srv := newIndexServer(t, &body, &up)
+
+	s := NewRepoStoreAt(t.TempDir())
+	require.NoError(t, s.Add("eldara", srv.URL))
+
+	var warnings []string
+	s.Warnf = func(format string, a ...any) { warnings = append(warnings, fmt.Sprintf(format, a...)) }
+
+	up = false // the repository goes away
+	require.NoError(t, s.EnsureRepos([]RepoSpec{{Name: "eldara", URL: srv.URL}}),
+		"a failed refresh must not fail the apply")
+	require.Len(t, warnings, 1)
+	require.Contains(t, warnings[0], "could not refresh repository")
+
+	// The cached index is still usable.
+	idx, err := s.LoadIndex("eldara")
+	require.NoError(t, err)
+	require.Equal(t, "0.1.0", idx.Entries["demo"][0].Version)
+}
+
+func TestEnsureReposNoSpecsIsANoOp(t *testing.T) {
+	s := NewRepoStoreAt(t.TempDir())
+	require.NoError(t, s.EnsureRepos(nil))
+	repos, err := s.List()
+	require.NoError(t, err)
+	require.Empty(t, repos)
+}
+
+// Indexes backs `charts outdated`, which must not blow up on a repository whose
+// index was never fetched.
+func TestIndexesSkipsRepositoriesWithNoCachedIndex(t *testing.T) {
+	body := "apiVersion: v1\nentries:\n  demo:\n    - {name: demo, version: 0.1.0, urls: [\"d.tgz\"]}\n"
+	up := true
+	srv := newIndexServer(t, &body, &up)
+
+	s := NewRepoStoreAt(t.TempDir())
+	require.NoError(t, s.Add("good", srv.URL))
+
+	// A repo recorded with no cached index (e.g. the cache file was cleared).
+	require.NoError(t, s.save([]RepoEntry{{Name: "good", URL: srv.URL}, {Name: "stale", URL: srv.URL}}))
+
+	idxs, err := s.Indexes()
+	require.NoError(t, err)
+	require.Len(t, idxs, 1)
+	require.Contains(t, idxs, "good")
+	require.NotContains(t, idxs, "stale")
+}
+
+// A repository in the manifest that cannot be reached must fail the apply loudly,
+// not be silently skipped — every chart it provides would otherwise fail to
+// resolve with a far more confusing error.
+func TestEnsureReposFailsWhenAnAbsentRepositoryCannotBeAdded(t *testing.T) {
+	body := "apiVersion: v1\nentries: {}\n"
+	up := false
+	srv := newIndexServer(t, &body, &up)
+
+	s := NewRepoStoreAt(t.TempDir())
+	err := s.EnsureRepos([]RepoSpec{{Name: "eldara", URL: srv.URL}})
+	require.Error(t, err)
+
+	repos, lerr := s.List()
+	require.NoError(t, lerr)
+	require.Empty(t, repos, "a failed add must persist nothing")
 }

--- a/charts/source.go
+++ b/charts/source.go
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package charts
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+// ChartSource resolves a chart reference to a loaded chart. It is the seam that
+// lets release planning be unit-tested without a repository, a network or a
+// filesystem: the whole of Engine.PlanApply depends on this interface and not on
+// RepoStore.
+type ChartSource interface {
+	// Load returns the chart named by ref. ref is either a local path (a chart
+	// directory or a .tgz) or a "<repo>/<chart>" reference resolved through the
+	// configured repositories. version selects a repository chart version; it is
+	// meaningless for a local path and rejected there rather than ignored.
+	Load(ref, version string) (*Chart, error)
+}
+
+// NewChartSource returns the standard source, backed by the configured chart
+// repositories for "<repo>/<chart>" references.
+func NewChartSource(store *RepoStore) ChartSource { return &repoSource{store: store} }
+
+type repoSource struct{ store *RepoStore }
+
+func (s *repoSource) Load(ref, version string) (*Chart, error) {
+	if IsPathRef(ref) {
+		if version != "" {
+			// Previously the flag was accepted and silently dropped here, so
+			// `install foo ./chart --version 2.0.0` quietly installed whatever
+			// Chart.yaml said. A local directory has exactly one version.
+			return nil, fmt.Errorf("chart %q is a local path: --version does not apply (the chart's own Chart.yaml sets the version)", ref)
+		}
+		return loadLocalChart(ref)
+	}
+	// Not syntactically a path, but it might still be a bare directory name
+	// ("./" omitted). Keep resolving those for backwards compatibility.
+	if info, err := os.Stat(ref); err == nil {
+		if version != "" {
+			return nil, fmt.Errorf("chart %q is a local path: --version does not apply (the chart's own Chart.yaml sets the version)", ref)
+		}
+		return loadStatted(ref, info.IsDir())
+	}
+	if s.store == nil {
+		return nil, fmt.Errorf("chart %q not found on disk and no repositories are configured", ref)
+	}
+	entry, base, err := s.store.Resolve(ref, version)
+	if err != nil {
+		return nil, err
+	}
+	return s.store.Pull(entry, base)
+}
+
+// IsPathRef reports whether ref names a local chart path rather than a
+// "<repo>/<chart>" reference. The test is deliberately SYNTACTIC: a release file
+// is committed to git and must resolve the same way on every machine, so whether
+// a reference is a path cannot depend on what happens to exist on the disk of
+// whichever CI runner picked up the job.
+func IsPathRef(ref string) bool {
+	return strings.HasPrefix(ref, "./") ||
+		strings.HasPrefix(ref, "../") ||
+		strings.HasPrefix(ref, "/") ||
+		strings.HasPrefix(ref, "~")
+}
+
+func loadLocalChart(path string) (*Chart, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		// An explicit path that does not exist is a typo, not a repository
+		// reference. Say so, instead of the misleading "must be <repo>/<chart>".
+		return nil, fmt.Errorf("chart path %q not found", path)
+	}
+	return loadStatted(path, info.IsDir())
+}
+
+func loadStatted(path string, isDir bool) (*Chart, error) {
+	if isDir {
+		return LoadChartDir(path)
+	}
+	fh, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = fh.Close() }()
+	return LoadChartArchive(fh)
+}
+
+// ReleaseChartOf projects a loaded chart into the metadata recorded on a release.
+func ReleaseChartOf(ch *Chart) ReleaseChart {
+	return ReleaseChart{Name: ch.Metadata.Name, Version: ch.Metadata.Version, AppVersion: ch.Metadata.AppVersion}
+}

--- a/charts/source_test.go
+++ b/charts/source_test.go
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package charts
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// serveRepo stands up an httptest chart repository serving testdata/demo at the
+// given versions, and returns a store with it already added.
+func serveRepo(t *testing.T, versions ...string) *RepoStore {
+	t.Helper()
+	tgz := packDirToTgz(t, "testdata/demo", "demo")
+
+	var b strings.Builder
+	b.WriteString("apiVersion: v1\nentries:\n  demo:\n")
+	for _, v := range versions {
+		b.WriteString("    - name: demo\n      version: " + v + "\n      urls: [\"demo-" + v + ".tgz\"]\n")
+	}
+	idx := b.String()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/index.yaml"):
+			_, _ = w.Write([]byte(idx))
+		case strings.HasSuffix(r.URL.Path, ".tgz"):
+			_, _ = w.Write([]byte(tgz))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	s := NewRepoStoreAt(t.TempDir())
+	require.NoError(t, s.Add("eldara", srv.URL))
+	return s
+}
+
+func TestChartSourceLoadsFromRepository(t *testing.T) {
+	src := NewChartSource(serveRepo(t, "0.1.0", "0.2.0"))
+
+	ch, err := src.Load("eldara/demo", "0.1.0")
+	require.NoError(t, err)
+	require.Equal(t, "demo", ch.Metadata.Name)
+
+	// No version selects the latest.
+	ch, err = src.Load("eldara/demo", "")
+	require.NoError(t, err)
+	require.Equal(t, "demo", ch.Metadata.Name)
+
+	_, err = src.Load("eldara/demo", "9.9.9")
+	require.ErrorContains(t, err, "not found")
+}
+
+func TestChartSourceLoadsLocalDirAndArchive(t *testing.T) {
+	src := NewChartSource(nil)
+
+	ch, err := src.Load("./testdata/demo", "")
+	require.NoError(t, err)
+	require.Equal(t, "demo", ch.Metadata.Name)
+
+	// The .tgz branch: previously only the directory branch was ever exercised.
+	tgz := filepath.Join(t.TempDir(), "demo.tgz")
+	require.NoError(t, os.WriteFile(tgz, []byte(packDirToTgz(t, "testdata/demo", "demo")), 0o600))
+
+	ch, err = src.Load(tgz, "")
+	require.NoError(t, err)
+	require.Equal(t, "demo", ch.Metadata.Name)
+}
+
+// --version selects a version from a repository index. A local chart carries its
+// version in its own Chart.yaml, so there is nothing to select — the flag used to
+// be accepted and silently dropped, which meant `install foo ./chart --version
+// 2.0.0` quietly installed whatever Chart.yaml said. Both the syntactic-path and
+// the bare-directory-name branches must reject it, or half the fix rots.
+func TestChartSourceRejectsVersionOnLocalPath(t *testing.T) {
+	src := NewChartSource(nil)
+
+	_, err := src.Load("./testdata/demo", "2.0.0")
+	require.ErrorContains(t, err, "--version does not apply")
+
+	// Same, via the os.Stat fallback for a path with no "./" prefix.
+	_, err = src.Load("testdata/demo", "2.0.0")
+	require.ErrorContains(t, err, "--version does not apply")
+}
+
+// An explicit path that does not exist is a typo, not a repository reference. It
+// must say so, rather than the misleading "must be <repo>/<chart>".
+func TestChartSourceMissingLocalPath(t *testing.T) {
+	_, err := NewChartSource(nil).Load("./nope/not-here", "")
+	require.ErrorContains(t, err, "chart path")
+	require.ErrorContains(t, err, "not found")
+	require.NotContains(t, err.Error(), "<repo>/<chart>")
+}
+
+func TestChartSourceNoRepositoriesConfigured(t *testing.T) {
+	_, err := NewChartSource(nil).Load("eldara/demo", "0.1.0")
+	require.ErrorContains(t, err, "no repositories are configured")
+}
+
+func TestReleaseChartOf(t *testing.T) {
+	ch, err := LoadChartDir("testdata/demo")
+	require.NoError(t, err)
+	rc := ReleaseChartOf(ch)
+	require.Equal(t, ch.Metadata.Name, rc.Name)
+	require.Equal(t, ch.Metadata.Version, rc.Version)
+	require.Equal(t, ch.Metadata.AppVersion, rc.AppVersion)
+}

--- a/cli/apply.go
+++ b/cli/apply.go
@@ -1,0 +1,198 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package cli
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"swarmcli/charts"
+)
+
+// chartsApply converges the swarm to a declarative release manifest.
+func chartsApply(args []string) int {
+	pos, f, err := parseArgs(args)
+	if err != nil {
+		return usageErr(err.Error())
+	}
+	// apply's -f names the release manifest, not a values file: per-release values
+	// live inside the manifest. A bare positional works too.
+	paths := append(append([]string{}, f.values...), pos...)
+	if len(paths) != 1 {
+		return usageErr("charts apply -f <release-file>")
+	}
+	if err := rejectUnsupported(f); err != nil {
+		return usageErr(err.Error())
+	}
+
+	rf, err := charts.LoadReleaseFile(paths[0])
+	if err != nil {
+		return fail(err)
+	}
+
+	store, code := newStore()
+	if code >= 0 {
+		return code
+	}
+	if err := store.EnsureRepos(rf.Repositories); err != nil {
+		return fail(err)
+	}
+
+	e := charts.NewEngine()
+	plan, err := e.PlanApply(context.Background(), rf, charts.NewChartSource(store))
+	if err != nil {
+		return fail(err)
+	}
+
+	printPlan(plan, f.diff)
+
+	// --diff is a preview verb; it must never deploy.
+	if f.dryRun || f.diff {
+		outln("\ndry-run: nothing was deployed")
+		return 0
+	}
+
+	install, upgrade, _ := plan.Counts()
+	if install+upgrade == 0 {
+		reportUnmanaged(plan)
+		return 0
+	}
+
+	results, err := e.Apply(context.Background(), plan, charts.InstallOptions{
+		Wait:       f.wait,
+		Timeout:    f.timeout,
+		HistoryMax: f.historyMax,
+	})
+	// Report what did happen before surfacing the failure: a partial apply has
+	// still changed the swarm, and the operator needs to know how far it got.
+	for _, r := range results {
+		if r.Action == charts.ActionUnchanged {
+			continue
+		}
+		outf("%s %s (revision %d)\n", r.Name, r.Action, r.Revision)
+	}
+	if err != nil {
+		return fail(err)
+	}
+	reportUnmanaged(plan)
+	return 0
+}
+
+// rejectUnsupported fails on flags apply does not honour. The charts flag set is
+// global, so every subcommand parses every flag and silently ignores whatever it
+// does not read. For a command whose entire contract is "the file is the only
+// source of truth", quietly discarding --set or --version would be a correctness
+// bug, not a cosmetic one.
+func rejectUnsupported(f flags) error {
+	var bad []string
+	if len(f.sets) > 0 {
+		bad = append(bad, "--set")
+	}
+	if f.version != "" {
+		bad = append(bad, "--version")
+	}
+	if f.reuseValues {
+		bad = append(bad, "--reuse-values")
+	}
+	if f.install {
+		bad = append(bad, "--install")
+	}
+	if f.purge {
+		bad = append(bad, "--purge-volumes")
+	}
+	if f.requirements {
+		bad = append(bad, "--requirements")
+	}
+	if f.revision != 0 {
+		bad = append(bad, "--revision")
+	}
+	if len(bad) == 0 {
+		return nil
+	}
+	return fmt.Errorf("%s not supported by apply: the release file is the only source of truth "+
+		"(set chart versions and values there)", strings.Join(bad, ", "))
+}
+
+func printPlan(plan *charts.Plan, withDiff bool) {
+	var rows [][]string
+	for _, r := range plan.Releases {
+		from := r.FromVersion
+		if from == "" {
+			from = "-"
+		}
+		rows = append(rows, []string{r.Name, r.Ref, from, r.ToVersion, string(r.Action)})
+	}
+	table([]string{"RELEASE", "CHART", "FROM", "TO", "ACTION"}, rows)
+
+	if withDiff {
+		for _, r := range plan.Releases {
+			if r.Action == charts.ActionUnchanged {
+				continue
+			}
+			outf("\n--- %s (%s) ---\n", r.Name, r.Action)
+			out(lineDiff(r.CurrentManifest, r.Manifest))
+		}
+	}
+
+	install, upgrade, unchanged := plan.Counts()
+	outf("\n%d to install, %d to upgrade, %d unchanged\n", install, upgrade, unchanged)
+}
+
+// reportUnmanaged names releases on the swarm that the file does not describe.
+// apply never removes them: a release records nothing about which manifest
+// produced it, so there is no way to tell one owned by a second file, or one
+// installed by hand, from a genuinely obsolete one.
+func reportUnmanaged(plan *charts.Plan) {
+	if len(plan.Unmanaged) == 0 {
+		return
+	}
+	outf("\n%d release(s) exist on this swarm but are not in the release file:\n", len(plan.Unmanaged))
+	for _, n := range plan.Unmanaged {
+		outf("  %s\n", n)
+	}
+	out("apply does not remove them; uninstall explicitly if they are obsolete:\n")
+	for _, n := range plan.Unmanaged {
+		outf("  swarmcli charts uninstall %s\n", n)
+	}
+}
+
+// chartsOutdated compares every installed release against the newest chart
+// version its repositories offer. It is the human-facing complement to an
+// automated updater watching the release file.
+func chartsOutdated(args []string) int {
+	if _, _, err := parseArgs(args); err != nil {
+		return usageErr(err.Error())
+	}
+	store, code := newStore()
+	if code >= 0 {
+		return code
+	}
+	// A read-only informational command must degrade, not fail: report against the
+	// cached indexes when the network is unavailable.
+	if _, _, err := store.Update(""); err != nil {
+		errf("could not refresh repositories (%v); comparing against the cached indexes\n", err)
+	}
+	indexes, err := store.Indexes()
+	if err != nil {
+		return fail(err)
+	}
+	rels, err := charts.NewEngine().List(context.Background())
+	if err != nil {
+		return fail(err)
+	}
+
+	entries := charts.Outdated(rels, indexes)
+	if len(entries) == 0 {
+		outln("All releases are up to date.")
+		return 0
+	}
+	var rows [][]string
+	for _, e := range entries {
+		rows = append(rows, []string{e.Release, e.Chart, e.Repo, e.Installed, e.Latest})
+	}
+	table([]string{"RELEASE", "CHART", "REPO", "INSTALLED", "LATEST"}, rows)
+	outf("\n%d of %d release(s) outdated.\n", len(entries), len(rels))
+	return 0
+}

--- a/cli/args.go
+++ b/cli/args.go
@@ -23,6 +23,7 @@ type flags struct {
 	purge        bool          // --purge-volumes
 	install      bool          // --install (upgrade)
 	reuseValues  bool          // --reuse-values (upgrade)
+	diff         bool          // --diff (apply): show each changed release's manifest diff
 	revision     int           // --revision (get)
 	timeout      time.Duration // --timeout
 	historyMax   int           // --history-max
@@ -109,6 +110,8 @@ func parseArgs(args []string) ([]string, flags, error) {
 			f.revision = n
 		case "--reuse-values":
 			f.reuseValues = true
+		case "--diff":
+			f.diff = true
 		case "--dry-run":
 			f.dryRun = true
 		case "--wait":

--- a/cli/charts.go
+++ b/cli/charts.go
@@ -66,9 +66,10 @@ install pre-flights them (auto-creating networks marked autoCreate, validating
 the rest) and uninstall reports any auto-created networks it leaves in place.
 
 Common options:
-  -f, --values <file>   Values file (repeatable)
+  -f, --values <file>   Values file (repeatable). For apply: the release file.
       --set k=v         Override a value (repeatable)
-      --version <ver>   Chart version (default: latest)
+      --version <ver>   Chart version, for a <repo>/<chart> reference (default: latest).
+                        Not valid with a local chart path — its Chart.yaml sets the version.
       --dry-run         Render and validate without deploying
       --requirements    template: emit rendered requirements.yaml, not the manifest
       --wait            Wait for services to converge
@@ -79,6 +80,12 @@ Common options:
       --revision <n>    get: select a specific revision
       --purge-volumes   uninstall: also remove the release's volumes
       --diff            apply: show each changed release's manifest diff (implies --dry-run)
+
+apply honours --wait, --timeout and --history-max. It REJECTS --set, --version,
+--reuse-values, --install, --purge-volumes, --requirements and --revision rather
+than ignoring them: the release file is the only source of truth, so a value passed
+on the command line would be a lie. outdated refreshes the repository indexes first
+and falls back to the cached ones if the network is unavailable.
 `
 
 // chartsMain dispatches `swarmcli charts ...`.

--- a/cli/charts.go
+++ b/cli/charts.go
@@ -42,6 +42,25 @@ Releases:
   list                        List releases
   status <release>            Show release status and services
 
+GitOps:
+  apply -f <file>             Converge the swarm to a declarative release file
+  outdated                    Show releases with a newer chart version available
+
+A release file pins each release to a chart version, so it is reproducible and an
+automated updater (e.g. Renovate) has something concrete to bump. apply installs
+what is missing, upgrades what changed, and skips what already matches. It never
+removes a release the file does not mention — it reports those instead.
+
+  # swarmcli-release.yaml
+  repositories:
+    - name: swarmcli-charts
+      url: https://eldara-tech.github.io/swarmcli-charts
+  releases:
+    - name: edge
+      chart: swarmcli-charts/traefik
+      version: "0.1.1"
+      values: [./traefik.yaml]     # relative to the release file, not the CWD
+
 A chart may declare its external networks/secrets/configs in requirements.yaml:
 install pre-flights them (auto-creating networks marked autoCreate, validating
 the rest) and uninstall reports any auto-created networks it leaves in place.
@@ -59,6 +78,7 @@ Common options:
       --reuse-values    upgrade/diff: layer overrides on previous values
       --revision <n>    get: select a specific revision
       --purge-volumes   uninstall: also remove the release's volumes
+      --diff            apply: show each changed release's manifest diff (implies --dry-run)
 `
 
 // chartsMain dispatches `swarmcli charts ...`.
@@ -100,6 +120,10 @@ func chartsMain(args []string) int {
 		return chartsList(rest)
 	case "status":
 		return chartsStatus(rest)
+	case "apply":
+		return chartsApply(rest)
+	case "outdated":
+		return chartsOutdated(rest)
 	default:
 		return usageErr(fmt.Sprintf("unknown charts command %q\n\n%s", sub, chartsUsage))
 	}
@@ -669,49 +693,18 @@ func chartsStatus(args []string) int {
 
 // loadChart resolves a chart reference: an existing local directory or .tgz
 // path, otherwise a "repo/chart" reference pulled from a configured repository.
+// The resolution itself lives in charts.ChartSource, so apply and the imperative
+// commands cannot drift apart.
 func loadChart(ref, version string) (*charts.Chart, charts.ReleaseChart, int) {
-	if info, err := os.Stat(ref); err == nil {
-		var (
-			ch   *charts.Chart
-			lerr error
-		)
-		if info.IsDir() {
-			ch, lerr = charts.LoadChartDir(ref)
-		} else {
-			ch, lerr = loadArchivePath(ref)
-		}
-		if lerr != nil {
-			return nil, charts.ReleaseChart{}, fail(lerr)
-		}
-		return ch, releaseChartOf(ch), -1
+	store, code := newStore()
+	if code >= 0 {
+		return nil, charts.ReleaseChart{}, code
 	}
-
-	store, err := charts.NewRepoStore()
+	ch, err := charts.NewChartSource(store).Load(ref, version)
 	if err != nil {
 		return nil, charts.ReleaseChart{}, fail(err)
 	}
-	entry, base, err := store.Resolve(ref, version)
-	if err != nil {
-		return nil, charts.ReleaseChart{}, fail(err)
-	}
-	ch, err := store.Pull(entry, base)
-	if err != nil {
-		return nil, charts.ReleaseChart{}, fail(err)
-	}
-	return ch, releaseChartOf(ch), -1
-}
-
-func loadArchivePath(path string) (*charts.Chart, error) {
-	fh, err := os.Open(path)
-	if err != nil {
-		return nil, err
-	}
-	defer func() { _ = fh.Close() }()
-	return charts.LoadChartArchive(fh)
-}
-
-func releaseChartOf(ch *charts.Chart) charts.ReleaseChart {
-	return charts.ReleaseChart{Name: ch.Metadata.Name, Version: ch.Metadata.Version, AppVersion: ch.Metadata.AppVersion}
+	return ch, charts.ReleaseChartOf(ch), -1
 }
 
 func readValuesFiles(paths []string) ([][]byte, error) {

--- a/cli/charts_test.go
+++ b/cli/charts_test.go
@@ -143,3 +143,58 @@ func TestParseIntRejectsGarbage(t *testing.T) {
 		require.Errorf(t, err, "expected %q to be rejected", bad)
 	}
 }
+
+// --- apply (Docker-free paths only; the engine is covered in charts/) ---
+
+func TestChartsApplyRequiresExactlyOneFile(t *testing.T) {
+	var code int
+	capture(t, func() { code = chartsApply(nil) })
+	require.Equal(t, 2, code, "no release file")
+
+	capture(t, func() { code = chartsApply([]string{"-f", "a.yaml", "-f", "b.yaml"}) })
+	require.Equal(t, 2, code, "two release files")
+}
+
+func TestChartsApplyMissingFile(t *testing.T) {
+	var code int
+	_, e := capture(t, func() { code = chartsApply([]string{"-f", filepath.Join(t.TempDir(), "nope.yaml")}) })
+	require.Equal(t, 1, code)
+	require.Contains(t, e, "nope.yaml")
+}
+
+// A typo in a file an automated updater rewrites must fail loudly and name the key.
+//
+//nolint:misspell // "verison" is a deliberate typo — it is what the test rejects.
+func TestChartsApplyRejectsUnknownKey(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "rel.yaml")
+	require.NoError(t, os.WriteFile(path, []byte("releases:\n  - name: a\n    chart: r/c\n    verison: \"1\"\n"), 0o600))
+
+	var code int
+	_, e := capture(t, func() { code = chartsApply([]string{"-f", path}) })
+	require.Equal(t, 1, code)
+	require.Contains(t, e, "verison")
+}
+
+// The charts flag set is global, so every subcommand parses every flag. apply must
+// REJECT the ones it does not honour rather than silently ignoring them: its whole
+// contract is that the file is the only source of truth.
+func TestChartsApplyRejectsUnsupportedFlags(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "rel.yaml")
+	require.NoError(t, os.WriteFile(path, []byte("releases:\n  - {name: a, chart: r/c, version: \"1\"}\n"), 0o600))
+
+	for _, flag := range [][]string{
+		{"--set", "a=1"},
+		{"--version", "1.0.0"},
+		{"--reuse-values"},
+		{"--install"},
+		{"--purge-volumes"},
+	} {
+		t.Run(flag[0], func(t *testing.T) {
+			var code int
+			_, e := capture(t, func() { code = chartsApply(append([]string{"-f", path}, flag...)) })
+			require.Equal(t, 2, code)
+			require.Contains(t, e, flag[0])
+			require.Contains(t, e, "only source of truth")
+		})
+	}
+}

--- a/cli/charts_test.go
+++ b/cli/charts_test.go
@@ -11,6 +11,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"swarmcli/charts"
 )
 
 // capture redirects stdout/stderr to separate buffers for the duration of fn
@@ -197,4 +199,53 @@ func TestChartsApplyRejectsUnsupportedFlags(t *testing.T) {
 			require.Contains(t, e, "only source of truth")
 		})
 	}
+}
+
+func TestPrintPlan(t *testing.T) {
+	plan := &charts.Plan{Releases: []charts.ReleasePlan{
+		{Name: "hello", Ref: "r/whoami", Action: charts.ActionInstall, ToVersion: "0.1.8"},
+		{Name: "edge", Ref: "r/traefik", Action: charts.ActionUpgrade, FromVersion: "0.1.0", ToVersion: "0.1.1"},
+		{Name: "cache", Ref: "r/redis", Action: charts.ActionUnchanged, FromVersion: "0.1.1", ToVersion: "0.1.1"},
+	}}
+	o, _ := capture(t, func() { printPlan(plan, false) })
+
+	require.Contains(t, o, "RELEASE")
+	require.Contains(t, o, "hello")
+	require.Contains(t, o, "install")
+	require.Contains(t, o, "upgrade")
+	require.Contains(t, o, "unchanged")
+	// An install has no prior version; it must render as "-", not empty.
+	require.Regexp(t, `hello\s+r/whoami\s+-\s+0\.1\.8\s+install`, o)
+	require.Contains(t, o, "1 to install, 1 to upgrade, 1 unchanged")
+}
+
+// --diff shows a manifest diff for changed releases and skips unchanged ones.
+func TestPrintPlanWithDiff(t *testing.T) {
+	plan := &charts.Plan{Releases: []charts.ReleasePlan{
+		{
+			Name: "edge", Ref: "r/traefik", Action: charts.ActionUpgrade,
+			FromVersion: "0.1.0", ToVersion: "0.1.1",
+			CurrentManifest: "services:\n  a: 1\n", Manifest: "services:\n  a: 2\n",
+		},
+		{Name: "cache", Ref: "r/redis", Action: charts.ActionUnchanged, ToVersion: "0.1.1"},
+	}}
+	o, _ := capture(t, func() { printPlan(plan, true) })
+
+	require.Contains(t, o, "--- edge (upgrade) ---")
+	require.NotContains(t, o, "--- cache", "an unchanged release has nothing to diff")
+}
+
+// apply never deletes; it reports what it left alone, with the command to remove it.
+func TestReportUnmanaged(t *testing.T) {
+	o, _ := capture(t, func() {
+		reportUnmanaged(&charts.Plan{Unmanaged: []string{"legacy", "scratch"}})
+	})
+	require.Contains(t, o, "2 release(s) exist on this swarm but are not in the release file")
+	require.Contains(t, o, "swarmcli charts uninstall legacy")
+	require.Contains(t, o, "swarmcli charts uninstall scratch")
+
+	// Nothing unmanaged must print nothing at all — not a stray header on every
+	// clean apply.
+	o, _ = capture(t, func() { reportUnmanaged(&charts.Plan{}) })
+	require.Empty(t, o)
 }

--- a/integration-tests/charts/charts_apply_test.go
+++ b/integration-tests/charts/charts_apply_test.go
@@ -6,16 +6,23 @@
 package charts
 
 import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
 	"context"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
 
 	"swarmcli/charts"
+	"swarmcli/cli"
 	swarmlog "swarmcli/utils/log"
 )
 
@@ -144,4 +151,177 @@ func TestChartsApplyLeavesUnmanagedReleasesRunning(t *testing.T) {
 	cur, _, err := eng.Status(ctx, byHand)
 	require.NoError(t, err)
 	require.Equal(t, charts.StatusDeployed, cur.Status, "apply must not touch an unmanaged release")
+}
+
+// --diff (and --dry-run) are preview verbs: if either ever deployed, that would be
+// a production incident. This drives the real CLI against the real swarm, because
+// with no Docker daemon a unit test fails at the ping long before reaching the
+// short-circuit — and would pass for entirely the wrong reason.
+func TestChartsApplyDiffDoesNotDeploy(t *testing.T) {
+	swarmlog.InitTestIfTestLogEnv()
+
+	ctx := context.Background()
+	release := fmt.Sprintf("itest-diff-%d", time.Now().UnixNano())
+
+	chartDir := writeDemoChart(t)
+	dir := t.TempDir()
+	relFile := filepath.Join(dir, "swarmcli-release.yaml")
+	require.NoError(t, os.WriteFile(relFile, []byte(fmt.Sprintf(
+		"releases:\n  - name: %s\n    chart: %s\n", release, chartDir)), 0o600))
+
+	eng := charts.NewEngine()
+	defer func() { _, _ = eng.Uninstall(ctx, release, true) }()
+
+	for _, flag := range []string{"--diff", "--dry-run"} {
+		t.Run(flag, func(t *testing.T) {
+			code := cli.Dispatch([]string{"charts", "apply", "-f", relFile, flag}, "test")
+			require.Equal(t, 0, code)
+
+			// Nothing may have been deployed and no revision recorded.
+			list, err := eng.List(ctx)
+			require.NoError(t, err)
+			for _, r := range list {
+				require.NotEqual(t, release, r.Name, "%s must not deploy", flag)
+			}
+			_, err = eng.History(ctx, release)
+			require.Error(t, err, "%s must not record a revision", flag)
+		})
+	}
+
+	// The same file, applied for real, does deploy — so the guard above is not
+	// simply testing a broken path.
+	rf, err := charts.LoadReleaseFile(relFile)
+	require.NoError(t, err)
+	plan, err := eng.PlanApply(ctx, rf, charts.NewChartSource(nil))
+	require.NoError(t, err)
+	_, err = eng.Apply(ctx, plan, charts.InstallOptions{Wait: true, Timeout: 90 * time.Second})
+	require.NoError(t, err)
+
+	hist, err := eng.History(ctx, release)
+	require.NoError(t, err)
+	require.Len(t, hist, 1)
+}
+
+// The repository path, end to end on a real swarm: a release file with a
+// `repositories:` block -> EnsureRepos -> Resolve -> Pull -> render -> apply, then
+// `charts outdated` against a newer published version.
+//
+// This is the flow a downstream user actually runs, and it was covered by nothing:
+// the unit tests use a fake chart source that never touches RepoStore, and the
+// other integration cases pass a nil store with a local chart directory.
+func TestChartsApplyFromARepositoryAndOutdated(t *testing.T) {
+	swarmlog.InitTestIfTestLogEnv()
+
+	ctx := context.Background()
+	release := fmt.Sprintf("itest-repo-%d", time.Now().UnixNano())
+
+	tgz := packChartToTgz(t, writeDemoChart(t))
+	// Start with only 0.1.0 published.
+	published := []string{"0.1.0"}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/index.yaml") {
+			var b strings.Builder
+			b.WriteString("apiVersion: v1\nentries:\n  itest:\n")
+			for _, v := range published {
+				b.WriteString("    - name: itest\n      version: " + v + "\n      urls: [\"itest-" + v + ".tgz\"]\n")
+			}
+			_, _ = w.Write([]byte(b.String()))
+			return
+		}
+		if strings.HasSuffix(r.URL.Path, ".tgz") {
+			_, _ = w.Write(tgz)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	// Keep the repo store out of the developer's real XDG state dir.
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+
+	dir := t.TempDir()
+	relFile := filepath.Join(dir, "swarmcli-release.yaml")
+	require.NoError(t, os.WriteFile(relFile, []byte(fmt.Sprintf(
+		"repositories:\n  - name: itest-repo\n    url: %s\n"+
+			"releases:\n  - name: %s\n    chart: itest-repo/itest\n    version: \"0.1.0\"\n",
+		srv.URL, release)), 0o600))
+
+	eng := charts.NewEngine()
+	defer func() { _, _ = eng.Uninstall(ctx, release, true) }()
+
+	// apply adds the repository itself — `apply -f` is the only command a CI job
+	// should need to run.
+	require.Equal(t, 0, cli.Dispatch([]string{"charts", "apply", "-f", relFile, "--wait"}, "test"))
+
+	cur, _, err := eng.Status(ctx, release)
+	require.NoError(t, err)
+	require.Equal(t, charts.StatusDeployed, cur.Status)
+	require.Equal(t, "0.1.0", cur.Chart.Version, "the PINNED version must be installed")
+
+	// Nothing newer is published yet.
+	require.Equal(t, 0, cli.Dispatch([]string{"charts", "outdated"}, "test"))
+
+	// Publish 0.2.0; `outdated` must now see it, without the file changing.
+	published = append(published, "0.2.0")
+	require.Equal(t, 0, cli.Dispatch([]string{"charts", "outdated"}, "test"))
+
+	rels, err := eng.List(ctx)
+	require.NoError(t, err)
+	idxs, err := repoIndexes(t)
+	require.NoError(t, err)
+	entries := charts.Outdated(rels, idxs)
+
+	var found bool
+	for _, e := range entries {
+		if e.Release == release {
+			found = true
+			require.Equal(t, "0.1.0", e.Installed)
+			require.Equal(t, "0.2.0", e.Latest)
+			require.Equal(t, "itest-repo", e.Repo)
+		}
+	}
+	require.True(t, found, "outdated must report the release once a newer chart is published")
+}
+
+// repoIndexes reads the indexes `charts outdated` would compare against.
+func repoIndexes(t *testing.T) (map[string]*charts.Index, error) {
+	t.Helper()
+	store, err := charts.NewRepoStore()
+	require.NoError(t, err)
+	_, _, _ = store.Update("")
+	return store.Indexes()
+}
+
+// packChartToTgz packs a chart directory into a .tgz the repo store can pull.
+func packChartToTgz(t *testing.T, dir string) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+
+	require.NoError(t, filepath.Walk(dir, func(path string, fi os.FileInfo, err error) error {
+		if err != nil || fi.IsDir() {
+			return err
+		}
+		rel, err := filepath.Rel(dir, path)
+		if err != nil {
+			return err
+		}
+		body, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		if err := tw.WriteHeader(&tar.Header{
+			Name: filepath.ToSlash(filepath.Join("itest", rel)),
+			Mode: 0o644,
+			Size: int64(len(body)),
+		}); err != nil {
+			return err
+		}
+		_, err = tw.Write(body)
+		return err
+	}))
+	require.NoError(t, tw.Close())
+	require.NoError(t, gz.Close())
+	return buf.Bytes()
 }

--- a/integration-tests/charts/charts_apply_test.go
+++ b/integration-tests/charts/charts_apply_test.go
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+//go:build integration
+
+package charts
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"swarmcli/charts"
+	swarmlog "swarmcli/utils/log"
+)
+
+// TestChartsApplyIsIdempotentAgainstARealSwarm is the one thing the unit tests
+// cannot prove. Release history is one Docker Config per revision, so an apply
+// that recorded a revision even when nothing changed would grow the swarm's
+// config store on every CI run, forever. The fake backend can only simulate that;
+// this counts the real Configs on a real swarm before and after a second apply.
+func TestChartsApplyIsIdempotentAgainstARealSwarm(t *testing.T) {
+	swarmlog.InitTestIfTestLogEnv()
+
+	ctx := context.Background()
+	release := fmt.Sprintf("itest-apply-%d", time.Now().UnixNano())
+
+	chartDir := writeDemoChart(t)
+	dir := t.TempDir()
+	relFile := filepath.Join(dir, "swarmcli-release.yaml")
+	require.NoError(t, os.WriteFile(relFile, []byte(fmt.Sprintf(
+		"releases:\n  - name: %s\n    chart: %s\n", release, chartDir)), 0o600))
+
+	rf, err := charts.LoadReleaseFile(relFile)
+	require.NoError(t, err)
+
+	eng := charts.NewEngine()
+	src := charts.NewChartSource(nil) // local chart path: no repository needed
+	defer func() { _, _ = eng.Uninstall(ctx, release, true) }()
+
+	opts := charts.InstallOptions{Wait: true, Timeout: 90 * time.Second}
+
+	// First apply installs.
+	plan, err := eng.PlanApply(ctx, rf, src)
+	require.NoError(t, err)
+	require.Len(t, plan.Releases, 1)
+	require.Equal(t, charts.ActionInstall, plan.Releases[0].Action)
+
+	res, err := eng.Apply(ctx, plan, opts)
+	require.NoError(t, err)
+	require.Equal(t, 1, res[0].Revision)
+
+	hist, err := eng.History(ctx, release)
+	require.NoError(t, err)
+	require.Len(t, hist, 1)
+
+	// Second apply, nothing changed: it must plan `unchanged`, deploy nothing, and
+	// record NO new revision.
+	plan2, err := eng.PlanApply(ctx, rf, src)
+	require.NoError(t, err)
+	require.Equal(t, charts.ActionUnchanged, plan2.Releases[0].Action)
+
+	res2, err := eng.Apply(ctx, plan2, opts)
+	require.NoError(t, err)
+	require.Equal(t, charts.ActionUnchanged, res2[0].Action)
+	require.Zero(t, res2[0].Revision)
+
+	hist2, err := eng.History(ctx, release)
+	require.NoError(t, err)
+	require.Len(t, hist2, 1, "a no-op apply must not record a revision on a real swarm")
+
+	// A changed value is a real upgrade, so the mechanism is not simply inert.
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "v.yaml"), []byte("replicas: 2\n"), 0o600))
+	require.NoError(t, os.WriteFile(relFile, []byte(fmt.Sprintf(
+		"releases:\n  - name: %s\n    chart: %s\n    values: [./v.yaml]\n", release, chartDir)), 0o600))
+
+	rf2, err := charts.LoadReleaseFile(relFile)
+	require.NoError(t, err)
+	plan3, err := eng.PlanApply(ctx, rf2, src)
+	require.NoError(t, err)
+	require.Equal(t, charts.ActionUpgrade, plan3.Releases[0].Action)
+
+	res3, err := eng.Apply(ctx, plan3, opts)
+	require.NoError(t, err)
+	require.Equal(t, 2, res3[0].Revision)
+
+	hist3, err := eng.History(ctx, release)
+	require.NoError(t, err)
+	require.Len(t, hist3, 2)
+}
+
+// apply never removes a release the file does not describe: a release records
+// nothing about which manifest produced it, so a prune could not distinguish one
+// owned by a second file, or installed by hand, from a genuinely obsolete one.
+func TestChartsApplyLeavesUnmanagedReleasesRunning(t *testing.T) {
+	swarmlog.InitTestIfTestLogEnv()
+
+	ctx := context.Background()
+	managed := fmt.Sprintf("itest-managed-%d", time.Now().UnixNano())
+	byHand := fmt.Sprintf("itest-byhand-%d", time.Now().UnixNano())
+
+	chartDir := writeDemoChart(t)
+	eng := charts.NewEngine()
+	src := charts.NewChartSource(nil)
+	opts := charts.InstallOptions{Wait: true, Timeout: 90 * time.Second}
+
+	defer func() {
+		_, _ = eng.Uninstall(ctx, managed, true)
+		_, _ = eng.Uninstall(ctx, byHand, true)
+	}()
+
+	// A release installed outside the file.
+	ch, err := charts.LoadChartDir(chartDir)
+	require.NoError(t, err)
+	manifest, err := charts.Render(ch, charts.RenderContext{
+		Values:  ch.Values,
+		Release: charts.ReleaseMeta{Name: byHand, Namespace: byHand, Revision: 1},
+		Chart:   charts.ChartMeta{Name: ch.Metadata.Name, Version: ch.Metadata.Version},
+	})
+	require.NoError(t, err)
+	_, err = eng.Install(ctx, byHand, charts.ReleaseChartOf(ch), ch.Values, manifest, opts)
+	require.NoError(t, err)
+
+	dir := t.TempDir()
+	relFile := filepath.Join(dir, "swarmcli-release.yaml")
+	require.NoError(t, os.WriteFile(relFile, []byte(fmt.Sprintf(
+		"releases:\n  - name: %s\n    chart: %s\n", managed, chartDir)), 0o600))
+	rf, err := charts.LoadReleaseFile(relFile)
+	require.NoError(t, err)
+
+	plan, err := eng.PlanApply(ctx, rf, src)
+	require.NoError(t, err)
+	require.Contains(t, plan.Unmanaged, byHand, "the hand-installed release must be reported")
+
+	_, err = eng.Apply(ctx, plan, opts)
+	require.NoError(t, err)
+
+	// It is still there.
+	cur, _, err := eng.Status(ctx, byHand)
+	require.NoError(t, err)
+	require.Equal(t, charts.StatusDeployed, cur.Status, "apply must not touch an unmanaged release")
+}


### PR DESCRIPTION
Closes the gap that blocked downstream users from automating chart updates.

## Why

`charts install`/`upgrade` are **imperative** — two positionals and flags — and release state lives in gzipped Docker Configs inside the swarm. So **nothing in git says what should be running**, and a downstream user wanting an automated updater had nothing for it to edit. That, not any limitation of Renovate, was the blocker.

(`charts/README.md` already claimed charts were "scriptable for CI/CD and GitOps". This is what makes that true.)

## What

```yaml
# swarmcli-release.yaml
repositories:
  - name: swarmcli-charts
    url: https://eldara-tech.github.io/swarmcli-charts
releases:
  - name: edge
    chart: swarmcli-charts/traefik
    version: "0.1.1"          # an updater bumps this
    values: [./traefik.yaml]  # relative to the FILE, not the CWD
```

```bash
swarmcli charts apply -f swarmcli-release.yaml --dry-run   # plan table
swarmcli charts apply -f swarmcli-release.yaml --diff      # + manifest diffs
swarmcli charts apply -f swarmcli-release.yaml             # converge
swarmcli charts outdated                                   # what has a newer chart?
```

**The key names deliberately mirror Helmfile’s.** Renovate ships a `helmfile` manager that reads exactly `repositories[].{name,url}` and `releases[].{name,chart,version}`, so pointing it at this file needs **one line of config and no hand-written regex** — nothing for us to own and no `matchString` to rot. I read its zod schema first to confirm it is non-strict, so our extra `apiVersion:`/`values:` keys are ignored rather than fatal. The obvious hazard of borrowing another tool’s vocabulary is contained by rejecting unknown keys: pasting real Helmfile syntax fails loudly and names the key.

## Semantics, and why each one

| Decision | Reason |
|---|---|
| **Never deletes** | A release records nothing about *which* file produced it, so a prune could not tell one owned by a second manifest, or installed by hand, from a genuinely obsolete one. Unmanaged releases are reported with the exact `uninstall` command. |
| **Skips unchanged releases entirely** | Not an optimisation — a *requirement*. History is one Docker Config per revision, so an apply that recorded a revision when nothing changed would grow the swarm’s config store **on every CI run, forever**. |
| **Values compared via a YAML round-trip, not `reflect.DeepEqual`** | Stored values come back through YAML, so a value merged as `float64(1.0)` may decode as `int(1)`. `DeepEqual` would call those different and churn a revision *every single run*. |
| **Plans everything before deploying anything** | A bad value in the third release aborts the apply instead of leaving the swarm half-converged — and `--dry-run` is just “stop after planning”. |
| **`version` required for repo charts, forbidden for local paths** | A floating pin would silently upgrade production. The local-path rule surfaces the pre-existing “`--version` silently ignored on a local path” bug as an explicit error. |
| **Applies via `Upgrade` with `Install` set** | A release that appears between planning and applying upgrades cleanly instead of colliding with “already exists”. |
| **`apply` REJECTS `--set`/`--version`/`--reuse-values`/…** | The charts flag set is global: every subcommand parses every flag and silently drops what it does not read. For a command whose contract is “the file is the only source of truth”, that would be a correctness bug. |

Sequential, file order, fail-fast. **No `needs:`** — the real coupling between stacks is the external network, which `requirements.yaml` + `ensureExternalNetworks` already handle, and Swarm converges eventually. File order plus `--wait` is a dependency system that costs zero code.

`charts outdated` joins installed releases against the newest version in each repository index. Nothing compared the two before.

Chart resolution moves into `charts.ChartSource` — the seam that lets planning be tested without Docker, a network or a filesystem. `cli/loadChart` collapses onto it, so `apply` and the imperative commands cannot drift apart, and **`cli/` gets smaller**.

## Verification — against the live chart repo, not just fakes

A scratch downstream repo with this file and **one line** of Renovate config:

```
manager=helmfile  traefik  0.1.0 -> 0.1.1   registry=https://eldara-tech.github.io/swarmcli-charts
manager=helmfile  whoami   0.1.6 -> 0.1.8
manager=helmfile  redis    0.1.0 -> 0.1.1
sourceUrl derived: https://github.com/Eldara-Tech/swarmcli-charts   # changelogs resolve
branches: renovate/traefik-0.x, renovate/whoami-0.x, renovate/redis-0.x
```

**The no-churn guarantee is mutation-tested.** Breaking `unchanged()` to always report “changed” makes `TestApplyInstallsThenIsIdempotent` fail; swapping the YAML canonicalisation for `reflect.DeepEqual` makes `TestSameValuesIgnoresYAMLTypeSkew` fail with *"int(1) and float64(1.0) must not look like a change"*. The tests are load-bearing, not decorative.

There is also an **integration test that counts real Docker Configs on a real swarm** across a re-apply — the one property a fake backend can only simulate.

Docker-free paths driven against the real binary:

```
$ swarmcli charts apply -f rel.yaml --set foo=bar
Error: --set not supported by apply: the release file is the only source of truth  (exit 2)

$ swarmcli charts apply -f floating.yaml
Error: releases[0] (hello): version is required — a release manifest must be reproducible;
       run `swarmcli charts search whoami` and pin one  (exit 1)

$ swarmcli charts apply -f typo.yaml
Error: line 4: field verison not found in type charts.ReleaseSpec  (exit 1)
```

`go test ./...`, `go vet`, `gofmt`, and `golangci-lint --build-tags=integration` all clean.

## Note on merge order

Touches `charts/repo.go` alongside #447 (chart digest verification), which adds the same `RepoStore.Warnf` seam. Independent changes; if #447 lands first this rebases with a trivial conflict.

The companion downstream preset and index changes are in Eldara-Tech/swarmcli-charts#76.

🤖 Generated with [Claude Code](https://claude.com/claude-code)