### PR TITLE
feat(charts): add `charts lint`

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,9 @@ swarmcli charts repo remove <name>        # remove a repo
 swarmcli charts search [keyword]          # search charts across repos
 swarmcli charts show chart  <repo/chart>  # chart metadata (also: values, schema)
 
+# Authoring
+swarmcli charts lint <chart>                      # check a chart without deploying it
+
 # Releases
 swarmcli charts template <release> <repo/chart>   # render manifest (no deploy)
 swarmcli charts install  <release> <repo/chart>   # install a chart as a release

--- a/charts/README.md
+++ b/charts/README.md
@@ -171,6 +171,31 @@ Note that only builds carrying this check can honour it: `Chart.yaml` is parsed
 leniently, so an older swarmcli silently ignores `swarmcliVersion` — the same
 bootstrapping limit Helm's own `apiVersion` gate has.
 
+### Linting a chart
+
+```bash
+swarmcli charts lint ./mychart                      # against this build
+swarmcli charts lint ./mychart --for-version 1.12.0 # against another version
+```
+
+`lint` renders the chart with its own default values and reports every problem it
+finds — a broken template, values that fail `values.schema.json`, a
+`swarmcliVersion` this build does not satisfy — rather than stopping at the
+first. A chart that declares no `swarmcliVersion` gets a warning, not an error:
+the field is optional, but a chart naming no floor leaves an operator on an old
+build nothing to act on.
+
+`--for-version` asks **whether the chart's declared floor admits that version**.
+It cannot tell you the chart *runs* on it: this binary carries one engine's
+behaviour and cannot emulate another's, so it checks the claim's shape, not its
+truth. Rendering with a real binary of that version is the only thing that
+settles it — which is what a chart repository's CI should do:
+
+```bash
+SWARMCLI_REF=v1.10.0 scripts/install-swarmcli.sh ./bin  # build the declared floor
+./bin/swarmcli charts template t ./mychart              # prove the chart runs on it
+```
+
 Templates are rendered with Go `text/template` + [Sprig], exposing:
 
 - `.Values` — merged values (defaults < `-f` files < `--set`)

--- a/charts/README.md
+++ b/charts/README.md
@@ -174,16 +174,19 @@ bootstrapping limit Helm's own `apiVersion` gate has.
 ### Linting a chart
 
 ```bash
-swarmcli charts lint ./mychart                      # against this build
-swarmcli charts lint ./mychart --for-version 1.12.0 # against another version
+swarmcli charts lint ./mychart                       # against this build
+swarmcli charts lint ./mychart -f ./ci/default-values.yaml
+swarmcli charts lint ./mychart --for-version 1.12.0  # against another version
 ```
 
-`lint` renders the chart with its own default values and reports every problem it
-finds — a broken template, values that fail `values.schema.json`, a
-`swarmcliVersion` this build does not satisfy — rather than stopping at the
-first. A chart that declares no `swarmcliVersion` gets a warning, not an error:
-the field is optional, but a chart naming no floor leaves an operator on an old
-build nothing to act on.
+`lint` renders the chart and reports every problem it finds — a broken template,
+values that fail `values.schema.json`, a `swarmcliVersion` this build does not
+satisfy — rather than stopping at the first. It renders from the chart defaults,
+layering any `-f`/`--set` on top: a chart with a required, undefaulted input (a
+`{{ required }}` / `{{ fail }}` guard) cannot render from bare defaults, so lint
+it with the values a real install would supply. A chart that declares no
+`swarmcliVersion` gets a warning, not an error: the field is optional, but a
+chart naming no floor leaves an operator on an old build nothing to act on.
 
 `--for-version` asks **whether the chart's declared floor admits that version**.
 It cannot tell you the chart *runs* on it: this binary carries one engine's

--- a/charts/compat.go
+++ b/charts/compat.go
@@ -41,17 +41,27 @@ type CompatFinding struct {
 
 // CheckCompat classifies a chart's swarmcliVersion constraint against the chart
 // engine this binary embeds.
+func CheckCompat(cf Chartfile) CompatFinding { return CheckCompatAgainst(cf, engineVersion) }
+
+// CheckCompatAgainst classifies a chart's swarmcliVersion against an arbitrary
+// chart-engine version rather than this build's. It is what lets `charts lint
+// --for-version` ask "does this chart's declared floor admit X?" without an X to
+// hand.
+//
+// Note what that question is NOT: whether the chart actually runs on X. This
+// binary carries one engine's behaviour, so it cannot emulate another's — only a
+// real X can prove that. This checks the claim's shape, not its truth.
 //
 // It never returns an error. A constraint this build cannot make sense of yields
 // CompatUnknown, not a failure: the check is a compatibility aid, not a security
 // boundary — a chart already renders to an arbitrary stack — so failing open on
 // our own inability to parse costs nothing, whereas failing closed would break
 // working charts for a cosmetic reason.
-func CheckCompat(cf Chartfile) CompatFinding {
+func CheckCompatAgainst(cf Chartfile, engine string) CompatFinding {
 	f := CompatFinding{
 		Chart:    strings.TrimSpace(cf.Name + " " + cf.Version),
 		Required: cf.SwarmcliVersion,
-		Engine:   engineVersion,
+		Engine:   engine,
 	}
 	if cf.SwarmcliVersion == "" {
 		return f // nothing declared: the common case, and silently fine
@@ -65,13 +75,13 @@ func CheckCompat(cf Chartfile) CompatFinding {
 		f.Reason = fmt.Sprintf("swarmcliVersion %q is not a valid SemVer constraint", cf.SwarmcliVersion)
 		return f
 	}
-	if strings.TrimSpace(engineVersion) == "" {
+	if strings.TrimSpace(engine) == "" {
 		f.Reason = "this build reports no chart-engine version"
 		return f
 	}
-	core, ok := coreVersion(engineVersion)
+	core, ok := coreVersion(engine)
 	if !ok {
-		f.Reason = fmt.Sprintf("this build's chart-engine version %q is not valid SemVer", engineVersion)
+		f.Reason = fmt.Sprintf("chart-engine version %q is not valid SemVer", engine)
 		return f
 	}
 	if c.Check(core) {

--- a/charts/lint.go
+++ b/charts/lint.go
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package charts
+
+import "fmt"
+
+// LintSeverity ranks a lint finding. Only LintError fails a lint.
+type LintSeverity int
+
+const (
+	// LintWarning is advice: the chart works, but something is worth fixing.
+	LintWarning LintSeverity = iota
+	// LintError means the chart is broken — either outright, or for the engine
+	// version it was linted against.
+	LintError
+)
+
+func (s LintSeverity) String() string {
+	if s == LintError {
+		return "error"
+	}
+	return "warning"
+}
+
+// LintFinding is one thing lint noticed about a chart.
+type LintFinding struct {
+	Severity LintSeverity
+	Message  string
+}
+
+// lintRelease is the placeholder release name a lint render uses. Templates that
+// interpolate .Release.Name still need one; nothing is deployed.
+const lintRelease = "lint"
+
+// Lint checks a loaded chart against the chart engine named by engine — this
+// build's, or one the caller is asking about via --for-version.
+//
+// It reports everything it finds instead of stopping at the first problem: a
+// chart author wants the list, not a game of whack-a-mole.
+//
+// Structural validation already happened in LoadChartDir / LoadChartArchive,
+// which refuse a chart with no name, version or templates, or an apiVersion this
+// build cannot read. Lint covers what only becomes visible once a chart is
+// rendered with its own defaults.
+//
+// One thing it deliberately cannot do: prove a chart runs on the version it
+// declares. This binary carries one engine's behaviour and cannot emulate
+// another's — rendering with a real binary of that version is the only thing
+// that settles it. See CheckCompatAgainst.
+func Lint(ch *Chart, engine string) []LintFinding {
+	var out []LintFinding
+	add := func(s LintSeverity, format string, a ...any) {
+		out = append(out, LintFinding{Severity: s, Message: fmt.Sprintf(format, a...)})
+	}
+
+	switch f := CheckCompatAgainst(ch.Metadata, engine); f.Status {
+	case CompatIncompatible:
+		// Deliberately not CompatFinding.Message: that says "this build
+		// provides X", which is a lie under --for-version, where X is a version
+		// the caller is asking about and not the one running.
+		add(LintError, "Chart.yaml requires swarmcli %s, which %s does not satisfy", f.Required, f.Engine)
+	case CompatUnknown:
+		if f.Reason != "" {
+			add(LintWarning, "%s", f.Reason)
+			break
+		}
+		// Not an error: the field is optional and most charts predate it. But a
+		// chart that names no floor gives an operator on an old build nothing to
+		// act on, which is the whole problem swarmcliVersion exists to fix.
+		add(LintWarning, "Chart.yaml declares no swarmcliVersion: nothing states which swarmcli this chart needs")
+	}
+
+	values, err := MergeValues(ch.Values, nil, nil)
+	if err != nil {
+		add(LintError, "values.yaml: %v", err)
+		return out // everything below renders from these values
+	}
+	if err := ValidateValues(ch.Schema, values); err != nil {
+		add(LintError, "values.yaml does not satisfy values.schema.json: %v", err)
+	}
+
+	ctx := RenderContext{
+		Values:  values,
+		Release: ReleaseMeta{Name: lintRelease, Namespace: lintRelease, Revision: 1},
+		Chart:   ChartMeta{Name: ch.Metadata.Name, Version: ch.Metadata.Version, AppVersion: ch.Metadata.AppVersion},
+	}
+	if _, err := Render(ch, ctx); err != nil {
+		add(LintError, "render with default values failed: %v", err)
+		return out
+	}
+	if _, err := RenderRequirements(ch, ctx); err != nil {
+		add(LintError, "requirements.yaml: %v", err)
+	}
+	return out
+}
+
+// HasErrors reports whether any finding is fatal, i.e. whether the lint failed.
+func HasErrors(findings []LintFinding) bool {
+	for _, f := range findings {
+		if f.Severity == LintError {
+			return true
+		}
+	}
+	return false
+}

--- a/charts/lint.go
+++ b/charts/lint.go
@@ -36,19 +36,25 @@ const lintRelease = "lint"
 // Lint checks a loaded chart against the chart engine named by engine — this
 // build's, or one the caller is asking about via --for-version.
 //
+// files and sets are extra values layered over the chart defaults for the render
+// check, exactly as `charts template -f/--set` would: a chart that requires an
+// input it deliberately leaves undefaulted (a {{ required }} / {{ fail }} guard)
+// cannot render from bare defaults, so linting it needs the same values a real
+// install would supply. Pass nil for both to lint against defaults alone.
+//
 // It reports everything it finds instead of stopping at the first problem: a
 // chart author wants the list, not a game of whack-a-mole.
 //
 // Structural validation already happened in LoadChartDir / LoadChartArchive,
 // which refuse a chart with no name, version or templates, or an apiVersion this
 // build cannot read. Lint covers what only becomes visible once a chart is
-// rendered with its own defaults.
+// rendered.
 //
 // One thing it deliberately cannot do: prove a chart runs on the version it
 // declares. This binary carries one engine's behaviour and cannot emulate
 // another's — rendering with a real binary of that version is the only thing
 // that settles it. See CheckCompatAgainst.
-func Lint(ch *Chart, engine string) []LintFinding {
+func Lint(ch *Chart, engine string, files [][]byte, sets []string) []LintFinding {
 	var out []LintFinding
 	add := func(s LintSeverity, format string, a ...any) {
 		out = append(out, LintFinding{Severity: s, Message: fmt.Sprintf(format, a...)})
@@ -71,9 +77,9 @@ func Lint(ch *Chart, engine string) []LintFinding {
 		add(LintWarning, "Chart.yaml declares no swarmcliVersion: nothing states which swarmcli this chart needs")
 	}
 
-	values, err := MergeValues(ch.Values, nil, nil)
+	values, err := MergeValues(ch.Values, files, sets)
 	if err != nil {
-		add(LintError, "values.yaml: %v", err)
+		add(LintError, "%v", err)
 		return out // everything below renders from these values
 	}
 	if err := ValidateValues(ch.Schema, values); err != nil {

--- a/charts/lint_test.go
+++ b/charts/lint_test.go
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package charts
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// lintChart loads testdata/demo and applies opt, so each test starts from a
+// chart that is known to lint clean.
+func lintChart(t *testing.T, opt func(*Chart)) *Chart {
+	t.Helper()
+	ch, err := LoadChartDir("testdata/demo")
+	require.NoError(t, err)
+	if opt != nil {
+		opt(ch)
+	}
+	return ch
+}
+
+func messages(findings []LintFinding) string {
+	var s string
+	for _, f := range findings {
+		s += f.Severity.String() + ": " + f.Message + "\n"
+	}
+	return s
+}
+
+func TestLintCleanChart(t *testing.T) {
+	ch := lintChart(t, func(c *Chart) { c.Metadata.SwarmcliVersion = ">= 1.0.0" })
+	findings := Lint(ch, "1.13.0")
+	require.Empty(t, findings, "a satisfied chart must lint silently, got:\n%s", messages(findings))
+	require.False(t, HasErrors(findings))
+}
+
+// The field is optional, so its absence is advice rather than a failure — but a
+// chart that names no floor is the problem swarmcliVersion exists to fix.
+func TestLintNoSwarmcliVersionWarnsButPasses(t *testing.T) {
+	findings := Lint(lintChart(t, nil), "1.13.0")
+	require.Len(t, findings, 1)
+	require.Equal(t, LintWarning, findings[0].Severity)
+	require.Contains(t, findings[0].Message, "declares no swarmcliVersion")
+	require.False(t, HasErrors(findings), "a missing floor must not fail a lint")
+}
+
+func TestLintUnsatisfiedFloorIsAnError(t *testing.T) {
+	ch := lintChart(t, func(c *Chart) { c.Metadata.SwarmcliVersion = ">= 1.13.0" })
+	findings := Lint(ch, "1.12.0")
+	require.True(t, HasErrors(findings))
+	require.Contains(t, messages(findings), "requires swarmcli >= 1.13.0")
+	require.Contains(t, messages(findings), "1.12.0 does not satisfy")
+}
+
+// Lint must never claim the version it was asked about is the one running: under
+// --for-version it is not.
+func TestLintDoesNotClaimTheAskedVersionIsThisBuild(t *testing.T) {
+	withEngineVersion(t, "1.13.0") // this build
+	ch := lintChart(t, func(c *Chart) { c.Metadata.SwarmcliVersion = ">= 2.0.0" })
+	require.NotContains(t, messages(Lint(ch, "1.9.0")), "this build provides")
+}
+
+func TestLintUnparseableConstraintWarns(t *testing.T) {
+	ch := lintChart(t, func(c *Chart) { c.Metadata.SwarmcliVersion = "newer than 1.13 please" })
+	findings := Lint(ch, "1.13.0")
+	require.False(t, HasErrors(findings), "an unusable constraint is a warning, matching CheckCompat")
+	require.Contains(t, messages(findings), "not a valid SemVer constraint")
+}
+
+// Without --for-version an unstamped dev build has nothing to compare against.
+// That must not manufacture an error.
+func TestLintUnstampedEngineWarns(t *testing.T) {
+	ch := lintChart(t, func(c *Chart) { c.Metadata.SwarmcliVersion = ">= 1.13.0" })
+	findings := Lint(ch, "")
+	require.False(t, HasErrors(findings))
+	require.Contains(t, messages(findings), "no chart-engine version")
+}
+
+func TestLintBrokenTemplateIsAnError(t *testing.T) {
+	ch := lintChart(t, func(c *Chart) {
+		c.Metadata.SwarmcliVersion = ">= 1.0.0"
+		c.Templates = map[string]string{"templates/stack.yaml": "{{ toYamlPretty .Values }}"}
+	})
+	findings := Lint(ch, "1.13.0")
+	require.True(t, HasErrors(findings))
+	require.Contains(t, messages(findings), "render with default values failed")
+	require.Contains(t, messages(findings), "toYamlPretty")
+}
+
+func TestLintValuesFailingSchemaIsAnError(t *testing.T) {
+	ch := lintChart(t, func(c *Chart) {
+		c.Metadata.SwarmcliVersion = ">= 1.0.0"
+		c.Schema = []byte(`{"type":"object","properties":{"replicas":{"type":"string"}}}`)
+	})
+	findings := Lint(ch, "1.13.0")
+	require.True(t, HasErrors(findings))
+	require.Contains(t, messages(findings), "values.schema.json")
+}
+
+// A chart author wants the list, not a game of whack-a-mole.
+func TestLintReportsEveryProblemNotJustTheFirst(t *testing.T) {
+	ch := lintChart(t, func(c *Chart) {
+		c.Metadata.SwarmcliVersion = ">= 1.13.0"                                           // problem 1
+		c.Schema = []byte(`{"type":"object","properties":{"replicas":{"type":"string"}}}`) // problem 2
+	})
+	findings := Lint(ch, "1.12.0")
+	require.GreaterOrEqual(t, len(findings), 2, "got:\n%s", messages(findings))
+}
+
+func TestHasErrors(t *testing.T) {
+	require.False(t, HasErrors(nil))
+	require.False(t, HasErrors([]LintFinding{{Severity: LintWarning}}))
+	require.True(t, HasErrors([]LintFinding{{Severity: LintWarning}, {Severity: LintError}}))
+}

--- a/charts/lint_test.go
+++ b/charts/lint_test.go
@@ -31,7 +31,7 @@ func messages(findings []LintFinding) string {
 
 func TestLintCleanChart(t *testing.T) {
 	ch := lintChart(t, func(c *Chart) { c.Metadata.SwarmcliVersion = ">= 1.0.0" })
-	findings := Lint(ch, "1.13.0")
+	findings := Lint(ch, "1.13.0", nil, nil)
 	require.Empty(t, findings, "a satisfied chart must lint silently, got:\n%s", messages(findings))
 	require.False(t, HasErrors(findings))
 }
@@ -39,7 +39,7 @@ func TestLintCleanChart(t *testing.T) {
 // The field is optional, so its absence is advice rather than a failure — but a
 // chart that names no floor is the problem swarmcliVersion exists to fix.
 func TestLintNoSwarmcliVersionWarnsButPasses(t *testing.T) {
-	findings := Lint(lintChart(t, nil), "1.13.0")
+	findings := Lint(lintChart(t, nil), "1.13.0", nil, nil)
 	require.Len(t, findings, 1)
 	require.Equal(t, LintWarning, findings[0].Severity)
 	require.Contains(t, findings[0].Message, "declares no swarmcliVersion")
@@ -48,7 +48,7 @@ func TestLintNoSwarmcliVersionWarnsButPasses(t *testing.T) {
 
 func TestLintUnsatisfiedFloorIsAnError(t *testing.T) {
 	ch := lintChart(t, func(c *Chart) { c.Metadata.SwarmcliVersion = ">= 1.13.0" })
-	findings := Lint(ch, "1.12.0")
+	findings := Lint(ch, "1.12.0", nil, nil)
 	require.True(t, HasErrors(findings))
 	require.Contains(t, messages(findings), "requires swarmcli >= 1.13.0")
 	require.Contains(t, messages(findings), "1.12.0 does not satisfy")
@@ -59,12 +59,12 @@ func TestLintUnsatisfiedFloorIsAnError(t *testing.T) {
 func TestLintDoesNotClaimTheAskedVersionIsThisBuild(t *testing.T) {
 	withEngineVersion(t, "1.13.0") // this build
 	ch := lintChart(t, func(c *Chart) { c.Metadata.SwarmcliVersion = ">= 2.0.0" })
-	require.NotContains(t, messages(Lint(ch, "1.9.0")), "this build provides")
+	require.NotContains(t, messages(Lint(ch, "1.9.0", nil, nil)), "this build provides")
 }
 
 func TestLintUnparseableConstraintWarns(t *testing.T) {
 	ch := lintChart(t, func(c *Chart) { c.Metadata.SwarmcliVersion = "newer than 1.13 please" })
-	findings := Lint(ch, "1.13.0")
+	findings := Lint(ch, "1.13.0", nil, nil)
 	require.False(t, HasErrors(findings), "an unusable constraint is a warning, matching CheckCompat")
 	require.Contains(t, messages(findings), "not a valid SemVer constraint")
 }
@@ -73,7 +73,7 @@ func TestLintUnparseableConstraintWarns(t *testing.T) {
 // That must not manufacture an error.
 func TestLintUnstampedEngineWarns(t *testing.T) {
 	ch := lintChart(t, func(c *Chart) { c.Metadata.SwarmcliVersion = ">= 1.13.0" })
-	findings := Lint(ch, "")
+	findings := Lint(ch, "", nil, nil)
 	require.False(t, HasErrors(findings))
 	require.Contains(t, messages(findings), "no chart-engine version")
 }
@@ -83,10 +83,49 @@ func TestLintBrokenTemplateIsAnError(t *testing.T) {
 		c.Metadata.SwarmcliVersion = ">= 1.0.0"
 		c.Templates = map[string]string{"templates/stack.yaml": "{{ toYamlPretty .Values }}"}
 	})
-	findings := Lint(ch, "1.13.0")
+	findings := Lint(ch, "1.13.0", nil, nil)
 	require.True(t, HasErrors(findings))
 	require.Contains(t, messages(findings), "render with default values failed")
 	require.Contains(t, messages(findings), "toYamlPretty")
+}
+
+// A chart with a required, undefaulted input (a {{ fail }} / {{ required }}
+// guard) cannot render from bare defaults — so lint must accept the same values
+// an install would supply, or it flags a working chart as broken. This is the
+// renovate case found by linting the real charts.
+func TestLintRequiredInputNeedsValues(t *testing.T) {
+	newChart := func() *Chart {
+		return lintChart(t, func(c *Chart) {
+			c.Metadata.SwarmcliVersion = ">= 1.0.0"
+			c.Values = map[string]any{}
+			c.Schema = nil
+			c.Templates = map[string]string{
+				"templates/stack.yaml": `{{ if not .Values.repositories }}{{ fail "set repositories" }}{{ end }}` +
+					"\nservices:\n  app:\n    image: busybox\n",
+			}
+		})
+	}
+
+	bare := Lint(newChart(), "1.13.0", nil, nil)
+	require.True(t, HasErrors(bare), "bare defaults must surface the unmet requirement")
+	require.Contains(t, messages(bare), "set repositories")
+
+	withValues := Lint(newChart(), "1.13.0", [][]byte{[]byte("repositories: [owner/repo]\n")}, nil)
+	require.False(t, HasErrors(withValues), "supplying the value must clear it, got:\n%s", messages(withValues))
+}
+
+// --set reaches the render too.
+func TestLintSetOverride(t *testing.T) {
+	ch := lintChart(t, func(c *Chart) {
+		c.Metadata.SwarmcliVersion = ">= 1.0.0"
+		c.Values = map[string]any{}
+		c.Schema = nil
+		c.Templates = map[string]string{
+			"templates/stack.yaml": `{{ if not .Values.enabled }}{{ fail "set enabled=true" }}{{ end }}` +
+				"\nservices:\n  app:\n    image: busybox\n",
+		}
+	})
+	require.False(t, HasErrors(Lint(ch, "1.13.0", nil, []string{"enabled=true"})))
 }
 
 func TestLintValuesFailingSchemaIsAnError(t *testing.T) {
@@ -94,7 +133,7 @@ func TestLintValuesFailingSchemaIsAnError(t *testing.T) {
 		c.Metadata.SwarmcliVersion = ">= 1.0.0"
 		c.Schema = []byte(`{"type":"object","properties":{"replicas":{"type":"string"}}}`)
 	})
-	findings := Lint(ch, "1.13.0")
+	findings := Lint(ch, "1.13.0", nil, nil)
 	require.True(t, HasErrors(findings))
 	require.Contains(t, messages(findings), "values.schema.json")
 }
@@ -105,7 +144,7 @@ func TestLintReportsEveryProblemNotJustTheFirst(t *testing.T) {
 		c.Metadata.SwarmcliVersion = ">= 1.13.0"                                           // problem 1
 		c.Schema = []byte(`{"type":"object","properties":{"replicas":{"type":"string"}}}`) // problem 2
 	})
-	findings := Lint(ch, "1.12.0")
+	findings := Lint(ch, "1.12.0", nil, nil)
 	require.GreaterOrEqual(t, len(findings), 2, "got:\n%s", messages(findings))
 }
 

--- a/cli/args.go
+++ b/cli/args.go
@@ -30,6 +30,9 @@ type flags struct {
 	// skipCompatCheck (--skip-compat-check) downgrades a chart's unmet
 	// swarmcliVersion requirement from a refusal to a warning.
 	skipCompatCheck bool
+	// forVersion (--for-version) lints a chart against a chart-engine version
+	// other than this build's.
+	forVersion string
 }
 
 // parseArgs splits raw args into positionals and flags. It understands the
@@ -129,6 +132,12 @@ func parseArgs(args []string) ([]string, flags, error) {
 			f.install = true
 		case "--skip-compat-check":
 			f.skipCompatCheck = true
+		case "--for-version":
+			v, err := next()
+			if err != nil {
+				return nil, f, err
+			}
+			f.forVersion = v
 		default:
 			return nil, f, fmt.Errorf("unknown flag %q", name)
 		}

--- a/cli/charts.go
+++ b/cli/charts.go
@@ -29,6 +29,9 @@ Discovery:
   show values <repo/chart>   Show default values.yaml
   show schema <repo/chart>   Show values.schema.json
 
+Authoring:
+  lint <chart>                Check a chart without deploying it
+
 Releases:
   template <release> <chart>  Render manifest to stdout (no deploy)
   install  <release> <chart>  Install a chart as a release
@@ -92,6 +95,15 @@ Common options:
       --purge-volumes   uninstall: also remove the release's volumes
       --diff            apply: show each changed release's manifest diff (implies --dry-run)
       --skip-compat-check  Proceed despite a chart's unmet swarmcliVersion constraint
+      --for-version <ver>  lint: check the chart's swarmcliVersion against <ver>
+                        instead of this build's chart engine
+
+lint renders a chart with its own default values and reports every problem it
+finds: a broken template, values that fail values.schema.json, a swarmcliVersion
+this build does not satisfy. --for-version asks whether the chart's declared
+floor admits some other version — it cannot tell you the chart RUNS on that
+version, because this binary carries only its own engine's behaviour. Rendering
+with a real binary of that version is the only thing that settles that.
 
 apply honours --wait, --timeout and --history-max. It REJECTS --set, --version,
 --reuse-values, --install, --purge-volumes, --requirements and --revision rather
@@ -117,6 +129,8 @@ func chartsMain(args []string) int {
 		return chartsSearch(rest)
 	case "show":
 		return chartsShow(rest)
+	case "lint":
+		return chartsLint(rest)
 	case "template":
 		return chartsTemplate(rest)
 	case "install":
@@ -327,6 +341,41 @@ func printChartMeta(ch *charts.Chart) {
 }
 
 // --- template / install ---
+
+// chartsLint checks a chart without deploying anything: it is what a chart
+// author runs before publishing, and what a chart repository's CI runs per
+// chart.
+//
+// --for-version lints against a chart-engine version other than this build's,
+// which answers "does this chart's declared floor admit X?". It cannot answer
+// "does this chart run on X" — only a real X can (see charts.CheckCompatAgainst).
+func chartsLint(args []string) int {
+	pos, f, err := parseArgs(args)
+	if err != nil {
+		return usageErr(err.Error())
+	}
+	if len(pos) != 1 {
+		return usageErr("charts lint <chart>")
+	}
+	ch, _, code := loadChart(pos[0], f.version)
+	if code >= 0 {
+		return code
+	}
+
+	engine := charts.EngineVersion()
+	if f.forVersion != "" {
+		engine = f.forVersion
+	}
+	findings := charts.Lint(ch, engine)
+	for _, fd := range findings {
+		errf("%s: %s\n", fd.Severity, fd.Message)
+	}
+	if charts.HasErrors(findings) {
+		return 1
+	}
+	outf("%s %s: ok\n", ch.Metadata.Name, ch.Metadata.Version)
+	return 0
+}
 
 func chartsTemplate(args []string) int {
 	pos, f, err := parseArgs(args)

--- a/cli/charts.go
+++ b/cli/charts.go
@@ -98,12 +98,14 @@ Common options:
       --for-version <ver>  lint: check the chart's swarmcliVersion against <ver>
                         instead of this build's chart engine
 
-lint renders a chart with its own default values and reports every problem it
-finds: a broken template, values that fail values.schema.json, a swarmcliVersion
-this build does not satisfy. --for-version asks whether the chart's declared
-floor admits some other version — it cannot tell you the chart RUNS on that
-version, because this binary carries only its own engine's behaviour. Rendering
-with a real binary of that version is the only thing that settles that.
+lint renders a chart and reports every problem it finds: a broken template,
+values that fail values.schema.json, a swarmcliVersion this build does not
+satisfy. It renders from the chart defaults, layering any -f/--set on top — a
+chart with a required, undefaulted input needs them supplied, exactly as an
+install would. --for-version asks whether the chart's declared floor admits some
+other version — it cannot tell you the chart RUNS on that version, because this
+binary carries only its own engine's behaviour. Rendering with a real binary of
+that version is the only thing that settles that.
 
 apply honours --wait, --timeout and --history-max. It REJECTS --set, --version,
 --reuse-values, --install, --purge-volumes, --requirements and --revision rather
@@ -344,7 +346,8 @@ func printChartMeta(ch *charts.Chart) {
 
 // chartsLint checks a chart without deploying anything: it is what a chart
 // author runs before publishing, and what a chart repository's CI runs per
-// chart.
+// chart. -f/--set supply the values the render check needs — a chart with a
+// required, undefaulted input cannot render from bare defaults.
 //
 // --for-version lints against a chart-engine version other than this build's,
 // which answers "does this chart's declared floor admit X?". It cannot answer
@@ -361,12 +364,16 @@ func chartsLint(args []string) int {
 	if code >= 0 {
 		return code
 	}
+	files, err := readValuesFiles(f.values)
+	if err != nil {
+		return fail(err)
+	}
 
 	engine := charts.EngineVersion()
 	if f.forVersion != "" {
 		engine = f.forVersion
 	}
-	findings := charts.Lint(ch, engine)
+	findings := charts.Lint(ch, engine, files, f.sets)
 	for _, fd := range findings {
 		errf("%s: %s\n", fd.Severity, fd.Message)
 	}


### PR DESCRIPTION
> **Stacked on #461** — base is `feat/charts-swarmcli-version`, not `main`. Review #461 first; I'll retarget this to `main` once it merges. The diff shown here is only this PR's own commit.
>
> ⚠️ **This PR has no CI, and its green "mergeable" state is meaningless.** `ci.yml`, `integration-tests.yml` and `licence.yml` all trigger on `pull_request: branches: [main]`, so a non-main-based PR runs none of them — GitHub reports `mergeable_state=clean` simply because no required check ran. Do not read that as passing. It was verified locally (`go test ./...`, `-race`, `golangci-lint --build-tags=integration`, all clean) and real CI will run the moment this is retargeted to `main`.

## Why

A chart author had no way to check a chart before publishing it, and `swarmcli-charts` CI had no per-chart check beyond "does `template` exit 0". That gap is concrete: while testing #461 I made `traefik` declare `swarmcliVersion: ">= 99.0.0"` and the charts repo's `test-charts.sh` still reported **"All charts passed"** with the warning nowhere in the log — `template` is warn-only by design, and the harness discards stderr on success.

## What

```bash
swarmcli charts lint ./mychart                      # against this build
swarmcli charts lint ./mychart --for-version 1.12.0 # against another version
```

Renders the chart with its own default values and reports **every** problem, not just the first — an author wants the list, not a game of whack-a-mole:

```
$ swarmcli charts lint ./traefik
warning: Chart.yaml declares no swarmcliVersion: nothing states which swarmcli this chart needs
error: render with default values failed: template templates/stack.yaml.tmpl: parse error: function "toYamlPretty" not defined
```

| Finding | Severity |
|---|---|
| broken template, values failing `values.schema.json`, unsatisfied `swarmcliVersion` | **error** (exit 1) |
| no `swarmcliVersion` declared | warning (exit 0) — optional field, but a chart naming no floor leaves an operator nothing to act on |
| unusable constraint, unstamped engine | warning (exit 0) — matching `CheckCompat`; lint must not manufacture an error out of not knowing |

## `-f` / `--set` — for charts with required input

Found by testing this PR against the real charts in swarmcli-charts#85: `charts lint` rendered with **bare defaults only**, so a chart with a required, undefaulted input flagged as an error even though it works. `charts/renovate` guards with `{{ fail "set repositories: … or autodiscover: true" }}`; every ci fixture supplies that, but bare lint tripped it and reported a working, published chart as broken.

`lint` now takes the same `-f`/`--set` as `template`:

```
$ charts lint ./renovate                            # error (exit 1) — no input given
$ charts lint ./renovate -f ci/default-values.yaml  # renovate 0.1.0: ok
```

Bare lint of a required-input chart still errors, which is correct — you gave it nothing (helm lint behaves identically). With this, all 12 charts in swarmcli-charts#85 lint clean against their default fixture.

## What `--for-version` does and does not do

It answers **whether the chart's declared floor admits that version**. It does **not** answer whether the chart *runs* on it — this binary carries one engine's behaviour and cannot emulate another's, so it checks the claim's shape, not its truth. Emulating an older engine faithfully would need a per-version registry tagging every template function forever, which is the capabilities vocabulary we deliberately deferred.

What actually proves a floor is rendering with a real binary of that version — and no new code is needed for it, because `SWARMCLI_REF` is passed straight to `git clone --branch`, which takes a tag as happily as a branch:

```bash
SWARMCLI_REF=v1.10.0 scripts/install-swarmcli.sh ./bin  # build the declared floor
./bin/swarmcli charts template t ./mychart              # prove the chart runs on it
```

That's the companion `swarmcli-charts` CI job, filed separately. The two are complementary: lint is fast author feedback, floor-render is the proof.

Because of this, lint deliberately does **not** reuse `CompatFinding.Message` — that renders "this build provides X", which is a lie under `--for-version` where X is a hypothetical. It uses neutral phrasing, with a test pinning that it never claims otherwise.

## Notes

- `CheckCompat(cf)` becomes a one-liner over the new `CheckCompatAgainst(cf, engine)`; behaviour is unchanged.
- Structural validation is not duplicated: `LoadChartDir`/`LoadChartArchive` already refuse a chart with no name/version/templates or an unreadable `apiVersion`. Lint covers what only appears once a chart is rendered.
- All logic is in `charts/` per `CLAUDE.md` ("the charts package is where the coverage bar applies"); the `cli/` half is ~25 lines.

## Verification

`go test ./...`, `-race`, and `golangci-lint --build-tags=integration` all clean. Driven against the real `swarmcli-charts` traefik chart: clean chart → `ok`; no floor → warning, exit 0; `--for-version` below the floor → error, exit 1; above it → exit 0; broken template → error naming the function.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

