### PR TITLE
fix(charts): allow control flow in requirements.yaml

### DIFF
--- a/charts/chart.go
+++ b/charts/chart.go
@@ -69,7 +69,7 @@ func LoadChartDir(dir string) (*Chart, error) {
 
 	if rq, err := os.ReadFile(filepath.Join(dir, requirementsName)); err == nil {
 		ch.RequirementsRaw = rq
-		if ch.Requirements, err = parseRequirements(rq); err != nil {
+		if err := ch.loadRequirements(rq); err != nil {
 			return nil, err
 		}
 	} else if !os.IsNotExist(err) {
@@ -103,6 +103,30 @@ func LoadChartDir(dir string) (*Chart, error) {
 		return nil, err
 	}
 	return ch, nil
+}
+
+// loadRequirements records the UNRENDERED view of requirements.yaml, shared by both
+// loaders.
+//
+// requirements.yaml is a Go TEMPLATE: a chart may `range` over a user-supplied list
+// (e.g. the extra overlays to attach to), and a template action on its own line is not
+// parseable YAML. When the raw bytes do not parse we therefore keep no unrendered view
+// and defer entirely to RenderRequirements — the AUTHORITATIVE parse, which renders
+// with the release's values first and reports a genuinely broken file at
+// template/install time.
+//
+// When the raw bytes DO parse we still validate eagerly, so a chart that declares
+// something invalid (a nameless network) is rejected at load exactly as before.
+func (ch *Chart) loadRequirements(raw []byte) error {
+	req, err := unmarshalRequirements(raw)
+	if err != nil {
+		return nil // not YAML on its own => a template; RenderRequirements decides.
+	}
+	if err := validateRequirements(req); err != nil {
+		return err
+	}
+	ch.Requirements = req
+	return nil
 }
 
 // LoadChartArchive loads a chart from a gzipped tar (.tgz) stream. The archive
@@ -162,7 +186,7 @@ func LoadChartArchive(r io.Reader) (*Chart, error) {
 			ch.Schema = body
 		case rel == requirementsName:
 			ch.RequirementsRaw = body
-			if ch.Requirements, err = parseRequirements(body); err != nil {
+			if err := ch.loadRequirements(body); err != nil {
 				return nil, err
 			}
 		case rel == readmeName:

--- a/charts/chart_test.go
+++ b/charts/chart_test.go
@@ -122,6 +122,56 @@ func TestLoadChartDirParsesRequirements(t *testing.T) {
 	require.True(t, *ch.Requirements.Networks[0].AutoCreate) // defaulted
 }
 
+// requirements.yaml is a Go template, so a chart may `range` over a user-supplied
+// list (e.g. the extra overlays to attach to). Its raw bytes are then not valid YAML
+// on their own — chart load must NOT fail on that, and RenderRequirements must
+// resolve it against the release's values.
+func TestLoadChartDirRequirementsTemplateWithControlFlow(t *testing.T) {
+	dir := t.TempDir()
+	writeMinimalChart(t, dir)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "requirements.yaml"), []byte(
+		"networks:\n"+
+			"{{- range .Values.extraNetworks }}\n"+
+			"  - name: \"{{ . }}\"\n"+
+			"    autoCreate: false\n"+
+			"{{- end }}\n"), 0o644))
+
+	ch, err := LoadChartDir(dir)
+	require.NoError(t, err, "a templated requirements.yaml must not fail chart load")
+	require.NotNil(t, ch.RequirementsRaw)
+
+	req, err := RenderRequirements(ch, RenderContext{Values: map[string]any{
+		"extraNetworks": []any{"ai-internal", "mail-internal"},
+	}})
+	require.NoError(t, err)
+	require.Len(t, req.Networks, 2)
+	require.Equal(t, "ai-internal", req.Networks[0].Name)
+	require.Equal(t, "mail-internal", req.Networks[1].Name)
+	require.False(t, *req.Networks[0].AutoCreate)
+	require.Equal(t, "overlay", req.Networks[0].Driver) // defaulted
+
+	// An empty list declares nothing at all.
+	empty, err := RenderRequirements(ch, RenderContext{Values: map[string]any{"extraNetworks": []any{}}})
+	require.NoError(t, err)
+	require.Empty(t, empty.Networks)
+}
+
+// Load is best-effort, but the authoritative parse must still reject a genuinely
+// malformed requirements.yaml — the error just surfaces at render time instead.
+func TestRenderRequirementsRejectsMalformedAfterRender(t *testing.T) {
+	dir := t.TempDir()
+	writeMinimalChart(t, dir)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "requirements.yaml"),
+		[]byte("networks:\n  - name: \"a\"\n   bad-indent: oops\n"), 0o644))
+
+	ch, err := LoadChartDir(dir)
+	require.NoError(t, err)
+
+	_, err = RenderRequirements(ch, RenderContext{Values: map[string]any{}})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), requirementsName)
+}
+
 func TestLoadChartDirNoRequirementsIsNil(t *testing.T) {
 	dir := t.TempDir()
 	writeMinimalChart(t, dir)

--- a/charts/requirements.go
+++ b/charts/requirements.go
@@ -14,12 +14,25 @@ import (
 // each network's Driver defaults to "overlay" and its AutoCreate/Attachable
 // default to true. Every entry must carry a non-empty name.
 func parseRequirements(data []byte) (*Requirements, error) {
+	req, err := unmarshalRequirements(data)
+	if err != nil {
+		return nil, err
+	}
+	if err := validateRequirements(req); err != nil {
+		return nil, err
+	}
+	return req, nil
+}
+
+// unmarshalRequirements decodes requirements.yaml WITHOUT validating it. Chart
+// loading needs the two steps apart: requirements.yaml is a Go template, so a chart
+// may `range` over a user-supplied list and the raw bytes then do not parse as YAML
+// at all — which is not an error. A file that DOES parse but declares something
+// invalid still is.
+func unmarshalRequirements(data []byte) (*Requirements, error) {
 	var req Requirements
 	if err := yaml.Unmarshal(data, &req); err != nil {
 		return nil, fmt.Errorf("parse %s: %w", requirementsName, err)
-	}
-	if err := validateRequirements(&req); err != nil {
-		return nil, err
 	}
 	return &req, nil
 }


### PR DESCRIPTION
## Why

`requirements.yaml` is rendered as a Go template with the release's values — but both loaders hard-parsed the **raw** bytes as YAML *first* (`LoadChartDir`, `LoadChartArchive`). A template action on its own line isn't valid YAML, so a chart could never `range` over a user-supplied list: it failed to load before it was ever rendered.

That silently forced chart authors to cap such values at **exactly one entry** — e.g. "attach to one extra overlay" — for a reason that was purely an artifact of the loader, not a property of the data. It surfaced in [swarmcli-charts#82](https://github.com/Eldara-Tech/swarmcli-charts/pull/82), where the Zammad chart wants `extraNetworks: []` so an operator can reach several co-located, port-unexposed services (a self-hosted Ollama + an in-swarm mail server + LDAP), each of which lives on its own stack overlay.

## What

Split unmarshal from validate, and defer **only** the unmarshal:

- Raw bytes that aren't YAML at all ⇒ it's a template. Keep no unrendered view and let `RenderRequirements` — the authoritative parse, which renders first — decide. A genuinely broken file still hard-fails at template/install time.
- Raw bytes that **do** parse are still validated eagerly, so a nameless network is rejected at load exactly as before (`TestLoadChartArchiveInvalidRequirements` still passes unchanged).

`Chart.Requirements` is only ever read by tests — every real path (install / apply / template) goes through `RenderRequirements` — so nothing downstream changes.

## Tests

- `TestLoadChartDirRequirementsTemplateWithControlFlow` — a `range`-ing requirements.yaml loads, renders per-values to N entries, and renders to none for an empty list.
- `TestRenderRequirementsRejectsMalformedAfterRender` — the safety net survives: a genuinely malformed file still errors, just at the authoritative parse.
- Existing eager-validation and parse tests unchanged and passing; full `go test ./...` green.

Verified end-to-end against swarmcli-charts#82: the Zammad chart's `extraNetworks` now renders both overlays as `autoCreate: false` requirements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)