### PR TITLE
fix(charts): --wait returned before anything was running

### DIFF
--- a/charts/backend_docker.go
+++ b/charts/backend_docker.go
@@ -59,18 +59,33 @@ func (dockerBackend) DeleteConfig(ctx context.Context, name string) error {
 
 func (dockerBackend) StackServices(name string) []ServiceState {
 	entries := docker.LoadStackServices(name)
+	// Convergence facts come from a separate loader because ServiceEntry counts
+	// replicas by desired state, which is right for the services view but wrong
+	// for deciding a rollout finished (issues #473, #480).
+	conv := make(map[string]docker.ServiceConvergence, len(entries))
+	for _, c := range docker.LoadStackConvergence(name) {
+		conv[c.Name] = c
+	}
+
 	out := make([]ServiceState, 0, len(entries))
 	for _, e := range entries {
 		replicas := ""
 		if e.Mode == "replicated" {
 			replicas = fmt.Sprintf("%d/%d", e.ReplicasOnNode, e.ReplicasTotal)
 		}
-		out = append(out, ServiceState{
+		st := ServiceState{
 			Name:     e.ServiceName,
 			Mode:     e.Mode,
 			Replicas: replicas,
 			Status:   e.Status,
-		})
+		}
+		if c, ok := conv[e.ServiceName]; ok {
+			st.Running = c.Running
+			st.Desired = c.Desired
+			st.UpdateState = c.UpdateState
+			st.Monitor = c.Monitor
+		}
+		out = append(out, st)
 	}
 	return out
 }

--- a/charts/release.go
+++ b/charts/release.go
@@ -29,12 +29,28 @@ type ConfigMeta struct {
 	Labels map[string]string
 }
 
-// ServiceState is a minimal live status line for a release's services.
+// ServiceState is a live status line for a release's services, plus the facts
+// --wait needs to decide whether the rollout is actually finished.
 type ServiceState struct {
 	Name     string
 	Mode     string
-	Replicas string // "running/desired" for replicated, "" otherwise
+	Replicas string // "running/desired" for replicated, "" otherwise — display only
 	Status   string
+
+	// Running counts tasks that are actually running on an active node.
+	// Deliberately not derived from Replicas: that string counts tasks by
+	// DESIRED state, so it reaches its target the moment Swarm schedules the
+	// tasks rather than when they are up (see issue #480).
+	Running int
+	// Desired is the target task count over active nodes.
+	Desired int
+	// UpdateState is swarm's UpdateStatus.State, empty when the service has
+	// never been updated. Empty means "no rollout has ever run" — NOT "the
+	// rollout finished", which is why a fresh install cannot rely on it.
+	UpdateState string
+	// Monitor is UpdateConfig.Monitor: the window after a task is created in
+	// which its failure still counts against the rollout.
+	Monitor time.Duration
 }
 
 // Backend abstracts the Docker operations the release engine needs, so the
@@ -833,51 +849,99 @@ func (e *Engine) pruneHistory(ctx context.Context, release string, keep int) {
 	}
 }
 
-// waitReady polls service convergence until all replicated services report
-// their desired replica count, or the timeout elapses.
+// waitPollInterval is how often waitReady re-reads service state. A variable so
+// tests can shrink it; a real sleep in a unit test is otherwise unavoidable
+// because the stability window is wall-clock.
+var waitPollInterval = 2 * time.Second
+
+// defaultStabilityWindow mirrors the Docker CLI's own default monitor period.
+// Reaching the target replica count is necessary but not sufficient: a task that
+// starts and then dies inside UpdateConfig.Monitor counts as a rollout failure,
+// so returning at first parity reports success for a service that is about to
+// crash-loop.
+const defaultStabilityWindow = 5 * time.Second
+
+// waitReady polls until every service in the release is running its target task
+// count and has held it for the stability window, or the timeout elapses.
+//
+// It returns early with an error when swarm reports the rollout wedged
+// ("paused" / "rollback_paused"): swarmkit never rolls back a rollback, so
+// those states need a human and waiting out the timeout only delays the report.
 func (e *Engine) waitReady(release string, timeout time.Duration) error {
 	if timeout <= 0 {
 		timeout = 5 * time.Minute
 	}
 	deadline := e.now().Add(timeout)
+	var convergedAt time.Time
 	for {
 		states := e.Backend.StackServices(release)
+		if err := rolloutWedged(states); err != nil {
+			return fmt.Errorf("release %q: %w", release, err)
+		}
 		if len(states) > 0 && allConverged(states) {
-			return nil
+			if convergedAt.IsZero() {
+				convergedAt = e.now()
+			}
+			if !e.now().Before(convergedAt.Add(stabilityWindow(states))) {
+				return nil
+			}
+		} else {
+			// Lost parity — a task died inside the window. Start it again rather
+			// than counting the earlier, now-invalidated stretch.
+			convergedAt = time.Time{}
 		}
 		if !e.now().Before(deadline) {
 			return fmt.Errorf("timed out after %s waiting for release %q to converge", timeout, release)
 		}
-		time.Sleep(2 * time.Second)
+		time.Sleep(waitPollInterval)
 	}
 }
 
+// stabilityWindow is the longest monitor period across the release's services,
+// so the slowest service governs. Services declaring none use the CLI default.
+func stabilityWindow(states []ServiceState) time.Duration {
+	window := defaultStabilityWindow
+	for _, s := range states {
+		if s.Monitor > window {
+			window = s.Monitor
+		}
+	}
+	return window
+}
+
+// rolloutWedged reports a rollout swarm has given up on.
+func rolloutWedged(states []ServiceState) error {
+	for _, s := range states {
+		switch s.UpdateState {
+		case "paused":
+			return fmt.Errorf("service %q: update paused after a task failure; swarm will not continue without intervention", s.Name)
+		case "rollback_paused":
+			return fmt.Errorf("service %q: rollback paused; swarm never rolls back a rollback, so this needs manual recovery", s.Name)
+		}
+	}
+	return nil
+}
+
+// allConverged reports whether every service is running its target task count.
+//
+// It uses the actual running count rather than the Replicas display string.
+// That string counts tasks by DESIRED state, so it reaches parity the instant
+// swarm schedules the tasks — before any container is up — which made --wait
+// return immediately on a fresh install, where UpdateState is empty and the
+// in-flight guard below cannot fire either (issue #473).
 func allConverged(states []ServiceState) bool {
 	for _, s := range states {
-		// A rolling update in flight is not converged even if the (old)
-		// replica ratio still reads N/N — wait for the update to settle.
-		if inProgressStatus(s.Status) {
+		// A rolling update in flight is not converged even if the task count
+		// already reads N/N: the count may still be the outgoing generation.
+		switch s.UpdateState {
+		case "updating", "rollback_started":
 			return false
 		}
-		if s.Replicas == "" {
-			continue // global services: no replica ratio to check
-		}
-		run, des, ok := strings.Cut(s.Replicas, "/")
-		if !ok || run != des {
+		if s.Running < s.Desired {
 			return false
 		}
 	}
 	return true
-}
-
-// inProgressStatus reports whether a service's status string (as produced by
-// docker.getServiceStatus) indicates an in-flight create/update/rollback.
-func inProgressStatus(status string) bool {
-	switch status {
-	case "updating", "paused", "rolling back", "rollback paused":
-		return true
-	}
-	return false
 }
 
 func releaseConfigName(release string, rev int) string {

--- a/charts/release_test.go
+++ b/charts/release_test.go
@@ -342,11 +342,57 @@ func mustGzipRelease(t *testing.T, rel *Release) []byte {
 
 // A converged service whose update is still in flight must not count as ready.
 func TestAllConvergedRejectsInProgress(t *testing.T) {
-	require.True(t, allConverged([]ServiceState{{Replicas: "2/2", Status: "active"}}))
-	require.True(t, allConverged([]ServiceState{{Replicas: "1/1", Status: "updated"}}))
-	require.False(t, allConverged([]ServiceState{{Replicas: "2/2", Status: "updating"}}))
-	require.False(t, allConverged([]ServiceState{{Replicas: "1/1", Status: "rolling back"}}))
-	require.False(t, allConverged([]ServiceState{{Replicas: "1/2", Status: "active"}}))
+	require.True(t, allConverged([]ServiceState{{Running: 2, Desired: 2}}))
+	require.True(t, allConverged([]ServiceState{{Running: 1, Desired: 1, UpdateState: "completed"}}))
+	require.False(t, allConverged([]ServiceState{{Running: 2, Desired: 2, UpdateState: "updating"}}))
+	require.False(t, allConverged([]ServiceState{{Running: 1, Desired: 1, UpdateState: "rollback_started"}}))
+	require.False(t, allConverged([]ServiceState{{Running: 1, Desired: 2}}))
+}
+
+// The bug in #473: a fresh install has no UpdateStatus, so the in-flight guard
+// cannot fire, and the old check compared a Replicas string counting tasks by
+// DESIRED state — which reaches parity the moment swarm schedules them. A
+// release whose tasks are all still pending must not read as converged.
+func TestAllConvergedRejectsScheduledButNotRunning(t *testing.T) {
+	scheduled := []ServiceState{{
+		Name:        "api",
+		Replicas:    "3/3", // what the old check saw: 3 tasks DESIRED running
+		Status:      "active",
+		Running:     0, // ...none of which had actually started
+		Desired:     3,
+		UpdateState: "", // fresh install: never updated
+	}}
+	require.False(t, allConverged(scheduled), "tasks that are merely scheduled must not count as converged")
+}
+
+// A global service on a drained node lowers the target rather than leaving the
+// release permanently short of a replica that can never be scheduled.
+func TestAllConvergedGlobalTracksActiveNodes(t *testing.T) {
+	require.True(t, allConverged([]ServiceState{{Mode: "global", Running: 2, Desired: 2}}))
+	require.False(t, allConverged([]ServiceState{{Mode: "global", Running: 1, Desired: 2}}))
+}
+
+func TestStabilityWindowTakesTheLongestMonitor(t *testing.T) {
+	require.Equal(t, defaultStabilityWindow, stabilityWindow(nil))
+	require.Equal(t, defaultStabilityWindow,
+		stabilityWindow([]ServiceState{{Monitor: time.Second}}), "a shorter monitor must not weaken the default")
+	require.Equal(t, 30*time.Second,
+		stabilityWindow([]ServiceState{{Monitor: 10 * time.Second}, {Monitor: 30 * time.Second}}))
+}
+
+// paused and rollback_paused are terminal: swarmkit never rolls back a
+// rollback, so waiting out the timeout only delays the report.
+func TestRolloutWedged(t *testing.T) {
+	require.NoError(t, rolloutWedged([]ServiceState{{Name: "api", UpdateState: "updating"}}))
+	require.NoError(t, rolloutWedged([]ServiceState{{Name: "api", UpdateState: ""}}))
+
+	err := rolloutWedged([]ServiceState{{Name: "api", UpdateState: "paused"}})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "api")
+
+	err = rolloutWedged([]ServiceState{{Name: "api", UpdateState: "rollback_paused"}})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "manual recovery")
 }
 
 // When a concurrent actor claims the next revision number between read and
@@ -391,4 +437,109 @@ func TestUninstallContinuesOnPartialFailure(t *testing.T) {
 	_, err = e.Uninstall(ctx, "demo", false)
 	require.ErrorContains(t, err, "removing stack")
 	require.Empty(t, fb.configs) // history cleaned up despite the stack-removal failure
+}
+
+// waitReady must hold parity for the stability window before reporting success:
+// a task that starts and then dies inside UpdateConfig.Monitor is a rollout
+// failure, so returning at first parity reports success for a service that is
+// about to crash-loop.
+func TestWaitReadyHoldsTheStabilityWindow(t *testing.T) {
+	prev := waitPollInterval
+	waitPollInterval = time.Millisecond
+	defer func() { waitPollInterval = prev }()
+
+	b := &convergenceBackend{states: []ServiceState{{Name: "api", Running: 1, Desired: 1}}}
+
+	// The clock advances far too slowly to clear the 5s stability window, but
+	// fast enough to reach a 50ms deadline. Parity is immediate, so a waitReady
+	// that returned at first parity would report success here.
+	clock := time.Now()
+	e := &Engine{Backend: b, now: func() time.Time {
+		clock = clock.Add(time.Millisecond)
+		return clock
+	}}
+
+	err := e.waitReady("rel", 50*time.Millisecond)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "timed out")
+	require.Greater(t, b.calls, 1, "should keep polling rather than returning at first parity")
+}
+
+func TestWaitReadyReturnsOnceTheWindowElapses(t *testing.T) {
+	prev := waitPollInterval
+	waitPollInterval = time.Millisecond
+	defer func() { waitPollInterval = prev }()
+
+	b := &convergenceBackend{states: []ServiceState{{Name: "api", Running: 1, Desired: 1}}}
+	clock := time.Now()
+	e := &Engine{Backend: b, now: func() time.Time {
+		clock = clock.Add(2 * time.Second) // clears defaultStabilityWindow quickly
+		return clock
+	}}
+	require.NoError(t, e.waitReady("rel", time.Hour))
+}
+
+// Losing parity inside the window restarts it, rather than counting the earlier
+// stretch that a task failure has invalidated.
+func TestWaitReadyRestartsWindowOnLostParity(t *testing.T) {
+	prev := waitPollInterval
+	waitPollInterval = time.Millisecond
+	defer func() { waitPollInterval = prev }()
+
+	converged := []ServiceState{{Name: "api", Running: 1, Desired: 1}}
+	lost := []ServiceState{{Name: "api", Running: 0, Desired: 1}}
+
+	b := &scriptedBackend{script: [][]ServiceState{converged, lost, converged}}
+	clock := time.Now()
+	e := &Engine{Backend: b, now: func() time.Time {
+		clock = clock.Add(3 * time.Second)
+		return clock
+	}}
+	require.NoError(t, e.waitReady("rel", time.Hour))
+	// Had the window not restarted, it would have returned on the 2nd poll.
+	require.GreaterOrEqual(t, b.calls, 3, "losing parity must restart the stability window")
+}
+
+// A wedged rollout is reported immediately rather than after the full timeout.
+func TestWaitReadyFailsFastOnWedgedRollout(t *testing.T) {
+	prev := waitPollInterval
+	waitPollInterval = time.Millisecond
+	defer func() { waitPollInterval = prev }()
+
+	b := &convergenceBackend{states: []ServiceState{{Name: "api", Running: 0, Desired: 1, UpdateState: "paused"}}}
+	e := &Engine{Backend: b, now: time.Now}
+
+	err := e.waitReady("rel", time.Hour)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "update paused")
+	require.Equal(t, 1, b.calls, "should fail on the first observation, not wait out the timeout")
+}
+
+// convergenceBackend is a Backend that only answers StackServices; waitReady
+// touches nothing else.
+type convergenceBackend struct {
+	Backend
+	states []ServiceState
+	calls  int
+}
+
+func (b *convergenceBackend) StackServices(string) []ServiceState {
+	b.calls++
+	return b.states
+}
+
+// scriptedBackend returns a different state per poll, then repeats the last.
+type scriptedBackend struct {
+	Backend
+	script [][]ServiceState
+	calls  int
+}
+
+func (b *scriptedBackend) StackServices(string) []ServiceState {
+	i := b.calls
+	b.calls++
+	if i >= len(b.script) {
+		i = len(b.script) - 1
+	}
+	return b.script[i]
 }

--- a/docker/convergence.go
+++ b/docker/convergence.go
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package docker
+
+import (
+	"time"
+
+	"github.com/docker/docker/api/types/swarm"
+)
+
+// ServiceConvergence is what a caller needs to decide whether one service has
+// finished rolling out. It is deliberately separate from ServiceEntry: that
+// struct backs the services view, and its ReplicasOnNode counts tasks by
+// DESIRED state, which answers "what does the orchestrator intend" rather than
+// "what is actually up" (see issue #480).
+type ServiceConvergence struct {
+	Name string
+	Mode string
+	// Running counts tasks that are actually running, on an active node.
+	Running int
+	// Desired is the target count over active nodes.
+	Desired int
+	// UpdateState is the raw swarm UpdateStatus.State, empty when the service
+	// has never been updated. Note that a nil UpdateStatus means "no rollout has
+	// ever run", NOT "the rollout finished".
+	UpdateState string
+	// Monitor is UpdateConfig.Monitor: the window after a task is created during
+	// which its failure still counts against the rollout. Zero when unset.
+	Monitor time.Duration
+}
+
+// activeNodeIDs returns the nodes that can currently run tasks. A task pinned to
+// a node that is down never converges, so counting it in the denominator would
+// make a release hang until timeout for a reason no redeploy can fix.
+func activeNodeIDs(snap *SwarmSnapshot) map[string]struct{} {
+	active := make(map[string]struct{}, len(snap.Nodes))
+	for _, n := range snap.Nodes {
+		if n.Status.State == swarm.NodeStateReady && n.Spec.Availability == swarm.NodeAvailabilityActive {
+			active[n.ID] = struct{}{}
+		}
+	}
+	return active
+}
+
+// LoadStackConvergence returns per-service convergence facts for a stack.
+//
+// Running counts tasks whose ACTUAL state is running — not their desired state.
+// Up-to-dateness comes free: on a rolling update Swarm marks superseded tasks
+// DesiredState=shutdown, so requiring both DesiredState and Status.State to be
+// running counts exactly the current generation.
+func LoadStackConvergence(stackName string) []ServiceConvergence {
+	snap, err := GetOrRefreshSnapshot()
+	if err != nil {
+		l().Warnf("failed to get snapshot: %v", err)
+		return nil
+	}
+	active := activeNodeIDs(snap)
+
+	var out []ServiceConvergence
+	for _, svc := range snap.Services {
+		if svc.Spec.Labels["com.docker.stack.namespace"] != stackName {
+			continue
+		}
+
+		running := 0
+		for _, t := range snap.Tasks {
+			if t.ServiceID != svc.ID {
+				continue
+			}
+			if t.DesiredState != swarm.TaskStateRunning || t.Status.State != swarm.TaskStateRunning {
+				continue
+			}
+			// A task not yet assigned has no NodeID; it is by definition not
+			// running yet, but guard anyway rather than counting it as active.
+			if t.NodeID == "" {
+				continue
+			}
+			if _, ok := active[t.NodeID]; !ok {
+				continue
+			}
+			running++
+		}
+
+		out = append(out, ServiceConvergence{
+			Name:        svc.Spec.Name,
+			Mode:        getServiceMode(svc),
+			Running:     running,
+			Desired:     desiredOverActiveNodes(svc, len(active)),
+			UpdateState: updateState(svc),
+			Monitor:     monitorWindow(svc),
+		})
+	}
+	return out
+}
+
+// desiredOverActiveNodes is the target task count. For a global service that is
+// one per active node, so draining a node lowers the target rather than making
+// the service permanently short.
+func desiredOverActiveNodes(svc swarm.Service, activeNodes int) int {
+	switch {
+	case svc.Spec.Mode.Replicated != nil && svc.Spec.Mode.Replicated.Replicas != nil:
+		return int(*svc.Spec.Mode.Replicated.Replicas)
+	case svc.Spec.Mode.Global != nil:
+		return activeNodes
+	default:
+		return 1
+	}
+}
+
+func updateState(svc swarm.Service) string {
+	if svc.UpdateStatus == nil {
+		return ""
+	}
+	return string(svc.UpdateStatus.State)
+}
+
+func monitorWindow(svc swarm.Service) time.Duration {
+	if svc.Spec.UpdateConfig == nil {
+		return 0
+	}
+	return svc.Spec.UpdateConfig.Monitor
+}


### PR DESCRIPTION
Closes #473. Part of Eldara-Tech/swarmcli-cd#1 (Phase 0). Related: #480.

## The bug is worse than the issue first described

`charts install --wait` was close to a no-op. `docker.countTasksForNode` counts tasks by **`DesiredState`** — what the orchestrator intends to run:

```go
if t.DesiredState != swarm.TaskStateRunning { continue }   // DESIRED, not actual
```

A task is created with `DesiredState=RUNNING` and only *then* walks `new → pending → assigned → preparing → starting → running`. Proven with a constructed snapshot (the task list is fetched unfiltered, so nothing upstream removes them):

```
countTasksForNode = 3   (actually running = 1)
   task 1: Status=running   task 2: Status=pending   task 3: Status=starting
```

So on a fresh install: swarm creates N tasks within milliseconds → the ratio reads N/N → `UpdateStatus` is **nil** on a never-updated service, so `inProgressStatus` could not fire either → `allConverged` returned true → `waitReady` returned **before a single container was running**. On upgrade the `UpdateStatus` guard partially masked it, which is likely why it went unnoticed.

A stability window alone would not have fixed this — it would have started counting from an already-wrong signal.

## Fix

**`docker.LoadStackConvergence`** counts tasks whose *actual* `Status.State` is running, on nodes that are `Ready` **and** `Active`.

Up-to-dateness falls out of the same check rather than needing extra machinery: on a rolling update swarm marks superseded tasks `DesiredState=shutdown`, so requiring **both** `DesiredState` and `Status.State` to be running counts exactly the current generation. That avoids depending on the `_up-to-date=true` task filter the Docker CLI uses, which is **undocumented** — it appears nowhere in the Engine API swagger.

Excluding down nodes matters in the other direction too: a task pinned to a dead node never converges, so counting it would hang `--wait` until timeout for a reason no redeploy can fix. For a global service the target tracks active nodes, so draining one lowers the target instead of leaving the release permanently short.

**`waitReady`** now:
- holds parity for a **stability window** — the longest `UpdateConfig.Monitor` across the release, else the CLI’s 5s default — and **restarts it if parity is lost**, because a task that starts then dies inside `Monitor` is a rollout failure;
- **fails fast** on `paused` / `rollback_paused` instead of waiting out the timeout. swarmkit never rolls back a rollback, so those states need a human and the timeout only delays the report.

## Deliberately not changed

`ReplicasOnNode` also backs the services view, so fixing it in place would change what the TUI displays. Left alone; tracked as **#480**.

## Tests

Regression test reproduces the exact bug — a service with `Replicas: "3/3"` (what the old check saw) but `Running: 0`, `UpdateState: ""` must not read as converged. Plus: global services tracking active nodes, the stability window taking the longest monitor, parity loss restarting the window, and fail-fast on wedged rollouts.

`waitPollInterval` became a var so tests need not sleep for real. Note the clock must *advance* in tests — a frozen `now` makes the deadline unreachable and the loop never exits.

`inProgressStatus` is removed, orphaned by the switch to the raw `UpdateStatus` state.

## Verification

`gofmt`, `go build`, `go vet`, `go test -race -count=1 ./...`, `golangci-lint run ./... --build-tags=integration` → **0 issues**.