### PR TITLE
charts: expose --resolve-image on install, upgrade and apply

### DIFF
--- a/charts/backend_docker.go
+++ b/charts/backend_docker.go
@@ -15,8 +15,8 @@ import (
 // dockerBackend implements Backend against the live github.com/Eldara-Tech/swarmcli/docker package.
 type dockerBackend struct{}
 
-func (dockerBackend) DeployStack(name, manifest string) error {
-	return docker.DeployStack(name, manifest)
+func (dockerBackend) DeployStack(name, manifest, resolve string) error {
+	return docker.DeployStackResolved(name, manifest, docker.ResolveImage(resolve))
 }
 
 func (dockerBackend) RemoveStack(name string) error {

--- a/charts/release.go
+++ b/charts/release.go
@@ -56,7 +56,7 @@ type ServiceState struct {
 // Backend abstracts the Docker operations the release engine needs, so the
 // lifecycle logic is unit-testable without a live Swarm.
 type Backend interface {
-	DeployStack(name, manifest string) error
+	DeployStack(name, manifest string, resolve string) error
 	RemoveStack(name string) error
 	// RefreshSnapshot invalidates the shared Docker state cache after a mutation
 	// so subsequent reads (status, convergence polling) do not see stale data.
@@ -107,6 +107,10 @@ type InstallOptions struct {
 	Install    bool // upgrade: create the release if it does not exist
 	Timeout    time.Duration
 	HistoryMax int // 0 = keep all
+	// ResolveImage selects how the daemon resolves image tags at deploy time
+	// ("always" | "changed" | "never"); empty leaves Docker's default of
+	// "always". See docker.ResolveImage for why "changed" suits automation.
+	ResolveImage string
 	// Requirements is the chart's parsed requirements.yaml, when present. It
 	// drives the external-resource pre-flight (auto-create vs validate-only, the
 	// network driver/attachability, and remediation descriptions) and, when set,
@@ -252,7 +256,7 @@ func (e *Engine) deployAndRecord(ctx context.Context, rel *Release, opts Install
 		}
 		return rel, err
 	}
-	if err := e.Backend.DeployStack(rel.Name, rel.Manifest); err != nil {
+	if err := e.Backend.DeployStack(rel.Name, rel.Manifest, opts.ResolveImage); err != nil {
 		rel.Status = StatusFailed
 		// Roll back networks we auto-created for this install so a failed deploy
 		// leaves no trace; pre-existing networks are untouched.

--- a/charts/release_test.go
+++ b/charts/release_test.go
@@ -53,7 +53,7 @@ func newFakeBackend() *fakeBackend {
 	}
 }
 
-func (f *fakeBackend) DeployStack(name, manifest string) error {
+func (f *fakeBackend) DeployStack(name, manifest, resolve string) error {
 	if f.failNext {
 		f.failNext = false
 		return fmt.Errorf("boom")

--- a/cli/apply.go
+++ b/cli/apply.go
@@ -83,9 +83,10 @@ func chartsApply(args []string) int {
 	}
 
 	results, err := e.Apply(context.Background(), plan, charts.InstallOptions{
-		Wait:       f.wait,
-		Timeout:    f.timeout,
-		HistoryMax: f.historyMax,
+		Wait:         f.wait,
+		Timeout:      f.timeout,
+		HistoryMax:   f.historyMax,
+		ResolveImage: f.resolveImage,
 	})
 	// Report what did happen before surfacing the failure: a partial apply has
 	// still changed the swarm, and the operator needs to know how far it got.

--- a/cli/args.go
+++ b/cli/args.go
@@ -8,6 +8,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/Eldara-Tech/swarmcli/docker"
 )
 
 // flags holds the parsed flag values shared across charts subcommands. Not
@@ -33,6 +35,9 @@ type flags struct {
 	// forVersion (--for-version) lints a chart against a chart-engine version
 	// other than this build's.
 	forVersion string
+	// resolveImage (--resolve-image) selects the daemon's tag-to-digest
+	// resolution at deploy time: always | changed | never.
+	resolveImage string
 }
 
 // parseArgs splits raw args into positionals and flags. It understands the
@@ -78,6 +83,15 @@ func parseArgs(args []string) ([]string, flags, error) {
 				return nil, f, err
 			}
 			f.sets = append(f.sets, v)
+		case "--resolve-image":
+			v, err := next()
+			if err != nil {
+				return nil, f, err
+			}
+			if !docker.ResolveImage(v).Valid() || v == "" {
+				return nil, f, fmt.Errorf("invalid value for --resolve-image: %q (want always, changed or never)", v)
+			}
+			f.resolveImage = v
 		case "--version":
 			v, err := next()
 			if err != nil {

--- a/cli/charts.go
+++ b/cli/charts.go
@@ -90,6 +90,8 @@ Common options:
       --wait            Wait for services to converge
       --timeout <dur>   Wait timeout, e.g. 10m (default 5m)
       --history-max <n> Max release revisions to retain
+      --resolve-image <mode>  always | changed | never — how the daemon resolves
+                        image tags to digests at deploy time (default: always)
       --install         upgrade: install the release if absent
       --reuse-values    upgrade/diff: layer overrides on previous values
       --revision <n>    get: select a specific revision
@@ -108,7 +110,7 @@ other version — it cannot tell you the chart RUNS on that version, because thi
 binary carries only its own engine's behaviour. Rendering with a real binary of
 that version is the only thing that settles that.
 
-apply honours --wait, --timeout and --history-max. It REJECTS --set, --version,
+apply honours --wait, --timeout, --history-max and --resolve-image. It REJECTS --set, --version,
 --reuse-values, --install, --purge-volumes, --requirements and --revision rather
 than ignoring them: the release file is the only source of truth, so a value passed
 on the command line would be a lie. outdated refreshes the repository indexes first
@@ -435,6 +437,7 @@ func chartsInstall(args []string) int {
 		Timeout:      f.timeout,
 		HistoryMax:   f.historyMax,
 		Requirements: req,
+		ResolveImage: f.resolveImage,
 	})
 	if err != nil {
 		return fail(err)
@@ -476,6 +479,7 @@ func chartsUpgrade(args []string) int {
 		Timeout:      f.timeout,
 		HistoryMax:   f.historyMax,
 		Requirements: req,
+		ResolveImage: f.resolveImage,
 	})
 	if err != nil {
 		return fail(err)

--- a/cli/flags_test.go
+++ b/cli/flags_test.go
@@ -16,3 +16,30 @@ func TestUpgradeFlagsParse(t *testing.T) {
 	require.True(t, f.reuseValues)
 	require.Equal(t, 3, f.revision)
 }
+
+func TestParseArgsResolveImage(t *testing.T) {
+	for _, mode := range []string{"always", "changed", "never"} {
+		_, f, err := parseArgs([]string{"rel", "repo/chart", "--resolve-image", mode})
+		require.NoError(t, err)
+		require.Equal(t, mode, f.resolveImage)
+	}
+
+	_, f, err := parseArgs([]string{"rel", "repo/chart", "--resolve-image=changed"})
+	require.NoError(t, err)
+	require.Equal(t, "changed", f.resolveImage)
+
+	// Unset means "pass no flag", leaving Docker's own default of always.
+	_, f, err = parseArgs([]string{"rel", "repo/chart"})
+	require.NoError(t, err)
+	require.Empty(t, f.resolveImage)
+}
+
+// A typo must fail loudly rather than silently deploying with the default,
+// matching the strict-flag philosophy of the other charts flags.
+func TestParseArgsResolveImageRejectsGarbage(t *testing.T) {
+	for _, bad := range []string{"latest", "Always", ""} {
+		_, _, err := parseArgs([]string{"rel", "repo/chart", "--resolve-image=" + bad})
+		require.Error(t, err, "mode %q should be rejected", bad)
+		require.Contains(t, err.Error(), "--resolve-image")
+	}
+}

--- a/docker/resolveimage_test.go
+++ b/docker/resolveimage_test.go
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package docker
+
+import "testing"
+
+func TestResolveImageValid(t *testing.T) {
+	valid := []ResolveImage{ResolveImageDefault, ResolveImageAlways, ResolveImageChanged, ResolveImageNever}
+	for _, r := range valid {
+		if !r.Valid() {
+			t.Errorf("ResolveImage(%q).Valid() = false, want true", string(r))
+		}
+	}
+	for _, r := range []ResolveImage{"latest", "Always", "digest"} {
+		if r.Valid() {
+			t.Errorf("ResolveImage(%q).Valid() = true, want false", string(r))
+		}
+	}
+}
+
+// An invalid mode must be refused before anything is written or deployed.
+func TestDeployStackResolvedRejectsInvalidMode(t *testing.T) {
+	err := DeployStackResolved("stack", "services:\n  a:\n    image: nginx\n", "bogus")
+	if err == nil {
+		t.Fatal("DeployStackResolved with an invalid mode returned nil, want an error")
+	}
+	if got := err.Error(); got == "" || !contains(got, "--resolve-image") {
+		t.Errorf("error = %q, want it to name --resolve-image", got)
+	}
+}
+
+func contains(s, sub string) bool {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/docker/stack_deploy.go
+++ b/docker/stack_deploy.go
@@ -47,8 +47,47 @@ func ValidateStackYAML(content string) error {
 	return nil
 }
 
-// DeployStack deploys a stack with the provided name and YAML content.
+// ResolveImage selects how the daemon resolves image tags to digests at deploy
+// time, mirroring `docker stack deploy --resolve-image`.
+//
+// The empty value passes no flag, leaving Docker's own default of "always": the
+// manager queries the registry for every service on every deploy. That makes a
+// deploy fail when the registry is unreachable even though every node already
+// has the image, and it rewrites the spec to repo:tag@sha256:..., so anything
+// diffing desired against live sees every service as changed.
+//
+// "changed" re-resolves only when the compose file's image string differs from
+// the com.docker.stack.image label the CLI stashes, which is what a reconciler
+// wants. "never" has an open upstream rollout bug (moby#51658).
+type ResolveImage string
+
+const (
+	ResolveImageDefault ResolveImage = ""
+	ResolveImageAlways  ResolveImage = "always"
+	ResolveImageChanged ResolveImage = "changed"
+	ResolveImageNever   ResolveImage = "never"
+)
+
+// Valid reports whether r is a mode the docker CLI accepts.
+func (r ResolveImage) Valid() bool {
+	switch r {
+	case ResolveImageDefault, ResolveImageAlways, ResolveImageChanged, ResolveImageNever:
+		return true
+	}
+	return false
+}
+
+// DeployStack deploys a stack with the provided name and YAML content, leaving
+// image resolution at Docker's default. See DeployStackResolved.
 func DeployStack(stackName string, yamlContent string) error {
+	return DeployStackResolved(stackName, yamlContent, ResolveImageDefault)
+}
+
+// DeployStackResolved deploys a stack with an explicit image-resolution mode.
+func DeployStackResolved(stackName string, yamlContent string, resolve ResolveImage) error {
+	if !resolve.Valid() {
+		return fmt.Errorf("invalid --resolve-image %q: want always, changed or never", string(resolve))
+	}
 	// Validate first
 	if err := ValidateStackYAML(yamlContent); err != nil {
 		return fmt.Errorf("validation failed: %w", err)
@@ -83,7 +122,12 @@ func DeployStack(stackName string, yamlContent string) error {
 	}
 
 	// Execute docker stack deploy command
-	cmd := exec.Command("docker", "--context", ctx, "stack", "deploy", "-c", tmpFile.Name(), stackName)
+	args := []string{"--context", ctx, "stack", "deploy", "-c", tmpFile.Name()}
+	if resolve != ResolveImageDefault {
+		args = append(args, "--resolve-image", string(resolve))
+	}
+	args = append(args, stackName)
+	cmd := exec.Command("docker", args...)
 	cmd.Env = os.Environ()
 
 	// Capture output for error reporting


### PR DESCRIPTION
Closes #474. Part of Eldara-Tech/swarmcli-cd#1 (Phase 0).

`docker.DeployStack` never passed `--resolve-image`, so every deploy got Docker's default of **`always`**: the manager queries the registry for every service in the stack, on every deploy.

- a **registry outage fails deploys** for images every node already has (moby#31427)
- **rate limiting** is a real failure mode at scale — SwarmCD hit permanent 429s for exactly this (m-adawi/swarm-cd#126)
- it rewrites the spec to `repo:tag@sha256:…`, so anything diffing desired against live reads **every service as changed** — which is why this is a Phase 0 prerequisite for swarmcli-cd

## Change

`docker.ResolveImage` (`always` | `changed` | `never`), threaded through `charts.InstallOptions.ResolveImage` and exposed as `--resolve-image` on `install`, `upgrade` and `apply`.

**The default is unchanged.** An empty mode passes no flag, so existing behaviour is byte-identical; this only adds the ability to ask for something else.

`changed` is what automation wants: it re-resolves only when the compose image string differs from the `com.docker.stack.image` label the CLI stashes, and otherwise copies the previously-resolved digest back into the spec so the update is not spuriously dirty.

`never` is accepted but has an open upstream rollout bug (moby#51658), noted in the doc comment rather than silently recommended.

## Why `apply` accepts it

`rejectUnsupported` refuses `--set`, `--version`, `--install` and friends because they would override the release file as the source of truth. `--resolve-image` is a *deploy-time* concern and overrides nothing in the file, so it is honoured rather than rejected — a deliberate asymmetry.

## Notes

- An invalid mode is refused **before** anything is written or deployed, rather than being passed through for the docker CLI to reject.
- `Backend.DeployStack` gains a parameter; exactly one fake implements it.

## Verification

`gofmt`, `go build`, `go vet`, `go test -race -count=1 ./...`, `golangci-lint run ./... --build-tags=integration` → **0 issues**.