### PR TITLE
refactor: move lineDiff to utils/textdiff so it can be reused

### DIFF
--- a/cli/apply.go
+++ b/cli/apply.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/Eldara-Tech/swarmcli/charts"
+	"github.com/Eldara-Tech/swarmcli/utils/textdiff"
 )
 
 // chartsApply converges the swarm to a declarative release manifest.
@@ -153,7 +154,7 @@ func printPlan(plan *charts.Plan, withDiff bool) {
 				continue
 			}
 			outf("\n--- %s (%s) ---\n", r.Name, r.Action)
-			out(lineDiff(r.CurrentManifest, r.Manifest))
+			out(textdiff.Lines(r.CurrentManifest, r.Manifest))
 		}
 	}
 

--- a/cli/charts.go
+++ b/cli/charts.go
@@ -13,6 +13,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/Eldara-Tech/swarmcli/charts"
+	"github.com/Eldara-Tech/swarmcli/utils/textdiff"
 )
 
 const chartsUsage = `Usage: swarmcli charts <command> [options]
@@ -647,7 +648,7 @@ func chartsDiff(args []string) int {
 		outln("No changes.")
 		return 0
 	}
-	out(lineDiff(cur.Manifest, next))
+	out(textdiff.Lines(cur.Manifest, next))
 	return 0
 }
 

--- a/cli/flags_test.go
+++ b/cli/flags_test.go
@@ -4,27 +4,10 @@
 package cli
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
-
-func TestLineDiff(t *testing.T) {
-	a := "a\nb\nc\n"
-	b := "a\nB\nc\nd\n"
-	d := lineDiff(a, b)
-	lines := strings.Split(strings.TrimRight(d, "\n"), "\n")
-	require.Equal(t, "  a", lines[0])
-	require.Contains(t, d, "- b")
-	require.Contains(t, d, "+ B")
-	require.Contains(t, d, "+ d")
-}
-
-func TestLineDiffIdentical(t *testing.T) {
-	d := lineDiff("x\ny\n", "x\ny\n")
-	require.Equal(t, "  x\n  y\n", d)
-}
 
 func TestUpgradeFlagsParse(t *testing.T) {
 	_, f, err := parseArgs([]string{"rel", "repo/chart", "--install", "--reuse-values", "--revision", "3"})

--- a/utils/textdiff/textdiff.go
+++ b/utils/textdiff/textdiff.go
@@ -1,15 +1,21 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright © 2026 Eldara Tech
 
-package cli
+// Package textdiff renders compact, human-readable line diffs.
+//
+// It lives outside the cli package so that everything presenting a manifest
+// change — the CLI, a TUI view, an API response — renders it identically. The
+// alternative is each caller reimplementing an LCS and drifting from what
+// `swarmcli charts apply --diff` actually prints.
+package textdiff
 
 import "strings"
 
-// lineDiff returns a compact line-oriented diff of a vs b using a longest
+// Lines returns a compact line-oriented diff of a vs b using a longest
 // common subsequence. Removed lines are prefixed "-", added lines "+", and
 // unchanged lines " ". It is intended for human-readable upgrade previews, not
 // machine patching, so it omits hunk headers.
-func lineDiff(a, b string) string {
+func Lines(a, b string) string {
 	al := splitLines(a)
 	bl := splitLines(b)
 

--- a/utils/textdiff/textdiff_test.go
+++ b/utils/textdiff/textdiff_test.go
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package textdiff
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLineDiff(t *testing.T) {
+	a := "a\nb\nc\n"
+	b := "a\nB\nc\nd\n"
+	d := Lines(a, b)
+	lines := strings.Split(strings.TrimRight(d, "\n"), "\n")
+	require.Equal(t, "  a", lines[0])
+	require.Contains(t, d, "- b")
+	require.Contains(t, d, "+ B")
+	require.Contains(t, d, "+ d")
+}
+
+func TestLineDiffIdentical(t *testing.T) {
+	d := Lines("x\ny\n", "x\ny\n")
+	require.Equal(t, "  x\n  y\n", d)
+}


### PR DESCRIPTION
Closes #471. Part of Eldara-Tech/swarmcli-cd#1 (Phase 0).

`cli/diff.go`'s `lineDiff` was unexported in a package that exports **nothing** — `grep '^func [A-Z]' cli/*.go` matches only test functions. So the diff rendering users already see from `charts apply --diff` was unreachable to anything else, and a TUI view or API response would each reimplement an LCS and drift from what the CLI actually prints.

## Change

| Was | Now |
|---|---|
| `cli.lineDiff(a, b)` | `textdiff.Lines(a, b)` |
| `cli/diff.go` | `utils/textdiff/textdiff.go` |
| `cli/diff_test.go` | `utils/textdiff/textdiff_test.go` |

`splitLines` stays unexported next to it. Callers (`cli/apply.go`, `cli/charts.go`) call through — output is byte-identical.

## One thing worth a look

`cli/diff_test.go` also contained `TestUpgradeFlagsParse`, which exercises `parseArgs` and has nothing to do with diffing — it lived there incidentally. Moving the file wholesale broke the build (`undefined: parseArgs`), so that test moved to a new `cli/flags_test.go` instead of travelling to `textdiff`.

## Verification

`gofmt`, `go build`, `go vet`, full unit suite, `golangci-lint run ./... --build-tags=integration` → **0 issues**. No behaviour change.