### PR TITLE
feat(charts): let a chart declare the swarmcli it needs

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -34,6 +34,7 @@ builds:
       - -X main.version={{.Version}}
       - -X main.commit={{.Commit}}
       - -X main.date={{.Date}}
+      - -X swarmcli/charts.engineVersion={{.Version}}
     main: .
 
   - id: osx
@@ -49,6 +50,7 @@ builds:
       - -X main.version={{.Version}}
       - -X main.commit={{.Commit}}
       - -X main.date={{.Date}}
+      - -X swarmcli/charts.engineVersion={{.Version}}
     main: .
 
   - id: windows
@@ -65,6 +67,7 @@ builds:
       - -X main.version={{.Version}}
       - -X main.commit={{.Commit}}
       - -X main.date={{.Date}}
+      - -X swarmcli/charts.engineVersion={{.Version}}
     main: .
 
   - id: freebsd
@@ -80,6 +83,7 @@ builds:
       - -X main.version={{.Version}}
       - -X main.commit={{.Commit}}
       - -X main.date={{.Date}}
+      - -X swarmcli/charts.engineVersion={{.Version}}
     main: .
 
 archives:

--- a/README.md
+++ b/README.md
@@ -105,6 +105,11 @@ deployed state is reproducible and an automated updater (e.g. Renovate) has
 something concrete to bump. It never removes a release the file does not mention —
 it reports those instead. See [charts/README.md](charts/README.md#declarative-releases-gitops).
 
+A chart can declare the swarmcli it needs (`swarmcliVersion: ">= 1.13.0"` in
+`Chart.yaml`). Installing it on an older build fails naming the version to
+upgrade to, instead of breaking somewhere inside the template; `--skip-compat-check`
+proceeds anyway. See [charts/README.md](charts/README.md#declaring-the-swarmcli-a-chart-needs).
+
 Run `swarmcli charts --help` for the full command and option reference.
 
 ## Business Edition

--- a/charts/README.md
+++ b/charts/README.md
@@ -131,7 +131,7 @@ version is published, with the chart's release notes attached. Merge it, and
 
 ```
 mychart/
-├── Chart.yaml          # name, version, appVersion, description, maintainers
+├── Chart.yaml          # apiVersion, name, version, appVersion, swarmcliVersion, …
 ├── values.yaml         # default values
 ├── values.schema.json  # optional JSON Schema validated before render
 ├── README.md
@@ -141,6 +141,35 @@ mychart/
     ├── secrets.yaml
     └── volumes.yaml
 ```
+
+`apiVersion` is `v1` (the only format this build reads; absent means `v1`).
+
+### Declaring the swarmcli a chart needs
+
+A chart may state the chart engine it requires, as a SemVer constraint:
+
+```yaml
+# Chart.yaml
+swarmcliVersion: ">= 1.13.0"
+```
+
+`install`, `upgrade` and `apply` refuse a chart this build is too old for, so the
+failure names the version to upgrade to rather than surfacing as whatever error
+the missing feature happens to produce (`function "toYamlPretty" not defined`).
+`install` and `upgrade` ask before refusing when run interactively; `apply` never
+does — it is meant to run unattended. `template`, `diff` and `show` only warn:
+they change nothing, and `show` is how you find out what a chart wants. Pass
+`--skip-compat-check` to proceed anyway.
+
+The constraint is checked against the **chart engine's** version, which is not
+necessarily the version the binary reports for itself — a binary embedding this
+package carries whichever engine it pinned. A build that reports no engine
+version (any `go build`) warns rather than refusing: not knowing is not evidence
+of incompatibility. Charts declaring nothing are unaffected.
+
+Note that only builds carrying this check can honour it: `Chart.yaml` is parsed
+leniently, so an older swarmcli silently ignores `swarmcliVersion` — the same
+bootstrapping limit Helm's own `apiVersion` gate has.
 
 Templates are rendered with Go `text/template` + [Sprig], exposing:
 

--- a/charts/apply.go
+++ b/charts/apply.go
@@ -35,6 +35,12 @@ type ReleasePlan struct {
 	Requirements *Requirements
 	// CurrentManifest is the deployed manifest, for diffing. Empty for an install.
 	CurrentManifest string
+	// Compat is the chart's engine requirement checked against this build.
+	// Planning records it but never acts on it: apply's contract is to plan
+	// every release before converging any, so the whole plan is gated at once
+	// by the caller — which is also the layer that knows whether blocking is
+	// appropriate for the verb being run.
+	Compat CompatFinding
 }
 
 // Plan is what apply would do to the whole swarm.
@@ -105,6 +111,7 @@ func (e *Engine) planRelease(rf *ReleaseFile, spec ReleaseSpec, src ChartSource,
 	if err != nil {
 		return ReleasePlan{}, fmt.Errorf("%s: release %q: %w", rf.Path, spec.Name, err)
 	}
+	compat := CheckCompat(ch.Metadata)
 
 	files, err := readFiles(rf.ValuesPaths(spec))
 	if err != nil {
@@ -126,13 +133,16 @@ func (e *Engine) planRelease(rf *ReleaseFile, spec ReleaseSpec, src ChartSource,
 		Release: ReleaseMeta{Name: spec.Name, Namespace: spec.Name, Revision: 1},
 		Chart:   ChartMeta{Name: rc.Name, Version: rc.Version, AppVersion: rc.AppVersion},
 	}
+	// A chart needing a newer engine usually fails here rather than reaching the
+	// caller's gate, so name the requirement alongside whatever the missing
+	// feature produced (compatHint is empty unless the chart is incompatible).
 	manifest, err := Render(ch, rctx)
 	if err != nil {
-		return ReleasePlan{}, fmt.Errorf("%s: release %q: %w", rf.Path, spec.Name, err)
+		return ReleasePlan{}, fmt.Errorf("%s: release %q: %w%s", rf.Path, spec.Name, err, compatHint(compat))
 	}
 	req, err := RenderRequirements(ch, rctx)
 	if err != nil {
-		return ReleasePlan{}, fmt.Errorf("%s: release %q: %w", rf.Path, spec.Name, err)
+		return ReleasePlan{}, fmt.Errorf("%s: release %q: %w%s", rf.Path, spec.Name, err, compatHint(compat))
 	}
 
 	rp := ReleasePlan{
@@ -143,6 +153,7 @@ func (e *Engine) planRelease(rf *ReleaseFile, spec ReleaseSpec, src ChartSource,
 		Values:       values,
 		Manifest:     manifest,
 		Requirements: req,
+		Compat:       compat,
 	}
 
 	cur, ok := deployed[spec.Name]

--- a/charts/apply_test.go
+++ b/charts/apply_test.go
@@ -67,6 +67,60 @@ releases:
     version: "0.1.0"
 `
 
+// Planning records a chart's engine requirement but must not act on it: apply
+// plans every release before converging any, so the whole plan is gated at once
+// by the caller.
+func TestPlanApplyRecordsCompatFinding(t *testing.T) {
+	withEngineVersion(t, "1.12.0")
+	e, _, src, rf := applyEnv(t, oneRelease)
+
+	ch := demoChart(t, "0.1.0")
+	ch.Metadata.SwarmcliVersion = ">= 1.13.0"
+	src.charts["swarmcli-charts/demo@0.1.0"] = ch
+
+	plan, err := e.PlanApply(context.Background(), rf, src)
+	require.NoError(t, err, "an incompatible chart must still plan; refusing is the caller's call")
+	require.Len(t, plan.Releases, 1)
+	require.Equal(t, ActionInstall, plan.Releases[0].Action)
+	require.Equal(t, CompatIncompatible, plan.Releases[0].Compat.Status)
+	require.Equal(t, ">= 1.13.0", plan.Releases[0].Compat.Required)
+}
+
+// The motivating case: a chart needing a newer engine usually dies inside Render
+// long before the caller's gate sees the finding, so the render error itself has
+// to carry the diagnosis.
+func TestPlanApplyRenderErrorNamesTheEngineRequirement(t *testing.T) {
+	withEngineVersion(t, "1.12.0")
+	e, _, src, rf := applyEnv(t, oneRelease)
+
+	broken := demoChart(t, "0.1.0")
+	broken.Metadata.SwarmcliVersion = ">= 1.13.0"
+	broken.Templates = map[string]string{"templates/stack.yaml": "{{ toYamlPretty .Values }}"}
+	src.charts["swarmcli-charts/demo@0.1.0"] = broken
+
+	_, err := e.PlanApply(context.Background(), rf, src)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "toYamlPretty", "the underlying failure must survive")
+	require.ErrorContains(t, err, "requires swarmcli >= 1.13.0", "and be diagnosed")
+	require.ErrorContains(t, err, "likely a consequence")
+}
+
+// The same failure on a chart that declared nothing must not acquire a spurious
+// compatibility story.
+func TestPlanApplyRenderErrorUnannotatedWhenNothingDeclared(t *testing.T) {
+	withEngineVersion(t, "1.12.0")
+	e, _, src, rf := applyEnv(t, oneRelease)
+
+	broken := demoChart(t, "0.1.0")
+	broken.Templates = map[string]string{"templates/stack.yaml": "{{ toYamlPretty .Values }}"}
+	src.charts["swarmcli-charts/demo@0.1.0"] = broken
+
+	_, err := e.PlanApply(context.Background(), rf, src)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "toYamlPretty")
+	require.NotContains(t, err.Error(), "likely a consequence")
+}
+
 func TestApplyInstallsThenIsIdempotent(t *testing.T) {
 	e, fb, src, rf := applyEnv(t, oneRelease, "0.1.0")
 	ctx := context.Background()

--- a/charts/buildinfo.go
+++ b/charts/buildinfo.go
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package charts
+
+// engineVersion is the chart-engine feature level, stamped at build time with
+//
+//	-X swarmcli/charts.engineVersion=<version>
+//
+// It names the version of THIS module, which is not necessarily the version the
+// surrounding binary reports for itself: the chart engine is this module's code,
+// so a downstream binary that embeds it carries whichever engine it pinned,
+// regardless of its own tag. Such a build stamps this with the swarmcli version
+// it pins; a plain swarmcli build stamps it with its own.
+//
+// It is empty in an unstamped build (`go build`, `go run`, dev), and CheckCompat
+// then reports CompatUnknown rather than blocking — not knowing the engine
+// version is not evidence that a chart is incompatible with it.
+var engineVersion = ""
+
+// EngineVersion reports the chart-engine version this binary embeds, or the
+// empty string for an unstamped build.
+func EngineVersion() string { return engineVersion }

--- a/charts/chart.go
+++ b/charts/chart.go
@@ -25,6 +25,12 @@ const (
 	templatesDir     = "templates"
 )
 
+// chartAPIVersionV1 is the only Chart.yaml schema this build understands. An
+// absent apiVersion means v1: charts predate the field, and none in the wild set
+// it. Validating it is what reserves a future value for a format break — an
+// older swarmcli must refuse a chart it cannot read, not load half of it.
+const chartAPIVersionV1 = "v1"
+
 // maxChartFileSize bounds any single file read from a chart archive to guard
 // against decompression bombs in downloaded tarballs.
 const maxChartFileSize = 10 << 20 // 10 MiB
@@ -219,6 +225,12 @@ func validateChart(ch *Chart) error {
 	}
 	if ch.Metadata.Version == "" {
 		return fmt.Errorf("Chart.yaml: version is required")
+	}
+	switch ch.Metadata.APIVersion {
+	case "", chartAPIVersionV1:
+	default:
+		return fmt.Errorf("Chart.yaml: unsupported apiVersion %q (expected %q)",
+			ch.Metadata.APIVersion, chartAPIVersionV1)
 	}
 	if len(ch.Templates) == 0 {
 		return fmt.Errorf("chart %q has no templates", ch.Metadata.Name)

--- a/charts/chart_test.go
+++ b/charts/chart_test.go
@@ -43,6 +43,59 @@ func TestLoadChartArchiveMissingChartfile(t *testing.T) {
 	require.ErrorContains(t, err, "name is required")
 }
 
+// Validating apiVersion is what reserves a future value for a format break: an
+// older build must refuse a chart it cannot read rather than load half of it.
+func TestLoadChartAPIVersion(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		line    string
+		wantErr string
+	}{
+		{name: "absent means v1", line: ""},
+		{name: "explicit v1", line: "apiVersion: v1\n"},
+		{name: "a future format is refused", line: "apiVersion: v2\n", wantErr: `unsupported apiVersion "v2"`},
+		{name: "nonsense is refused", line: "apiVersion: v99\n", wantErr: `unsupported apiVersion "v99"`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tgz := packEntries(t, map[string]string{
+				"demo/Chart.yaml":           tc.line + "name: demo\nversion: 0.1.0\n",
+				"demo/templates/stack.yaml": "services: {}",
+			})
+			ch, err := LoadChartArchive(strings.NewReader(tgz))
+			if tc.wantErr != "" {
+				require.ErrorContains(t, err, tc.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, "demo", ch.Metadata.Name)
+		})
+	}
+}
+
+func TestLoadChartSwarmcliVersion(t *testing.T) {
+	tgz := packEntries(t, map[string]string{
+		"demo/Chart.yaml":           "name: demo\nversion: 0.1.0\nswarmcliVersion: \">= 1.13.0\"\n",
+		"demo/templates/stack.yaml": "services: {}",
+	})
+	ch, err := LoadChartArchive(strings.NewReader(tgz))
+	require.NoError(t, err)
+	require.Equal(t, ">= 1.13.0", ch.Metadata.SwarmcliVersion)
+}
+
+// The constraint is metadata, not a gate inside the loader: loading must succeed
+// so callers can read the requirement and report it. Refusing here would make
+// `charts show` unable to answer which version the chart wants.
+func TestLoadChartUnsatisfiableSwarmcliVersionStillLoads(t *testing.T) {
+	withEngineVersion(t, "1.0.0")
+	tgz := packEntries(t, map[string]string{
+		"demo/Chart.yaml":           "name: demo\nversion: 0.1.0\nswarmcliVersion: \">= 99.0.0\"\n",
+		"demo/templates/stack.yaml": "services: {}",
+	})
+	ch, err := LoadChartArchive(strings.NewReader(tgz))
+	require.NoError(t, err)
+	require.Equal(t, CompatIncompatible, CheckCompat(ch.Metadata).Status)
+}
+
 func TestLoadChartArchiveTooManyFiles(t *testing.T) {
 	files := map[string]string{}
 	for i := 0; i <= maxChartFiles; i++ {

--- a/charts/compat.go
+++ b/charts/compat.go
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package charts
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/Masterminds/semver/v3"
+)
+
+// maxConstraintLen bounds swarmcliVersion before it reaches the constraint
+// parser, which is regexp-backed and fed from chart metadata that may have come
+// off the network. A real constraint is a handful of characters.
+const maxConstraintLen = 256
+
+// CompatStatus classifies a chart's declared engine requirement against this build.
+type CompatStatus int
+
+const (
+	// CompatUnknown means the chart declared no requirement, this build reports
+	// no engine version, or the declared constraint could not be parsed.
+	// Callers must not block on it: it is not evidence of an incompatible chart.
+	CompatUnknown CompatStatus = iota
+	// CompatOK means this build's chart engine satisfies the constraint.
+	CompatOK
+	// CompatIncompatible means it does not. This is the only status callers
+	// block on.
+	CompatIncompatible
+)
+
+// CompatFinding is the result of checking one chart against this build.
+type CompatFinding struct {
+	Chart    string // "<name> <version>", for messages
+	Required string // the chart's constraint as declared, e.g. ">= 1.13.0"
+	Engine   string // this build's chart-engine version; "" when unstamped
+	Status   CompatStatus
+	Reason   string // why the check was skipped; set only with CompatUnknown
+}
+
+// CheckCompat classifies a chart's swarmcliVersion constraint against the chart
+// engine this binary embeds.
+//
+// It never returns an error. A constraint this build cannot make sense of yields
+// CompatUnknown, not a failure: the check is a compatibility aid, not a security
+// boundary — a chart already renders to an arbitrary stack — so failing open on
+// our own inability to parse costs nothing, whereas failing closed would break
+// working charts for a cosmetic reason.
+func CheckCompat(cf Chartfile) CompatFinding {
+	f := CompatFinding{
+		Chart:    strings.TrimSpace(cf.Name + " " + cf.Version),
+		Required: cf.SwarmcliVersion,
+		Engine:   engineVersion,
+	}
+	if cf.SwarmcliVersion == "" {
+		return f // nothing declared: the common case, and silently fine
+	}
+	if len(cf.SwarmcliVersion) > maxConstraintLen {
+		f.Reason = fmt.Sprintf("swarmcliVersion is longer than %d bytes", maxConstraintLen)
+		return f
+	}
+	c, err := semver.NewConstraint(cf.SwarmcliVersion)
+	if err != nil {
+		f.Reason = fmt.Sprintf("swarmcliVersion %q is not a valid SemVer constraint", cf.SwarmcliVersion)
+		return f
+	}
+	if strings.TrimSpace(engineVersion) == "" {
+		f.Reason = "this build reports no chart-engine version"
+		return f
+	}
+	core, ok := coreVersion(engineVersion)
+	if !ok {
+		f.Reason = fmt.Sprintf("this build's chart-engine version %q is not valid SemVer", engineVersion)
+		return f
+	}
+	if c.Check(core) {
+		f.Status = CompatOK
+	} else {
+		f.Status = CompatIncompatible
+	}
+	return f
+}
+
+// coreVersion parses an engine version down to major.minor.patch, dropping any
+// prerelease and build metadata.
+//
+// The drop is deliberate. SemVer constraints exclude prereleases by default, so
+// ">= 1.13.0" does not match "1.13.0-rc1" — yet a release candidate of 1.13.0
+// carries 1.13.0's chart features. Without this, every chart requiring the
+// version under test would be reported incompatible precisely while that release
+// is being tested.
+func coreVersion(v string) (*semver.Version, bool) {
+	if strings.TrimSpace(v) == "" {
+		return nil, false
+	}
+	parsed, err := semver.NewVersion(strings.TrimSpace(v))
+	if err != nil {
+		return nil, false
+	}
+	return semver.New(parsed.Major(), parsed.Minor(), parsed.Patch(), "", ""), true
+}
+
+// Message renders the finding as a one-line diagnostic naming what the chart
+// wants and what this build has.
+//
+// binaryVersion is the version the binary reports for itself. When it differs
+// from the engine's, both are named: a binary embedding this module may carry
+// its own version, and naming only the engine's would cite a release the user
+// cannot map back to anything they installed. Pass "" to name only the engine.
+func (f CompatFinding) Message(binaryVersion string) string {
+	var provides string
+	switch {
+	case f.Engine == "":
+		provides = "this build reports no chart-engine version"
+	case binaryVersion == "" || normalizeSemver(f.Engine) == normalizeSemver(binaryVersion):
+		provides = fmt.Sprintf("this build provides %s", f.Engine)
+	default:
+		provides = fmt.Sprintf("this build provides chart engine %s (swarmcli %s)", f.Engine, binaryVersion)
+	}
+	return fmt.Sprintf("chart %s requires swarmcli %s; %s", f.Chart, f.Required, provides)
+}
+
+// compatHint returns a trailing note for an error an incompatible chart engine
+// probably caused, or "" when it did not.
+//
+// A chart needing a newer engine usually fails inside Render first — with
+// whatever error the missing feature happens to produce — so the finding never
+// reaches the caller's compatibility gate. Naming it alongside that error turns
+// `function "toYamlPretty" not defined` into a diagnosis.
+func compatHint(f CompatFinding) string {
+	if f.Status != CompatIncompatible {
+		return ""
+	}
+	return "\n  (" + f.Message("") + " — this error is likely a consequence)"
+}

--- a/charts/compat_test.go
+++ b/charts/compat_test.go
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package charts
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// withEngineVersion sets the build-stamped engine version for one test and
+// restores it afterwards.
+func withEngineVersion(t *testing.T, v string) {
+	t.Helper()
+	prev := engineVersion
+	engineVersion = v
+	t.Cleanup(func() { engineVersion = prev })
+}
+
+func TestEngineVersion(t *testing.T) {
+	withEngineVersion(t, "1.13.0")
+	require.Equal(t, "1.13.0", EngineVersion())
+}
+
+func TestCheckCompat(t *testing.T) {
+	tests := []struct {
+		name       string
+		engine     string
+		constraint string
+		want       CompatStatus
+		reason     string // substring; empty means Reason must be empty too
+	}{
+		{name: "nothing declared", engine: "1.12.0", constraint: "", want: CompatUnknown},
+		{name: "satisfied exactly", engine: "1.13.0", constraint: ">= 1.13.0", want: CompatOK},
+		{name: "satisfied by newer", engine: "1.14.2", constraint: ">= 1.13.0", want: CompatOK},
+		{name: "unsatisfied", engine: "1.12.0", constraint: ">= 1.13.0", want: CompatIncompatible},
+		{name: "unsatisfied across a major", engine: "0.9.0", constraint: ">= 1.13.0", want: CompatIncompatible},
+		{name: "caret range satisfied", engine: "1.13.4", constraint: "^1.13.0", want: CompatOK},
+		{name: "caret range unsatisfied", engine: "2.0.0", constraint: "^1.13.0", want: CompatIncompatible},
+		{name: "compound range satisfied", engine: "1.13.0", constraint: ">= 1.13.0, < 2.0.0", want: CompatOK},
+		{name: "engine carries a v prefix", engine: "v1.13.0", constraint: ">= 1.13.0", want: CompatOK},
+
+		// A release candidate carries its release's chart features. SemVer
+		// constraints exclude prereleases by default, so without the core-version
+		// strip these would report incompatible exactly while a release is being
+		// tested.
+		{name: "rc satisfies its own release", engine: "1.13.0-rc1", constraint: ">= 1.13.0", want: CompatOK},
+		{name: "rc of a newer minor satisfies", engine: "v1.14.0-rc2", constraint: ">= 1.13.0", want: CompatOK},
+		{name: "rc below the floor still fails", engine: "1.12.0-rc1", constraint: ">= 1.13.0", want: CompatIncompatible},
+		{name: "build metadata is ignored", engine: "1.13.0+abc123", constraint: ">= 1.13.0", want: CompatOK},
+
+		{
+			name:   "unparseable constraint is ignored, not fatal",
+			engine: "1.12.0", constraint: "newer than 1.13 please",
+			want: CompatUnknown, reason: "not a valid SemVer constraint",
+		},
+		{
+			name:   "unstamped build cannot check",
+			engine: "", constraint: ">= 1.13.0",
+			want: CompatUnknown, reason: "reports no chart-engine version",
+		},
+		{
+			name:   "unparseable engine cannot check",
+			engine: "not-a-version", constraint: ">= 1.13.0",
+			want: CompatUnknown, reason: "is not valid SemVer",
+		},
+		{
+			name:   "over-long constraint is refused before parsing",
+			engine: "1.12.0", constraint: ">= 1.13.0" + strings.Repeat(" ", maxConstraintLen),
+			want: CompatUnknown, reason: "longer than 256 bytes",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			withEngineVersion(t, tc.engine)
+
+			f := CheckCompat(Chartfile{Name: "demo", Version: "0.2.0", SwarmcliVersion: tc.constraint})
+
+			require.Equal(t, tc.want, f.Status)
+			if tc.reason == "" {
+				require.Empty(t, f.Reason)
+			} else {
+				require.Contains(t, f.Reason, tc.reason)
+			}
+			// The finding always carries enough to render a message.
+			require.Equal(t, "demo 0.2.0", f.Chart)
+			require.Equal(t, tc.constraint, f.Required)
+			require.Equal(t, tc.engine, f.Engine)
+		})
+	}
+}
+
+// CheckCompat is a compatibility aid, not a security boundary: a constraint it
+// cannot use must never become a failure.
+func TestCheckCompatNeverBlocksOnUnusableInput(t *testing.T) {
+	withEngineVersion(t, "1.12.0")
+	for _, c := range []string{"", "  ", ">>>", "1.2.3.4.5", "not a constraint", strings.Repeat(">", 5000)} {
+		f := CheckCompat(Chartfile{Name: "demo", Version: "0.1.0", SwarmcliVersion: c})
+		require.NotEqual(t, CompatIncompatible, f.Status, "constraint %q must not block", c)
+	}
+}
+
+func TestCompatFindingMessage(t *testing.T) {
+	f := CompatFinding{Chart: "traefik 0.2.0", Required: ">= 1.13.0", Engine: "1.12.0", Status: CompatIncompatible}
+	const want = "chart traefik 0.2.0 requires swarmcli >= 1.13.0; this build provides 1.12.0"
+
+	t.Run("same version names it once", func(t *testing.T) {
+		require.Equal(t, want, f.Message("1.12.0"))
+	})
+	t.Run("a v-prefix skew is not a difference", func(t *testing.T) {
+		require.Equal(t, want, f.Message("v1.12.0"))
+	})
+	t.Run("no binary version names only the engine", func(t *testing.T) {
+		require.Equal(t, want, f.Message(""))
+	})
+	// The case the whole design exists for: a binary embedding an engine other
+	// than its own version must name both, or it cites a release the reader
+	// cannot map to anything they installed.
+	t.Run("differing versions name both", func(t *testing.T) {
+		require.Equal(t,
+			"chart traefik 0.2.0 requires swarmcli >= 1.13.0; this build provides chart engine 1.12.0 (swarmcli 1.12.1)",
+			f.Message("1.12.1"))
+	})
+}
+
+func TestCompatFindingMessageUnstampedEngine(t *testing.T) {
+	f := CompatFinding{Chart: "traefik 0.2.0", Required: ">= 1.13.0"}
+	require.Equal(t,
+		"chart traefik 0.2.0 requires swarmcli >= 1.13.0; this build reports no chart-engine version",
+		f.Message("1.12.0"))
+}
+
+func TestCompatHint(t *testing.T) {
+	incompatible := CompatFinding{
+		Chart: "traefik 0.2.0", Required: ">= 1.13.0", Engine: "1.12.0", Status: CompatIncompatible,
+	}
+	hint := compatHint(incompatible)
+	require.Contains(t, hint, "requires swarmcli >= 1.13.0")
+	require.Contains(t, hint, "likely a consequence")
+
+	// Anything else must add nothing to an unrelated error.
+	for _, f := range []CompatFinding{{Status: CompatOK}, {Status: CompatUnknown}} {
+		require.Empty(t, compatHint(f))
+	}
+}

--- a/charts/testdata/demo/Chart.yaml
+++ b/charts/testdata/demo/Chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: v2
+apiVersion: v1
 name: demo
 version: 0.1.0
 appVersion: "1.0"

--- a/charts/types.go
+++ b/charts/types.go
@@ -36,12 +36,16 @@ const (
 
 // Chartfile is the parsed Chart.yaml metadata.
 type Chartfile struct {
-	APIVersion  string       `yaml:"apiVersion"`
-	Name        string       `yaml:"name"`
-	Version     string       `yaml:"version"`
-	AppVersion  string       `yaml:"appVersion,omitempty"`
-	Description string       `yaml:"description,omitempty"`
-	Maintainers []Maintainer `yaml:"maintainers,omitempty"`
+	APIVersion string `yaml:"apiVersion"`
+	Name       string `yaml:"name"`
+	Version    string `yaml:"version"`
+	AppVersion string `yaml:"appVersion,omitempty"`
+	// SwarmcliVersion is a SemVer constraint on the chart engine this chart
+	// needs, e.g. ">= 1.13.0". Optional; absent means any. It constrains the
+	// engine's version rather than the running binary's — see buildinfo.go.
+	SwarmcliVersion string       `yaml:"swarmcliVersion,omitempty"`
+	Description     string       `yaml:"description,omitempty"`
+	Maintainers     []Maintainer `yaml:"maintainers,omitempty"`
 	// Dependencies are parsed but not resolved in Phase 1 (subcharts are Phase 3).
 	Dependencies []Dependency `yaml:"dependencies,omitempty"`
 }

--- a/cli/apply.go
+++ b/cli/apply.go
@@ -48,6 +48,27 @@ func chartsApply(args []string) int {
 
 	printPlan(plan, f.diff)
 
+	// Gate the whole plan before converging any of it, matching PlanApply: a
+	// release that cannot run on this build must not leave the swarm half
+	// converged. Unchanged releases are exempt — they are already deployed, and
+	// apply is not going to touch them.
+	//
+	// The preview verbs only report, so they warn; the rest refuse without ever
+	// prompting, because apply is meant to run unattended and must not block on
+	// stdin just because a terminal happens to be attached.
+	pol := compatEnforceNoPrompt
+	if f.dryRun || f.diff {
+		pol = compatWarn
+	}
+	for _, r := range plan.Releases {
+		if r.Action == charts.ActionUnchanged {
+			continue
+		}
+		if code := applyCompat(r.Compat, pol, f.skipCompatCheck); code >= 0 {
+			return code
+		}
+	}
+
 	// --diff is a preview verb; it must never deploy.
 	if f.dryRun || f.diff {
 		outln("\ndry-run: nothing was deployed")

--- a/cli/args.go
+++ b/cli/args.go
@@ -27,6 +27,9 @@ type flags struct {
 	revision     int           // --revision (get)
 	timeout      time.Duration // --timeout
 	historyMax   int           // --history-max
+	// skipCompatCheck (--skip-compat-check) downgrades a chart's unmet
+	// swarmcliVersion requirement from a refusal to a warning.
+	skipCompatCheck bool
 }
 
 // parseArgs splits raw args into positionals and flags. It understands the
@@ -124,6 +127,8 @@ func parseArgs(args []string) ([]string, flags, error) {
 			f.purge = true
 		case "--install":
 			f.install = true
+		case "--skip-compat-check":
+			f.skipCompatCheck = true
 		default:
 			return nil, f, fmt.Errorf("unknown flag %q", name)
 		}

--- a/cli/charts.go
+++ b/cli/charts.go
@@ -65,6 +65,17 @@ A chart may declare its external networks/secrets/configs in requirements.yaml:
 install pre-flights them (auto-creating networks marked autoCreate, validating
 the rest) and uninstall reports any auto-created networks it leaves in place.
 
+A chart may also declare the swarmcli it needs, as a SemVer constraint:
+
+  # Chart.yaml
+  swarmcliVersion: ">= 1.13.0"
+
+install, upgrade and apply refuse a chart this build is too old for, so the
+failure names the version to upgrade to instead of surfacing as whatever error
+the missing feature happens to produce. install and upgrade ask first when run
+interactively; apply never does. template, diff and show only warn. Pass
+--skip-compat-check to try anyway. Charts declaring nothing are unaffected.
+
 Common options:
   -f, --values <file>   Values file (repeatable). For apply: the release file.
       --set k=v         Override a value (repeatable)
@@ -80,6 +91,7 @@ Common options:
       --revision <n>    get: select a specific revision
       --purge-volumes   uninstall: also remove the release's volumes
       --diff            apply: show each changed release's manifest diff (implies --dry-run)
+      --skip-compat-check  Proceed despite a chart's unmet swarmcliVersion constraint
 
 apply honours --wait, --timeout and --history-max. It REJECTS --set, --version,
 --reuse-values, --install, --purge-volumes, --requirements and --revision rather
@@ -264,6 +276,9 @@ func chartsShow(args []string) int {
 	if code >= 0 {
 		return code
 	}
+	if code := applyCompat(charts.CheckCompat(ch.Metadata), compatWarn, f.skipCompatCheck); code >= 0 {
+		return code
+	}
 	switch what {
 	case "chart":
 		printChartMeta(ch)
@@ -322,7 +337,7 @@ func chartsTemplate(args []string) int {
 		return usageErr("charts template <release> <repo/chart>")
 	}
 	release, ref := pos[0], pos[1]
-	manifest, _, _, req, code := prepare(release, ref, f, nil)
+	manifest, _, _, req, code := prepare(release, ref, f, nil, compatWarn)
 	if code >= 0 {
 		return code
 	}
@@ -353,7 +368,7 @@ func chartsInstall(args []string) int {
 		return usageErr("charts install <release> <repo/chart>")
 	}
 	release, ref := pos[0], pos[1]
-	manifest, values, rc, req, code := prepare(release, ref, f, nil)
+	manifest, values, rc, req, code := prepare(release, ref, f, nil, compatEnforce)
 	if code >= 0 {
 		return code
 	}
@@ -393,7 +408,7 @@ func chartsUpgrade(args []string) int {
 			// re-validates the release, so a genuine backend error still surfaces.
 		}
 	}
-	manifest, values, rc, req, code := prepare(release, ref, f, base)
+	manifest, values, rc, req, code := prepare(release, ref, f, base, compatEnforce)
 	if code >= 0 {
 		return code
 	}
@@ -568,7 +583,7 @@ func chartsDiff(args []string) int {
 	if f.reuseValues {
 		base = cur.Values
 	}
-	next, _, _, _, code := prepare(release, ref, f, base)
+	next, _, _, _, code := prepare(release, ref, f, base, compatWarn)
 	if code >= 0 {
 		return code
 	}
@@ -583,9 +598,15 @@ func chartsDiff(args []string) int {
 // prepare loads the chart, merges + validates values, and renders the manifest.
 // base, when non-nil, replaces the chart defaults as the merge base (used by
 // `upgrade --reuse-values` to layer overrides over the previous release).
-func prepare(release, ref string, f flags, base map[string]any) (manifest string, values map[string]any, rc charts.ReleaseChart, req *charts.Requirements, code int) {
+func prepare(release, ref string, f flags, base map[string]any, pol compatPolicy) (manifest string, values map[string]any, rc charts.ReleaseChart, req *charts.Requirements, code int) {
 	ch, _, c := loadChart(ref, f.version)
 	if c >= 0 {
+		return "", nil, rc, nil, c
+	}
+	// Before rendering, not after: a chart that needs a newer engine would
+	// otherwise fail somewhere inside Render, and "function X not defined" is a
+	// far worse answer than naming the version it wants.
+	if c := applyCompat(charts.CheckCompat(ch.Metadata), pol, f.skipCompatCheck); c >= 0 {
 		return "", nil, rc, nil, c
 	}
 	if base == nil {

--- a/cli/compat.go
+++ b/cli/compat.go
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package cli
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"swarmcli/charts"
+)
+
+// compatPolicy is what a subcommand does with a chart that declares a newer
+// chart engine than this build provides. Detection lives in the charts package;
+// this is the half that decides what it costs.
+type compatPolicy int
+
+const (
+	// compatWarn reports and carries on. It is for the read-only verbs: they
+	// change nothing, and `charts show` in particular is how an operator finds
+	// out which version a chart wants — refusing to run it would withhold the
+	// answer to the question being asked.
+	compatWarn compatPolicy = iota
+	// compatEnforce refuses, asking first when there is someone to ask.
+	compatEnforce
+	// compatEnforceNoPrompt refuses without ever reading stdin. It is for apply,
+	// whose contract is to run unattended: prompting merely because it happened
+	// to be launched from a terminal would make it hang in the one place that
+	// must never hang.
+	compatEnforceNoPrompt
+)
+
+// isInteractive reports whether there is a human to prompt — both stdin and
+// stdout must be a terminal. A var so tests can drive both branches without a
+// pty. Using os.ModeCharDevice keeps this dependency-free: nothing else in the
+// chart CLI has any reason to know about terminals.
+var isInteractive = func() bool {
+	return isCharDevice(os.Stdin) && isCharDevice(os.Stdout)
+}
+
+func isCharDevice(f *os.File) bool {
+	fi, err := f.Stat()
+	return err == nil && fi.Mode()&os.ModeCharDevice != 0
+}
+
+// stdin is a package var for the same reason stdout/stderr are: so tests can
+// feed it.
+var stdin io.Reader = os.Stdin
+
+// applyCompat applies pol to a compatibility finding. It returns an exit code
+// >= 0 when the caller must stop, or -1 to carry on.
+func applyCompat(f charts.CompatFinding, pol compatPolicy, skip bool) int {
+	switch f.Status {
+	case charts.CompatOK:
+		return -1
+	case charts.CompatUnknown:
+		// A chart that declared nothing is the common case and says nothing. One
+		// that declared something unusable is worth a word: its author expected
+		// the constraint to be honoured, and silence would hide that it was not.
+		if f.Reason != "" {
+			errf("chart %s: %s; compatibility was not checked\n", f.Chart, f.Reason)
+		}
+		return -1
+	}
+
+	msg := f.Message(binaryVersion)
+	switch {
+	case skip:
+		errf("%s; continuing anyway (--skip-compat-check)\n", msg)
+		return -1
+	case pol == compatWarn:
+		errf("%s\n", msg)
+		return -1
+	case pol == compatEnforce && isInteractive():
+		errf("%s\n", msg)
+		if confirm("Continue anyway?") {
+			return -1
+		}
+		return 1
+	default:
+		return fail(fmt.Errorf("%s\n  upgrade swarmcli, or re-run with --skip-compat-check to try anyway", msg))
+	}
+}
+
+// confirm asks a yes/no question on stderr and reads one line from stdin.
+//
+// Anything but an explicit yes — a blank line, EOF, a read error — is no. The
+// prompt exists to stop an install that is expected to break, so the safe answer
+// must be the one that takes no keystroke.
+func confirm(question string) bool {
+	errf("\n%s [y/N] ", question)
+	line, err := bufio.NewReader(stdin).ReadString('\n')
+	if err != nil && line == "" {
+		errf("\n")
+		return false
+	}
+	switch strings.ToLower(strings.TrimSpace(line)) {
+	case "y", "yes":
+		return true
+	default:
+		return false
+	}
+}

--- a/cli/compat_test.go
+++ b/cli/compat_test.go
@@ -1,0 +1,164 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package cli
+
+import (
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"swarmcli/charts"
+)
+
+// withInteractive forces the "is there a human to ask" answer for one test, so
+// both branches are reachable without a pty.
+func withInteractive(t *testing.T, v bool) {
+	t.Helper()
+	prev := isInteractive
+	isInteractive = func() bool { return v }
+	t.Cleanup(func() { isInteractive = prev })
+}
+
+// withStdin feeds a canned answer to the confirm prompt.
+func withStdin(t *testing.T, s string) {
+	t.Helper()
+	prev := stdin
+	stdin = strings.NewReader(s)
+	t.Cleanup(func() { stdin = prev })
+}
+
+func withBinaryVersion(t *testing.T, v string) {
+	t.Helper()
+	prev := binaryVersion
+	binaryVersion = v
+	t.Cleanup(func() { binaryVersion = prev })
+}
+
+// failingReader fails the test if anything reads it.
+type failingReader struct{ t *testing.T }
+
+func (r failingReader) Read([]byte) (int, error) {
+	r.t.Error("stdin was read under a policy that forbids prompting")
+	return 0, io.EOF
+}
+
+func incompatibleFinding() charts.CompatFinding {
+	return charts.CompatFinding{
+		Chart:    "traefik 0.2.0",
+		Required: ">= 1.13.0",
+		Engine:   "1.12.0",
+		Status:   charts.CompatIncompatible,
+	}
+}
+
+func TestApplyCompatProceedsWhenCompatible(t *testing.T) {
+	for _, pol := range []compatPolicy{compatWarn, compatEnforce, compatEnforceNoPrompt} {
+		var code int
+		_, e := capture(t, func() {
+			code = applyCompat(charts.CompatFinding{Status: charts.CompatOK}, pol, false)
+		})
+		require.Equal(t, -1, code)
+		require.Empty(t, e, "a compatible chart must say nothing")
+	}
+}
+
+func TestApplyCompatUnknownNeverBlocks(t *testing.T) {
+	t.Run("silent when the chart declared nothing", func(t *testing.T) {
+		var code int
+		_, e := capture(t, func() {
+			code = applyCompat(charts.CompatFinding{Status: charts.CompatUnknown}, compatEnforce, false)
+		})
+		require.Equal(t, -1, code)
+		require.Empty(t, e)
+	})
+
+	// The author expected the constraint to be honoured; silence would hide that
+	// it was not.
+	t.Run("warns when a declared constraint was unusable", func(t *testing.T) {
+		f := charts.CompatFinding{
+			Chart:  "demo 0.1.0",
+			Status: charts.CompatUnknown,
+			Reason: `swarmcliVersion "nope" is not a valid SemVer constraint`,
+		}
+		var code int
+		_, e := capture(t, func() { code = applyCompat(f, compatEnforce, false) })
+		require.Equal(t, -1, code)
+		require.Contains(t, e, "demo 0.1.0")
+		require.Contains(t, e, "compatibility was not checked")
+	})
+}
+
+func TestApplyCompatWarnNeverBlocks(t *testing.T) {
+	withInteractive(t, false)
+	var code int
+	_, e := capture(t, func() { code = applyCompat(incompatibleFinding(), compatWarn, false) })
+	require.Equal(t, -1, code)
+	require.Contains(t, e, "requires swarmcli >= 1.13.0")
+}
+
+// The CI contract: no terminal means abort, never hang.
+func TestApplyCompatEnforceNonInteractiveAborts(t *testing.T) {
+	withInteractive(t, false)
+	withBinaryVersion(t, "1.12.0")
+	for _, pol := range []compatPolicy{compatEnforce, compatEnforceNoPrompt} {
+		var code int
+		_, e := capture(t, func() { code = applyCompat(incompatibleFinding(), pol, false) })
+		require.Equal(t, 1, code)
+		require.Contains(t, e, "requires swarmcli >= 1.13.0")
+		require.Contains(t, e, "--skip-compat-check", "the abort must name its own escape hatch")
+	}
+}
+
+func TestApplyCompatSkipProceeds(t *testing.T) {
+	withInteractive(t, false)
+	for _, pol := range []compatPolicy{compatWarn, compatEnforce, compatEnforceNoPrompt} {
+		var code int
+		_, e := capture(t, func() { code = applyCompat(incompatibleFinding(), pol, true) })
+		require.Equal(t, -1, code)
+		require.Contains(t, e, "--skip-compat-check", "a forced run must still leave a trace")
+	}
+}
+
+func TestApplyCompatEnforceInteractivePrompt(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		input string
+		want  int
+	}{
+		{name: "y proceeds", input: "y\n", want: -1},
+		{name: "yes proceeds", input: "yes\n", want: -1},
+		{name: "uppercase Y proceeds", input: "Y\n", want: -1},
+		{name: "y without a newline proceeds", input: "y", want: -1},
+		{name: "n aborts", input: "n\n", want: 1},
+		// Default-deny: the safe answer is the one that takes no keystroke.
+		{name: "a blank line aborts", input: "\n", want: 1},
+		{name: "EOF aborts", input: "", want: 1},
+		{name: "anything else aborts", input: "maybe\n", want: 1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			withInteractive(t, true)
+			withStdin(t, tc.input)
+			var code int
+			_, e := capture(t, func() { code = applyCompat(incompatibleFinding(), compatEnforce, false) })
+			require.Equal(t, tc.want, code)
+			require.Contains(t, e, "Continue anyway?")
+		})
+	}
+}
+
+// apply is meant to run unattended: a terminal happening to be attached must not
+// make it block on stdin.
+func TestApplyCompatEnforceNoPromptNeverReadsStdin(t *testing.T) {
+	withInteractive(t, true)
+	prev := stdin
+	stdin = failingReader{t: t}
+	t.Cleanup(func() { stdin = prev })
+
+	var code int
+	_, e := capture(t, func() { code = applyCompat(incompatibleFinding(), compatEnforceNoPrompt, false) })
+	require.Equal(t, 1, code)
+	require.NotContains(t, e, "Continue anyway?")
+}

--- a/cli/dispatch.go
+++ b/cli/dispatch.go
@@ -15,11 +15,18 @@ Commands:
 Run "swarmcli charts help" for chart commands.
 `
 
+// binaryVersion is the version this binary reports for itself, recorded by
+// Dispatch so diagnostics can name it. It is not necessarily the version of the
+// chart engine the binary embeds (charts.EngineVersion), which is what chart
+// compatibility is actually checked against.
+var binaryVersion string
+
 // Dispatch runs a non-interactive command and returns a process exit code. It
 // is invoked from main when the binary is given arguments; an empty args slice
 // is never passed (main launches the TUI in that case). version is the build
 // version string for `swarmcli version`.
 func Dispatch(args []string, version string) int {
+	binaryVersion = version
 	switch args[0] {
 	case "charts":
 		return chartsMain(args[1:])

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.26
 toolchain go1.26.5
 
 require (
+	github.com/Masterminds/semver/v3 v3.3.0
 	github.com/Masterminds/sprig/v3 v3.3.0
 	github.com/briandowns/spinner v1.23.2
 	github.com/charmbracelet/bubbles v1.0.0
@@ -26,7 +27,6 @@ require (
 require (
 	dario.cat/mergo v1.0.1 // indirect
 	github.com/Masterminds/goutils v1.1.1 // indirect
-	github.com/Masterminds/semver/v3 v3.3.0 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect

--- a/integration-tests/charts/charts_lifecycle_test.go
+++ b/integration-tests/charts/charts_lifecycle_test.go
@@ -42,7 +42,7 @@ func writeDemoChart(t *testing.T) string {
 	t.Helper()
 	dir := t.TempDir()
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "Chart.yaml"),
-		[]byte("apiVersion: v2\nname: itest\nversion: 0.1.0\nappVersion: \"1.0\"\n"), 0o644))
+		[]byte("apiVersion: v1\nname: itest\nversion: 0.1.0\nappVersion: \"1.0\"\n"), 0o644))
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "values.yaml"),
 		[]byte("replicas: 1\n"), 0o644))
 	require.NoError(t, os.MkdirAll(filepath.Join(dir, "templates"), 0o755))
@@ -250,7 +250,7 @@ func writeExtNetChart(t *testing.T, netName string) string {
 	t.Helper()
 	dir := t.TempDir()
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "Chart.yaml"),
-		[]byte("apiVersion: v2\nname: itest\nversion: 0.1.0\nappVersion: \"1.0\"\n"), 0o644))
+		[]byte("apiVersion: v1\nname: itest\nversion: 0.1.0\nappVersion: \"1.0\"\n"), 0o644))
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "values.yaml"),
 		[]byte("replicas: 1\n"), 0o644))
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "requirements.yaml"),


### PR DESCRIPTION
## Why

Charts increasingly depend on chart-engine behaviour newer than the swarmcli a user has installed — `swarmcli-charts/scripts/install-swarmcli.sh` builds CE from `main` precisely because it tracks unreleased features. There was no field in which a chart could say so, so installing one on an older build failed at render time with whatever the missing feature happened to produce:

```
template: stack.yaml:14: function "toYamlPretty" not defined
```

which leaves "my swarmcli is too old" indistinguishable from "this chart is broken".

## What

A chart may now declare a SemVer constraint on the chart engine, modelled on npm's `engines` (Helm has no `helmVersion` field — this is a gap in Helm, not a pattern copied from it):

```yaml
# Chart.yaml
swarmcliVersion: ">= 1.13.0"
```

```
$ swarmcli charts install web ./traefik
chart traefik 0.2.0 requires swarmcli >= 1.13.0; this build provides 1.12.0

Continue anyway? [y/N]
```

Detection is a pure function in `charts/` (`CheckCompat`); policy lives in `cli/`, mirroring the existing `RepoStore.Warnf` split — so `charts` stays testable without a terminal.

| Verb | Behaviour |
|---|---|
| `install`, `upgrade` | refuse; prompt `[y/N]` (default **No**) when interactive, abort when not |
| `apply` | refuse, **never** prompts — it is meant to run unattended and must not block on stdin |
| `apply --dry-run` / `--diff`, `template`, `diff`, `show` | warn only |
| any | `--skip-compat-check` forces through |

Nothing declared, an unstamped build, or an unparseable constraint all yield `CompatUnknown` and **never block** — mirroring the doctrine already in `swarmcli-be/internal/compat`: an unknown version "is not evidence of an incompatible stack". This is a compatibility aid, not a security boundary (a chart already renders to an arbitrary stack), so it fails open on our own inability to parse rather than breaking working charts for a cosmetic reason.

### The engine version, not `main.version`

The constraint is checked against the **chart engine's** version, stamped via `-X swarmcli/charts.engineVersion`, *not* `main.version`. The engine is this module's code, so a binary embedding it carries whichever engine it pinned regardless of its own tag — comparing against the binary's own version would be silently wrong there. When the two differ the diagnostic names both, so the number cited is one the reader can map to something they installed:

```
chart traefik 0.2.0 requires swarmcli >= 1.13.0; this build provides chart engine 1.12.0 (swarmcli 1.12.1)
```

Release candidates are compared on their **core** version: SemVer constraints exclude prereleases, so `>= 1.13.0` would otherwise reject `1.13.0-rc1` — firing exactly while a release is under test.

## Chart.yaml `apiVersion` is now validated

`Chartfile.APIVersion` was parsed but never validated — `apiVersion: v99` loaded fine. It is now allowlisted to `{"", "v1"}`, matching `releasefile.go:87` and `generate-index.sh`, which reserves `v2`+ for a real format break. This is the structural gate Helm's own `apiVersion` provides, and the reason a future format change can make older builds refuse a chart they cannot read.

This narrows the Chart.yaml contract — a chart declaring `apiVersion: v2` is now refused — so it deserves an explicit note on why it is labelled **C0-breaks-nothing** rather than C1:

- **No user is affected.** None of the 12 published charts set `apiVersion` (0/12), and `swarmcli-charts` is the ecosystem today. `new-chart.sh` does not scaffold it either.
- **The only `v2` in existence was ours.** `charts/testdata/demo/Chart.yaml` and both `integration-tests` fixtures said `v2` — Helm-3 muscle memory that arrived unexamined in #415 and survived only because nothing validated it, while the *same* PR's release-file parser enforces `v1`. Those three migrate to `v1` here.
- **Weighed against the alternative.** C1 would force the next GA to `v2.0.0` (current: v1.12.0), signalling a migration to users when there is none, and would hold `swarmcliVersion` — whose whole value is forward-looking — behind a major release.

Flagging it plainly since the label is this repo's only breaking-change gate (the changelog is type-only): if you would rather record the contract change formally, relabel to C1 and this ships as `v2.0.0` with `.github/UPGRADE_NOTES.md` filled.

## Known limitation (by design, stated not engineered around)

`Chart.yaml` is parsed leniently, so **every already-released swarmcli silently ignores `swarmcliVersion`**. Only builds carrying this check can honour it — the same bootstrapping limit Helm's `apiVersion` gate has. Making `Chart.yaml` strict would not fix it and *would* break the published charts, which ship `annotations`/`keywords`/`home`/`sources` that `Chartfile` does not model. The value is forward-looking, so the sooner this lands the sooner the floor moves.

## Verification

Beyond `go test ./...`, `-race` on `charts`/`cli`, and `golangci-lint --build-tags=integration` (all clean), the built binary was driven end-to-end:

- read-only verbs warn and exit 0; `install` refuses **before touching Docker**; `--skip-compat-check` forces through; an unknown flag still fails loudly
- interactive prompt on a real pty: `n` and a bare Enter both abort (exit 1), `y` proceeds through to Docker
- unstamped `go build` warns and proceeds; a satisfied constraint is completely silent
- `apiVersion: v99` refused; **all 12 published charts still load**
- binary/engine divergence stamped separately renders the two-version message

`apply`'s gate is unit-tested (including that it never reads stdin on a TTY); it could not be driven end-to-end here because `PlanApply` lists releases from Docker first.

## Follow-ups (not in this PR)

- **swarmcli-be**: stamp `charts.engineVersion` from `.swarmcli-ref` in its goreleaser — without it BE reports an unstamped engine and warns instead of refusing. Needs this PR merged first (deploy order).
- **swarmcli-charts**: scaffold `swarmcliVersion` in `new-chart.sh`; document the field.
- Deferred by decision: index-aware version resolution, `.Capabilities` in templates, `charts lint`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
