### PR TITLE
docs: update module-path references missed by the rename

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,7 @@ main.go                    Entry point; version injection via ldflags. With args
 cli/                       Arg-based CLI dispatch (cli.Dispatch): `charts`, `version`, `help`; cli/apply.go holds the GitOps subcommands (`charts apply`, `charts outdated`)
 charts/                    Helm-like package manager (repos, chart rendering, releases) + declarative releases (releasefile.go, apply.go, outdated.go). charts.ChartSource (source.go) is the seam that resolves a chart ref — repo or local path — so release planning is testable without Docker, a network or a filesystem
 app/
-  app.go                   Init(); triggers command autoload via _ "swarmcli/commands" and view autoload via _ "swarmcli/views" (view factory registry lives in views/view/registry.go)
+  app.go                   Init(); triggers command autoload via _ "github.com/Eldara-Tech/swarmcli/commands" and view autoload via _ "github.com/Eldara-Tech/swarmcli/views" (view factory registry lives in views/view/registry.go)
   hooks.go                 PreUpdateHook registration; StartupOverlay; RegisterShutdownHook / RunShutdownHooks (BE port-forward manager registers CloseAll here)
   model.go                 Central state: Model struct (viewport, currentView, viewStack, commandInput, searchInput, systemInfo)
   update.go                Main message router: navigation, resize, events, key dispatch
@@ -84,7 +84,7 @@ utils/log/
 
 - **Bubble Tea MVC**: Input → Update() → tea.Cmd → View(). All state changes via `tea.Msg` types.
 - **View Stack**: `viewStack.Push(old)` / `Pop()` for breadcrumb navigation.
-- **View Factory**: Views auto-register via `init()` + `view.RegisterView(name, factory)` in each view's `register.go` (registry in `views/view/registry.go`, looked up with `GetFactory`). `app/app.go`'s blank import `_ "swarmcli/views"` pulls `views/autoload.go`, which blank-imports every view — exactly mirroring the command autoload pattern.
+- **View Factory**: Views auto-register via `init()` + `view.RegisterView(name, factory)` in each view's `register.go` (registry in `views/view/registry.go`, looked up with `GetFactory`). `app/app.go`'s blank import `_ "github.com/Eldara-Tech/swarmcli/views"` pulls `views/autoload.go`, which blank-imports every view — exactly mirroring the command autoload pattern.
 - **Command Registry**: Commands in `commands/command/` auto-register via `init()` + `registry.Register()`. Accessed via `:` input.
 - **Command Spec**: Commands optionally implement `registry.CommandWithSpec` (`Spec() registry.CommandSpec`, discovered by type assertion like `Aliaser`). The spec declares `Usage`, `Flags` (the allow-list), and `Examples`. `api.ParseInput` is the single chokepoint that, in order: short-circuits `Passthrough` specs, intercepts `--help`/`-h`/`-help` (and `:help <cmd>`) into a per-command help screen reusing the detailed help view, then rejects any undeclared flag (**global strict**, with a `did you mean --x?` suggestion). Unknown-flag rejection means every registered command MUST declare a spec — a missing/empty spec rejects all flags. `Passthrough:true` is the narrow escape-hatch for delegating/unavailable stubs (e.g. the OSS `bootstrap` stub): it skips both help interception and validation so every arg reaches `Execute` unchanged and the command keeps its own messaging (and no Pro flag internals leak into OSS — see Pro Feature Boundary).
 - **Snapshot Cache**: `docker.GetSnapshot()` / `docker.RefreshSnapshot()` — 3s TTL, background event-driven invalidation.

--- a/charts/backend_docker.go
+++ b/charts/backend_docker.go
@@ -12,7 +12,7 @@ import (
 	"github.com/Eldara-Tech/swarmcli/docker"
 )
 
-// dockerBackend implements Backend against the live swarmcli/docker package.
+// dockerBackend implements Backend against the live github.com/Eldara-Tech/swarmcli/docker package.
 type dockerBackend struct{}
 
 func (dockerBackend) DeployStack(name, manifest string) error {

--- a/charts/buildinfo.go
+++ b/charts/buildinfo.go
@@ -5,7 +5,7 @@ package charts
 
 // engineVersion is the chart-engine feature level, stamped at build time with
 //
-//	-X swarmcli/charts.engineVersion=<version>
+//	-X github.com/Eldara-Tech/swarmcli/charts.engineVersion=<version>
 //
 // It names the version of THIS module, which is not necessarily the version the
 // surrounding binary reports for itself: the chart engine is this module's code,


### PR DESCRIPTION
Follow-up to #476.

The rename rewrote **quoted import paths**, which is what the compiler sees. Prose and ldflag documentation kept the old bare path and drifted.

| File | Was |
|---|---|
| `charts/buildinfo.go` | `-X swarmcli/charts.engineVersion=<version>` |
| `charts/backend_docker.go` | "against the live swarmcli/docker package" |
| `CLAUDE.md` (×2) | `_ "swarmcli/commands"`, `_ "swarmcli/views"` |

`charts/buildinfo.go` is the one that matters. It documents the ldflag that stamps `engineVersion`, which is what chart `swarmcliVersion` floor constraints resolve against — and a wrong path there fails **silently**, producing an unstamped engine rather than a build error. The comment now matches what `.goreleaser.yml` actually passes.

Filesystem paths (`~/.local/state/swarmcli/charts`, `$XDG_STATE_HOME/swarmcli/charts`) are **not** module paths and are deliberately untouched.

Docs and comments only — no code change. `go build` and `gofmt` clean.