### PR TITLE
charts lint: warn when update_config.monitor is shorter than the healthcheck can prove

### DIFF
--- a/charts/lint.go
+++ b/charts/lint.go
@@ -3,7 +3,13 @@
 
 package charts
 
-import "fmt"
+import (
+	"fmt"
+	"sort"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
 
 // LintSeverity ranks a lint finding. Only LintError fails a lint.
 type LintSeverity int
@@ -91,10 +97,12 @@ func Lint(ch *Chart, engine string, files [][]byte, sets []string) []LintFinding
 		Release: ReleaseMeta{Name: lintRelease, Namespace: lintRelease, Revision: 1},
 		Chart:   ChartMeta{Name: ch.Metadata.Name, Version: ch.Metadata.Version, AppVersion: ch.Metadata.AppVersion},
 	}
-	if _, err := Render(ch, ctx); err != nil {
+	manifest, err := Render(ch, ctx)
+	if err != nil {
 		add(LintError, "render with default values failed: %v", err)
 		return out
 	}
+	lintHealthcheckMonitor(manifest, add)
 	if _, err := RenderRequirements(ch, ctx); err != nil {
 		add(LintError, "requirements.yaml: %v", err)
 	}
@@ -107,6 +115,116 @@ func HasErrors(findings []LintFinding) bool {
 		if f.Severity == LintError {
 			return true
 		}
+	}
+	return false
+}
+
+// composeHealthLint is the sliver of the rendered stack that lintHealthcheckMonitor
+// reads. Durations stay strings because compose writes them as "30s"/"1m30s".
+type composeHealthLint struct {
+	Services map[string]struct {
+		Healthcheck *struct {
+			Test        any    `yaml:"test"`
+			Interval    string `yaml:"interval"`
+			Retries     *int   `yaml:"retries"`
+			StartPeriod string `yaml:"start_period"`
+			Disable     bool   `yaml:"disable"`
+		} `yaml:"healthcheck"`
+		Deploy struct {
+			UpdateConfig *struct {
+				Monitor string `yaml:"monitor"`
+			} `yaml:"update_config"`
+		} `yaml:"deploy"`
+	} `yaml:"services"`
+}
+
+// Docker's own defaults for an unspecified healthcheck field.
+const (
+	defaultHealthInterval = 30 * time.Second
+	defaultHealthRetries  = 3
+)
+
+// lintHealthcheckMonitor warns when a service cannot fail its healthcheck before
+// swarm stops watching.
+//
+// Swarm counts a task failure against a rollout only if it happens within
+// UpdateConfig.Monitor of the task being created. A container that goes
+// unhealthy after that window does NOT trigger update_config.failure_action —
+// the rollout is reported completed and the task quietly restart-loops. So if
+// monitor is shorter than the healthcheck's own worst case, a broken deploy can
+// report success. Kubernetes has no analogue of this, so it reliably surprises
+// people arriving from there.
+//
+// Warning, not error: a short monitor is legitimate when the operator wants a
+// fast rollout and is watching by other means.
+func lintHealthcheckMonitor(manifest string, add func(LintSeverity, string, ...any)) {
+	var doc composeHealthLint
+	if err := yaml.Unmarshal([]byte(manifest), &doc); err != nil {
+		return // the manifest already rendered; shape problems are not lint's business here
+	}
+
+	// Map iteration is random; sort so findings do not shuffle between runs.
+	names := make([]string, 0, len(doc.Services))
+	for name := range doc.Services {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	for _, name := range names {
+		svc := doc.Services[name]
+		hc := svc.Healthcheck
+		if hc == nil || hc.Disable || isHealthcheckNone(hc.Test) {
+			continue
+		}
+		if svc.Deploy.UpdateConfig == nil || svc.Deploy.UpdateConfig.Monitor == "" {
+			// No explicit monitor: swarm's own 5s default applies. Deliberately
+			// not flagged — it would fire on nearly every chart with a
+			// healthcheck, and the issue scoped this to the explicit case.
+			continue
+		}
+		monitor, err := time.ParseDuration(svc.Deploy.UpdateConfig.Monitor)
+		if err != nil {
+			continue
+		}
+
+		interval := defaultHealthInterval
+		if hc.Interval != "" {
+			if d, err := time.ParseDuration(hc.Interval); err == nil {
+				interval = d
+			}
+		}
+		retries := defaultHealthRetries
+		if hc.Retries != nil {
+			retries = *hc.Retries
+		}
+		var startPeriod time.Duration
+		if hc.StartPeriod != "" {
+			if d, err := time.ParseDuration(hc.StartPeriod); err == nil {
+				startPeriod = d
+			}
+		}
+		if retries < 0 {
+			continue
+		}
+
+		needed := startPeriod + time.Duration(retries)*interval
+		if monitor >= needed {
+			continue
+		}
+		add(LintWarning,
+			"service %q: deploy.update_config.monitor (%s) is shorter than the healthcheck needs to fail (%s = start_period %s + interval %s x retries %d); a container that goes unhealthy after the monitor window does not fail the rollout, so a broken deploy reports success",
+			name, monitor, needed, startPeriod, interval, retries)
+	}
+}
+
+// isHealthcheckNone reports the compose "disable the image healthcheck" spelling,
+// test: ["NONE"] or test: NONE.
+func isHealthcheckNone(test any) bool {
+	switch v := test.(type) {
+	case string:
+		return v == "NONE"
+	case []any:
+		return len(v) > 0 && v[0] == "NONE"
 	}
 	return false
 }

--- a/charts/lint_test.go
+++ b/charts/lint_test.go
@@ -4,6 +4,7 @@
 package charts
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -152,4 +153,122 @@ func TestHasErrors(t *testing.T) {
 	require.False(t, HasErrors(nil))
 	require.False(t, HasErrors([]LintFinding{{Severity: LintWarning}}))
 	require.True(t, HasErrors([]LintFinding{{Severity: LintWarning}, {Severity: LintError}}))
+}
+
+func lintMonitorFindings(t *testing.T, manifest string) []LintFinding {
+	t.Helper()
+	var out []LintFinding
+	lintHealthcheckMonitor(manifest, func(s LintSeverity, format string, a ...any) {
+		out = append(out, LintFinding{Severity: s, Message: fmt.Sprintf(format, a...)})
+	})
+	return out
+}
+
+// The footgun: monitor elapses before the healthcheck can fail even once, so a
+// container that goes unhealthy afterwards leaves the rollout reported as
+// completed.
+func TestLintHealthcheckMonitorTooShort(t *testing.T) {
+	got := lintMonitorFindings(t, `
+services:
+  api:
+    image: nginx
+    healthcheck:
+      test: ["CMD", "true"]
+      interval: 10s
+      retries: 3
+      start_period: 30s
+    deploy:
+      update_config:
+        monitor: 15s
+`)
+	require.Len(t, got, 1)
+	require.Equal(t, LintWarning, got[0].Severity)
+	require.Contains(t, got[0].Message, `service "api"`)
+	require.Contains(t, got[0].Message, "1m0s") // 30s + 3x10s
+}
+
+func TestLintHealthcheckMonitorSufficient(t *testing.T) {
+	require.Empty(t, lintMonitorFindings(t, `
+services:
+  api:
+    healthcheck:
+      test: ["CMD", "true"]
+      interval: 10s
+      retries: 3
+      start_period: 30s
+    deploy:
+      update_config:
+        monitor: 90s
+`))
+}
+
+// Docker's defaults (interval 30s, retries 3) apply when the chart omits them,
+// so the implied window is 90s and a 30s monitor is still too short.
+func TestLintHealthcheckMonitorUsesDockerDefaults(t *testing.T) {
+	got := lintMonitorFindings(t, `
+services:
+  api:
+    healthcheck:
+      test: ["CMD", "true"]
+    deploy:
+      update_config:
+        monitor: 30s
+`)
+	require.Len(t, got, 1)
+	require.Contains(t, got[0].Message, "1m30s") // 3 x 30s
+}
+
+// No explicit monitor is deliberately not flagged: swarm's 5s default would make
+// this fire on nearly every chart that defines a healthcheck.
+func TestLintHealthcheckMonitorSkipsImplicitDefault(t *testing.T) {
+	require.Empty(t, lintMonitorFindings(t, `
+services:
+  api:
+    healthcheck:
+      test: ["CMD", "true"]
+      interval: 10s
+`))
+}
+
+func TestLintHealthcheckMonitorSkipsDisabled(t *testing.T) {
+	require.Empty(t, lintMonitorFindings(t, `
+services:
+  a:
+    healthcheck:
+      test: ["NONE"]
+    deploy:
+      update_config:
+        monitor: 1s
+  b:
+    healthcheck:
+      test: ["CMD", "true"]
+      disable: true
+    deploy:
+      update_config:
+        monitor: 1s
+  c:
+    image: nginx
+    deploy:
+      update_config:
+        monitor: 1s
+`))
+}
+
+// Findings must not shuffle between runs — service names come out of a map.
+func TestLintHealthcheckMonitorIsOrdered(t *testing.T) {
+	manifest := `
+services:
+  zebra:
+    healthcheck: {test: ["CMD", "true"], interval: 10s, retries: 3}
+    deploy: {update_config: {monitor: 1s}}
+  alpha:
+    healthcheck: {test: ["CMD", "true"], interval: 10s, retries: 3}
+    deploy: {update_config: {monitor: 1s}}
+`
+	for i := 0; i < 20; i++ {
+		got := lintMonitorFindings(t, manifest)
+		require.Len(t, got, 2)
+		require.Contains(t, got[0].Message, `"alpha"`)
+		require.Contains(t, got[1].Message, `"zebra"`)
+	}
 }


### PR DESCRIPTION
Closes #475. Part of Eldara-Tech/swarmcli-cd#1 (Phase 0).

Swarm counts a task failure against a rollout only if it happens within `UpdateConfig.Monitor` of the task being created. A container that goes unhealthy *after* that window does **not** trigger `update_config.failure_action` — the rollout is reported completed and the task quietly restart-loops. So a deploy that is actually broken reports success. Kubernetes re-evaluates readiness continuously and has no analogue, so this reliably catches people arriving from there.

Warns when a service defines a healthcheck **and** an explicit `monitor` shorter than `start_period + interval × retries`, applying Docker's own defaults (interval 30s, retries 3) for omitted fields. `test: NONE` and `disable: true` are skipped.

Warning, not error — a short monitor is legitimate when the operator wants a fast rollout and is watching by other means.

Findings are sorted by service name; they come out of a map and would otherwise shuffle between runs.

## ⚠️ It fires on none of the current charts, and that is the interesting part

I ran it across the whole `swarmcli-charts` library. **Zero findings** — because no chart sets `update_config.monitor` at all.

But 8 of 12 charts *do* define healthchecks: `keycloak`, `mariadb`, `ollama`, `openclaw`, `postgres`, `redis`, `superset`, `zammad`. With no explicit monitor they get **swarm's 5s default**, against healthcheck windows that are typically 90s or more (30s interval × 3 retries, plus start_period).

So every one of those charts is exposed to exactly this footgun, and this rule — scoped to the explicit case as the issue specified — catches none of them.

**That is a product decision I did not want to make unilaterally.** Extending the rule to the implicit case would immediately warn on ~8 of 12 community charts. That is *correct*, but it is a lot of new noise on a library people are already using, and it implies either fixing those charts or teaching people to ignore the warning.

Three options, happy to do any:

1. **Ship as-is** (this PR). Prevents future misconfiguration, silent on today's charts.
2. **Extend to the implicit default**, and fix the 8 charts in `swarmcli-charts`.
3. **Extend behind a flag** (e.g. `--strict`), so CI can opt in without warning every casual `charts lint`.

My lean is 1 now and 2 as a follow-up, because the charts need fixing regardless — but the noise tradeoff is yours.

## Verification

Tests cover: too-short, sufficient, Docker defaults applied, implicit-default skipped, `NONE`/`disable`/no-healthcheck skipped, and deterministic ordering across 20 runs.

`gofmt`, `go build`, `go vet`, `go test -race -count=1 ./...`, `golangci-lint run ./... --build-tags=integration` → **0 issues**.