### PR TITLE
charts lint: flag the inherited 5s monitor, not just an explicit short one

### DIFF
--- a/charts/lint.go
+++ b/charts/lint.go
@@ -144,6 +144,12 @@ const (
 	defaultHealthRetries  = 3
 )
 
+// swarmDefaultMonitor is what UpdateConfig.Monitor is when a compose file sets
+// none. Same fact as defaultStabilityWindow in release.go, which is the window
+// --wait has to sit through; naming it separately here keeps the lint readable
+// without a second copy of the number.
+const swarmDefaultMonitor = defaultStabilityWindow
+
 // lintHealthcheckMonitor warns when a service cannot fail its healthcheck before
 // swarm stops watching.
 //
@@ -154,6 +160,10 @@ const (
 // monitor is shorter than the healthcheck's own worst case, a broken deploy can
 // report success. Kubernetes has no analogue of this, so it reliably surprises
 // people arriving from there.
+//
+// An unset monitor is the common way to hit this, not an exemption from it:
+// swarm's default is 5s, shorter than almost any healthcheck's worst case. The
+// rule originally skipped that case, which meant it fired on nothing at all.
 //
 // Warning, not error: a short monitor is legitimate when the operator wants a
 // fast rollout and is watching by other means.
@@ -176,15 +186,13 @@ func lintHealthcheckMonitor(manifest string, add func(LintSeverity, string, ...a
 		if hc == nil || hc.Disable || isHealthcheckNone(hc.Test) {
 			continue
 		}
-		if svc.Deploy.UpdateConfig == nil || svc.Deploy.UpdateConfig.Monitor == "" {
-			// No explicit monitor: swarm's own 5s default applies. Deliberately
-			// not flagged — it would fire on nearly every chart with a
-			// healthcheck, and the issue scoped this to the explicit case.
-			continue
-		}
-		monitor, err := time.ParseDuration(svc.Deploy.UpdateConfig.Monitor)
-		if err != nil {
-			continue
+		monitor, declared := swarmDefaultMonitor, false
+		if svc.Deploy.UpdateConfig != nil && svc.Deploy.UpdateConfig.Monitor != "" {
+			d, err := time.ParseDuration(svc.Deploy.UpdateConfig.Monitor)
+			if err != nil {
+				continue
+			}
+			monitor, declared = d, true
 		}
 
 		interval := defaultHealthInterval
@@ -211,9 +219,13 @@ func lintHealthcheckMonitor(manifest string, add func(LintSeverity, string, ...a
 		if monitor >= needed {
 			continue
 		}
+		had := fmt.Sprintf("deploy.update_config.monitor (%s)", monitor)
+		if !declared {
+			had = fmt.Sprintf("no deploy.update_config.monitor, so swarm's %s default applies, which", monitor)
+		}
 		add(LintWarning,
-			"service %q: deploy.update_config.monitor (%s) is shorter than the healthcheck needs to fail (%s = start_period %s + interval %s x retries %d); a container that goes unhealthy after the monitor window does not fail the rollout, so a broken deploy reports success",
-			name, monitor, needed, startPeriod, interval, retries)
+			"service %q: %s is shorter than the healthcheck needs to fail (%s = start_period %s + interval %s x retries %d); a container that goes unhealthy after the monitor window does not fail the rollout, so a broken deploy reports success. Set deploy.update_config.monitor to at least %s",
+			name, had, needed, startPeriod, interval, retries, needed)
 	}
 }
 

--- a/charts/lint_test.go
+++ b/charts/lint_test.go
@@ -218,15 +218,35 @@ services:
 	require.Contains(t, got[0].Message, "1m30s") // 3 x 30s
 }
 
-// No explicit monitor is deliberately not flagged: swarm's 5s default would make
-// this fire on nearly every chart that defines a healthcheck.
-func TestLintHealthcheckMonitorSkipsImplicitDefault(t *testing.T) {
-	require.Empty(t, lintMonitorFindings(t, `
+// An unset monitor is the common way to hit this, not an exemption from it:
+// swarm silently applies a 5s default, and a healthcheck needing 30s to fail
+// therefore cannot fail the rollout. The rule originally skipped this case,
+// which is why it fired on nothing at all.
+func TestLintHealthcheckMonitorFlagsTheInheritedDefault(t *testing.T) {
+	got := lintMonitorFindings(t, `
 services:
   api:
     healthcheck:
       test: ["CMD", "true"]
       interval: 10s
+`)
+	require.Len(t, got, 1)
+	require.Contains(t, got[0].Message, "no deploy.update_config.monitor")
+	require.Contains(t, got[0].Message, "5s default")
+	require.Contains(t, got[0].Message, "at least 30s", "the finding names the value to set")
+}
+
+// A monitor that already covers the healthcheck is fine whether it was declared
+// or inherited: a fast healthcheck under swarm's 5s default is not a finding.
+func TestLintHealthcheckMonitorAcceptsAnAdequateInheritedDefault(t *testing.T) {
+	require.Empty(t, lintMonitorFindings(t, `
+services:
+  api:
+    healthcheck:
+      test: ["CMD", "true"]
+      interval: 1s
+      retries: 3
+      start_period: 1s
 `))
 }
 


### PR DESCRIPTION
Follow-up to #482, raised in its PR body and deferred there.

## The rule currently fires on nothing

#482 added a lint warning for `deploy.update_config.monitor` being shorter than the healthcheck needs to fail, but skipped services that set no monitor at all — on the grounds that flagging swarm's 5s default would fire on nearly every chart with a healthcheck.

Measured against `swarmcli-charts`: **no chart sets `update_config.monitor` anywhere**, so the rule fires on **zero** charts. Meanwhile **8 of its 12 charts define healthchecks** and silently inherit the 5s default.

## Firing on 8 of 12 is the finding, not the problem

A 5s monitor with a healthcheck that needs 30s to fail means the container goes unhealthy *after* swarm has stopped watching. `update_config.failure_action` never runs, the rollout is reported complete, and the task quietly restart-loops — a broken deploy reporting success. That is precisely what the rule exists to name, and **the unset case is the common way to reach it**, not an exemption from it.

The skip made the rule cover only the case where someone thought about `monitor` and got it wrong, which is the rarer and less dangerous half.

## Not noisy in the way that matters

**Only `LintError` fails a lint** (`charts/lint.go:115`), so this stays advisory and cannot break `swarmcli-charts` CI. The finding now also names the value to set, since it fires on real charts:

```
service "api": no deploy.update_config.monitor, so swarm's 5s default applies,
which is shorter than the healthcheck needs to fail (30s = start_period 0s +
interval 10s x retries 3); a container that goes unhealthy after the monitor
window does not fail the rollout, so a broken deploy reports success.
Set deploy.update_config.monitor to at least 30s
```

A chart whose healthcheck is fast enough to fail inside 5s is still silent — the rule compares against the real window either way, it no longer just declines to look.

The 5s constant is aliased from `defaultStabilityWindow` in `release.go` rather than copied: it is the same fact, and `--wait` already sits through exactly that window.

## Companion

The 8 charts are fixed in a separate `swarmcli-charts` PR; this repo's change stands on its own and neither blocks the other.

## Verification

`gofmt`, `go vet ./...`, `go test -race -count=1 ./...`, `golangci-lint run ./... --build-tags=integration` → 0 issues.

`TestLintHealthcheckMonitorSkipsImplicitDefault` asserted the old skip and is replaced by two tests: one that the inherited default is flagged with the remediation value, one that an *adequate* inherited default stays silent.