### PR TITLE
UI: recolor & reformat service/stack view headers (#453)

### DIFF
--- a/ui/framedbox.go
+++ b/ui/framedbox.go
@@ -15,7 +15,7 @@ import (
 // line and raw content are returned (no borders).
 func RenderViewFrame(title, header, content, footer string, width, height int, fullscreen bool) string {
 	if fullscreen {
-		titleText := FrameTitleStyle.Render(title)
+		titleText := styleFrameTitle(title)
 		titleLine := lipgloss.NewStyle().
 			Width(width).
 			Align(lipgloss.Center).

--- a/ui/title.go
+++ b/ui/title.go
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package ui
+
+import (
+	"fmt"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+// Frame-title token styles. A scoped title reads "Label(scope)[count]"; the
+// label and its surrounding separators share one colour so the title reads as
+// a single unit, while the scope and count are highlighted distinctly.
+var (
+	titleLabelStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("#8be4e4")).Bold(true)
+	titleScopeStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("#ff04ff")).Bold(true)
+	titleCountStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("#ffefd5")).Bold(true)
+)
+
+// ScopedTitle renders a frame title of the form "Label(scope)[count]" with the
+// label/separators, scope, and count coloured distinctly. The returned string
+// already carries its own ANSI styling, so RenderFramedBox passes it through
+// unchanged instead of re-applying FrameTitleStyle (see styleFrameTitle).
+func ScopedTitle(label, scope string, count int) string {
+	return titleLabelStyle.Render(label) +
+		titleLabelStyle.Render("(") +
+		titleScopeStyle.Render(scope) +
+		titleLabelStyle.Render(")") +
+		titleLabelStyle.Render("[") +
+		titleCountStyle.Render(fmt.Sprintf("%d", count)) +
+		titleLabelStyle.Render("]")
+}

--- a/ui/title.go
+++ b/ui/title.go
@@ -31,3 +31,33 @@ func ScopedTitle(label, scope string, count int) string {
 		titleCountStyle.Render(fmt.Sprintf("%d", count)) +
 		titleLabelStyle.Render("]")
 }
+
+// maxFilterFragmentRunes caps the filter text baked into a title so a long
+// query cannot overflow the frame title.
+const maxFilterFragmentRunes = 24
+
+// FilterFragment renders a trailing " </query>" fragment marking an active `/`
+// filter, mirroring k9s (which appends the filter rather than folding it into
+// the scope). The angle brackets share the label colour while the "/query"
+// reuses the scope colour, so the filter reads as a scope refinement. It
+// returns "" when no filter is active. Like the rest of ScopedTitle the result
+// already carries ANSI styling, so styleFrameTitle passes it through unchanged.
+func FilterFragment(query string) string {
+	if query == "" {
+		return ""
+	}
+	if r := []rune(query); len(r) > maxFilterFragmentRunes {
+		query = string(r[:maxFilterFragmentRunes-1]) + "…"
+	}
+	return " " + titleLabelStyle.Render("<") +
+		titleScopeStyle.Render("/"+query) +
+		titleLabelStyle.Render(">")
+}
+
+// ScopedTitleFiltered renders ScopedTitle and, when filter is non-empty, appends
+// a FilterFragment so the header reflects the active `/` filter, e.g.
+// "Stacks(all)[1] </pos>". The count is expected to be the post-filter row
+// count. See FilterFragment.
+func ScopedTitleFiltered(label, scope string, count int, filter string) string {
+	return ScopedTitle(label, scope, count) + FilterFragment(filter)
+}

--- a/ui/title_test.go
+++ b/ui/title_test.go
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package ui
+
+import (
+	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
+	"github.com/muesli/termenv"
+	"github.com/stretchr/testify/require"
+)
+
+func TestScopedTitle_Format(t *testing.T) {
+	cases := []struct {
+		label, scope string
+		count        int
+		want         string
+	}{
+		{"Services", "postgres-ha", 8, "Services(postgres-ha)[8]"},
+		{"Services", "all", 0, "Services(all)[0]"},
+		{"Services", "no stack", 3, "Services(no stack)[3]"},
+		{"Stacks", "all", 38, "Stacks(all)[38]"},
+	}
+	for _, c := range cases {
+		require.Equal(t, c.want, ansi.Strip(ScopedTitle(c.label, c.scope, c.count)))
+	}
+}
+
+func TestScopedTitle_TokenStyles(t *testing.T) {
+	// Lock the colours the issue specifies for each token.
+	require.Equal(t, lipgloss.Color("#8be4e4"), titleLabelStyle.GetForeground())
+	require.Equal(t, lipgloss.Color("#ff04ff"), titleScopeStyle.GetForeground())
+	require.Equal(t, lipgloss.Color("#ffefd5"), titleCountStyle.GetForeground())
+
+	// Under a colour-capable profile each token is wrapped in its own style
+	// (label/separators, scope, count) rather than a single uniform colour.
+	prev := lipgloss.ColorProfile()
+	lipgloss.SetColorProfile(termenv.TrueColor)
+	defer lipgloss.SetColorProfile(prev)
+
+	out := ScopedTitle("Services", "postgres-ha", 8)
+	require.Contains(t, out, titleLabelStyle.Render("Services"))
+	require.Contains(t, out, titleScopeStyle.Render("postgres-ha"))
+	require.Contains(t, out, titleCountStyle.Render("8"))
+	require.Equal(t, "Services(postgres-ha)[8]", ansi.Strip(out))
+}
+
+func TestStyleFrameTitle_PassesThroughStyled(t *testing.T) {
+	styled := "\x1b[95mpre-styled\x1b[0m"
+	require.Equal(t, styled, styleFrameTitle(styled))
+}
+
+func TestStyleFrameTitle_StylesPlain(t *testing.T) {
+	require.Equal(t, FrameTitleStyle.Render("plain"), styleFrameTitle("plain"))
+}

--- a/ui/title_test.go
+++ b/ui/title_test.go
@@ -4,6 +4,7 @@
 package ui
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/charmbracelet/lipgloss"
@@ -45,6 +46,39 @@ func TestScopedTitle_TokenStyles(t *testing.T) {
 	require.Contains(t, out, titleScopeStyle.Render("postgres-ha"))
 	require.Contains(t, out, titleCountStyle.Render("8"))
 	require.Equal(t, "Services(postgres-ha)[8]", ansi.Strip(out))
+}
+
+func TestScopedTitleFiltered_NoFilter_EqualsScopedTitle(t *testing.T) {
+	// With no active filter the title is identical to the plain ScopedTitle.
+	require.Equal(t, ScopedTitle("Stacks", "all", 3), ScopedTitleFiltered("Stacks", "all", 3, ""))
+}
+
+func TestScopedTitleFiltered_WithFilter_AppendsFragment(t *testing.T) {
+	// k9s-style: scope kept, count is the (caller-supplied, post-filter) value,
+	// filter appended as a " </query>" fragment rather than folded into scope.
+	out := ScopedTitleFiltered("Stacks", "all", 1, "pos")
+	require.Equal(t, "Stacks(all)[1] </pos>", ansi.Strip(out))
+}
+
+func TestFilterFragment_Empty(t *testing.T) {
+	require.Equal(t, "", FilterFragment(""))
+}
+
+func TestFilterFragment_Truncates(t *testing.T) {
+	stripped := ansi.Strip(FilterFragment(strings.Repeat("x", 40)))
+	require.Contains(t, stripped, "…")
+	// " </" + at most maxFilterFragmentRunes runes + ">".
+	require.LessOrEqual(t, len([]rune(stripped)), len(" </>")+maxFilterFragmentRunes)
+}
+
+func TestFilterFragment_TokenStyles(t *testing.T) {
+	prev := lipgloss.ColorProfile()
+	lipgloss.SetColorProfile(termenv.TrueColor)
+	defer lipgloss.SetColorProfile(prev)
+
+	out := FilterFragment("pos")
+	require.Contains(t, out, titleScopeStyle.Render("/pos")) // "/query" reuses the scope colour
+	require.Contains(t, out, titleLabelStyle.Render("<"))    // brackets share the label colour
 }
 
 func TestStyleFrameTitle_PassesThroughStyled(t *testing.T) {

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -32,6 +32,17 @@ var (
 				Bold(true)
 )
 
+// styleFrameTitle applies the default frame-title style to a plain title. A
+// title that already carries its own ANSI styling (e.g. from ScopedTitle) is
+// returned unchanged so the caller's per-segment colours are preserved rather
+// than clobbered by re-wrapping.
+func styleFrameTitle(title string) string {
+	if ansi.Strip(title) != title {
+		return title
+	}
+	return FrameTitleStyle.Render(title)
+}
+
 // RenderFramedBox draws a bordered frame with title, optional header, and content.
 // If width <= 0, defaults to content width + padding.
 // ANSI sequences in content are preserved.
@@ -53,7 +64,7 @@ func RenderFramedBox(title, header, content, footer string, width int) string {
 		width = contentWidth + 4 // padding left/right
 	}
 
-	titleStyled := FrameTitleStyle.Render(" " + title + " ")
+	titleStyled := styleFrameTitle(" " + title + " ")
 	headerStyled := FrameHeaderStyle.Render(header)
 
 	borderWidth := width - 2 // left/right borders

--- a/views/nodes/view.go
+++ b/views/nodes/view.go
@@ -13,14 +13,18 @@ import (
 )
 
 func (m *Model) FrameTitle() string {
-	total := len(m.List.Items)
+	// Count over the post-`/`-filter rows so the header tracks the filter.
 	managers := 0
-	for _, n := range m.List.Items {
+	for _, n := range m.List.Filtered {
 		if n.Manager {
 			managers++
 		}
 	}
-	return fmt.Sprintf("Nodes (%d total, %d manager%s)", total, managers, plural(managers))
+	base := fmt.Sprintf("Nodes (%d total, %d manager%s)", len(m.List.Filtered), managers, plural(managers))
+	// Pre-style the plain base: appending the ANSI FilterFragment would otherwise
+	// make styleFrameTitle treat the whole title as pre-styled and skip
+	// FrameTitleStyle, dropping the base's colour.
+	return ui.FrameTitleStyle.Render(base) + ui.FilterFragment(m.List.Query)
 }
 
 func (m *Model) FrameHeader() string { return m.List.RenderHeader() }

--- a/views/nodes/view_test.go
+++ b/views/nodes/view_test.go
@@ -6,6 +6,7 @@ package nodesview
 import (
 	"testing"
 
+	"github.com/charmbracelet/x/ansi"
 	"github.com/stretchr/testify/require"
 )
 
@@ -88,4 +89,20 @@ func TestView_ManagerCount(t *testing.T) {
 	m.List.Viewport.Height = 20
 	out := m.View()
 	require.Contains(t, out, "1 manager")
+}
+
+func TestView_ActiveFilter_TitleReflectsFilteredCount(t *testing.T) {
+	m := testModel()
+	m.Visible = true
+	m.ready = true
+	entries := fakeNodes("mgr", "worker")
+	entries[0].Manager = true
+	loadNodes(m, entries)
+	m.List.Query = "work" // matches "worker" only
+	m.List.ApplyFilter()
+	m.List.Viewport.Width = 80
+	m.List.Viewport.Height = 20
+	out := ansi.Strip(m.View())
+	require.Contains(t, out, "Nodes (1 total, 0 managers)") // counts over filtered rows
+	require.Contains(t, out, "</work>")                     // active filter appended, k9s-style
 }

--- a/views/services/columns_test.go
+++ b/views/services/columns_test.go
@@ -31,7 +31,7 @@ const longServiceName = "myproject_some-very-long-service-name"
 
 // loadWithFilter pushes entries into the model under a given scope.
 func loadWithFilter(m *Model, ft FilterType, entries []docker.ServiceEntry) {
-	m.Update(Msg{Title: "T", Entries: entries, FilterType: ft})
+	m.Update(Msg{Scope: "all", Entries: entries, FilterType: ft})
 }
 
 func hasColumn(m *Model, label string) bool {

--- a/views/services/messages.go
+++ b/views/services/messages.go
@@ -9,7 +9,7 @@ import (
 )
 
 type Msg struct {
-	Title      string
+	Scope      string
 	Entries    []docker.ServiceEntry
 	FilterType FilterType
 	NodeID     string

--- a/views/services/model.go
+++ b/views/services/model.go
@@ -44,7 +44,7 @@ type Model struct {
 	deps         docker.Deps
 	List         filterlist.FilterableList[docker.ServiceEntry]
 	Visible      bool
-	title        string
+	titleScope   string
 	ready        bool
 	firstResize  bool // tracks if we've received the first window size
 	width        int

--- a/views/services/model_test.go
+++ b/views/services/model_test.go
@@ -15,6 +15,7 @@ import (
 	"swarmcli/views/view"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/x/ansi"
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/stretchr/testify/require"
 )
@@ -676,7 +677,7 @@ func TestLoadServicesForView_AllFilter(t *testing.T) {
 	m := testModel(func(m *Model) { m.deps.Services = mock })
 	entries, title := m.loadServicesForView(AllFilter, "", "")
 	require.Len(t, entries, 2)
-	require.Contains(t, title, "All Services")
+	require.Contains(t, ansi.Strip(title), "Services(all)[2]")
 }
 
 func TestLoadServicesForView_StackFilter(t *testing.T) {
@@ -688,7 +689,7 @@ func TestLoadServicesForView_StackFilter(t *testing.T) {
 	m := testModel(func(m *Model) { m.deps.Services = mock })
 	entries, title := m.loadServicesForView(StackFilter, "", "mystack")
 	require.Len(t, entries, 1)
-	require.Contains(t, title, "mystack")
+	require.Contains(t, ansi.Strip(title), "Services(mystack)[1]")
 }
 
 func TestLoadServicesForView_NodeFilter(t *testing.T) {
@@ -700,7 +701,7 @@ func TestLoadServicesForView_NodeFilter(t *testing.T) {
 	m := testModel(func(m *Model) { m.deps.Services = mock })
 	entries, title := m.loadServicesForView(NodeFilter, "node1", "")
 	require.Len(t, entries, 1)
-	require.Contains(t, title, "node1")
+	require.Contains(t, ansi.Strip(title), "Services(node1)[1]")
 }
 
 func TestFormatRelativeTime_Zero(t *testing.T) {

--- a/views/services/model_test.go
+++ b/views/services/model_test.go
@@ -211,7 +211,7 @@ func fakeEntries(names ...string) []docker.ServiceEntry {
 
 func loadServices(m *Model, entries []docker.ServiceEntry) {
 	m.Update(Msg{
-		Title:      "Test Services",
+		Scope:      "all",
 		Entries:    entries,
 		FilterType: AllFilter,
 	})
@@ -271,7 +271,7 @@ func TestMsg_SetsContentAndVisible(t *testing.T) {
 func TestMsg_EmptyStackFilter_ShowsDialog(t *testing.T) {
 	m := testModel()
 	m.Update(Msg{
-		Title:      "Test",
+		Scope:      "mystack",
 		Entries:    nil,
 		FilterType: StackFilter,
 	})
@@ -644,6 +644,18 @@ func TestView_ShowsServices(t *testing.T) {
 	require.Contains(t, out, "api")
 }
 
+func TestView_ActiveFilter_TitleReflectsFilteredCount(t *testing.T) {
+	m := testModel()
+	loadServices(m, fakeEntries("web", "api")) // Scope "all"
+	m.ApplySearchQuery("api")                  // matches "api" only
+	m.setRenderItem()
+	m.List.Viewport.Width = 80
+	m.List.Viewport.Height = 20
+	out := ansi.Strip(m.View())
+	require.Contains(t, out, "Services(all)[1]") // count is the filtered row count
+	require.Contains(t, out, "</api>")           // active filter appended, k9s-style
+}
+
 func TestView_ConfirmDialog(t *testing.T) {
 	m := testModel()
 	loadServices(m, fakeEntries("web"))
@@ -675,9 +687,9 @@ func TestLoadServicesForView_AllFilter(t *testing.T) {
 		return fakeEntries("web", "db")
 	}
 	m := testModel(func(m *Model) { m.deps.Services = mock })
-	entries, title := m.loadServicesForView(AllFilter, "", "")
+	entries, scope := m.loadServicesForView(AllFilter, "", "")
 	require.Len(t, entries, 2)
-	require.Contains(t, ansi.Strip(title), "Services(all)[2]")
+	require.Equal(t, "all", scope)
 }
 
 func TestLoadServicesForView_StackFilter(t *testing.T) {
@@ -687,9 +699,9 @@ func TestLoadServicesForView_StackFilter(t *testing.T) {
 		return fakeEntries("web")
 	}
 	m := testModel(func(m *Model) { m.deps.Services = mock })
-	entries, title := m.loadServicesForView(StackFilter, "", "mystack")
+	entries, scope := m.loadServicesForView(StackFilter, "", "mystack")
 	require.Len(t, entries, 1)
-	require.Contains(t, ansi.Strip(title), "Services(mystack)[1]")
+	require.Equal(t, "mystack", scope)
 }
 
 func TestLoadServicesForView_NodeFilter(t *testing.T) {
@@ -699,9 +711,9 @@ func TestLoadServicesForView_NodeFilter(t *testing.T) {
 		return fakeEntries("web")
 	}
 	m := testModel(func(m *Model) { m.deps.Services = mock })
-	entries, title := m.loadServicesForView(NodeFilter, "node1", "")
+	entries, scope := m.loadServicesForView(NodeFilter, "node1", "")
 	require.Len(t, entries, 1)
-	require.Contains(t, ansi.Strip(title), "Services(node1)[1]")
+	require.Equal(t, "node1", scope)
 }
 
 func TestFormatRelativeTime_Zero(t *testing.T) {

--- a/views/services/register.go
+++ b/views/services/register.go
@@ -56,11 +56,11 @@ func factory(deps docker.Deps, w, h int, payload any) (view.View, tea.Cmd) {
 		v.SetPendingSelectServiceName(selectServiceName)
 	}
 
-	entries, title := v.loadServicesForView(filterType, nodeID, stackName)
+	entries, scope := v.loadServicesForView(filterType, nodeID, stackName)
 
 	// Apply data directly so keys work immediately (no race with async Cmd).
 	msg := Msg{
-		Title:      title,
+		Scope:      scope,
 		Entries:    entries,
 		FilterType: filterType,
 		NodeID:     nodeID,

--- a/views/services/service.go
+++ b/views/services/service.go
@@ -6,7 +6,6 @@ package servicesview
 import (
 	"swarmcli/core/primitives/hash"
 	"swarmcli/docker"
-	"swarmcli/ui"
 
 	tea "github.com/charmbracelet/bubbletea"
 )
@@ -22,9 +21,9 @@ func (m *Model) refreshServicesCmd(nodeID, stackName string, filterType FilterTy
 			l().Errorf("refreshServicesCmd: RefreshSnapshot failed: %v", err)
 		}
 
-		entries, title := loadServicesForViewWith(serviceOps, filterType, nodeID, stackName)
+		entries, scope := loadServicesForViewWith(serviceOps, filterType, nodeID, stackName)
 		return Msg{
-			Title:      title,
+			Scope:      scope,
 			Entries:    entries,
 			FilterType: filterType,
 			NodeID:     nodeID,
@@ -33,12 +32,15 @@ func (m *Model) refreshServicesCmd(nodeID, stackName string, filterType FilterTy
 	}
 }
 
-func (m *Model) loadServicesForView(filterType FilterType, nodeID, stackName string) (entries []docker.ServiceEntry, title string) {
+func (m *Model) loadServicesForView(filterType FilterType, nodeID, stackName string) (entries []docker.ServiceEntry, scope string) {
 	return loadServicesForViewWith(m.deps.Services, filterType, nodeID, stackName)
 }
 
-func loadServicesForViewWith(serviceOps docker.ServiceOps, filterType FilterType, nodeID, stackName string) (entries []docker.ServiceEntry, title string) {
-	var scope string
+// loadServicesForViewWith loads the services for the given data scope and
+// returns the entries alongside the scope label used in the frame title
+// (nodeID / stackName / "no stack" / "all"). The title itself is built live in
+// FrameTitle so it can reflect the post-`/`-filter row count.
+func loadServicesForViewWith(serviceOps docker.ServiceOps, filterType FilterType, nodeID, stackName string) (entries []docker.ServiceEntry, scope string) {
 	switch filterType {
 	case NodeFilter:
 		entries = serviceOps.LoadNodeServices(nodeID)
@@ -54,7 +56,6 @@ func loadServicesForViewWith(serviceOps docker.ServiceOps, filterType FilterType
 		entries = serviceOps.LoadAllServices()
 		scope = "all"
 	}
-	title = ui.ScopedTitle("Services", scope, len(entries))
 	return
 }
 
@@ -69,7 +70,7 @@ func (m *Model) checkServicesCmd(lastHash uint64, filterType FilterType, nodeID,
 		// and use the cached snapshot for quick checks.
 		snapshotOps.TriggerRefreshIfNeeded()
 
-		entries, title := loadServicesForViewWith(serviceOps, filterType, nodeID, stackName)
+		entries, scope := loadServicesForViewWith(serviceOps, filterType, nodeID, stackName)
 		newHash, err := hash.Compute(entries)
 		if err != nil {
 			l().Errorf("checkServicesCmd: Hash computation failed: %v", err)
@@ -83,7 +84,7 @@ func (m *Model) checkServicesCmd(lastHash uint64, filterType FilterType, nodeID,
 		if newHash != lastHash {
 			l().Info("checkServicesCmd: Change detected! Refreshing service list")
 			return Msg{
-				Title:      title,
+				Scope:      scope,
 				Entries:    entries,
 				FilterType: filterType,
 				NodeID:     nodeID,

--- a/views/services/service.go
+++ b/views/services/service.go
@@ -6,6 +6,7 @@ package servicesview
 import (
 	"swarmcli/core/primitives/hash"
 	"swarmcli/docker"
+	"swarmcli/ui"
 
 	tea "github.com/charmbracelet/bubbletea"
 )
@@ -37,21 +38,23 @@ func (m *Model) loadServicesForView(filterType FilterType, nodeID, stackName str
 }
 
 func loadServicesForViewWith(serviceOps docker.ServiceOps, filterType FilterType, nodeID, stackName string) (entries []docker.ServiceEntry, title string) {
+	var scope string
 	switch filterType {
 	case NodeFilter:
 		entries = serviceOps.LoadNodeServices(nodeID)
-		title = "Services on Node: " + nodeID
+		scope = nodeID
 	case StackFilter:
 		entries = serviceOps.LoadStackServices(stackName)
-		title = "Services in Stack: " + stackName
+		scope = stackName
 	case NoStackFilter:
 		// docker marks services without a stack namespace as stack "-".
 		entries = serviceOps.LoadStackServices("-")
-		title = "Services (no stack)"
+		scope = "no stack"
 	default: // All services
 		entries = serviceOps.LoadAllServices()
-		title = "All Services"
+		scope = "all"
 	}
+	title = ui.ScopedTitle("Services", scope, len(entries))
 	return
 }
 

--- a/views/services/update.go
+++ b/views/services/update.go
@@ -587,7 +587,7 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 func (m *Model) SetContent(msg Msg) {
 	l().Infof("ServicesView.SetContent: Updating display with %d services", len(msg.Entries))
 
-	m.title = msg.Title
+	m.titleScope = msg.Scope
 
 	m.List.Items = msg.Entries
 	m.List.ApplyFilter()

--- a/views/services/view.go
+++ b/views/services/view.go
@@ -7,7 +7,9 @@ import (
 	"swarmcli/ui"
 )
 
-func (m *Model) FrameTitle() string  { return m.title }
+func (m *Model) FrameTitle() string {
+	return ui.ScopedTitleFiltered("Services", m.titleScope, len(m.List.Filtered), m.List.Query)
+}
 func (m *Model) FrameHeader() string { return m.List.RenderHeader() }
 func (m *Model) FrameFooter() string {
 	footer := m.List.RenderFooter()

--- a/views/stacks/view.go
+++ b/views/stacks/view.go
@@ -12,7 +12,7 @@ import (
 )
 
 func (m *Model) FrameTitle() string {
-	return ui.ScopedTitle("Stacks", "all", len(m.List.Items))
+	return ui.ScopedTitleFiltered("Stacks", "all", len(m.List.Filtered), m.List.Query)
 }
 
 func (m *Model) FrameHeader() string { return m.List.RenderHeader() }

--- a/views/stacks/view.go
+++ b/views/stacks/view.go
@@ -12,7 +12,7 @@ import (
 )
 
 func (m *Model) FrameTitle() string {
-	return fmt.Sprintf("Stacks on Node (Total: %d)", len(m.List.Items))
+	return ui.ScopedTitle("Stacks", "all", len(m.List.Items))
 }
 
 func (m *Model) FrameHeader() string { return m.List.RenderHeader() }

--- a/views/stacks/view_test.go
+++ b/views/stacks/view_test.go
@@ -8,6 +8,7 @@ import (
 
 	"swarmcli/docker"
 
+	"github.com/charmbracelet/x/ansi"
 	"github.com/stretchr/testify/require"
 )
 
@@ -23,9 +24,8 @@ func TestView_WithStacks_ShowsTitle(t *testing.T) {
 	m.setRenderItem()
 	m.List.Viewport.Width = 80
 	m.List.Viewport.Height = 20
-	out := m.View()
-	require.Contains(t, out, "Stacks on Node")
-	require.Contains(t, out, "Total: 2")
+	out := ansi.Strip(m.View())
+	require.Contains(t, out, "Stacks(all)[2]")
 }
 
 func TestView_ShowsStackNames(t *testing.T) {

--- a/views/stacks/view_test.go
+++ b/views/stacks/view_test.go
@@ -28,6 +28,18 @@ func TestView_WithStacks_ShowsTitle(t *testing.T) {
 	require.Contains(t, out, "Stacks(all)[2]")
 }
 
+func TestView_ActiveFilter_TitleReflectsFilteredCount(t *testing.T) {
+	m := testModel()
+	loadStacks(m, fakeStacks("alpha", "beta"))
+	m.ApplySearchQuery("alp") // matches "alpha" only
+	m.setRenderItem()
+	m.List.Viewport.Width = 80
+	m.List.Viewport.Height = 20
+	out := ansi.Strip(m.View())
+	require.Contains(t, out, "Stacks(all)[1]") // count is the filtered row count
+	require.Contains(t, out, "</alp>")         // active filter appended, k9s-style
+}
+
 func TestView_ShowsStackNames(t *testing.T) {
 	m := testModel()
 	loadStacks(m, fakeStacks("webstack", "apistack"))


### PR DESCRIPTION
## What
Reformats the service-view and stack-view frame titles into a coloured `Label(scope)[count]` form (issue #453):

- Service view: `Services in Stack: postgres-ha` → `Services(postgres-ha)[8]`
- Stack view: `Stacks on Node (Total: 38)` → `Stacks(all)[38]`

Per-token colours: label + separators cyan `#8be4e4`, scope magenta `#ff04ff`, count peach `#ffefd5`.

Per discussion on the issue, **all four** service-view title variants are harmonized to the same format for consistency:

| Filter | Header |
|---|---|
| stack | `Services(<stack>)[n]` |
| node | `Services(<nodeID>)[n]` |
| no-stack | `Services(no stack)[n]` |
| all | `Services(all)[n]` |

## How
- New `ui.ScopedTitle(label, scope, count)` builds the per-segment-coloured title.
- `ui.styleFrameTitle` teaches the frame renderer to pass an already-styled (ANSI-containing) title through unchanged instead of re-wrapping it with `FrameTitleStyle`. Without this, lipgloss's inner colour resets clobber the outer style on the separators. Plain titles from every other view are unaffected (backward-compatible).

## Tests
- New `ui/title_test.go`: title format across variants, per-token colour wiring, and the pass-through guard.
- Updated the two view tests that asserted the old header strings.
- Full suite + `golangci-lint --build-tags=integration` pass; verified end-to-end under a forced truecolor profile that the segment colours survive into the rendered border.

Closes #453