### PR TITLE
Show ":help" hint on the stack bar, clamp breadcrumbs to width

### DIFF
--- a/app/model.go
+++ b/app/model.go
@@ -174,25 +174,85 @@ func (m *Model) replaceView(name string, data any) tea.Cmd {
 // Set from init() to display persistent status (e.g., license mode).
 var StackBarSuffix string
 
+// commandHintText advertises the ":" command bar, which is invisible until
+// pressed. ":help" opens the command list; "?" opens the keybindings — the
+// wording deliberately keeps those two distinct.
+const commandHintText = "Type :help for commands"
+
+// stackBarGap is the minimum number of blank columns kept between the
+// breadcrumbs and the right-aligned block, and between the segments inside it.
+const stackBarGap = 2
+
+// stackBarMaxCrumbs is the most breadcrumb segments shown before the oldest
+// are collapsed into a "…" prefix.
+const stackBarMaxCrumbs = 3
+
+var (
+	stackBarSuffixStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("208"))
+	stackBarHintStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("240"))
+)
+
 func (m *Model) renderStackBar() string {
 	names := make([]string, 0, m.viewStack.Len()+1)
 	for _, v := range m.viewStack.Views() {
 		names = append(names, v.Name())
 	}
 	names = append(names, m.currentView.Name())
-	result := RenderBreadcrumbs(names, 3)
-	if StackBarSuffix == "" {
-		return result
+	crumbs := m.fitBreadcrumbs(names)
+
+	// Try the right-aligned renderings widest-first and take the first that
+	// fits. The hint is dropped before the suffix: the suffix carries
+	// persistent status, the hint is only a discoverability aid.
+	for _, right := range m.stackBarRight() {
+		gap := m.terminalWidth - lipgloss.Width(crumbs) - lipgloss.Width(right)
+		if gap >= stackBarGap {
+			return crumbs + strings.Repeat(" ", gap) + right
+		}
 	}
-	style := lipgloss.NewStyle().Foreground(lipgloss.Color("208"))
-	suffix := style.Render(StackBarSuffix)
-	crumbWidth := lipgloss.Width(result)
-	suffixWidth := lipgloss.Width(suffix)
-	gap := m.terminalWidth - crumbWidth - suffixWidth
-	if gap < 2 {
-		return result
+	return crumbs
+}
+
+// stackBarRight returns the right-aligned stack bar renderings in preference
+// order, widest first. Empty when there is nothing to right-align.
+func (m *Model) stackBarRight() []string {
+	suffix := ""
+	if StackBarSuffix != "" {
+		suffix = stackBarSuffixStyle.Render(StackBarSuffix)
 	}
-	return result + strings.Repeat(" ", gap) + suffix
+	hint := ""
+	if !m.hidesGlobalKeys() {
+		hint = stackBarHintStyle.Render(commandHintText)
+	}
+
+	switch {
+	case hint != "" && suffix != "":
+		return []string{hint + strings.Repeat(" ", stackBarGap) + suffix, suffix}
+	case suffix != "":
+		return []string{suffix}
+	case hint != "":
+		return []string{hint}
+	default:
+		return nil
+	}
+}
+
+// fitBreadcrumbs renders the breadcrumb trail for names, shedding the oldest
+// segments until the line fits terminalWidth. RenderBreadcrumbs already
+// collapses what it drops into a "…" prefix, so narrowing maxDisplay degrades
+// gracefully and always keeps the current view — the rightmost segment, and
+// the one worth keeping. Truncates only when even a single segment overflows.
+func (m *Model) fitBreadcrumbs(names []string) string {
+	if m.terminalWidth <= 0 {
+		return RenderBreadcrumbs(names, stackBarMaxCrumbs)
+	}
+	crumbs := ""
+	for display := stackBarMaxCrumbs; display >= 1; display-- {
+		crumbs = RenderBreadcrumbs(names, display)
+		if lipgloss.Width(crumbs) <= m.terminalWidth {
+			return crumbs
+		}
+	}
+	return lipgloss.NewStyle().MaxWidth(m.terminalWidth).Render(crumbs)
 }
 
 func cmdBar() *commandinput.Model {

--- a/app/stackbar_test.go
+++ b/app/stackbar_test.go
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package app
+
+import (
+	"strings"
+	"testing"
+
+	"swarmcli/views/view"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
+	"github.com/stretchr/testify/require"
+)
+
+// capturingStubView simulates a view that swallows every keystroke, so the
+// app-level ":" bar is unreachable from it.
+type capturingStubView struct{ stubView }
+
+func (v *capturingStubView) HidesGlobalHelp() bool { return true }
+
+// setStackBarSuffix sets the package-level suffix for the duration of a test.
+func setStackBarSuffix(t *testing.T, suffix string) {
+	t.Helper()
+	orig := StackBarSuffix
+	t.Cleanup(func() { StackBarSuffix = orig })
+	StackBarSuffix = suffix
+}
+
+// deepTrail is a realistic nested trail. Only "stacks" is top-level, so
+// RenderBreadcrumbs keeps all five segments rather than trimming to a nearer
+// root — this is what exercises the maxDisplay cap and the "…" prefix.
+var deepTrail = []string{view.NameStacks, view.NameServices, view.NameTasks, view.NameInspect, view.NameLogs}
+
+// nestedModel returns a model whose view stack renders deepTrail.
+func nestedModel(t *testing.T) *Model {
+	t.Helper()
+	m := newTestAppModel(&stubView{name: deepTrail[len(deepTrail)-1]})
+	for _, n := range deepTrail[:len(deepTrail)-1] {
+		m.viewStack.Push(&stubView{name: n})
+	}
+	return m
+}
+
+func TestRenderStackBar_ShowsCommandHint(t *testing.T) {
+	setStackBarSuffix(t, "")
+	m := newTestAppModel(&stubView{name: view.NameStacks})
+
+	out := ansi.Strip(m.renderStackBar())
+
+	require.Contains(t, out, commandHintText)
+	require.Contains(t, out, view.NameStacks)
+}
+
+func TestRenderStackBar_HintCoexistsWithSuffix(t *testing.T) {
+	setStackBarSuffix(t, "status-suffix")
+	m := newTestAppModel(&stubView{name: view.NameStacks})
+
+	out := m.renderStackBar()
+	stripped := ansi.Strip(out)
+
+	require.Contains(t, stripped, commandHintText)
+	require.Contains(t, stripped, "status-suffix")
+	// The suffix keeps the right edge; the hint sits to its left.
+	require.True(t, strings.HasSuffix(stripped, "status-suffix"),
+		"suffix must be flush right, got %q", stripped)
+	require.Less(t, strings.Index(stripped, commandHintText), strings.Index(stripped, "status-suffix"))
+	require.LessOrEqual(t, lipgloss.Width(out), m.terminalWidth)
+}
+
+func TestRenderStackBar_SuffixSurvivesWhenHintDoesNot(t *testing.T) {
+	setStackBarSuffix(t, "status-suffix")
+	m := newTestAppModel(&stubView{name: view.NameStacks})
+
+	// Exactly enough room for the crumbs and the suffix, but not the hint.
+	crumbs := m.fitBreadcrumbs([]string{view.NameStacks})
+	m.terminalWidth = lipgloss.Width(crumbs) + stackBarGap + lipgloss.Width(StackBarSuffix)
+
+	out := ansi.Strip(m.renderStackBar())
+
+	require.Contains(t, out, "status-suffix")
+	require.NotContains(t, out, commandHintText)
+}
+
+func TestRenderStackBar_HiddenInHelpView(t *testing.T) {
+	setStackBarSuffix(t, "")
+	m := newTestAppModel(&stubView{name: view.NameHelp})
+
+	out := ansi.Strip(m.renderStackBar())
+
+	require.NotContains(t, out, commandHintText)
+	require.Contains(t, out, view.NameHelp)
+}
+
+func TestRenderStackBar_HiddenWhenViewHidesGlobalHelp(t *testing.T) {
+	setStackBarSuffix(t, "")
+	m := newTestAppModel(&capturingStubView{stubView{name: "shell"}})
+
+	out := ansi.Strip(m.renderStackBar())
+
+	require.NotContains(t, out, commandHintText)
+	require.Contains(t, out, "shell")
+}
+
+func TestFitBreadcrumbs_ShedsOldestToFit(t *testing.T) {
+	m := nestedModel(t)
+	m.terminalWidth = 30
+
+	out := m.fitBreadcrumbs(deepTrail)
+	stripped := ansi.Strip(out)
+
+	require.LessOrEqual(t, lipgloss.Width(out), 30)
+	require.Contains(t, stripped, "…", "shed segments must collapse into an ellipsis")
+	// Shedding is oldest-first: the current view always survives.
+	require.Contains(t, stripped, view.NameLogs)
+	require.NotContains(t, stripped, view.NameStacks, "oldest segments shed first")
+}
+
+func TestFitBreadcrumbs_TruncatesWhenSingleCrumbOverflows(t *testing.T) {
+	m := nestedModel(t)
+	m.terminalWidth = 5
+
+	out := m.fitBreadcrumbs(deepTrail)
+
+	require.LessOrEqual(t, lipgloss.Width(out), 5)
+}
+
+func TestFitBreadcrumbs_UnclampedWhenWidthUnset(t *testing.T) {
+	m := nestedModel(t)
+	m.terminalWidth = 0
+
+	out := m.fitBreadcrumbs(deepTrail)
+
+	require.Equal(t, RenderBreadcrumbs(deepTrail, stackBarMaxCrumbs), out)
+	require.NotEmpty(t, out)
+}
+
+func TestRenderStackBar_NeverExceedsTerminalWidth(t *testing.T) {
+	orig := StackBarSuffix
+	t.Cleanup(func() { StackBarSuffix = orig })
+
+	m := nestedModel(t)
+
+	for w := 10; w <= 200; w += 2 {
+		for _, suffix := range []string{"", "status-suffix", strings.Repeat("s", 60)} {
+			StackBarSuffix = suffix
+			m.terminalWidth = w
+			out := m.renderStackBar()
+			require.LessOrEqualf(t, lipgloss.Width(out), w, "width overflow at w=%d suffix=%q", w, suffix)
+			require.Equalf(t, 1, lipgloss.Height(out), "stack bar must stay one line at w=%d", w)
+		}
+	}
+}

--- a/app/view.go
+++ b/app/view.go
@@ -30,11 +30,7 @@ func (m *Model) View() string {
 		{Key: "?", Desc: "Help"},
 		{Key: "ctrl+q", Desc: "Quit"},
 	}
-	if m.currentView.Name() == view.NameHelp {
-		globalHelp = []helpbar.HelpEntry{}
-	}
-	// Suppress global keys when the view hides them (e.g., shell).
-	if vc, ok := m.currentView.(interface{ HidesGlobalHelp() bool }); ok && vc.HidesGlobalHelp() {
+	if m.hidesGlobalKeys() {
 		globalHelp = []helpbar.HelpEntry{}
 	}
 
@@ -110,6 +106,17 @@ func (m *Model) View() string {
 		m.renderStackBar(),
 	)
 	return m.overlayStartup(m.overlayUnlock(m.overlayAppError(m.overlayUpdate(out))))
+}
+
+// hidesGlobalKeys reports whether the current view suppresses the app-level
+// keybindings: the help view already lists them, and a view may capture every
+// keystroke (implementing HidesGlobalHelp), which makes ":"/"?" unreachable.
+func (m *Model) hidesGlobalKeys() bool {
+	if m.currentView.Name() == view.NameHelp {
+		return true
+	}
+	vc, ok := m.currentView.(interface{ HidesGlobalHelp() bool })
+	return ok && vc.HidesGlobalHelp()
 }
 
 // overlayAppError overlays the app-level error dialog on top of the rendered output.


### PR DESCRIPTION
Closes #459.

## What

Adds a muted `Type :help for commands` to the **breadcrumb bar** (the last line of the screen), right-aligned.

The `:` command bar is invisible until pressed (`commandinput.View()` returns `""` when inactive), and neither help surface advertises it — the helpbar's `<?> Help` opens the *keybinding cheat-sheet*, while the *command list* lives behind `:help`. So `:stack`, `:service`, `:node` … were effectively undiscoverable.

```
 stacks                                    Type :help for commands
```

## Two deviations from the issue worth reviewing

**1. Placement is one row below the screenshot.** The red box in #459 sits on the `Stack 1 of 10` row *inside* the frame border — the view's `FrameFooter`. Putting the hint there costs `logs`/`inspect`/`contexts`/`loading` one content row each: they return `""` from `FrameFooter()`, so a hint flips `footerLines` 0→1 in `ui/framecalc.go:57` (14→13 rows on the log viewer at 80×24, where vertical space matters most). It would also mean `app/view.go` doing string surgery on view-owned, already-styled footers plus duplicating `borderWidth` math that `ui/` owns.

The breadcrumb bar is one row lower, costs **zero** rows (the line already exists and is already budgeted by `view.go:56`'s `-1` and `update.go:468`'s `-7`), and needs no layout arithmetic changes at all.

**2. A pre-existing bugfix is folded in** (at the reviewer's request). Breadcrumbs were never width-clamped, so a nested trail rendered *wider than the terminal* below ~40 columns — `model.go:193` returned them unclamped. `fitBreadcrumbs` sheds the oldest segments until the line fits, reusing the `…` collapse `RenderBreadcrumbs` already implements, so **the current view always survives** (a plain right-truncation would eat exactly the crumb that matters most). `MaxWidth` backstops the pathological case.

`TestRenderStackBar_NeverExceedsTerminalWidth` **fails on `main`** — verified: the trail renders 34 columns into a 10-column terminal. That failure is the bugfix landing. It also turns `renderStackBar`'s `gap` arithmetic from sound-by-assumption into sound-by-construction.

## Extension-point safety

`StackBarSuffix` is **read, never written**. The hint composes as a separate segment to its left; the suffix keeps its documented right-edge anchor (no jitter when the hint drops), and the hint is dropped first when the line is narrow — persistent status outranks a discoverability aid. Rendering is a strict superset of today's: byte-identical when the hint doesn't fit, gaining the hint only when there is room.

Verified against the BE module (which has `replace swarmcli => ../swarmcli`): full suite green, including the four packages that assert on `StackBarSuffix`.

```
 stacks       Type :help for commands  No valid license · Community Edition   (w=80)
 stacks                                No valid license · Community Edition   (w=60, hint sheds)
```

## Suppression

Hidden in the help view (`:help` is what opens it — `?` lands on the same view name, so one check covers both) and under `HidesGlobalHelp()`, where the view captures every keystroke and `:` genuinely does not work — advertising it there would be a lie. Reuses the check the helpbar already needed; `hidesGlobalKeys()` is extracted rather than duplicated (net −4 lines in `view.go`).

Fullscreen needs no handling: `view.go:16-23` returns before `renderStackBar` is called.

## Wording

"Type", not "Press" — the prompt glyph renders `> `, so there is no `:` on screen to press. "for commands", not "for help" — `?` shows keybindings, `:help` shows the command list; the wording is what keeps them distinct.

## Test / verification

`app/stackbar_test.go` is net-new coverage — `renderStackBar` had **zero** tests. 9 tests: hint shown, BE coexistence + ordering, degradation order, both suppressions, the three clamp cases, and a width sweep (10→200 × 3 suffix lengths) asserting the bar never exceeds `terminalWidth` and stays one line.

`gofmt` / `go vet` / `golangci-lint` (0 issues) / `go test -race -count=1 ./...` all green in both repos. Rendered output eyeballed at widths 10–120 across OSS, BE-unlicensed, and both suppressed surfaces.

## Labels

`A0-ui` even though the clamp is a bugfix — group A takes one label and the headline intent is the hint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)