### PR TITLE
charts: stamp an owner on release history so a prune could be safe

### DIFF
--- a/charts/README.md
+++ b/charts/README.md
@@ -53,6 +53,7 @@ converges the swarm to a file you commit.
 ```yaml
 # swarmcli-release.yaml
 apiVersion: v1
+owner: prod-swarm              # optional; see Ownership below
 repositories:
   - name: swarmcli-charts
     url: https://eldara-tech.github.io/swarmcli-charts
@@ -79,14 +80,44 @@ swarmcli charts outdated                                   # what has a newer ch
 | Changed chart version, values, or rendered manifest | upgraded |
 | Identical | **skipped — no new revision** |
 | On the swarm but not in the file | **reported, never removed** |
+| Installed by this file, no longer in it | **reported as an orphan, still never removed** |
 
-Two of those deserve the emphasis. Releases are **never deleted**: a release
-records nothing about which file produced it, so a prune could not tell one owned
-by another manifest, or installed by hand, from a genuinely obsolete one — it
-prints the `uninstall` command instead and leaves the decision to you. And an
-unchanged release is skipped **entirely**: history is one Docker Config per
-revision, so re-applying on every CI push would otherwise grow the swarm's config
-store without bound.
+Two of those deserve the emphasis. Releases are **never deleted** — apply prints
+the `uninstall` command and leaves the decision to you. And an unchanged release
+is skipped **entirely**: history is one Docker Config per revision, so re-applying
+on every CI push would otherwise grow the swarm's config store without bound.
+
+### Ownership
+
+`owner:` names the manifest, and every release it installs is stamped with that
+name — in the release-history Config's `com.swarmcli.owner` label and in the
+stored record — so a later apply can tell a release *this file* installed from
+one it has simply never seen. Dropping a release from the file then reports it as
+an **orphan**: provably obsolete, because the stamp says this manifest produced
+it and nothing else claims it. A release with no stamp, or another manifest's
+stamp, stays merely *unmanaged*.
+
+Nothing is deleted either way. The distinction is the prerequisite for a prune
+that could be: it is what separates "this is obsolete" from "I do not recognise
+this", and only the first is ever safe to act on.
+
+```
+com.swarmcli.owner: apply/prod-swarm:release/hello
+                    └──── id ─────┘ └── resource ──┘
+```
+
+The stamp names the **resource** as well as the owner, and both halves must match
+for it to count. A bare owner string cannot tell a release this file installed
+from a copy of one — ArgoCD shipped exactly that as `app.kubernetes.io/instance`
+and replaced it in 3.0 for the same reason. The `apply/` prefix keeps a manifest
+applied from the command line from colliding with a controller that happened to
+pick the same name.
+
+`owner:` is optional and has **no default**. A derived one would either change
+between a laptop and a CI checkout (a path hash) or be shared by every repository
+using the conventional filename (a basename) — and either would let two unrelated
+manifests claim each other's releases. Omit it and nothing is claimed, which is
+exactly the behaviour of every version before this one.
 
 For a `repo/chart`, **`version` is required** — a floating pin would silently
 upgrade production on the next `apply`. For a **local** chart path (`chart:

--- a/charts/apply.go
+++ b/charts/apply.go
@@ -45,11 +45,21 @@ type ReleasePlan struct {
 
 // Plan is what apply would do to the whole swarm.
 type Plan struct {
+	// Owner is the owner id this plan was classified against, from the release
+	// file's `owner:` key. Empty when the file declares none, in which case
+	// nothing on the swarm is claimable and Orphaned is always empty.
+	Owner string `json:"owner,omitempty"`
 	// Releases, in file order.
 	Releases []ReleasePlan `json:"releases"`
-	// Unmanaged names releases that exist on the swarm but are absent from the
-	// file. Apply never touches them — see Engine.Apply.
+	// Unmanaged names releases that exist on the swarm, are absent from the
+	// file, and carry no stamp saying this file produced them. Apply never
+	// touches them — see Engine.Apply.
 	Unmanaged []string `json:"unmanaged,omitempty"`
+	// Orphaned names releases this file's own owner installed that the file no
+	// longer declares. Unlike Unmanaged they are provably obsolete rather than
+	// merely unrecognised, which is what makes deleting them safe. Apply still
+	// does not delete them.
+	Orphaned []string `json:"orphaned,omitempty"`
 }
 
 // Counts summarises a plan.
@@ -83,7 +93,7 @@ func (e *Engine) PlanApply(ctx context.Context, rf *ReleaseFile, src ChartSource
 		deployed[rel.Name] = rel
 	}
 
-	plan := &Plan{}
+	plan := &Plan{Owner: rf.ownerID()}
 	managed := map[string]bool{}
 
 	for _, spec := range rf.Releases {
@@ -97,11 +107,31 @@ func (e *Engine) PlanApply(ctx context.Context, rf *ReleaseFile, src ChartSource
 	}
 
 	for _, rel := range current {
-		if !managed[rel.Name] {
+		switch {
+		case managed[rel.Name]:
+		case plan.Owner != "" && ownedBy(rel, plan.Owner):
+			plan.Orphaned = append(plan.Orphaned, rel.Name)
+		default:
 			plan.Unmanaged = append(plan.Unmanaged, rel.Name)
 		}
 	}
 	return plan, nil
+}
+
+// ownedBy reports whether a deployed release carries a stamp that this owner
+// wrote for that exact release.
+//
+// Both halves have to match. An id-only comparison would re-introduce the bare
+// owner label this encoding exists to avoid: a stamp copied onto a second
+// release would read as owned, and prune would then delete a release nobody
+// installed under that name. A stamp that does not parse is likewise not
+// evidence of anything, so it counts as unowned.
+func ownedBy(rel Release, id string) bool {
+	own, err := ParseOwner(rel.Owner)
+	if err != nil {
+		return false
+	}
+	return own == OwnerRef{ID: id, Kind: OwnerKindRelease, Name: rel.Name}
 }
 
 func (e *Engine) planRelease(rf *ReleaseFile, spec ReleaseSpec, src ChartSource, deployed map[string]Release) (ReleasePlan, error) {
@@ -186,9 +216,11 @@ type ApplyResult struct {
 // Apply converges the swarm to a plan, in file order.
 //
 // It never deletes. A release on the swarm that is absent from the file is
-// reported (Plan.Unmanaged) and left alone: a Release carries no marker saying
-// which manifest produced it, so a prune could not distinguish a release owned by
-// a second manifest, or one installed by hand, from a genuinely obsolete one.
+// reported and left alone — either as Plan.Unmanaged, where nothing says which
+// manifest produced it and so it may belong to a second file or to a human, or
+// as Plan.Orphaned, where its owner stamp names this file and it is therefore
+// provably obsolete. Only the second is safe to remove, which is what the stamp
+// exists to establish; acting on it is a separate change.
 //
 // Unchanged releases are skipped entirely. That is not an optimisation but a
 // requirement: history is one Docker Config per revision, so an apply that

--- a/charts/apply_test.go
+++ b/charts/apply_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 )
 
 // fakeChartSource serves charts from testdata without a repository, a network or
@@ -502,4 +503,133 @@ func TestPlanApplyDetectsChartNameChange(t *testing.T) {
 	plan2, err := e.PlanApply(ctx, rf, src)
 	require.NoError(t, err)
 	require.Equal(t, ActionUpgrade, plan2.Releases[0].Action)
+}
+
+// ownedRelease is a release file that claims what it installs.
+const ownedRelease = `owner: prod-swarm
+repositories:
+  - name: swarmcli-charts
+    url: https://eldara-tech.github.io/swarmcli-charts
+releases:
+  - name: hello
+    chart: swarmcli-charts/demo
+    version: "0.1.0"
+`
+
+// storeRelease writes a release record straight into the backend, so a test can
+// stage history that the engine would not produce itself — in particular a stamp
+// naming a release other than the one carrying it.
+func storeRelease(t *testing.T, fb *fakeBackend, rel Release) {
+	t.Helper()
+	payload, err := yaml.Marshal(rel)
+	require.NoError(t, err)
+	gz, err := gzipBytes(payload)
+	require.NoError(t, err)
+	labels := map[string]string{LabelType: TypeRelease, LabelRelease: rel.Name, LabelStatus: rel.Status}
+	if rel.Owner != "" {
+		labels[LabelOwner] = rel.Owner
+	}
+	require.NoError(t, fb.CreateConfig(context.Background(), releaseConfigName(rel.Name, rel.Revision), gz, labels))
+}
+
+// A release this file installed and no longer declares is provably obsolete: the
+// stamp names this manifest, so nothing else can be claiming it. That is the
+// distinction the stamp exists to draw, and it is the whole prerequisite for a
+// prune — so it must not land in Unmanaged alongside releases of unknown origin.
+func TestPlanApplySeparatesItsOwnOrphansFromUnmanagedReleases(t *testing.T) {
+	e, fb, src, rf := applyEnv(t, ownedRelease, "0.1.0")
+	ctx := context.Background()
+
+	storeRelease(t, fb, Release{Name: "ours", Revision: 1, Status: StatusDeployed, Owner: "apply/prod-swarm:release/ours"})
+	storeRelease(t, fb, Release{Name: "theirs", Revision: 1, Status: StatusDeployed, Owner: "apply/other-swarm:release/theirs"})
+	storeRelease(t, fb, Release{Name: "byhand", Revision: 1, Status: StatusDeployed})
+
+	plan, err := e.PlanApply(ctx, rf, src)
+	require.NoError(t, err)
+	require.Equal(t, "apply/prod-swarm", plan.Owner)
+	require.Equal(t, []string{"ours"}, plan.Orphaned)
+	require.ElementsMatch(t, []string{"byhand", "theirs"}, plan.Unmanaged)
+}
+
+// The stamp names the resource it was written for, which is the point of
+// encoding a tuple rather than a bare owner string: a record copied onto another
+// release still names the original, so it is not evidence that this manifest
+// installed the copy. ArgoCD's original bare instance label could not tell those
+// apart, and this is the case that proves ours can.
+func TestPlanApplyIgnoresAStampNamingAnotherRelease(t *testing.T) {
+	e, fb, src, rf := applyEnv(t, ownedRelease, "0.1.0")
+
+	// Right owner, wrong resource — a copy of "ours" filed under a new name.
+	storeRelease(t, fb, Release{Name: "copy", Revision: 1, Status: StatusDeployed, Owner: "apply/prod-swarm:release/ours"})
+	// Right owner, unparseable stamp.
+	storeRelease(t, fb, Release{Name: "garbled", Revision: 1, Status: StatusDeployed, Owner: "apply/prod-swarm"})
+
+	plan, err := e.PlanApply(context.Background(), rf, src)
+	require.NoError(t, err)
+	require.Empty(t, plan.Orphaned, "an unverifiable stamp is not ownership")
+	require.ElementsMatch(t, []string{"copy", "garbled"}, plan.Unmanaged)
+}
+
+// A file that declares no owner claims nothing, so every release on the swarm
+// stays unmanaged no matter what stamp it carries. That is what keeps the stamp
+// opt-in and today's behaviour the default.
+func TestPlanApplyWithoutAnOwnerClaimsNothing(t *testing.T) {
+	e, fb, src, rf := applyEnv(t, oneRelease, "0.1.0")
+
+	storeRelease(t, fb, Release{Name: "stamped", Revision: 1, Status: StatusDeployed, Owner: "apply/prod-swarm:release/stamped"})
+
+	plan, err := e.PlanApply(context.Background(), rf, src)
+	require.NoError(t, err)
+	require.Empty(t, plan.Owner)
+	require.Empty(t, plan.Orphaned)
+	require.Equal(t, []string{"stamped"}, plan.Unmanaged)
+}
+
+// Applying a plan stamps what it installs with the owner the plan was
+// classified against, so the next run recognises its own work.
+func TestApplyStampsTheOwnerItPlannedWith(t *testing.T) {
+	e, _, src, rf := applyEnv(t, ownedRelease, "0.1.0")
+	ctx := context.Background()
+
+	plan, err := e.PlanApply(ctx, rf, src)
+	require.NoError(t, err)
+	_, err = e.Apply(ctx, plan, InstallOptions{Owner: plan.Owner})
+	require.NoError(t, err)
+
+	rel, err := e.GetRevision(ctx, "hello", 0)
+	require.NoError(t, err)
+	require.Equal(t, "apply/prod-swarm:release/hello", rel.Owner)
+
+	// Drop it from the file — same owner, same swarm — and what apply installed,
+	// apply now recognises as its own orphan rather than as a stranger.
+	_, _, src2, rf2 := applyEnv(t, `owner: prod-swarm
+releases:
+  - name: other
+    chart: swarmcli-charts/demo
+    version: "0.1.0"
+`, "0.1.0")
+	plan2, err := e.PlanApply(ctx, rf2, src2)
+	require.NoError(t, err)
+	require.Equal(t, []string{"hello"}, plan2.Orphaned)
+}
+
+// apply still deletes nothing, orphan or not: the stamp establishes that it
+// could, and acting on it is a separate change.
+func TestApplyDoesNotRemoveItsOwnOrphans(t *testing.T) {
+	e, fb, src, rf := applyEnv(t, ownedRelease, "0.1.0")
+	ctx := context.Background()
+
+	ch := demoChart(t, "0.1.0")
+	_, err := e.Install(ctx, "obsolete", ReleaseChartOf(ch), ch.Values, "services: {}\n",
+		InstallOptions{Owner: "apply/prod-swarm"})
+	require.NoError(t, err)
+
+	plan, err := e.PlanApply(ctx, rf, src)
+	require.NoError(t, err)
+	require.Equal(t, []string{"obsolete"}, plan.Orphaned)
+
+	_, err = e.Apply(ctx, plan, InstallOptions{Owner: plan.Owner})
+	require.NoError(t, err)
+	require.Contains(t, fb.deployed, "obsolete")
+	require.Contains(t, fb.configs, "swarmcli.release.obsolete.v1")
 }

--- a/charts/json_test.go
+++ b/charts/json_test.go
@@ -89,3 +89,37 @@ func TestApplyResultJSONKeys(t *testing.T) {
 	// so a consumer cannot mistake it for revision zero.
 	require.NotContains(t, got, "revision")
 }
+
+// The owner stamp is served to API clients under the same key it is stored
+// under, and stays absent — not null, not "" — when nothing claimed the release.
+func TestReleaseOwnerJSONKey(t *testing.T) {
+	var got map[string]any
+	b, err := json.Marshal(Release{Name: "edge", Owner: "apply/prod:release/edge"})
+	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal(b, &got))
+	require.Equal(t, "apply/prod:release/edge", got["owner"])
+
+	var bare map[string]any
+	b, err = json.Marshal(Release{Name: "edge"})
+	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal(b, &bare))
+	require.NotContains(t, bare, "owner")
+}
+
+// A plan distinguishes releases it provably installed from releases of unknown
+// origin, and both keys stay absent when empty.
+func TestPlanOwnerAndOrphanedJSONKeys(t *testing.T) {
+	var got map[string]any
+	b, err := json.Marshal(Plan{Owner: "apply/prod", Orphaned: []string{"gone"}})
+	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal(b, &got))
+	require.Equal(t, "apply/prod", got["owner"])
+	require.Equal(t, []any{"gone"}, got["orphaned"])
+
+	var bare map[string]any
+	b, err = json.Marshal(Plan{})
+	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal(b, &bare))
+	require.NotContains(t, bare, "owner")
+	require.NotContains(t, bare, "orphaned")
+}

--- a/charts/owner.go
+++ b/charts/owner.go
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package charts
+
+import (
+	"fmt"
+	"strings"
+)
+
+// OwnerKindRelease is the resource kind of a release-history record, the only
+// thing an owner stamp names today.
+const OwnerKindRelease = "release"
+
+// OwnerRef identifies both who manages a resource and which resource the stamp
+// was written for. It is encoded as "<id>:<kind>/<name>", e.g.
+//
+//	apply/prod-swarm:release/whoami
+//
+// The resource half is what makes the stamp verifiable, and it is there
+// deliberately. A bare owner string cannot tell a resource this tool created
+// from a copy of one: ArgoCD shipped exactly that as the
+// app.kubernetes.io/instance label, and replaced it in 3.0 with an annotation
+// naming the resource too. Reading a stamp back therefore means checking that
+// it names the resource carrying it — one that does not is not evidence of
+// ownership, so it is treated as unowned rather than trusted.
+//
+// Docker label values have no length limit, which is the other half of what
+// ArgoCD had to work around (its label truncated at 63 bytes).
+type OwnerRef struct {
+	ID   string // the manifest or controller that manages the resource
+	Kind string // OwnerKindRelease
+	Name string // the resource's name on the swarm
+}
+
+// String encodes the reference for storage in a label or a release payload.
+func (o OwnerRef) String() string { return o.ID + ":" + o.Kind + "/" + o.Name }
+
+// ParseOwner decodes a stamp written by OwnerRef.String.
+//
+// The id may itself contain "/" (the "apply/<name>" convention), so the id is
+// cut at the first ":" and only the remainder is split into kind and name.
+func ParseOwner(s string) (OwnerRef, error) {
+	id, rest, ok := strings.Cut(s, ":")
+	if !ok {
+		return OwnerRef{}, fmt.Errorf("owner stamp %q is not <id>:<kind>/<name>", s)
+	}
+	kind, name, ok := strings.Cut(rest, "/")
+	if !ok {
+		return OwnerRef{}, fmt.Errorf("owner stamp %q is not <id>:<kind>/<name>", s)
+	}
+	if id == "" || kind == "" || name == "" {
+		return OwnerRef{}, fmt.Errorf("owner stamp %q has an empty id, kind or name", s)
+	}
+	return OwnerRef{ID: id, Kind: kind, Name: name}, nil
+}
+
+// validateOwnerID rejects an owner id that would not survive the encoding: ":"
+// separates the id from the resource half, so an id containing one would decode
+// as a different owner than it was written as.
+func validateOwnerID(id string) error {
+	switch {
+	case id == "":
+		return fmt.Errorf("owner is empty")
+	case strings.Contains(id, ":"):
+		return fmt.Errorf("invalid owner %q: must not contain ':'", id)
+	}
+	return nil
+}

--- a/charts/owner_test.go
+++ b/charts/owner_test.go
@@ -1,0 +1,163 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package charts
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestOwnerRefRoundTrip(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		ref  OwnerRef
+		want string
+	}{
+		{"apply", OwnerRef{ID: "apply/prod-swarm", Kind: OwnerKindRelease, Name: "whoami"}, "apply/prod-swarm:release/whoami"},
+		{"controller", OwnerRef{ID: "cd/edge", Kind: OwnerKindRelease, Name: "traefik"}, "cd/edge:release/traefik"},
+		// Release names admit '.', '-' and '_', none of which are separators.
+		{"punctuated name", OwnerRef{ID: "apply/a", Kind: OwnerKindRelease, Name: "a.b-c_d"}, "apply/a:release/a.b-c_d"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, tc.ref.String())
+			got, err := ParseOwner(tc.want)
+			require.NoError(t, err)
+			require.Equal(t, tc.ref, got)
+		})
+	}
+}
+
+// The id carries a '/' by convention ("apply/<name>"), so the split has to cut
+// the id at the first ':' rather than the first '/'.
+func TestParseOwnerKeepsSlashesInTheID(t *testing.T) {
+	got, err := ParseOwner("apply/deeply/nested:release/hello")
+	require.NoError(t, err)
+	require.Equal(t, OwnerRef{ID: "apply/deeply/nested", Kind: OwnerKindRelease, Name: "hello"}, got)
+}
+
+func TestParseOwnerRejectsMalformedStamps(t *testing.T) {
+	for _, s := range []string{
+		"",
+		"apply/prod",            // no resource half
+		"apply/prod:release",    // no name
+		":release/hello",        // no id
+		"apply/prod:/hello",     // no kind
+		"apply/prod:release/",   // empty name
+		"apply/prod release/hi", // wrong separator
+	} {
+		_, err := ParseOwner(s)
+		require.Error(t, err, "stamp %q must not parse", s)
+	}
+}
+
+func TestValidateOwnerID(t *testing.T) {
+	require.NoError(t, validateOwnerID("apply/prod-swarm"))
+	require.Error(t, validateOwnerID(""))
+	// ':' separates the id from the resource half; an id carrying one would
+	// decode as a different owner than it was written as.
+	require.Error(t, validateOwnerID("apply:prod"))
+}
+
+// --- stamping ---
+
+// A stamped install records the owner in both places it has to be: the Config
+// label, so a prune can find candidates without decoding every payload, and the
+// payload itself, so the record stays self-describing.
+func TestInstallStampsOwnerOnLabelAndPayload(t *testing.T) {
+	fb := newFakeBackend()
+	e := NewEngineWith(fb)
+	ctx := context.Background()
+
+	rel, err := e.Install(ctx, "hello", ReleaseChart{Name: "demo", Version: "0.1.0"}, nil,
+		"services: {}\n", InstallOptions{Owner: "apply/prod-swarm"})
+	require.NoError(t, err)
+	require.Equal(t, "apply/prod-swarm:release/hello", rel.Owner)
+
+	cfg := fb.configs["swarmcli.release.hello.v1"]
+	require.Equal(t, "apply/prod-swarm:release/hello", cfg.labels[LabelOwner])
+
+	stored, err := e.GetRevision(ctx, "hello", 1)
+	require.NoError(t, err)
+	require.Equal(t, "apply/prod-swarm:release/hello", stored.Owner)
+}
+
+// An unowned install is the default, and it must leave the label off entirely
+// rather than blank: a prune filtering on the label's presence would otherwise
+// match every release ever installed by hand.
+func TestInstallWithoutOwnerLeavesNoLabel(t *testing.T) {
+	fb := newFakeBackend()
+	e := NewEngineWith(fb)
+
+	rel, err := e.Install(context.Background(), "hello", ReleaseChart{Name: "demo", Version: "0.1.0"}, nil,
+		"services: {}\n", InstallOptions{})
+	require.NoError(t, err)
+	require.Empty(t, rel.Owner)
+	require.NotContains(t, fb.configs["swarmcli.release.hello.v1"].labels, LabelOwner)
+}
+
+// A malformed owner has to fail before anything is deployed: recording it would
+// produce a stamp that decodes as a different owner than the caller passed.
+func TestInstallRejectsMalformedOwnerBeforeDeploying(t *testing.T) {
+	fb := newFakeBackend()
+	e := NewEngineWith(fb)
+
+	_, err := e.Install(context.Background(), "hello", ReleaseChart{Name: "demo", Version: "0.1.0"}, nil,
+		"services: {}\n", InstallOptions{Owner: "apply:prod"})
+	require.ErrorContains(t, err, "must not contain ':'")
+	require.Empty(t, fb.deployed)
+	require.Empty(t, fb.configs)
+}
+
+// The stamp is computed before the dry-run return, so a plan shows the ownership
+// it would record without touching the swarm.
+func TestDryRunReportsTheOwnerItWouldRecord(t *testing.T) {
+	fb := newFakeBackend()
+	e := NewEngineWith(fb)
+
+	rel, err := e.Install(context.Background(), "hello", ReleaseChart{Name: "demo", Version: "0.1.0"}, nil,
+		"services: {}\n", InstallOptions{Owner: "cd/edge", DryRun: true})
+	require.NoError(t, err)
+	require.Equal(t, "cd/edge:release/hello", rel.Owner)
+	require.Empty(t, fb.configs)
+}
+
+// Every revision is stamped with whoever wrote it. A second manifest upgrading a
+// release takes it over, and the history says exactly where the handover
+// happened rather than silently keeping the first owner's claim alive.
+func TestUpgradeByAnotherOwnerTakesTheReleaseOver(t *testing.T) {
+	e := NewEngineWith(newFakeBackend())
+	ctx := context.Background()
+	chart := ReleaseChart{Name: "demo", Version: "0.1.0"}
+
+	_, err := e.Install(ctx, "hello", chart, nil, "services: {}\n", InstallOptions{Owner: "apply/a"})
+	require.NoError(t, err)
+	_, err = e.Upgrade(ctx, "hello", chart, nil, "services: {b: {}}\n", InstallOptions{Owner: "apply/b"})
+	require.NoError(t, err)
+
+	hist, err := e.History(ctx, "hello")
+	require.NoError(t, err)
+	require.Len(t, hist, 2)
+	require.Equal(t, "apply/a:release/hello", hist[0].Owner)
+	require.Equal(t, "apply/b:release/hello", hist[1].Owner)
+}
+
+// A rollback is a new revision written by whoever ran it, so it carries the
+// current owner rather than resurrecting the one the target revision recorded.
+func TestRollbackStampsTheCurrentOwnerNotTheTargets(t *testing.T) {
+	e := NewEngineWith(newFakeBackend())
+	ctx := context.Background()
+	chart := ReleaseChart{Name: "demo", Version: "0.1.0"}
+
+	_, err := e.Install(ctx, "hello", chart, nil, "services: {}\n", InstallOptions{Owner: "apply/a"})
+	require.NoError(t, err)
+	_, err = e.Upgrade(ctx, "hello", chart, nil, "services: {b: {}}\n", InstallOptions{Owner: "apply/b"})
+	require.NoError(t, err)
+
+	rel, err := e.Rollback(ctx, "hello", 1, InstallOptions{Owner: "apply/b"})
+	require.NoError(t, err)
+	require.Equal(t, "apply/b:release/hello", rel.Owner)
+	require.Equal(t, "services: {}\n", rel.Manifest, "rollback still restores the target's content")
+}

--- a/charts/release.go
+++ b/charts/release.go
@@ -117,6 +117,16 @@ type InstallOptions struct {
 	// every external resource the manifest references must be declared in it. Nil
 	// falls back to manifest-driven pre-flight (auto-create attachable overlays).
 	Requirements *Requirements
+	// Owner claims the release for a manifest or controller, e.g.
+	// "apply/prod-swarm" or "cd/edge". It is recorded on every revision this
+	// call writes, as the id half of an OwnerRef naming the release.
+	//
+	// Empty leaves the revision unowned, which is what an imperative install
+	// does and what keeps "never delete anything" the default: only a release
+	// stamped with a caller's own owner can ever be a prune candidate, so a
+	// release installed by hand or by somebody else's manifest is untouchable
+	// no matter what a later prune is asked to do.
+	Owner string
 }
 
 // Install deploys a freshly rendered manifest as revision 1 of a new release and
@@ -238,6 +248,18 @@ func (e *Engine) newRevision(release string, rev int, chart ReleaseChart, values
 // returns the prospective revision without touching Docker. On deploy failure
 // it records nothing, leaving the release retryable (no orphaned revision).
 func (e *Engine) deployAndRecord(ctx context.Context, rel *Release, opts InstallOptions) (*Release, error) {
+	// Stamp before the dry-run return so a plan shows the ownership it would
+	// record, and before any mutation so a malformed owner fails for free.
+	// A revision is stamped with whoever wrote it, not with whoever wrote the
+	// previous one: an upgrade or rollback by a second manifest takes the
+	// release over, and the history shows exactly where the handover happened.
+	if opts.Owner != "" {
+		if err := validateOwnerID(opts.Owner); err != nil {
+			rel.Status = StatusFailed
+			return rel, err
+		}
+		rel.Owner = OwnerRef{ID: opts.Owner, Kind: OwnerKindRelease, Name: rel.Name}.String()
+	}
 	if opts.DryRun {
 		return rel, nil
 	}
@@ -734,6 +756,11 @@ func (e *Engine) storeRevision(ctx context.Context, rel *Release) error {
 		LabelRevision:     strconv.Itoa(rel.Revision),
 		LabelStatus:       rel.Status,
 		LabelCreated:      rel.Created,
+	}
+	// Absent rather than empty when unowned: a prune filtering on the label's
+	// presence must not match a release that merely carries a blank one.
+	if rel.Owner != "" {
+		labels[LabelOwner] = rel.Owner
 	}
 	return e.Backend.CreateConfig(ctx, releaseConfigName(rel.Name, rel.Revision), gz, labels)
 }

--- a/charts/releasefile.go
+++ b/charts/releasefile.go
@@ -30,9 +30,16 @@ import (
 // syntax fails loudly and names the key, rather than silently doing half of what
 // was meant.
 type ReleaseFile struct {
-	APIVersion   string        `yaml:"apiVersion,omitempty"`
-	Repositories []RepoSpec    `yaml:"repositories,omitempty"`
-	Releases     []ReleaseSpec `yaml:"releases"`
+	APIVersion   string     `yaml:"apiVersion,omitempty"`
+	Repositories []RepoSpec `yaml:"repositories,omitempty"`
+	// Owner names this manifest, claiming every release it installs. It is
+	// optional and there is deliberately no default: a derived one would either
+	// change between a laptop and a CI checkout (a path hash) or be shared by
+	// every repository using the conventional filename (a basename), and either
+	// would let two unrelated manifests claim each other's releases. Absent
+	// means nothing is claimed, which is exactly today's behaviour.
+	Owner    string        `yaml:"owner,omitempty"`
+	Releases []ReleaseSpec `yaml:"releases"`
 
 	// Dir is the directory containing the file. Values files and local chart
 	// paths resolve against it, never the process working directory, so the
@@ -90,6 +97,11 @@ func (rf *ReleaseFile) validate() error {
 	if len(rf.Releases) == 0 {
 		return rf.errf("no releases declared")
 	}
+	if rf.Owner != "" {
+		if err := validateOwnerID(rf.Owner); err != nil {
+			return rf.errf("%v", err)
+		}
+	}
 
 	seenRepo := map[string]bool{}
 	for i, r := range rf.Repositories {
@@ -144,6 +156,17 @@ func (rf *ReleaseFile) validate() error {
 
 func (rf *ReleaseFile) errf(format string, a ...any) error {
 	return fmt.Errorf("%s: %s", rf.Path, fmt.Sprintf(format, a...))
+}
+
+// ownerID is the owner id stamped on releases this file produces: its declared
+// owner namespaced under "apply/", so a manifest applied from the command line
+// and an application reconciled by a controller cannot claim each other's
+// releases by happening to pick the same name. Empty when no owner is declared.
+func (rf *ReleaseFile) ownerID() string {
+	if rf.Owner == "" {
+		return ""
+	}
+	return "apply/" + rf.Owner
 }
 
 // ValuesPaths resolves a release's values files against the manifest's directory.

--- a/charts/releasefile_test.go
+++ b/charts/releasefile_test.go
@@ -157,3 +157,39 @@ func TestChartNameOf(t *testing.T) {
 	require.Equal(t, "whoami", chartNameOf("whoami"))
 	require.Equal(t, "c", chartNameOf("a/b/c"))
 }
+
+// The owner is optional and namespaced under "apply/" when stamped, so a
+// manifest applied from the command line and an application reconciled by a
+// controller cannot claim each other's releases by picking the same name.
+func TestReleaseFileOwner(t *testing.T) {
+	rf, err := ParseReleaseFile([]byte(`owner: prod-swarm
+releases:
+  - name: hello
+    chart: repo/demo
+    version: "1.0.0"
+`), "f.yaml")
+	require.NoError(t, err)
+	require.Equal(t, "prod-swarm", rf.Owner)
+	require.Equal(t, "apply/prod-swarm", rf.ownerID())
+
+	rf, err = ParseReleaseFile([]byte(`releases:
+  - name: hello
+    chart: repo/demo
+    version: "1.0.0"
+`), "f.yaml")
+	require.NoError(t, err)
+	require.Empty(t, rf.ownerID(), "no owner declared means nothing is claimed")
+}
+
+// ':' separates the id from the resource half of a stamp, so an owner carrying
+// one would decode as a different owner than it was written as. Catch it at
+// parse time, where the error can name the file.
+func TestReleaseFileRejectsOwnerWithColon(t *testing.T) {
+	_, err := ParseReleaseFile([]byte(`owner: "prod:swarm"
+releases:
+  - name: hello
+    chart: repo/demo
+    version: "1.0.0"
+`), "f.yaml")
+	require.ErrorContains(t, err, "must not contain ':'")
+}

--- a/charts/types.go
+++ b/charts/types.go
@@ -10,7 +10,7 @@
 // non-interactive CLI and, later, a TUI browser view.
 package charts
 
-// Label keys applied to every release-history Docker Config. They mirror the
+// Label keys applied to release-history Docker Configs. They mirror the
 // scheme documented in issue #413 and let list/status/history queries filter
 // Configs by release without an external database.
 const (
@@ -21,6 +21,9 @@ const (
 	LabelRevision     = "com.swarmcli.revision"      // revision number
 	LabelStatus       = "com.swarmcli.status"        // see Status* constants
 	LabelCreated      = "com.swarmcli.created"       // RFC3339 timestamp
+	// LabelOwner is the only optional one: "<id>:<kind>/<name>" (see OwnerRef),
+	// absent entirely when nothing claimed the release.
+	LabelOwner = "com.swarmcli.owner"
 
 	TypeRelease = "release"
 )
@@ -146,6 +149,11 @@ type Release struct {
 	// not remove them — they may be shared). Omitted for revisions that created
 	// none and for records written before this field existed.
 	ManagedNetworks []string `yaml:"managedNetworks,omitempty" json:"managedNetworks,omitempty"`
+	// Owner is the stamp naming whichever manifest or controller produced this
+	// revision, encoded as "<id>:<kind>/<name>" (see OwnerRef). Empty for a
+	// release nothing claimed — an imperative install, or an apply from a file
+	// declaring no owner — and an unowned release is never a prune candidate.
+	Owner string `yaml:"owner,omitempty" json:"owner,omitempty"`
 }
 
 // ReleaseChart is the chart reference recorded in a Release.

--- a/cli/apply.go
+++ b/cli/apply.go
@@ -78,6 +78,7 @@ func chartsApply(args []string) int {
 
 	install, upgrade, _ := plan.Counts()
 	if install+upgrade == 0 {
+		reportOrphaned(plan)
 		reportUnmanaged(plan)
 		return 0
 	}
@@ -87,6 +88,10 @@ func chartsApply(args []string) int {
 		Timeout:      f.timeout,
 		HistoryMax:   f.historyMax,
 		ResolveImage: f.resolveImage,
+		// From the plan, not recomputed from the file: apply must stamp the
+		// same owner it classified against, or a release would be installed
+		// under one id and go looking for orphans under another.
+		Owner: plan.Owner,
 	})
 	// Report what did happen before surfacing the failure: a partial apply has
 	// still changed the swarm, and the operator needs to know how far it got.
@@ -99,6 +104,7 @@ func chartsApply(args []string) int {
 	if err != nil {
 		return fail(err)
 	}
+	reportOrphaned(plan)
 	reportUnmanaged(plan)
 	return 0
 }
@@ -163,10 +169,28 @@ func printPlan(plan *charts.Plan, withDiff bool) {
 	outf("\n%d to install, %d to upgrade, %d unchanged\n", install, upgrade, unchanged)
 }
 
-// reportUnmanaged names releases on the swarm that the file does not describe.
-// apply never removes them: a release records nothing about which manifest
-// produced it, so there is no way to tell one owned by a second file, or one
-// installed by hand, from a genuinely obsolete one.
+// reportOrphaned names releases this file's own owner installed that it no
+// longer declares. Unlike the unmanaged set these are provably obsolete — the
+// stamp says this manifest produced them — but apply still removes nothing.
+func reportOrphaned(plan *charts.Plan) {
+	if len(plan.Orphaned) == 0 {
+		return
+	}
+	outf("\n%d release(s) were installed by this release file but are no longer declared in it:\n", len(plan.Orphaned))
+	for _, n := range plan.Orphaned {
+		outf("  %s\n", n)
+	}
+	out("apply does not remove them; uninstall to reclaim them:\n")
+	for _, n := range plan.Orphaned {
+		outf("  swarmcli charts uninstall %s\n", n)
+	}
+}
+
+// reportUnmanaged names releases on the swarm that the file neither describes
+// nor claims. apply never removes them: nothing says a second file, or a human,
+// did not install them, so a genuinely obsolete one is indistinguishable from
+// somebody else's. Releases this file does claim are reported by reportOrphaned
+// instead.
 func reportUnmanaged(plan *charts.Plan) {
 	if len(plan.Unmanaged) == 0 {
 		return

--- a/cli/charts_test.go
+++ b/cli/charts_test.go
@@ -249,3 +249,17 @@ func TestReportUnmanaged(t *testing.T) {
 	o, _ = capture(t, func() { reportUnmanaged(&charts.Plan{}) })
 	require.Empty(t, o)
 }
+
+// An orphan is reported separately from an unmanaged release, and in its own
+// words: the stamp says this file installed it, so "not in the release file"
+// would understate what is actually known about it.
+func TestReportOrphaned(t *testing.T) {
+	o, _ := capture(t, func() {
+		reportOrphaned(&charts.Plan{Owner: "apply/prod", Orphaned: []string{"gone"}})
+	})
+	require.Contains(t, o, "1 release(s) were installed by this release file but are no longer declared in it")
+	require.Contains(t, o, "swarmcli charts uninstall gone")
+
+	o, _ = capture(t, func() { reportOrphaned(&charts.Plan{}) })
+	require.Empty(t, o)
+}


### PR DESCRIPTION
Closes #470. Part of Eldara-Tech/swarmcli-cd#1 (Phase 0).

`charts apply` refuses to delete because a `Release` records nothing about which manifest produced it, so an obsolete release is indistinguishable from one a second file — or a human — installed. This adds the missing marker. **It still deletes nothing**; it establishes the fact that would make deleting safe.

## The stamp is a tuple

```
com.swarmcli.owner: apply/prod-swarm:release/hello
                    └──── id ─────┘ └── resource ──┘
```

Stored in the release-history Config's label *and* in the record itself. **Both halves must match** for a stamp to count: a record copied onto another release still names the original, so it does not read as owned, and neither does one that fails to parse.

That is the whole reason not to store a bare owner string. ArgoCD shipped exactly that as the `app.kubernetes.io/instance` label and replaced it in 3.0 with an annotation naming name + namespace + group + kind, after it proved unable to tell an owned resource from a copy of one. The other half of that history — 63-byte truncation — does not apply here at all: Docker label values have no length limit, so there is no reason to inherit either failure.

The encoding is deliberately kind-agnostic. Only `release` is stamped today, but pruning networks, configs and secrets is the thing no Swarm GitOps tool does safely, and it needs this same stamp on those objects.

## `owner:` is opt-in, with no default

```yaml
apiVersion: v1
owner: prod-swarm          # optional
releases:
  - name: hello
    chart: swarmcli-charts/demo
    version: "0.1.0"
```

There is deliberately no derived default. A path hash changes between a laptop and a CI checkout; a filename basename is shared by every repository using the conventional name. Either would let two unrelated manifests claim each other's releases — the precise failure this is meant to prevent. Omit `owner:` and nothing is claimed, which is behaviour identical to every version before this one.

The id is namespaced `apply/<owner>` so a manifest applied from the command line cannot collide with a controller that happened to pick the same name.

## What the plan now distinguishes

| | before | after |
|---|---|---|
| on the swarm, not in the file, unstamped | `Unmanaged` | `Unmanaged` |
| on the swarm, not in the file, another owner's stamp | `Unmanaged` | `Unmanaged` |
| on the swarm, not in the file, **this file's stamp** | `Unmanaged` | **`Orphaned`** |

`Orphaned` is provably obsolete: the stamp says this manifest produced it and nothing else claims it. `Unmanaged` is merely unrecognised. Only the first is ever safe to act on, and `charts apply --prune` later becomes "delete `Plan.Orphaned`". Both are reported with the `uninstall` command; neither is touched.

## Takeover

Every revision is stamped with whoever wrote it. A second manifest upgrading a release takes it over, no error, and the history shows exactly where the handover happened:

```
rev 3  owner=apply/a
rev 4  owner=apply/b
```

Refusing instead would add a failure mode to the hot path and would make adopting `owner:` on an already-deployed swarm need an override. The ownership fight this risks bites at prune time, where the stamp is always current, not here.

## Not breaking

Additive throughout: a new optional field on `Release` (absent on every existing record), a conditional label (absent, not blank, when unowned), two new `Plan` fields, one new optional release-file key. Nothing changes for a file that declares no owner, and no existing file can declare one.

One forward-compat note: release files reject unknown keys by design, so a file using `owner:` will fail to parse on an older binary. That is the format working as intended, but it does mean adopting the key pins the manifest to this version onwards.

## Also worth knowing

`--dry-run` / `--diff` return before either report is printed, so orphans are not shown in a preview. That is pre-existing (`reportUnmanaged` has always behaved this way) and left alone here rather than changed silently — but it is arguably the most useful place to see them, so say if it should move.

## Verification

`gofmt`, `go vet ./...`, `go test -race -count=1 ./...`, `golangci-lint run ./... --build-tags=integration` → 0 issues.

New tests cover: stamp round-trip and every malformed form; id-with-slashes parsing; label and payload written together; no label at all when unowned; malformed owner rejected before anything deploys; dry-run reporting the stamp it would write; takeover across upgrade and rollback; and the four plan classifications, including the copied-stamp case that a bare owner string would get wrong.