### PR TITLE
charts: give CompatStatus a name in JSON and lowercase CompatFinding's keys

### DIFF
--- a/charts/compat.go
+++ b/charts/compat.go
@@ -4,6 +4,7 @@
 package charts
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -30,13 +31,57 @@ const (
 	CompatIncompatible
 )
 
+// String names the status for humans and for JSON. The zero value is
+// deliberately the safe one, so an unset Status reads as "unknown" rather than
+// as a claim about the chart.
+func (s CompatStatus) String() string {
+	switch s {
+	case CompatOK:
+		return "ok"
+	case CompatIncompatible:
+		return "incompatible"
+	default:
+		return "unknown"
+	}
+}
+
+// MarshalJSON writes the name rather than the iota. A bare int in an API
+// payload is a number whose meaning lives only in this file: a client cannot
+// read it without a copy of the constant block, and appending a status later
+// would silently renumber nothing but still leave every existing reader
+// guessing. The names are the contract.
+func (s CompatStatus) MarshalJSON() ([]byte, error) {
+	return json.Marshal(s.String())
+}
+
+// UnmarshalJSON reads what MarshalJSON writes, so the type still round-trips.
+// An unrecognised name decodes to CompatUnknown rather than failing: a newer
+// producer naming a status this build does not know is not a reason to reject
+// the whole document, and "unknown" is the status callers already must not
+// block on.
+func (s *CompatStatus) UnmarshalJSON(b []byte) error {
+	var name string
+	if err := json.Unmarshal(b, &name); err != nil {
+		return err
+	}
+	switch name {
+	case "ok":
+		*s = CompatOK
+	case "incompatible":
+		*s = CompatIncompatible
+	default:
+		*s = CompatUnknown
+	}
+	return nil
+}
+
 // CompatFinding is the result of checking one chart against this build.
 type CompatFinding struct {
-	Chart    string // "<name> <version>", for messages
-	Required string // the chart's constraint as declared, e.g. ">= 1.13.0"
-	Engine   string // this build's chart-engine version; "" when unstamped
-	Status   CompatStatus
-	Reason   string // why the check was skipped; set only with CompatUnknown
+	Chart    string       `json:"chart"`              // "<name> <version>", for messages
+	Required string       `json:"required,omitempty"` // the chart's constraint as declared, e.g. ">= 1.13.0"
+	Engine   string       `json:"engine,omitempty"`   // this build's chart-engine version; "" when unstamped
+	Status   CompatStatus `json:"status"`
+	Reason   string       `json:"reason,omitempty"` // why the check was skipped; set only with CompatUnknown
 }
 
 // CheckCompat classifies a chart's swarmcliVersion constraint against the chart

--- a/charts/json_test.go
+++ b/charts/json_test.go
@@ -123,3 +123,43 @@ func TestPlanOwnerAndOrphanedJSONKeys(t *testing.T) {
 	require.NotContains(t, bare, "owner")
 	require.NotContains(t, bare, "orphaned")
 }
+
+// A compatibility finding is served alongside the plan, so it has to speak the
+// same JSON as everything around it: lowercase keys, and a status a client can
+// read without a copy of this package's constant block.
+func TestCompatFindingJSONShape(t *testing.T) {
+	var got map[string]any
+	b, err := json.Marshal(CompatFinding{
+		Chart: "traefik 0.1.1", Required: ">= 1.13.0", Engine: "1.13.0", Status: CompatOK,
+	})
+	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal(b, &got))
+	require.Equal(t, map[string]any{
+		"chart": "traefik 0.1.1", "required": ">= 1.13.0", "engine": "1.13.0", "status": "ok",
+	}, got)
+}
+
+// The zero value must read as "unknown", not as a claim about the chart: an
+// unset status is the one callers are explicitly told not to block on.
+func TestCompatStatusNames(t *testing.T) {
+	require.Equal(t, "unknown", CompatUnknown.String())
+	require.Equal(t, "ok", CompatOK.String())
+	require.Equal(t, "incompatible", CompatIncompatible.String())
+}
+
+// Marshalling to a name would be a regression if it could not be read back, so
+// the type still round-trips. An unrecognised name from a newer producer
+// degrades to unknown rather than failing the whole document.
+func TestCompatStatusRoundTrips(t *testing.T) {
+	for _, s := range []CompatStatus{CompatUnknown, CompatOK, CompatIncompatible} {
+		b, err := json.Marshal(s)
+		require.NoError(t, err)
+		var back CompatStatus
+		require.NoError(t, json.Unmarshal(b, &back))
+		require.Equal(t, s, back)
+	}
+
+	var back CompatStatus
+	require.NoError(t, json.Unmarshal([]byte(`"from-the-future"`), &back))
+	require.Equal(t, CompatUnknown, back)
+}


### PR DESCRIPTION
Follow-up to #479, raised in its PR body and deferred there.

`CompatFinding` is the one sub-object #479 missed. Everything around it in the `charts apply -o json` payload uses lowercase keys; it kept Go field names, and its status serialised as a bare iota:

```json
"compat":{"Chart":"traefik 0.1.1","Required":">= 1.13.0","Engine":"1.13.0","Status":1,"Reason":""}
```

A number whose meaning lives only in a Go constant block is unreadable to any client that does not vendor this package. After:

```json
"compat":{"chart":"traefik 0.1.1","required":">= 1.13.0","engine":"1.13.0","status":"ok"}
```

## Why now, specifically

**This shape has never shipped.** `v1.13.0-rc2` was tagged at 09:46; #479 merged at 12:47 the same day. No released binary emits it, so changing it costs nothing today. Once v1.13.0 ships it becomes a breaking change to a published payload and needs `C1-breaking-change`.

## `UnmarshalJSON` is not optional here

Adding only `MarshalJSON` would *break* round-tripping, which works fine today with the bare int — that would be a regression dressed as a fix. So the pair ships together. An unrecognised name decodes to `CompatUnknown` rather than erroring: a newer producer naming a status this build does not know is not a reason to reject the whole document, and `CompatUnknown` is the status callers are already explicitly told never to block on.

`String()` also improves `%v` and error output, matching `LintSeverity` in this same package, which already has one.

## Not breaking

Nothing in-tree reads `Status` as a number — `cli/compat.go` switches on the named constants. The only consumer of the JSON form is a hypothetical external client of an unreleased build.

## Verification

`gofmt`, `go vet ./...`, `go test -race -count=1 ./...`, `golangci-lint run ./... --build-tags=integration` → 0 issues. New tests assert the exact serialised map, all three names, round-tripping, and the unknown-name degradation.