### PR TITLE
charts: let an Engine target a specific Docker context

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,7 @@ tail -f ~/.local/state/swarmcli/app.log          # prod mode (JSON)
 ```
 main.go                    Entry point; version injection via ldflags. With args, dispatches non-interactive CLI subcommands via cli.Dispatch(); bare invocation launches the TUI (tea.NewProgram())
 cli/                       Arg-based CLI dispatch (cli.Dispatch): `charts`, `version`, `help`; cli/apply.go holds the GitOps subcommands (`charts apply`, `charts outdated`)
-charts/                    Helm-like package manager (repos, chart rendering, releases) + declarative releases (releasefile.go, apply.go, outdated.go). charts.ChartSource (source.go) is the seam that resolves a chart ref — repo or local path — so release planning is testable without Docker, a network or a filesystem
+charts/                    Helm-like package manager (repos, chart rendering, releases) + declarative releases (releasefile.go, apply.go, outdated.go). charts.ChartSource (source.go) is the seam that resolves a chart ref — repo or local path — so release planning is testable without Docker, a network or a filesystem. charts.NewDockerBackend(ctxName) + NewEngineWith is the seam that targets a *specific* swarm: the default backend uses the ambient Docker context, the SDK client singleton and the shared snapshot cache, all three of which are process-global
 app/
   app.go                   Init(); triggers command autoload via _ "github.com/Eldara-Tech/swarmcli/commands" and view autoload via _ "github.com/Eldara-Tech/swarmcli/views" (view factory registry lives in views/view/registry.go)
   hooks.go                 PreUpdateHook registration; StartupOverlay; RegisterShutdownHook / RunShutdownHooks (BE port-forward manager registers CloseAll here)

--- a/charts/backend_docker.go
+++ b/charts/backend_docker.go
@@ -8,33 +8,109 @@ import (
 	"fmt"
 
 	"github.com/docker/docker/api/types/network"
+	"github.com/docker/docker/client"
 
 	"github.com/Eldara-Tech/swarmcli/docker"
 )
 
 // dockerBackend implements Backend against the live github.com/Eldara-Tech/swarmcli/docker package.
-type dockerBackend struct{}
-
-func (dockerBackend) DeployStack(name, manifest, resolve string) error {
-	return docker.DeployStackResolved(name, manifest, docker.ResolveImage(resolve))
+//
+// Every operation is addressed to one Docker context. When ctxName is empty that
+// is the ambient one — whatever DOCKER_CONTEXT or `docker context show` resolves
+// to — which is what the CLI has always used and what NewEngine still builds.
+// When it is set, the backend resolves its own client and its own snapshots and
+// touches no process-wide state, so two backends can target two swarms at once.
+type dockerBackend struct {
+	ctxName string
 }
 
-func (dockerBackend) RemoveStack(name string) error {
-	return docker.RemoveStackCLI(name)
+// NewDockerBackend returns a Backend bound to an explicitly named Docker
+// context, for callers that must address a specific swarm rather than the one
+// the process happens to be pointed at.
+//
+// Pair it with NewEngineWith. The three pieces of process-global state this
+// avoids are the SDK client singleton, the `docker context show` lookup the
+// exec-based stack commands do, and the shared snapshot cache — all three, not
+// just the last: a backend that deployed to one swarm and read its history,
+// networks and convergence from another would be worse than an honestly
+// single-swarm one, because nothing would report the mismatch.
+func NewDockerBackend(ctxName string) Backend { return &dockerBackend{ctxName: ctxName} }
+
+// client resolves the SDK client this backend's API calls go through.
+func (b *dockerBackend) client() (*client.Client, error) {
+	if b.ctxName == "" {
+		return docker.GetClient()
+	}
+	return docker.ClientFor(b.ctxName)
 }
 
-func (dockerBackend) RefreshSnapshot() error {
+// contextName resolves the context the exec-based stack commands are aimed at.
+func (b *dockerBackend) contextName() (string, error) {
+	if b.ctxName != "" {
+		return b.ctxName, nil
+	}
+	return docker.GetDockerContext()
+}
+
+// snapshot reads the cluster state this backend's stack queries derive from.
+//
+// The ambient backend keeps using the shared cache, so the CLI's behaviour is
+// unchanged. An explicitly targeted one fetches its own every time: the shared
+// cache holds exactly one swarm, and a convergence poll that read another
+// swarm's tasks out of it would report a rollout finished that never started.
+func (b *dockerBackend) snapshot() (*docker.SwarmSnapshot, error) {
+	if b.ctxName == "" {
+		return docker.GetOrRefreshSnapshot()
+	}
+	cli, err := b.client()
+	if err != nil {
+		return nil, err
+	}
+	return docker.SnapshotWith(context.Background(), cli)
+}
+
+func (b *dockerBackend) DeployStack(name, manifest, resolve string) error {
+	ctxName, err := b.contextName()
+	if err != nil {
+		return err
+	}
+	return docker.DeployStackInContext(ctxName, name, manifest, docker.ResolveImage(resolve))
+}
+
+func (b *dockerBackend) RemoveStack(name string) error {
+	ctxName, err := b.contextName()
+	if err != nil {
+		return err
+	}
+	return docker.RemoveStackCLIInContext(ctxName, name)
+}
+
+// RefreshSnapshot invalidates the shared cache after a mutation. An explicitly
+// targeted backend has no shared cache to invalidate — snapshot() always
+// fetches — so there is nothing to do and nothing to get stale.
+func (b *dockerBackend) RefreshSnapshot() error {
+	if b.ctxName != "" {
+		return nil
+	}
 	_, err := docker.RefreshSnapshot()
 	return err
 }
 
-func (dockerBackend) CreateConfig(ctx context.Context, name string, data []byte, labels map[string]string) error {
-	_, err := docker.CreateConfig(ctx, name, data, labels)
+func (b *dockerBackend) CreateConfig(ctx context.Context, name string, data []byte, labels map[string]string) error {
+	cli, err := b.client()
+	if err != nil {
+		return err
+	}
+	_, err = docker.CreateConfigWith(ctx, cli, name, data, labels)
 	return err
 }
 
-func (dockerBackend) ListConfigs(ctx context.Context) ([]ConfigMeta, error) {
-	configs, err := docker.ListConfigs(ctx)
+func (b *dockerBackend) ListConfigs(ctx context.Context) ([]ConfigMeta, error) {
+	cli, err := b.client()
+	if err != nil {
+		return nil, err
+	}
+	configs, err := docker.ListConfigsWith(ctx, cli)
 	if err != nil {
 		return nil, err
 	}
@@ -45,25 +121,38 @@ func (dockerBackend) ListConfigs(ctx context.Context) ([]ConfigMeta, error) {
 	return out, nil
 }
 
-func (dockerBackend) InspectConfig(ctx context.Context, name string) ([]byte, error) {
-	cfg, err := docker.InspectConfig(ctx, name)
+func (b *dockerBackend) InspectConfig(ctx context.Context, name string) ([]byte, error) {
+	cli, err := b.client()
+	if err != nil {
+		return nil, err
+	}
+	cfg, err := docker.InspectConfigWith(ctx, cli, name)
 	if err != nil {
 		return nil, err
 	}
 	return cfg.Data, nil
 }
 
-func (dockerBackend) DeleteConfig(ctx context.Context, name string) error {
-	return docker.DeleteConfig(ctx, name)
+func (b *dockerBackend) DeleteConfig(ctx context.Context, name string) error {
+	cli, err := b.client()
+	if err != nil {
+		return err
+	}
+	return docker.DeleteConfigWith(ctx, cli, name)
 }
 
-func (dockerBackend) StackServices(name string) []ServiceState {
-	entries := docker.LoadStackServices(name)
+func (b *dockerBackend) StackServices(name string) []ServiceState {
+	snap, err := b.snapshot()
+	if err != nil {
+		return nil
+	}
+	entries := snap.StackServices(name)
 	// Convergence facts come from a separate loader because ServiceEntry counts
 	// replicas by desired state, which is right for the services view but wrong
-	// for deciding a rollout finished (issues #473, #480).
+	// for deciding a rollout finished (issues #473, #480). Both now read the
+	// same snapshot, so the display and the decision cannot disagree.
 	conv := make(map[string]docker.ServiceConvergence, len(entries))
-	for _, c := range docker.LoadStackConvergence(name) {
+	for _, c := range snap.StackConvergence(name) {
 		conv[c.Name] = c
 	}
 
@@ -90,8 +179,12 @@ func (dockerBackend) StackServices(name string) []ServiceState {
 	return out
 }
 
-func (dockerBackend) StackVolumes(ctx context.Context, name string) ([]string, error) {
-	vols, err := docker.ListVolumes(ctx)
+func (b *dockerBackend) StackVolumes(ctx context.Context, name string) ([]string, error) {
+	cli, err := b.client()
+	if err != nil {
+		return nil, err
+	}
+	vols, err := docker.ListVolumesWith(ctx, cli)
 	if err != nil {
 		return nil, err
 	}
@@ -104,12 +197,20 @@ func (dockerBackend) StackVolumes(ctx context.Context, name string) ([]string, e
 	return out, nil
 }
 
-func (dockerBackend) RemoveVolume(ctx context.Context, name string) error {
-	return docker.RemoveVolume(ctx, name, false)
+func (b *dockerBackend) RemoveVolume(ctx context.Context, name string) error {
+	cli, err := b.client()
+	if err != nil {
+		return err
+	}
+	return docker.RemoveVolumeWith(ctx, cli, name, false)
 }
 
-func (dockerBackend) NetworkScopes(ctx context.Context) (map[string]string, error) {
-	nets, err := docker.ListNetworks(ctx)
+func (b *dockerBackend) NetworkScopes(ctx context.Context) (map[string]string, error) {
+	cli, err := b.client()
+	if err != nil {
+		return nil, err
+	}
+	nets, err := docker.ListNetworksWith(ctx, cli)
 	if err != nil {
 		return nil, err
 	}
@@ -120,26 +221,38 @@ func (dockerBackend) NetworkScopes(ctx context.Context) (map[string]string, erro
 	return scopes, nil
 }
 
-func (dockerBackend) CreateOverlayNetwork(ctx context.Context, name, driver string, attachable bool) error {
-	_, _, err := docker.CreateNetwork(ctx, name, network.CreateOptions{Driver: driver, Attachable: attachable})
+func (b *dockerBackend) CreateOverlayNetwork(ctx context.Context, name, driver string, attachable bool) error {
+	cli, err := b.client()
+	if err != nil {
+		return err
+	}
+	_, _, err = docker.CreateNetworkWith(ctx, cli, name, network.CreateOptions{Driver: driver, Attachable: attachable})
 	return err
 }
 
-func (dockerBackend) RemoveOverlayNetwork(ctx context.Context, name string) error {
-	nets, err := docker.ListNetworks(ctx)
+func (b *dockerBackend) RemoveOverlayNetwork(ctx context.Context, name string) error {
+	cli, err := b.client()
+	if err != nil {
+		return err
+	}
+	nets, err := docker.ListNetworksWith(ctx, cli)
 	if err != nil {
 		return err
 	}
 	for _, n := range nets {
 		if n.Name == name {
-			return docker.RemoveNetwork(ctx, n.ID)
+			return docker.RemoveNetworkWith(ctx, cli, n.ID)
 		}
 	}
 	return nil // already gone
 }
 
-func (dockerBackend) SecretNames(ctx context.Context) (map[string]struct{}, error) {
-	secs, err := docker.ListSecrets(ctx)
+func (b *dockerBackend) SecretNames(ctx context.Context) (map[string]struct{}, error) {
+	cli, err := b.client()
+	if err != nil {
+		return nil, err
+	}
+	secs, err := docker.ListSecretsWith(ctx, cli)
 	if err != nil {
 		return nil, err
 	}

--- a/charts/backend_docker_test.go
+++ b/charts/backend_docker_test.go
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package charts
+
+import (
+	"testing"
+
+	"github.com/docker/docker/api/types/swarm"
+	"github.com/stretchr/testify/require"
+
+	"github.com/Eldara-Tech/swarmcli/docker"
+)
+
+// A named backend addresses the context it was constructed with, not the one
+// the process is pointed at. DOCKER_CONTEXT is set to something else here
+// precisely so a fallback would be visible.
+func TestNamedBackendIgnoresTheAmbientContext(t *testing.T) {
+	t.Setenv("DOCKER_CONTEXT", "ambient")
+
+	b, ok := NewDockerBackend("swarm-b").(*dockerBackend)
+	require.True(t, ok)
+
+	name, err := b.contextName()
+	require.NoError(t, err)
+	require.Equal(t, "swarm-b", name)
+}
+
+// The default backend keeps resolving the ambient context, so the CLI behaves
+// exactly as it did.
+func TestAmbientBackendResolvesTheProcessContext(t *testing.T) {
+	t.Setenv("DOCKER_CONTEXT", "ambient")
+
+	name, err := (&dockerBackend{}).contextName()
+	require.NoError(t, err)
+	require.Equal(t, "ambient", name)
+}
+
+// A named backend must not write to the shared snapshot cache. The cache holds
+// exactly one swarm, so a reconcile against a second one that refreshed it
+// would replace another swarm's state with its own — and every reader of the
+// cache, including a TUI in the same process, would silently follow.
+func TestNamedBackendRefreshDoesNotTouchTheSharedCache(t *testing.T) {
+	t.Cleanup(docker.InvalidateSnapshot)
+	mine := &docker.SwarmSnapshot{Services: []swarm.Service{{ID: "sentinel"}}}
+	docker.SetSnapshot(mine)
+
+	require.NoError(t, NewDockerBackend("swarm-b").RefreshSnapshot())
+
+	got := docker.GetSnapshot()
+	require.NotNil(t, got)
+	require.Len(t, got.Services, 1)
+	require.Equal(t, "sentinel", got.Services[0].ID, "the shared cache must be untouched")
+}

--- a/docker/client.go
+++ b/docker/client.go
@@ -19,7 +19,11 @@ import (
 
 var (
 	cachedClient *client.Client
-	clientMu     sync.Mutex
+	// contextClients caches one client per explicitly named context, kept apart
+	// from cachedClient so the ambient fast path stays exactly as it was: a warm
+	// GetClient must not start resolving a context name on every call.
+	contextClients map[string]*client.Client
+	clientMu       sync.Mutex
 )
 
 func l() *swarmlog.SwarmLogger {
@@ -58,9 +62,40 @@ func GetClient() (*client.Client, error) {
 	return cachedClient, nil
 }
 
-// ResetClient closes the cached client (if any) and clears the cache so the
-// next GetClient call creates a fresh connection. Safe to call when no client
-// has been cached yet.
+// ClientFor returns a client for an explicitly named Docker context, cached per
+// name.
+//
+// It is the seam that lets a caller address a specific swarm. GetClient resolves
+// DOCKER_CONTEXT or `docker context show` and caches one client for the whole
+// process — correct for a single-swarm CLI, and unusable for anything that has
+// to reconcile two swarms at once, because there is no argument by which to ask
+// for the other one.
+func ClientFor(ctxName string) (*client.Client, error) {
+	if ctxName == "" {
+		return nil, fmt.Errorf("docker context name is required")
+	}
+	clientMu.Lock()
+	defer clientMu.Unlock()
+
+	if cli, ok := contextClients[ctxName]; ok {
+		return cli, nil
+	}
+	cli, err := buildClientFor(ctxName)
+	if err != nil {
+		return nil, err
+	}
+	if contextClients == nil {
+		contextClients = make(map[string]*client.Client, 1)
+	}
+	contextClients[ctxName] = cli
+	return cli, nil
+}
+
+// ResetClient closes every cached client and clears the caches so the next
+// GetClient or ClientFor call creates a fresh connection. Safe to call when
+// nothing has been cached yet. Named clients are dropped too: a context switch
+// is not the only reason to reset, and a `docker context update` invalidates a
+// pinned client just as surely as the ambient one.
 func ResetClient() {
 	clientMu.Lock()
 	defer clientMu.Unlock()
@@ -68,6 +103,10 @@ func ResetClient() {
 	if cachedClient != nil {
 		_ = cachedClient.Close()
 		cachedClient = nil
+	}
+	for name, cli := range contextClients {
+		_ = cli.Close()
+		delete(contextClients, name)
 	}
 }
 
@@ -78,7 +117,11 @@ func buildClient() (*client.Client, error) {
 	if err != nil {
 		return nil, err
 	}
+	return buildClientFor(ctxName)
+}
 
+// buildClientFor creates and pings a client for one named context.
+func buildClientFor(ctxName string) (*client.Client, error) {
 	inspectOut, err := exec.Command("docker", "context", "inspect", ctxName).Output()
 	if err != nil {
 		return nil, fmt.Errorf("failed to inspect context: %w", err)

--- a/docker/config.go
+++ b/docker/config.go
@@ -113,12 +113,16 @@ func (cfg *ConfigWithDecodedData) PrettyJSON() ([]byte, error) {
 
 // ListConfigs retrieves all Docker Swarm configs.
 func ListConfigs(ctx context.Context) ([]swarm.Config, error) {
-	l().Debug("[ListConfigs] Listing all configs")
-
 	cli, err := GetClient()
 	if err != nil {
 		return nil, err
 	}
+	return ListConfigsWith(ctx, cli)
+}
+
+// ListConfigsWith is ListConfigs against an explicit client.
+func ListConfigsWith(ctx context.Context, cli *client.Client) ([]swarm.Config, error) {
+	l().Debug("[ListConfigs] Listing all configs")
 
 	configs, err := cli.ConfigList(ctx, swarm.ConfigListOptions{})
 	if err != nil {
@@ -149,12 +153,16 @@ func ListConfigs(ctx context.Context) ([]swarm.Config, error) {
 
 // InspectConfig fetches and returns the config data.
 func InspectConfig(ctx context.Context, nameOrID string) (*ConfigWithDecodedData, error) {
-	l().Debugf("[InspectConfig] Inspecting config: %s", nameOrID)
-
 	cli, err := GetClient()
 	if err != nil {
 		return nil, err
 	}
+	return InspectConfigWith(ctx, cli, nameOrID)
+}
+
+// InspectConfigWith is InspectConfig against an explicit client.
+func InspectConfigWith(ctx context.Context, cli *client.Client, nameOrID string) (*ConfigWithDecodedData, error) {
+	l().Debugf("[InspectConfig] Inspecting config: %s", nameOrID)
 
 	cfg, _, err := cli.ConfigInspectWithRaw(ctx, nameOrID)
 	if err != nil {
@@ -181,11 +189,24 @@ func CreateConfigVersion(ctx context.Context, baseConfig swarm.Config, newData [
 		Data: newData,
 	}
 
-	return createConfigWithSpec(ctx, spec, "[CreateConfigVersion]")
+	cli, err := GetClient()
+	if err != nil {
+		return swarm.Config{}, err
+	}
+	return createConfigWithSpec(ctx, cli, spec, "[CreateConfigVersion]")
 }
 
 // CreateConfig creates a new config with the given name and data
 func CreateConfig(ctx context.Context, name string, data []byte, labels map[string]string) (swarm.Config, error) {
+	cli, err := GetClient()
+	if err != nil {
+		return swarm.Config{}, err
+	}
+	return CreateConfigWith(ctx, cli, name, data, labels)
+}
+
+// CreateConfigWith is CreateConfig against an explicit client.
+func CreateConfigWith(ctx context.Context, cli *client.Client, name string, data []byte, labels map[string]string) (swarm.Config, error) {
 	l().Infof("[CreateConfig] Creating new config %q (size=%d bytes)", name, len(data))
 
 	// Merge user labels with swarmcli metadata
@@ -203,19 +224,14 @@ func CreateConfig(ctx context.Context, name string, data []byte, labels map[stri
 		Data: data,
 	}
 
-	return createConfigWithSpec(ctx, spec, "[CreateConfig]")
+	return createConfigWithSpec(ctx, cli, spec, "[CreateConfig]")
 }
 
 // createConfigWithSpec centralizes config creation: it calls the Docker API
 // to create a config from the provided spec, re-inspects the created config,
 // and returns the populated swarm.Config or an error. The caller may pass a
 // prefix for logging context (e.g. "[CreateConfigVersion]").
-func createConfigWithSpec(ctx context.Context, spec swarm.ConfigSpec, logPrefix string) (swarm.Config, error) {
-	cli, err := GetClient()
-	if err != nil {
-		return swarm.Config{}, err
-	}
-
+func createConfigWithSpec(ctx context.Context, cli *client.Client, spec swarm.ConfigSpec, logPrefix string) (swarm.Config, error) {
 	cfgName := spec.Name
 
 	id, err := cli.ConfigCreate(ctx, spec)
@@ -289,12 +305,16 @@ func RotateConfigInServices(ctx context.Context, oldCfg *swarm.Config, newCfg sw
 
 // DeleteConfig deletes a config only if it's not referenced by any service.
 func DeleteConfig(ctx context.Context, nameOrID string) error {
-	cfg, err := InspectConfig(ctx, nameOrID)
+	cli, err := GetClient()
 	if err != nil {
 		return err
 	}
+	return DeleteConfigWith(ctx, cli, nameOrID)
+}
 
-	cli, err := GetClient()
+// DeleteConfigWith is DeleteConfig against an explicit client.
+func DeleteConfigWith(ctx context.Context, cli *client.Client, nameOrID string) error {
+	cfg, err := InspectConfigWith(ctx, cli, nameOrID)
 	if err != nil {
 		return err
 	}

--- a/docker/context_lint_test.go
+++ b/docker/context_lint_test.go
@@ -19,6 +19,10 @@ var allowedBareBackground = map[string]string{
 	"views/configs/model.go": "addConfig",
 	"views/secrets/model.go": "addSecret",
 	"commands/api/api.go":    "New",
+	// RefreshSnapshot has no context parameter to inherit from, and the call it
+	// makes is bounded: SnapshotWith applies the 30s deadline itself, so the
+	// timeout lives in one place instead of at every call site.
+	"docker/snapshot.go": "RefreshSnapshot",
 }
 
 func TestNoBareContextBackground(t *testing.T) {

--- a/docker/convergence.go
+++ b/docker/convergence.go
@@ -55,6 +55,13 @@ func LoadStackConvergence(stackName string) []ServiceConvergence {
 		l().Warnf("failed to get snapshot: %v", err)
 		return nil
 	}
+	return snap.StackConvergence(stackName)
+}
+
+// StackConvergence is LoadStackConvergence against an already-fetched snapshot,
+// so a caller polling one specific swarm for convergence does not read another
+// swarm's tasks out of the process-wide cache.
+func (snap *SwarmSnapshot) StackConvergence(stackName string) []ServiceConvergence {
 	active := activeNodeIDs(snap)
 
 	var out []ServiceConvergence

--- a/docker/explicit_context_test.go
+++ b/docker/explicit_context_test.go
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package docker
+
+import (
+	"testing"
+
+	"github.com/docker/docker/api/types/swarm"
+	"github.com/stretchr/testify/require"
+)
+
+// An empty context name is rejected rather than quietly falling back to the
+// ambient one. Silently resolving it would defeat the whole point of the
+// explicit variants: a caller that meant to name a swarm and passed "" would
+// get the process default and no indication that it had.
+func TestExplicitContextRejectsEmptyName(t *testing.T) {
+	_, err := ClientFor("")
+	require.ErrorContains(t, err, "docker context name is required")
+
+	require.ErrorContains(t, DeployStackInContext("", "web", "services: {}\n", ResolveImageDefault),
+		"docker context name is required")
+	require.ErrorContains(t, RemoveStackCLIInContext("", "web"),
+		"docker context name is required")
+}
+
+// StackServices reads the snapshot it is given, not the process-wide cache.
+// That is what lets a caller polling one swarm avoid reading another's state:
+// with the global cache deliberately holding a different stack, the receiver
+// still wins.
+func TestStackServicesReadsItsOwnSnapshotNotTheGlobalCache(t *testing.T) {
+	t.Cleanup(InvalidateSnapshot)
+	SetSnapshot(&SwarmSnapshot{
+		Services: []swarm.Service{svcInStack("other-svc", "otherstack")},
+	})
+
+	mine := &SwarmSnapshot{Services: []swarm.Service{svcInStack("mine-svc", "mystack")}}
+
+	entries := mine.StackServices("mystack")
+	require.Len(t, entries, 1)
+	require.Equal(t, "mine-svc", entries[0].ServiceName)
+
+	// And the foreign snapshot's stack is invisible through this one.
+	require.Empty(t, mine.StackServices("otherstack"))
+}
+
+// The same for convergence, which is the one that would actually hurt: --wait
+// polls it, so reading another swarm's tasks would report a rollout finished
+// that had never started.
+func TestStackConvergenceReadsItsOwnSnapshotNotTheGlobalCache(t *testing.T) {
+	t.Cleanup(InvalidateSnapshot)
+	SetSnapshot(&SwarmSnapshot{
+		Nodes:    []swarm.Node{readyNode("n1")},
+		Services: []swarm.Service{svcInStack("other-svc", "otherstack")},
+	})
+
+	mine := &SwarmSnapshot{
+		Nodes:    []swarm.Node{readyNode("n1")},
+		Services: []swarm.Service{svcInStack("mine-svc", "mystack")},
+		Tasks: []swarm.Task{{
+			ServiceID:    "mine-svc",
+			NodeID:       "n1",
+			DesiredState: swarm.TaskStateRunning,
+			Status:       swarm.TaskStatus{State: swarm.TaskStateRunning},
+		}},
+	}
+
+	conv := mine.StackConvergence("mystack")
+	require.Len(t, conv, 1)
+	require.Equal(t, "mine-svc", conv[0].Name)
+	require.Equal(t, 1, conv[0].Running)
+
+	require.Empty(t, mine.StackConvergence("otherstack"))
+}
+
+func svcInStack(id, stack string) swarm.Service {
+	return swarm.Service{
+		ID: id,
+		Spec: swarm.ServiceSpec{
+			Annotations: swarm.Annotations{
+				Name:   id,
+				Labels: map[string]string{"com.docker.stack.namespace": stack},
+			},
+		},
+	}
+}
+
+func readyNode(id string) swarm.Node {
+	return swarm.Node{
+		ID:     id,
+		Status: swarm.NodeStatus{State: swarm.NodeStateReady},
+		Spec:   swarm.NodeSpec{Availability: swarm.NodeAvailabilityActive},
+	}
+}

--- a/docker/network.go
+++ b/docker/network.go
@@ -10,15 +10,21 @@ import (
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/api/types/swarm"
+	"github.com/docker/docker/client"
 )
 
-// ListNetworks returns all networks in the swarm
+// ListNetworks returns all networks in the swarm, on the ambient context.
 func ListNetworks(ctx context.Context) ([]network.Summary, error) {
-	client, err := GetClient()
+	cli, err := GetClient()
 	if err != nil {
 		return nil, err
 	}
-	return client.NetworkList(ctx, network.ListOptions{})
+	return ListNetworksWith(ctx, cli)
+}
+
+// ListNetworksWith is ListNetworks against an explicit client.
+func ListNetworksWith(ctx context.Context, cli *client.Client) ([]network.Summary, error) {
+	return cli.NetworkList(ctx, network.ListOptions{})
 }
 
 // InspectNetwork returns detailed information about a network
@@ -30,24 +36,33 @@ func InspectNetwork(ctx context.Context, networkID string) (network.Inspect, err
 	return client.NetworkInspect(ctx, networkID, network.InspectOptions{})
 }
 
-// RemoveNetwork removes a network
+// RemoveNetwork removes a network on the ambient context.
 func RemoveNetwork(ctx context.Context, networkID string) error {
-	client, err := GetClient()
+	cli, err := GetClient()
 	if err != nil {
 		return err
 	}
-	return client.NetworkRemove(ctx, networkID)
+	return RemoveNetworkWith(ctx, cli, networkID)
+}
+
+// RemoveNetworkWith is RemoveNetwork against an explicit client.
+func RemoveNetworkWith(ctx context.Context, cli *client.Client, networkID string) error {
+	return cli.NetworkRemove(ctx, networkID)
 }
 
 // CreateNetwork creates a new Docker network.
 // Returns the created network ID and any daemon warnings.
 func CreateNetwork(ctx context.Context, name string, opts network.CreateOptions) (string, []string, error) {
-	client, err := GetClient()
+	cli, err := GetClient()
 	if err != nil {
 		return "", nil, err
 	}
+	return CreateNetworkWith(ctx, cli, name, opts)
+}
 
-	resp, err := client.NetworkCreate(ctx, name, opts)
+// CreateNetworkWith is CreateNetwork against an explicit client.
+func CreateNetworkWith(ctx context.Context, cli *client.Client, name string, opts network.CreateOptions) (string, []string, error) {
+	resp, err := cli.NetworkCreate(ctx, name, opts)
 	if err != nil {
 		return "", nil, err
 	}

--- a/docker/secret.go
+++ b/docker/secret.go
@@ -66,12 +66,16 @@ func (sec *SecretWithDecodedData) PrettyJSON() ([]byte, error) {
 
 // ListSecrets retrieves all Docker Swarm secrets.
 func ListSecrets(ctx context.Context) ([]swarm.Secret, error) {
-	l().Debug("[ListSecrets] Listing all secrets")
-
 	cli, err := GetClient()
 	if err != nil {
 		return nil, err
 	}
+	return ListSecretsWith(ctx, cli)
+}
+
+// ListSecretsWith is ListSecrets against an explicit client.
+func ListSecretsWith(ctx context.Context, cli *client.Client) ([]swarm.Secret, error) {
+	l().Debug("[ListSecrets] Listing all secrets")
 
 	secrets, err := cli.SecretList(ctx, swarm.SecretListOptions{})
 	if err != nil {

--- a/docker/service.go
+++ b/docker/service.go
@@ -412,13 +412,20 @@ func LoadNodeServices(nodeID string) []ServiceEntry {
 	return entries
 }
 
+// LoadStackServices returns a stack's services from the process-wide snapshot.
 func LoadStackServices(stackName string) []ServiceEntry {
 	snap, err := GetOrRefreshSnapshot()
 	if err != nil {
 		l().Warnf("failed to get snapshot: %v", err)
 		return nil
 	}
+	return snap.StackServices(stackName)
+}
 
+// StackServices returns a stack's services from an already-fetched snapshot, so
+// a caller holding a snapshot of a specific swarm can read it without going
+// through the process-wide cache.
+func (snap *SwarmSnapshot) StackServices(stackName string) []ServiceEntry {
 	var entries []ServiceEntry
 
 	for _, svc := range snap.Services {

--- a/docker/snapshot.go
+++ b/docker/snapshot.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/api/types/system"
+	"github.com/docker/docker/client"
 )
 
 type NodeEntry struct {
@@ -87,7 +88,24 @@ func RefreshSnapshot() (*SwarmSnapshot, error) {
 	if err != nil {
 		return nil, fmt.Errorf("docker client: %w", err)
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	snap, err := SnapshotWith(context.Background(), c)
+	if err != nil {
+		return nil, err
+	}
+	SetSnapshot(snap)
+	return snap, nil
+}
+
+// SnapshotWith fetches a snapshot from an explicit client and returns it
+// WITHOUT touching the process-wide cache.
+//
+// That omission is the point. The cache is a single global with a 3s TTL and a
+// background refresh goroutine, sized for a TUI redrawing one swarm; two
+// reconciles against different swarms sharing it would not merely read each
+// other's data, they would evict each other's. A caller holding an explicit
+// client owns its own freshness.
+func SnapshotWith(parent context.Context, c *client.Client) (*SwarmSnapshot, error) {
+	ctx, cancel := context.WithTimeout(parent, 30*time.Second)
 	defer cancel()
 
 	nodes, err := c.NodeList(ctx, swarm.NodeListOptions{})
@@ -96,9 +114,7 @@ func RefreshSnapshot() (*SwarmSnapshot, error) {
 		// empty snapshot instead of a fatal error so the context switch is not
 		// reverted; the app prompts the user to unlock.
 		if IsSwarmLockedErr(err) {
-			snap := &SwarmSnapshot{Locked: true, Fetched: time.Now()}
-			SetSnapshot(snap)
-			return snap, nil
+			return &SwarmSnapshot{Locked: true, Fetched: time.Now()}, nil
 		}
 		return nil, fmt.Errorf("listing nodes: %w", err)
 	}
@@ -120,16 +136,13 @@ func RefreshSnapshot() (*SwarmSnapshot, error) {
 		clusterID = clusterIDFromInfo(info)
 	}
 
-	snap := &SwarmSnapshot{
+	return &SwarmSnapshot{
 		Nodes:     nodes,
 		Services:  services,
 		Tasks:     tasks,
 		Fetched:   time.Now(),
 		ClusterID: clusterID,
-	}
-
-	SetSnapshot(snap)
-	return snap, nil
+	}, nil
 }
 
 // clusterIDFromInfo extracts the swarm cluster ID from a Docker Info result.

--- a/docker/stack_deploy.go
+++ b/docker/stack_deploy.go
@@ -83,8 +83,26 @@ func DeployStack(stackName string, yamlContent string) error {
 	return DeployStackResolved(stackName, yamlContent, ResolveImageDefault)
 }
 
-// DeployStackResolved deploys a stack with an explicit image-resolution mode.
+// DeployStackResolved deploys a stack with an explicit image-resolution mode,
+// on whichever context the process is pointed at.
 func DeployStackResolved(stackName string, yamlContent string, resolve ResolveImage) error {
+	ctxName, err := GetDockerContext()
+	if err != nil {
+		return fmt.Errorf("failed to get docker context: %w", err)
+	}
+	return DeployStackInContext(ctxName, stackName, yamlContent, resolve)
+}
+
+// DeployStackInContext deploys a stack to an explicitly named Docker context.
+//
+// `docker stack deploy` has no SDK equivalent, so this shells out; naming the
+// context is what keeps the target an argument rather than whatever
+// DOCKER_CONTEXT or `docker context show` happens to say at the moment the
+// command runs.
+func DeployStackInContext(ctxName, stackName, yamlContent string, resolve ResolveImage) error {
+	if ctxName == "" {
+		return fmt.Errorf("docker context name is required")
+	}
 	if !resolve.Valid() {
 		return fmt.Errorf("invalid --resolve-image %q: want always, changed or never", string(resolve))
 	}
@@ -115,14 +133,8 @@ func DeployStackResolved(stackName string, yamlContent string, resolve ResolveIm
 		return fmt.Errorf("failed to close temporary file: %w", err)
 	}
 
-	// Get Docker context
-	ctx, err := GetDockerContext()
-	if err != nil {
-		return fmt.Errorf("failed to get docker context: %w", err)
-	}
-
 	// Execute docker stack deploy command
-	args := []string{"--context", ctx, "stack", "deploy", "-c", tmpFile.Name()}
+	args := []string{"--context", ctxName, "stack", "deploy", "-c", tmpFile.Name()}
 	if resolve != ResolveImageDefault {
 		args = append(args, "--resolve-image", string(resolve))
 	}
@@ -151,14 +163,22 @@ func DeployStackResolved(stackName string, yamlContent string, resolve ResolveIm
 // the stack's services, networks, configs and secrets while leaving volumes
 // intact — matching standard Docker stack semantics.
 func RemoveStackCLI(stackName string) error {
-	if stackName == "" {
-		return fmt.Errorf("stack name cannot be empty")
-	}
-	ctx, err := GetDockerContext()
+	ctxName, err := GetDockerContext()
 	if err != nil {
 		return fmt.Errorf("failed to get docker context: %w", err)
 	}
-	cmd := exec.Command("docker", "--context", ctx, "stack", "rm", stackName)
+	return RemoveStackCLIInContext(ctxName, stackName)
+}
+
+// RemoveStackCLIInContext is RemoveStackCLI against an explicitly named context.
+func RemoveStackCLIInContext(ctxName, stackName string) error {
+	if ctxName == "" {
+		return fmt.Errorf("docker context name is required")
+	}
+	if stackName == "" {
+		return fmt.Errorf("stack name cannot be empty")
+	}
+	cmd := exec.Command("docker", "--context", ctxName, "stack", "rm", stackName)
 	cmd.Env = os.Environ()
 	output, err := cmd.CombinedOutput()
 	if err != nil {

--- a/docker/volume.go
+++ b/docker/volume.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/docker/docker/api/types/volume"
+	"github.com/docker/docker/client"
 )
 
 // VolumeInfo is the edition-agnostic view of a Docker volume consumed by the
@@ -61,7 +62,11 @@ func ListVolumes(ctx context.Context) ([]VolumeInfo, error) {
 	if err != nil {
 		return nil, err
 	}
+	return ListVolumesWith(ctx, cli)
+}
 
+// ListVolumesWith is ListVolumes against an explicit client.
+func ListVolumesWith(ctx context.Context, cli *client.Client) ([]VolumeInfo, error) {
 	resp, err := cli.VolumeList(ctx, volume.ListOptions{})
 	if err != nil {
 		return nil, err
@@ -123,7 +128,12 @@ func RemoveVolume(ctx context.Context, name string, force bool) error {
 	if err != nil {
 		return fmt.Errorf("docker client: %w", err)
 	}
-	if err := c.VolumeRemove(ctx, name, force); err != nil {
+	return RemoveVolumeWith(ctx, c, name, force)
+}
+
+// RemoveVolumeWith is RemoveVolume against an explicit client.
+func RemoveVolumeWith(ctx context.Context, cli *client.Client, name string, force bool) error {
+	if err := cli.VolumeRemove(ctx, name, force); err != nil {
 		return fmt.Errorf("removing volume %q: %w", name, err)
 	}
 	return nil


### PR DESCRIPTION
Closes #469. Part of Eldara-Tech/swarmcli-cd#1 (Phase 0).

`charts.dockerBackend` was an empty struct, so there was no way to construct an `Engine` aimed at a named swarm — every operation resolved its target from process-global state.

## The issue's proposal was too small, and the gap is not safe

#469 proposed `DeployStackInContext` / `RemoveStackInContext` plus an exported constructor, describing that as "the only missing piece of the seam". It is not. The backend's 15 methods reach the daemon through **three** independent globals:

| global | Backend methods |
|---|---|
| `GetDockerContext()` (exec `docker --context`) | `DeployStack`, `RemoveStack` — **2** |
| `GetClient()` singleton | configs, volumes, networks, secrets — **10** |
| shared snapshot cache (3s TTL, background refresh) | `StackServices`, `RefreshSnapshot` — **3** |

Fixing only the first row would have shipped a backend that **deploys to one swarm and reads its release history, networks, secrets and convergence from another** — silently, because nothing reports the mismatch. `--wait` would have polled the wrong swarm's snapshot and reported a rollout finished that had never started. That is worse than today's honestly-single-swarm behaviour, so all three rows are addressed.

## What was added

```
docker.ClientFor(name)             client cached per context name
docker.<op>With(ctx, cli, …)       x10 — explicit-client variants
docker.SnapshotWith(ctx, cli)      fetches WITHOUT touching the cache
(*SwarmSnapshot).StackServices     read a stack out of a given snapshot
(*SwarmSnapshot).StackConvergence      "
docker.DeployStackInContext(…)     x2 — exec with an explicit --context

charts.NewDockerBackend(ctxName)   Backend bound to one context
```

Usage is `charts.NewEngineWith(charts.NewDockerBackend("swarm-b"))` — `NewEngineWith` was already exported, so no change there.

## The ambient path is unchanged by construction

An empty `ctxName` routes to `GetClient`, `GetDockerContext` and `GetOrRefreshSnapshot` exactly as before. Every existing `docker` function keeps its signature and becomes a two-line delegation to its `…With` sibling — no call site in `views/`, `commands/` or `cli/` was touched. `GetClient`'s documented warm-cache guarantee (no subprocess on a cache hit) is preserved by keeping the named-client cache separate from `cachedClient` rather than re-resolving a name per call.

## Why a named backend does not refresh the shared cache

The cache holds exactly one swarm. A reconcile against a second one that refreshed it would replace another swarm's state with its own, and every reader in the process — including a TUI — would silently follow. So a named backend fetches its own snapshot each time and its `RefreshSnapshot` is a no-op, with nothing stale to invalidate. `SnapshotWith` deliberately does not write the cache.

## Incidental fix

`StackServices` used to take **two independent snapshots** — one via `LoadStackServices` for the display counts, one via `LoadStackConvergence` for the convergence counts. They now come from one snapshot, so what the operator is shown and what `--wait` decides cannot disagree.

## One allow-list entry

`docker/context_lint_test.go` forbids bare `context.Background()` in `docker/`. `RefreshSnapshot` has no context parameter to inherit from and its call is bounded — `SnapshotWith` applies the 30s deadline itself, keeping the timeout in one place instead of at every call site — so it is allow-listed with that reason rather than the timeout being duplicated.

## Verification

`gofmt`, `go vet ./...`, `go test -race -count=1 ./...`, `golangci-lint run ./... --build-tags=integration` → 0 issues.

New tests, none needing a daemon: an empty context name is rejected rather than silently falling back to ambient (all three entry points); `StackServices` and `StackConvergence` read the snapshot they are given while the global cache deliberately holds a *different* stack; a named backend ignores `DOCKER_CONTEXT` while the default one still honours it; and a named backend's `RefreshSnapshot` leaves a sentinel in the shared cache untouched.