### PR TITLE
feat(charts): --set list values, and never silently ignore an override

### DIFF
--- a/charts/values.go
+++ b/charts/values.go
@@ -36,58 +36,155 @@ func MergeValues(defaults map[string]any, files [][]byte, sets []string) (map[st
 }
 
 // applySet applies one or more comma-separated "a.b.c=value" overrides to dst.
-// Values are type-inferred (bool, int, float, else string). List indexing is
-// intentionally not supported in Phase 1.
+// Values are type-inferred (bool, int, float, else string), and Helm's "{a,b}"
+// literal builds a list. Paths may index into lists Helm-style — "a[0]=x",
+// "a.b[1].c=y" — growing the list to fit.
+//
+// Every expression either applies or errors: a --set that silently did nothing
+// (as an unsupported "a[0]=x" once did) is the worst outcome, because the install
+// succeeds and the operator debugs the wrong thing.
 func applySet(dst map[string]any, expr string) error {
 	for _, pair := range splitSet(expr) {
 		eq := strings.IndexByte(pair, '=')
 		if eq < 0 {
 			return fmt.Errorf("--set %q: expected key=value", pair)
 		}
-		path := strings.TrimSpace(pair[:eq])
-		val := inferScalar(strings.TrimSpace(pair[eq+1:]))
+		path := unescapeCommas(strings.TrimSpace(pair[:eq]))
 		if path == "" {
 			return fmt.Errorf("--set %q: empty key", pair)
 		}
-		setPath(dst, strings.Split(path, "."), val)
+		steps, err := parseSetPath(path)
+		if err != nil {
+			return fmt.Errorf("--set %q: %w", pair, err)
+		}
+		// Every path starts with a map key and dst is non-nil, so setPath walks
+		// into dst and mutates it in place.
+		setPath(dst, steps, inferValue(strings.TrimSpace(pair[eq+1:])))
 	}
 	return nil
 }
 
-// splitSet splits on commas that are not escaped with a backslash, so values
-// may contain literal commas via "\,".
-func splitSet(s string) []string {
-	var parts []string
-	var cur strings.Builder
-	for i := 0; i < len(s); i++ {
-		if s[i] == '\\' && i+1 < len(s) && s[i+1] == ',' {
-			cur.WriteByte(',')
-			i++
-			continue
-		}
-		if s[i] == ',' {
-			parts = append(parts, cur.String())
-			cur.Reset()
-			continue
-		}
-		cur.WriteByte(s[i])
-	}
-	parts = append(parts, cur.String())
-	return parts
+// setStep is one hop of a --set path: a map key, or a list index.
+type setStep struct {
+	key     string
+	index   int
+	isIndex bool
 }
 
-// setPath assigns val at the dotted key path, creating intermediate maps. An
-// intermediate scalar is overwritten with a map so the deeper key can be set.
-func setPath(m map[string]any, keys []string, val any) {
-	for i := 0; i < len(keys)-1; i++ {
-		next, ok := m[keys[i]].(map[string]any)
-		if !ok {
-			next = map[string]any{}
-			m[keys[i]] = next
+// parseSetPath splits a dotted path into map-key and list-index hops, so
+// "a.b[0].c" walks map a -> map b -> element 0 -> key c. Anything malformed is an
+// error rather than a key with brackets in its name that no template ever reads.
+func parseSetPath(path string) ([]setStep, error) {
+	var steps []setStep
+	for _, seg := range strings.Split(path, ".") {
+		if seg == "" {
+			return nil, fmt.Errorf("empty path segment")
 		}
-		m = next
+		name, idx, indexed := strings.Cut(seg, "[")
+		if name == "" {
+			return nil, fmt.Errorf("list index %q has no key", seg)
+		}
+		if strings.ContainsRune(name, ']') {
+			return nil, fmt.Errorf("unbalanced ']' in %q", seg)
+		}
+		steps = append(steps, setStep{key: name})
+		for rest := "[" + idx; indexed && rest != ""; {
+			if rest[0] != '[' {
+				return nil, fmt.Errorf("unexpected %q after a list index in %q", rest, seg)
+			}
+			end := strings.IndexByte(rest, ']')
+			if end < 0 {
+				return nil, fmt.Errorf("unbalanced '[' in %q", seg)
+			}
+			n, err := strconv.Atoi(rest[1:end])
+			if err != nil || n < 0 {
+				return nil, fmt.Errorf("invalid list index %q in %q", rest[1:end], seg)
+			}
+			steps = append(steps, setStep{index: n, isIndex: true})
+			rest = rest[end+1:]
+		}
 	}
-	m[keys[len(keys)-1]] = val
+	return steps, nil
+}
+
+// splitSet splits on commas that are neither escaped ("\,") nor inside a "{}"
+// list literal. Escapes are left intact for inferValue to resolve, so a comma
+// inside a list element ("{a\,b}") survives both splits.
+func splitSet(s string) []string { return splitCommas(s, true) }
+
+// splitCommas splits s on unescaped commas, ignoring those nested in "{}" when
+// braces is set. Nested list literals are not supported.
+func splitCommas(s string, braces bool) []string {
+	var parts []string
+	var cur strings.Builder
+	depth := 0
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch {
+		case c == '\\' && i+1 < len(s) && s[i+1] == ',':
+			cur.WriteString(`\,`)
+			i++
+		case braces && c == '{':
+			depth++
+			cur.WriteByte(c)
+		case braces && c == '}':
+			if depth > 0 {
+				depth--
+			}
+			cur.WriteByte(c)
+		case c == ',' && depth == 0:
+			parts = append(parts, cur.String())
+			cur.Reset()
+		default:
+			cur.WriteByte(c)
+		}
+	}
+	return append(parts, cur.String())
+}
+
+// unescapeCommas resolves "\," to a literal comma.
+func unescapeCommas(s string) string { return strings.ReplaceAll(s, `\,`, ",") }
+
+// inferValue converts a --set value into a scalar, or into a list when written
+// Helm-style as "{a,b,c}" ("{}" is the empty list).
+func inferValue(s string) any {
+	if len(s) >= 2 && strings.HasPrefix(s, "{") && strings.HasSuffix(s, "}") {
+		inner := s[1 : len(s)-1]
+		if strings.TrimSpace(inner) == "" {
+			return []any{}
+		}
+		parts := splitCommas(inner, false)
+		out := make([]any, 0, len(parts))
+		for _, p := range parts {
+			out = append(out, inferScalar(unescapeCommas(strings.TrimSpace(p))))
+		}
+		return out
+	}
+	return inferScalar(unescapeCommas(s))
+}
+
+// setPath assigns val at the given hops, creating maps and lists along the way and
+// returning the (possibly new) container. A value of the wrong shape for the next
+// hop is replaced — an intermediate scalar becomes a map, as before — and a list
+// grows to fit the index, padding with nil.
+func setPath(cur any, steps []setStep, val any) any {
+	if len(steps) == 0 {
+		return val
+	}
+	if s := steps[0]; s.isIndex {
+		lst, _ := cur.([]any)
+		for len(lst) <= s.index {
+			lst = append(lst, nil)
+		}
+		lst[s.index] = setPath(lst[s.index], steps[1:], val)
+		return lst
+	}
+	m, _ := cur.(map[string]any)
+	if m == nil {
+		m = map[string]any{}
+	}
+	m[steps[0].key] = setPath(m[steps[0].key], steps[1:], val)
+	return m
 }
 
 // inferScalar converts a --set string into bool, int, float64, or string.

--- a/charts/values_test.go
+++ b/charts/values_test.go
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package charts
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// The regression this feature exists for: `--set 'extraNetworks[0]=x'` used to be
+// accepted and then silently do nothing — it landed as a key literally named
+// "extraNetworks[0]" that no template reads, so the install succeeded and the
+// operator debugged the wrong thing. It must now actually build the list.
+func TestMergeValuesSetListIndex(t *testing.T) {
+	got, err := MergeValues(map[string]any{}, nil, []string{
+		"extraNetworks[0]=ollama-net",
+		"extraNetworks[1]=mail-net",
+	})
+	require.NoError(t, err)
+	require.Equal(t, []any{"ollama-net", "mail-net"}, got["extraNetworks"])
+	require.NotContains(t, got, "extraNetworks[0]", "must not leak a bracketed key")
+}
+
+// Helm's list literal, the ergonomic form for a list of scalars.
+func TestMergeValuesSetListLiteral(t *testing.T) {
+	got, err := MergeValues(map[string]any{}, nil, []string{"extraNetworks={ollama-net,mail-net}"})
+	require.NoError(t, err)
+	require.Equal(t, []any{"ollama-net", "mail-net"}, got["extraNetworks"])
+
+	// A comma inside the expression must not be mistaken for a --set separator.
+	got, err = MergeValues(map[string]any{}, nil, []string{"a={x,y},b=1"})
+	require.NoError(t, err)
+	require.Equal(t, []any{"x", "y"}, got["a"])
+	require.Equal(t, 1, got["b"])
+
+	empty, err := MergeValues(map[string]any{}, nil, []string{"a={}"})
+	require.NoError(t, err)
+	require.Equal(t, []any{}, empty["a"])
+}
+
+// Elements are type-inferred, and a list replaces a default rather than merging.
+func TestMergeValuesSetListReplacesDefault(t *testing.T) {
+	defaults := map[string]any{"extraNetworks": []any{"stale-net", "other"}}
+	got, err := MergeValues(defaults, nil, []string{"extraNetworks={only-net}"})
+	require.NoError(t, err)
+	require.Equal(t, []any{"only-net"}, got["extraNetworks"])
+	require.Equal(t, []any{"stale-net", "other"}, defaults["extraNetworks"], "defaults must not be mutated")
+
+	mixed, err := MergeValues(map[string]any{}, nil, []string{"a={1,true,x}"})
+	require.NoError(t, err)
+	require.Equal(t, []any{1, true, "x"}, mixed["a"])
+}
+
+// Indexing into a list of maps, Helm-style.
+func TestMergeValuesSetListOfMaps(t *testing.T) {
+	got, err := MergeValues(map[string]any{}, nil, []string{"servers[0].port=80", "servers[0].host=a", "servers[1].port=443"})
+	require.NoError(t, err)
+	require.Equal(t, []any{
+		map[string]any{"port": 80, "host": "a"},
+		map[string]any{"port": 443},
+	}, got["servers"])
+}
+
+// A sparse index pads with nil rather than failing.
+func TestMergeValuesSetListSparseIndex(t *testing.T) {
+	got, err := MergeValues(map[string]any{}, nil, []string{"a[2]=x"})
+	require.NoError(t, err)
+	require.Equal(t, []any{nil, nil, "x"}, got["a"])
+}
+
+// Escaped commas survive both the --set split and the list split.
+func TestMergeValuesSetEscapedCommas(t *testing.T) {
+	got, err := MergeValues(map[string]any{}, nil, []string{`a=x\,y`})
+	require.NoError(t, err)
+	require.Equal(t, "x,y", got["a"])
+
+	lst, err := MergeValues(map[string]any{}, nil, []string{`a={x\,y,z}`})
+	require.NoError(t, err)
+	require.Equal(t, []any{"x,y", "z"}, lst["a"])
+}
+
+// A malformed path must fail loudly — never land as an unread bracketed key.
+func TestMergeValuesSetListErrors(t *testing.T) {
+	for _, expr := range []string{
+		"a[x]=1",  // non-numeric index
+		"a[-1]=1", // negative index
+		"a[0=1",   // unbalanced '['
+		"a]0]=1",  // unbalanced ']'
+		"[0]=1",   // index with no key
+		"a..b=1",  // empty segment
+		"a[0]x=1", // trailing junk after an index
+	} {
+		_, err := MergeValues(map[string]any{}, nil, []string{expr})
+		require.Error(t, err, "--set %q must be rejected, not silently ignored", expr)
+		require.Contains(t, err.Error(), "--set")
+	}
+}


### PR DESCRIPTION
## Why

`--set 'extraNetworks[0]=x'` was **accepted and then silently did nothing**. `applySet` split key paths on `.` only, so the unmatched key landed as a values entry named literally `extraNetworks[0]` — which no template reads. The install *succeeded* with the value unset, so the operator went off debugging the feature rather than the flag.

Reproduced against the zammad chart before this change:

```
--set 'extraNetworks[0]=eldara-ollama_ai-internal'   → exit 0, no error, no warning
  railsserver networks: zammad-internal, postgres-net, redis-net     ← overlay MISSING
```

This was never zammad-specific — it hit **every list value in swarmcli-charts**: `placement.constraints` on nearly every chart, openclaw's `allowedOrigins`/`trustedProxies`, traefik's entrypoints. It simply became far easier to hit now that [swarmcli-charts#82](https://github.com/Eldara-Tech/swarmcli-charts/pull/82) ships `extraNetworks`, the first list an operator has a real reason to set from the CLI.

## What

Both Helm forms, and everything else fails loudly:

```bash
--set 'extraNetworks[0]=ai-net'            # index assignment, grows the list
--set 'extraNetworks={ai-net,mail-net}'    # list literal ({} is the empty list)
--set 'servers[0].port=80'                 # indexing into a list of maps
--set 'extraNetworks[x]=oops'              # → Error: invalid list index "x"
```

`splitSet` is now brace-aware, so a comma inside `{}` isn't mistaken for a `--set` separator. It no longer resolves `\,` itself — the value parser does — so an escaped comma survives both splits (`{a\,b}` → `["a,b"]`). Escaped commas in a key path keep their previous meaning.

Malformed paths (bad/negative index, unbalanced brackets, index without a key, empty segment, trailing junk) are rejected: **a `--set` that quietly does nothing is worse than one that fails.**

## Tests

New `charts/values_test.go` covers index assignment, list literals, lists of maps, sparse-index padding, defaults not being mutated, escaped commas through both splits, and seven malformed paths that must error rather than no-op. Existing `MergeValues` precedence/error tests unchanged. Full `go test ./...` green; `golangci-lint run ./charts/...` reports 0 issues.

Verified end-to-end against swarmcli-charts#82: the previously-silent command now attaches the overlay, and a typo errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)