### PR TITLE
fix(charts): suggest `charts repo update` on digest mismatch (#456)

### DIFF
--- a/charts/repo.go
+++ b/charts/repo.go
@@ -412,6 +412,12 @@ func (s *RepoStore) Pull(entry IndexEntry, baseURL string) (*Chart, error) {
 // including hand-written and older ones — that does not publish digests.
 var errNoDigest = errors.New("no digest in index entry")
 
+// staleIndexHint is appended to a digest-mismatch error: the common cause is a
+// chart rebuilt and republished after the local index was cached, so refreshing
+// the index makes the two agree again.
+const staleIndexHint = "\nhint: the cached repository index may be stale (e.g. the chart was " +
+	"rebuilt since you last refreshed); run `swarmcli charts repo update` to update it"
+
 // verifyDigest checks a downloaded chart archive against the digest published in
 // the repository index. The index is fetched over HTTPS from the repository, but
 // the tarball URL may point anywhere (a GitHub Release asset, a CDN) — the digest
@@ -435,7 +441,7 @@ func verifyDigest(entry IndexEntry, body []byte) error {
 	got := hex.EncodeToString(sum[:])
 	if !strings.EqualFold(got, want) {
 		return fmt.Errorf("chart %q version %s: digest mismatch (index says %s, download is %s); "+
-			"the repository index and the chart archive disagree — refusing to install",
+			"the repository index and the chart archive disagree — refusing to install"+staleIndexHint,
 			entry.Name, entry.Version, want, got)
 	}
 	return nil

--- a/charts/repo_test.go
+++ b/charts/repo_test.go
@@ -330,6 +330,7 @@ func TestPullVerifiesDigest(t *testing.T) {
 		s, e, base := serveChart(t, "sha256:"+strings.Repeat("0", 64), tgz)
 		ch, err := s.Pull(e, base)
 		require.ErrorContains(t, err, "digest mismatch")
+		require.ErrorContains(t, err, "charts repo update")
 		require.Nil(t, ch)
 	})
 


### PR DESCRIPTION
Closes #456.

## What

When a chart archive's SHA-256 disagrees with the digest cached in the local repository index, `verifyDigest` aborts with a bare "digest mismatch … refusing to install". This appends a one-line hint pointing at the remedy:

```
Error: chart "zammad" version 0.1.0: digest mismatch (index says b3a8…, download is 23c4…); the repository index and the chart archive disagree — refusing to install
hint: the cached repository index may be stale (e.g. the chart was rebuilt since you last refreshed); run `swarmcli charts repo update` to update it
```

## Why

The overwhelmingly common cause of this mismatch is a chart that was rebuilt and republished after the index was last cached. `charts repo update` re-fetches `index.yaml`, so the stored digest matches the current archive and the pull succeeds.

## Notes

- The hint is worded "may be stale" rather than instructing the user to bypass anything. The digest check is an integrity guard; `charts repo update` only re-fetches the index over HTTPS and never skips verification, so the hint is safe even if the mismatch were a genuine integrity problem.
- Mirrors the existing `githubPagesHint` pattern in the same file; hint scoped to the mismatch branch only (not the no-digest or unsupported-algorithm paths).
- `swarmcli` is hardcoded, consistent with the existing `swarmcli charts repo add` hint in `repo list`. Both the CE (`swarmcli`) and BE (`swarmcli-be`) binaries share this code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)