### PR TITLE
charts: add JSON tags to Plan/ReleasePlan/Release

### DIFF
--- a/charts/apply.go
+++ b/charts/apply.go
@@ -22,34 +22,34 @@ const (
 
 // ReleasePlan is the computed desired state of one release.
 type ReleasePlan struct {
-	Name   string
-	Ref    string
-	Action Action
+	Name   string `json:"name"`
+	Ref    string `json:"ref"`
+	Action Action `json:"action"`
 	// FromVersion is the currently deployed chart version, empty for an install.
-	FromVersion string
-	ToVersion   string
+	FromVersion string `json:"fromVersion,omitempty"`
+	ToVersion   string `json:"toVersion"`
 
-	Chart        ReleaseChart
-	Values       map[string]any
-	Manifest     string
-	Requirements *Requirements
+	Chart        ReleaseChart   `json:"chart"`
+	Values       map[string]any `json:"values,omitempty"`
+	Manifest     string         `json:"manifest"`
+	Requirements *Requirements  `json:"requirements,omitempty"`
 	// CurrentManifest is the deployed manifest, for diffing. Empty for an install.
-	CurrentManifest string
+	CurrentManifest string `json:"currentManifest,omitempty"`
 	// Compat is the chart's engine requirement checked against this build.
 	// Planning records it but never acts on it: apply's contract is to plan
 	// every release before converging any, so the whole plan is gated at once
 	// by the caller — which is also the layer that knows whether blocking is
 	// appropriate for the verb being run.
-	Compat CompatFinding
+	Compat CompatFinding `json:"compat"`
 }
 
 // Plan is what apply would do to the whole swarm.
 type Plan struct {
 	// Releases, in file order.
-	Releases []ReleasePlan
+	Releases []ReleasePlan `json:"releases"`
 	// Unmanaged names releases that exist on the swarm but are absent from the
 	// file. Apply never touches them — see Engine.Apply.
-	Unmanaged []string
+	Unmanaged []string `json:"unmanaged,omitempty"`
 }
 
 // Counts summarises a plan.
@@ -178,9 +178,9 @@ func (e *Engine) planRelease(rf *ReleaseFile, spec ReleaseSpec, src ChartSource,
 
 // ApplyResult is what Apply actually did to one release.
 type ApplyResult struct {
-	Name     string
-	Action   Action
-	Revision int // 0 when unchanged (nothing was recorded)
+	Name     string `json:"name"`
+	Action   Action `json:"action"`
+	Revision int    `json:"revision,omitempty"` // 0 when unchanged (nothing was recorded)
 }
 
 // Apply converges the swarm to a plan, in file order.

--- a/charts/json_test.go
+++ b/charts/json_test.go
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package charts
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// A Release is stored as YAML in a Docker Config and served as JSON. The two
+// must name the same fields the same way, or the API and the stored record
+// describe the same release in two vocabularies.
+func TestReleaseJSONMirrorsYAMLKeys(t *testing.T) {
+	rel := Release{
+		Name:      "edge",
+		Revision:  3,
+		Status:    StatusDeployed,
+		Chart:     ReleaseChart{Name: "traefik", Version: "0.1.1", AppVersion: "3.1"},
+		Values:    map[string]any{"replicas": 2},
+		Manifest:  "services: {}\n",
+		Created:   "2026-07-21T00:00:00Z",
+		Namespace: "edge",
+	}
+
+	var got map[string]any
+	b, err := json.Marshal(rel)
+	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal(b, &got))
+
+	// "release", not "name" — mirroring the yaml tag rather than the Go field.
+	require.Contains(t, got, "release")
+	require.NotContains(t, got, "Name")
+	for _, k := range []string{"revision", "status", "chart", "values", "manifest", "created", "namespace"} {
+		require.Contains(t, got, k, "missing key %q", k)
+	}
+	// Absent and omitempty: must not appear.
+	require.NotContains(t, got, "managedNetworks")
+
+	chart, ok := got["chart"].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "traefik", chart["name"])
+	require.Equal(t, "3.1", chart["appVersion"])
+}
+
+func TestPlanJSONKeys(t *testing.T) {
+	p := Plan{
+		Releases: []ReleasePlan{{
+			Name:      "edge",
+			Ref:       "swarmcli-charts/traefik",
+			Action:    ActionUpgrade,
+			ToVersion: "0.1.1",
+			Manifest:  "services: {}\n",
+		}},
+	}
+
+	var got map[string]any
+	b, err := json.Marshal(p)
+	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal(b, &got))
+
+	require.Contains(t, got, "releases")
+	// Unmanaged is empty here and omitempty, so it must be absent rather than null.
+	require.NotContains(t, got, "unmanaged")
+
+	rels, ok := got["releases"].([]any)
+	require.True(t, ok)
+	rp, ok := rels[0].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "edge", rp["name"])
+	require.Equal(t, "upgrade", rp["action"])
+	require.Equal(t, "0.1.1", rp["toVersion"])
+	// Empty for an install/unchanged plan; omitempty keeps it out.
+	require.NotContains(t, rp, "fromVersion")
+	require.NotContains(t, rp, "currentManifest")
+}
+
+func TestApplyResultJSONKeys(t *testing.T) {
+	var got map[string]any
+	b, err := json.Marshal(ApplyResult{Name: "edge", Action: ActionUnchanged})
+	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal(b, &got))
+
+	require.Equal(t, "edge", got["name"])
+	require.Equal(t, "unchanged", got["action"])
+	// Revision is 0 when unchanged (nothing recorded) and omitempty drops it,
+	// so a consumer cannot mistake it for revision zero.
+	require.NotContains(t, got, "revision")
+}

--- a/charts/types.go
+++ b/charts/types.go
@@ -37,9 +37,9 @@ const (
 // Chartfile is the parsed Chart.yaml metadata.
 type Chartfile struct {
 	APIVersion string `yaml:"apiVersion"`
-	Name       string `yaml:"name"`
-	Version    string `yaml:"version"`
-	AppVersion string `yaml:"appVersion,omitempty"`
+	Name       string `yaml:"name" json:"name"`
+	Version    string `yaml:"version" json:"version"`
+	AppVersion string `yaml:"appVersion,omitempty" json:"appVersion,omitempty"`
 	// SwarmcliVersion is a SemVer constraint on the chart engine this chart
 	// needs, e.g. ">= 1.13.0". Optional; absent means any. It constrains the
 	// engine's version rather than the running binary's — see buildinfo.go.
@@ -133,24 +133,24 @@ type IndexEntry struct {
 // Release is the payload stored (gzipped) inside a release-history Config. It
 // fully describes one deployed revision so it can be inspected or rolled back.
 type Release struct {
-	Name      string         `yaml:"release"`
-	Revision  int            `yaml:"revision"`
-	Status    string         `yaml:"status"`
-	Chart     ReleaseChart   `yaml:"chart"`
-	Values    map[string]any `yaml:"values"`
-	Manifest  string         `yaml:"manifest"` // rendered Compose document
-	Created   string         `yaml:"created"`  // RFC3339
-	Namespace string         `yaml:"namespace"`
+	Name      string         `yaml:"release" json:"release"`
+	Revision  int            `yaml:"revision" json:"revision"`
+	Status    string         `yaml:"status" json:"status"`
+	Chart     ReleaseChart   `yaml:"chart" json:"chart"`
+	Values    map[string]any `yaml:"values" json:"values"`
+	Manifest  string         `yaml:"manifest" json:"manifest"` // rendered Compose document
+	Created   string         `yaml:"created" json:"created"`   // RFC3339
+	Namespace string         `yaml:"namespace" json:"namespace"`
 	// ManagedNetworks are the external networks swarmcli auto-created for this
 	// revision. Persisted so uninstall can report what it left behind (it does
 	// not remove them — they may be shared). Omitted for revisions that created
 	// none and for records written before this field existed.
-	ManagedNetworks []string `yaml:"managedNetworks,omitempty"`
+	ManagedNetworks []string `yaml:"managedNetworks,omitempty" json:"managedNetworks,omitempty"`
 }
 
 // ReleaseChart is the chart reference recorded in a Release.
 type ReleaseChart struct {
-	Name       string `yaml:"name"`
-	Version    string `yaml:"version"`
-	AppVersion string `yaml:"appVersion,omitempty"`
+	Name       string `yaml:"name" json:"name"`
+	Version    string `yaml:"version" json:"version"`
+	AppVersion string `yaml:"appVersion,omitempty" json:"appVersion,omitempty"`
 }


### PR DESCRIPTION
Closes #472. Part of Eldara-Tech/swarmcli-cd#1 (Phase 0).

Without tags these types serialise with Go field names (`Name`, `FromVersion`, `CurrentManifest`), so anything serving a plan or a release over HTTP needs a parallel DTO purely for casing.

## Approach

`Release` and `ReleaseChart` already carried `yaml` tags, so the `json` tags **mirror them exactly** — the top-level key is `"release"`, not `"name"`. The point is that the API response and the stored Docker Config describe the same release in one vocabulary, not two. `Plan`/`ReleasePlan`/`ApplyResult` had no tags and get camelCase.

`omitempty` is applied where absence carries meaning — notably `ApplyResult.Revision`, which is 0 when a release was *unchanged and nothing was recorded*; a consumer must not read that as revision zero.

Tests marshal each type and assert on the resulting keys, so the mirroring is enforced rather than merely intended.

## One thing I did not do, deliberately

`ReleasePlan.Compat` is a `CompatFinding`, whose `Status` field is a `CompatStatus int`. It now serialises as **`"status": 1`** — technically valid, practically unusable, and it partially defeats the "no parallel DTO" goal for that one field.

Fixing it means a `String()` + `MarshalJSON` on `CompatStatus`, which is a behaviour change rather than a tagging change, so I kept it out of scope here. Happy to follow up if you want `"compatible"`/`"incompatible"`/`"unknown"` on the wire — say the word and I'll open an issue.

## Verification

`gofmt`, `go build`, `go vet`, full unit suite, `golangci-lint run ./... --build-tags=integration` → **0 issues**. Additive; yaml encoding untouched.