### PR TITLE
feat(views): add Chromeless opt-in seam for full-terminal views

### DIFF
--- a/app/chromeless_test.go
+++ b/app/chromeless_test.go
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package app
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/stretchr/testify/require"
+)
+
+// A chromeless view is rendered verbatim: no help bar, no frame, no breadcrumbs.
+func TestChromelessView_RenderedVerbatim(t *testing.T) {
+	m := newTestAppModel(&chromelessStubView{})
+
+	out := m.View()
+
+	require.Equal(t, "CHROMELESS", out)
+	require.NotContains(t, out, "│")
+}
+
+// A chromeless view gets the raw terminal size, while m.viewport stays
+// chrome-sized so views further down the stack are restored correctly.
+func TestChromelessView_GetsFullTerminalSize(t *testing.T) {
+	cv := &chromelessStubView{}
+	m := newTestAppModel(cv)
+
+	m.updateForResize(tea.WindowSizeMsg{Width: 100, Height: 40})
+
+	require.Equal(t, []tea.WindowSizeMsg{{Width: 100, Height: 40}}, cv.receivedSizes)
+	require.Equal(t, 96, m.viewport.Width)
+	require.Equal(t, 40, m.viewport.Height)
+}
+
+// A framed view still gets the chrome-reduced size (help bar + breadcrumb bar).
+func TestFramedView_GetsChromeReducedSize(t *testing.T) {
+	m := newTestAppModel(&stubView{name: "framed"})
+
+	m.updateForResize(tea.WindowSizeMsg{Width: 100, Height: 40})
+
+	require.Equal(t, 96, m.viewport.Width)
+	require.Equal(t, 40, m.viewport.Height)
+}
+
+// ":" must not open the command bar over a chromeless view — it has nowhere to
+// render, and an invisible command bar swallows every subsequent key.
+func TestChromelessView_ColonDoesNotOpenCommandInput(t *testing.T) {
+	cv := &chromelessStubView{}
+	m := newTestAppModel(cv)
+
+	m.Update(runeKey(':'))
+
+	require.False(t, m.commandInput.Visible())
+	require.Len(t, cv.receivedKeys, 1)
+	require.Equal(t, ":", cv.receivedKeys[0].String())
+}
+
+// "/" must not open the search bar over a chromeless view either.
+func TestChromelessView_SlashDoesNotOpenSearchInput(t *testing.T) {
+	cv := &chromelessStubView{}
+	m := newTestAppModel(cv)
+
+	m.Update(runeKey('/'))
+
+	require.False(t, m.searchInput.Visible())
+	require.Len(t, cv.receivedKeys, 1)
+	require.Equal(t, "/", cv.receivedKeys[0].String())
+}
+
+// "f" is not a fullscreen toggle over a chromeless view — it is already
+// borderless, so the key belongs to the view.
+func TestChromelessView_FDoesNotToggleFullscreen(t *testing.T) {
+	cv := &chromelessStubView{}
+	m := newTestAppModel(cv)
+
+	m.Update(runeKey('f'))
+
+	require.False(t, m.fullscreen)
+	require.Len(t, cv.receivedKeys, 1)
+	require.Equal(t, "f", cv.receivedKeys[0].String())
+}
+
+// Entering a chromeless view while the app happens to be in fullscreen must not
+// cost the user a second Esc: the first Esc goes back, it does not silently
+// clear the (invisible) fullscreen flag.
+func TestChromelessView_EscGoesBackEvenWhenFullscreen(t *testing.T) {
+	cv := &chromelessStubView{}
+	m := newTestAppModel(cv)
+	m.fullscreen = true
+	m.viewStack.Push(&stubView{name: "services"})
+
+	m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+
+	require.Equal(t, "services", m.currentView.Name())
+}

--- a/app/model.go
+++ b/app/model.go
@@ -137,11 +137,14 @@ func (m *Model) switchToView(name string, data any) tea.Cmd {
 	exitCmd := m.currentView.OnExit()
 
 	newView, loadCmd := factory(m.deps, m.viewport.Width, m.viewport.Height, data)
-	resizeCmd := handleViewResize(newView, m.viewport.Width, m.viewport.Height, false)
 
 	// Push current view onto stack
 	m.viewStack.Push(m.currentView)
 	m.currentView = newView
+
+	// Size the view for the chrome it will actually be rendered with. Delivered
+	// synchronously, so the view is correctly sized before loadCmd runs.
+	resizeCmd := m.resizeView(newView)
 
 	// Enter hook for new view
 	enterCmd := newView.OnEnter()
@@ -159,10 +162,11 @@ func (m *Model) replaceView(name string, data any) tea.Cmd {
 	exitCmd := m.currentView.OnExit()
 
 	newView, loadCmd := factory(m.deps, m.viewport.Width, m.viewport.Height, data)
-	resizeCmd := handleViewResize(newView, m.viewport.Width, m.viewport.Height, false)
 
 	m.currentView = newView
 	m.viewStack.Reset()
+
+	resizeCmd := m.resizeView(newView)
 
 	// Run enter hook on new view
 	enterCmd := newView.OnEnter()

--- a/app/update.go
+++ b/app/update.go
@@ -149,6 +149,13 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m.handleKey(msg)
 		}
 
+		// A chromeless view leaves no room for the ":" command bar or the "/"
+		// search bar, and an unrendered command bar would silently swallow every
+		// subsequent key. Skip straight to the key handler.
+		if view.IsChromeless(m.currentView) {
+			return m.handleKey(msg)
+		}
+
 		if msg.String() == ":" {
 			// If current view is capturing input, don't intercept
 			if viewWithDialog, ok := m.currentView.(interface {
@@ -410,8 +417,6 @@ func (m *Model) delegateToCurrentView(msg tea.Msg) tea.Cmd {
 }
 
 func (m *Model) updateForResize(msg tea.WindowSizeMsg) tea.Cmd {
-	var cmd tea.Cmd
-
 	// Store terminal dimensions
 	m.terminalWidth = msg.Width
 	m.terminalHeight = msg.Height
@@ -454,9 +459,21 @@ func (m *Model) updateForResize(msg tea.WindowSizeMsg) tea.Cmd {
 	// keep header fixed) and reserve 3 lines by reducing usableHeight above.
 	m.viewport.YPosition = systeminfoview.Height
 
-	cmd = handleViewResize(m.currentView, usableWidth, usableHeight, isFullscreen)
-	return cmd
+	return m.resizeCurrentView()
 }
+
+// resizeView hands v a WindowSizeMsg sized for the chrome it is actually
+// rendered with: a chromeless view gets the raw terminal, a framed view gets the
+// viewport minus help bar, frame and breadcrumb bar. m.viewport itself always
+// stays chrome-sized, so views further down the stack are restored correctly.
+func (m *Model) resizeView(v view.View) tea.Cmd {
+	if view.IsChromeless(v) {
+		return v.Update(tea.WindowSizeMsg{Width: m.terminalWidth, Height: m.terminalHeight})
+	}
+	return handleViewResize(v, m.viewport.Width, m.viewport.Height, m.fullscreen)
+}
+
+func (m *Model) resizeCurrentView() tea.Cmd { return m.resizeView(m.currentView) }
 
 func handleViewResize(view view.View, width, height int, isFullscreen bool) tea.Cmd {
 	var adjustedHeight int
@@ -511,8 +528,10 @@ func (m *Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	}
 	// Check if current view is in fullscreen or search mode before handling global esc
 	if msg.Type == tea.KeyEsc || msg.String() == "esc" {
-		// If in fullscreen, exit fullscreen first
-		if m.fullscreen {
+		// If in fullscreen, exit fullscreen first. A chromeless view hides the
+		// fullscreen chrome anyway, so clearing the flag here would be invisible
+		// and would cost the user a second Esc to leave the view.
+		if m.fullscreen && !view.IsChromeless(m.currentView) {
 			m.fullscreen = false
 			cmd := m.updateForResize(tea.WindowSizeMsg{
 				Width:  m.terminalWidth,
@@ -609,8 +628,9 @@ func (m *Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, cmd
 	}
 
-	// Global fullscreen toggle
-	if msg.String() == "f" {
+	// Global fullscreen toggle. A chromeless view is already borderless, so the
+	// toggle has nothing to hide — pass "f" through to the view instead.
+	if msg.String() == "f" && !view.IsChromeless(m.currentView) {
 		// Don't intercept if view is searching
 		if searchView, ok := m.currentView.(interface{ IsSearching() bool }); ok && searchView.IsSearching() {
 			cmd := m.currentView.Update(msg)
@@ -652,7 +672,7 @@ func (m *Model) goBack() tea.Cmd {
 	enterCmd := m.currentView.OnEnter()
 
 	// Optionally notify the view about terminal size again
-	resizeCmd := handleViewResize(m.currentView, m.viewport.Width, m.viewport.Height, false)
+	resizeCmd := m.resizeCurrentView()
 
 	// Execute all lifecycle commands
 	return tea.Batch(exitCmd, enterCmd, resizeCmd)

--- a/app/update_test.go
+++ b/app/update_test.go
@@ -10,6 +10,7 @@ import (
 	"swarmcli/views/confirmdialog"
 	"swarmcli/views/helpbar"
 	"swarmcli/views/searchinput"
+	"swarmcli/views/unlockdialog"
 	"swarmcli/views/view"
 	"swarmcli/views/viewstack"
 
@@ -50,6 +51,26 @@ func (v *searchingStubView) Update(msg tea.Msg) tea.Cmd {
 	return nil
 }
 
+// chromelessStubView owns the whole terminal: it records the keys and window
+// sizes the app hands it, and renders a recognizable sentinel.
+type chromelessStubView struct {
+	stubView
+	receivedKeys  []tea.KeyMsg
+	receivedSizes []tea.WindowSizeMsg
+}
+
+func (v *chromelessStubView) Chromeless() bool { return true }
+func (v *chromelessStubView) View() string     { return "CHROMELESS" }
+func (v *chromelessStubView) Update(msg tea.Msg) tea.Cmd {
+	switch m := msg.(type) {
+	case tea.KeyMsg:
+		v.receivedKeys = append(v.receivedKeys, m)
+	case tea.WindowSizeMsg:
+		v.receivedSizes = append(v.receivedSizes, m)
+	}
+	return nil
+}
+
 func newTestAppModel(cv view.View) *Model {
 	return &Model{
 		viewport:       viewport.New(200, 50),
@@ -58,6 +79,8 @@ func newTestAppModel(cv view.View) *Model {
 		commandInput:   commandinput.New(),
 		searchInput:    searchinput.New(),
 		errorDialog:    confirmdialog.New(200, 50),
+		unlockDialog:   unlockdialog.New(200, 50),
+		updateDialog:   confirmdialog.New(200, 50),
 		terminalWidth:  200,
 		terminalHeight: 50,
 	}

--- a/app/view.go
+++ b/app/view.go
@@ -13,6 +13,13 @@ import (
 )
 
 func (m *Model) View() string {
+	// Chromeless views own the whole terminal and render themselves; only the
+	// app-level overlays composite on top.
+	if view.IsChromeless(m.currentView) {
+		out := m.currentView.View()
+		return m.overlayStartup(m.overlayUnlock(m.overlayAppError(m.overlayUpdate(out))))
+	}
+
 	// Fullscreen mode: show only the current view (no helpbar, no stackbar)
 	if m.fullscreen {
 		title := m.currentView.FrameTitle()

--- a/views/view/interface.go
+++ b/views/view/interface.go
@@ -37,3 +37,30 @@ type Filterable interface {
 	ApplySearchQuery(query string)
 	ClearSearchQuery()
 }
+
+// Chromeless is an opt-in interface for views that own the entire terminal.
+// When Chromeless() reports true, the app renders View() verbatim — no help
+// bar, no view frame, no breadcrumb bar — and hands the view the full terminal
+// size instead of the chrome-reduced viewport. App-level overlays (startup,
+// unlock, error, update) still composite on top. The ":" command bar and "/"
+// search bar are suppressed, as there is nowhere to draw them.
+//
+// Two contracts, both load-bearing:
+//
+// The value must be constant for the view's lifetime. It selects both the
+// chrome and the size handed to the view, and there is no re-resize hook on the
+// render path, so flipping it mid-life leaves the view sized for chrome that is
+// no longer drawn.
+//
+// View() must emit exactly terminalHeight lines with no trailing newline. Bubble
+// Tea drops lines from the *top* when the frame is taller than the terminal, so
+// a single extra line silently eats the view's first row.
+type Chromeless interface {
+	Chromeless() bool
+}
+
+// IsChromeless reports whether v owns the full terminal.
+func IsChromeless(v View) bool {
+	c, ok := v.(Chromeless)
+	return ok && c.Chromeless()
+}

--- a/views/view/interface_test.go
+++ b/views/view/interface_test.go
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package view
+
+import (
+	"testing"
+
+	"swarmcli/views/helpbar"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/stretchr/testify/require"
+)
+
+// framedStub is a view that does not implement Chromeless.
+type framedStub struct{}
+
+func (v *framedStub) Update(tea.Msg) tea.Cmd              { return nil }
+func (v *framedStub) View() string                        { return "" }
+func (v *framedStub) Init() tea.Cmd                       { return nil }
+func (v *framedStub) Name() string                        { return "framed" }
+func (v *framedStub) ShortHelpItems() []helpbar.HelpEntry { return nil }
+func (v *framedStub) OnEnter() tea.Cmd                    { return nil }
+func (v *framedStub) OnExit() tea.Cmd                     { return nil }
+func (v *framedStub) HasErrors() bool                     { return false }
+func (v *framedStub) FrameTitle() string                  { return "" }
+func (v *framedStub) FrameHeader() string                 { return "" }
+func (v *framedStub) FrameFooter() string                 { return "" }
+func (v *framedStub) FrameContent() string                { return "" }
+
+// chromelessStub opts in, with a configurable answer.
+type chromelessStub struct {
+	framedStub
+	chromeless bool
+}
+
+func (v *chromelessStub) Chromeless() bool { return v.chromeless }
+
+func TestIsChromeless_NotImplemented(t *testing.T) {
+	require.False(t, IsChromeless(&framedStub{}))
+}
+
+func TestIsChromeless_OptedIn(t *testing.T) {
+	require.True(t, IsChromeless(&chromelessStub{chromeless: true}))
+}
+
+func TestIsChromeless_OptedOut(t *testing.T) {
+	require.False(t, IsChromeless(&chromelessStub{chromeless: false}))
+}


### PR DESCRIPTION
## What

Adds an opt-in `Chromeless` view interface. When a view reports `Chromeless() == true`, the app renders its `View()` verbatim — no help bar, no view frame, no breadcrumb bar — and hands it the **full terminal size** instead of the chrome-reduced viewport. App-level overlays (startup, unlock, error, update) still composite on top.

## Why

Views return frame components and `app/view.go` wraps them in the chrome. A view that needs the raw terminal — an embedded terminal emulator, say, where the frame's `│` lands in the user's clipboard on copy — has no way to opt out. This is the generic extension point for that; no view in this repo uses it yet.

`m.currentView.View()` was dead code (the app only ever called the four `Frame*` methods), so this repurposes an existing interface method rather than adding one.

## Also in here

Three key-handling guards, each a correctness fix rather than polish:

- **`:`** would open a command bar that a chromeless view never renders — and an *invisible* command bar then swallows every subsequent keypress, since all keys are routed to it exclusively. Chromeless views now go straight to the key handler.
- **`esc`** while `m.fullscreen` happens to be set would invisibly clear the flag instead of going back, costing the user a second `esc` to leave the view.
- **`f`** has nothing to hide over an already-borderless view, so the key belongs to the view.

The four resize call sites are consolidated into `resizeView`/`resizeCurrentView`. That also fixes a pre-existing bug: `switchToView`/`replaceView`/`goBack` all resized the new view with a hardcoded `isFullscreen=false`, so entering a view while in fullscreen left the restored view six lines short on the way back.

`m.viewport` deliberately stays chrome-sized — `goBack` and the command/search-bar paths derive the *restored* view's dimensions from it.

## Contracts (documented on the interface)

- `Chromeless()` must be **constant** for the view's lifetime: it selects both the chrome and the size handed to the view, and there is no re-resize hook on the render path.
- `View()` must emit **exactly `terminalHeight` lines**, no trailing newline. Bubble Tea drops surplus lines from the *top*, so a one-line overshoot silently eats the view's first row.

## Test plan

- `views/view/interface_test.go` — `IsChromeless` for opting-in, opting-out and non-implementing views.
- `app/chromeless_test.go` — a chromeless view renders verbatim (no `│`); gets the raw terminal size while `m.viewport` stays chrome-sized; `:` / `/` do not open their bars; `f` does not toggle fullscreen; `esc` goes back even when `m.fullscreen` is set.
- `go test ./...` and `golangci-lint run ./... --build-tags=integration` clean.

First consumer is swarmcli-be's exec shell (Eldara-Tech/swarmcli-be#258).

🤖 Generated with [Claude Code](https://claude.com/claude-code)