### PR TITLE
fix(services): count replicas that are running, not merely scheduled

### DIFF
--- a/docker/service.go
+++ b/docker/service.go
@@ -495,26 +495,34 @@ func getServiceStackAndDesired(svc swarm.Service, snap *SwarmSnapshot) (stack st
 		stack = "-"
 	}
 
-	if svc.Spec.Mode.Replicated != nil && svc.Spec.Mode.Replicated.Replicas != nil {
-		desired = int(*svc.Spec.Mode.Replicated.Replicas)
-	} else if svc.Spec.Mode.Global != nil {
-		desired = len(snap.Nodes)
-	} else {
-		// One-off task
-		desired = 1
-	}
-
+	// Shared with the convergence path rather than duplicated: a global service's
+	// target is one task per node that can actually run one, so a drained or
+	// down node lowers the target instead of making the service read
+	// permanently short (issue #480).
+	desired = desiredOverActiveNodes(svc, len(activeNodeIDs(snap)))
 	return
 }
 
-// countTasksForNode counts tasks for a service; if nodeID == "", counts across all nodes
+// countTasksForNode counts the tasks of a service that are actually running; if
+// nodeID == "", counts across all nodes.
+//
+// It counts by Status.State, not DesiredState. Tasks are created with
+// DesiredState=running and only then walk new → pending → assigned → preparing
+// → starting → running, so counting intent reported a task that had never
+// started as if it were up. A service wedged on an unsatisfiable placement
+// constraint displayed as fully converged forever, which is exactly when the
+// operator most needs the truth (issue #480).
+//
+// Superseded tasks from a rolling update are still counted while they run,
+// matching `docker service ls`. Up-to-dateness is a different question from
+// readiness, and LoadStackConvergence is where --wait asks it.
 func countTasksForNode(serviceID, nodeID string, snap *SwarmSnapshot) int {
 	count := 0
 	for _, t := range snap.Tasks {
 		if t.ServiceID != serviceID {
 			continue
 		}
-		if t.DesiredState != swarm.TaskStateRunning {
+		if t.Status.State != swarm.TaskStateRunning {
 			continue
 		}
 		if nodeID == "" || t.NodeID == nodeID {

--- a/docker/service_test.go
+++ b/docker/service_test.go
@@ -61,11 +61,39 @@ func TestGetServiceStackAndDesired_Global(t *testing.T) {
 		},
 	}
 	snap := &SwarmSnapshot{
-		Nodes: []swarm.Node{{}, {}, {}},
+		Nodes: []swarm.Node{activeNode("n1"), activeNode("n2"), activeNode("n3")},
 	}
 	stack, desired := getServiceStackAndDesired(svc, snap)
 	require.Equal(t, "mystack", stack)
 	require.Equal(t, 3, desired)
+}
+
+// A global service targets one task per node that can actually run one. Counting
+// a drained or down node in the denominator made a fully healthy service read
+// permanently short (issue #480).
+func TestGetServiceStackAndDesired_GlobalIgnoresInactiveNodes(t *testing.T) {
+	svc := swarm.Service{
+		Spec: swarm.ServiceSpec{
+			Annotations: swarm.Annotations{Labels: map[string]string{"com.docker.stack.namespace": "mystack"}},
+			Mode:        swarm.ServiceMode{Global: &swarm.GlobalService{}},
+		},
+	}
+	drained := activeNode("n3")
+	drained.Spec.Availability = swarm.NodeAvailabilityDrain
+	down := activeNode("n4")
+	down.Status.State = swarm.NodeStateDown
+
+	snap := &SwarmSnapshot{Nodes: []swarm.Node{activeNode("n1"), activeNode("n2"), drained, down}}
+	_, desired := getServiceStackAndDesired(svc, snap)
+	require.Equal(t, 2, desired)
+}
+
+func activeNode(id string) swarm.Node {
+	return swarm.Node{
+		ID:     id,
+		Status: swarm.NodeStatus{State: swarm.NodeStateReady},
+		Spec:   swarm.NodeSpec{Availability: swarm.NodeAvailabilityActive},
+	}
 }
 
 func TestGetServiceStackAndDesired_NoStack(t *testing.T) {
@@ -80,12 +108,23 @@ func TestGetServiceStackAndDesired_NoStack(t *testing.T) {
 	require.Equal(t, "-", stack)
 }
 
+// runningTask is a task that is actually up: swarm intends to run it AND the
+// container reports running.
+func runningTask(svcID, nodeID string) swarm.Task {
+	return swarm.Task{
+		ServiceID:    svcID,
+		NodeID:       nodeID,
+		DesiredState: swarm.TaskStateRunning,
+		Status:       swarm.TaskStatus{State: swarm.TaskStateRunning},
+	}
+}
+
 func TestCountTasksForNode_All(t *testing.T) {
 	snap := &SwarmSnapshot{
 		Tasks: []swarm.Task{
-			{ServiceID: "svc1", NodeID: "n1", DesiredState: swarm.TaskStateRunning},
-			{ServiceID: "svc1", NodeID: "n2", DesiredState: swarm.TaskStateRunning},
-			{ServiceID: "svc2", NodeID: "n1", DesiredState: swarm.TaskStateRunning},
+			runningTask("svc1", "n1"),
+			runningTask("svc1", "n2"),
+			runningTask("svc2", "n1"),
 		},
 	}
 	require.Equal(t, 2, countTasksForNode("svc1", "", snap))
@@ -93,22 +132,50 @@ func TestCountTasksForNode_All(t *testing.T) {
 
 func TestCountTasksForNode_Specific(t *testing.T) {
 	snap := &SwarmSnapshot{
-		Tasks: []swarm.Task{
-			{ServiceID: "svc1", NodeID: "n1", DesiredState: swarm.TaskStateRunning},
-			{ServiceID: "svc1", NodeID: "n2", DesiredState: swarm.TaskStateRunning},
-		},
+		Tasks: []swarm.Task{runningTask("svc1", "n1"), runningTask("svc1", "n2")},
 	}
 	require.Equal(t, 1, countTasksForNode("svc1", "n1", snap))
 }
 
 func TestCountTasksForNode_SkipsNonRunning(t *testing.T) {
+	shutdown := runningTask("svc1", "n1")
+	shutdown.DesiredState = swarm.TaskStateShutdown
+	shutdown.Status.State = swarm.TaskStateShutdown
+
+	snap := &SwarmSnapshot{Tasks: []swarm.Task{runningTask("svc1", "n1"), shutdown}}
+	require.Equal(t, 1, countTasksForNode("svc1", "", snap))
+}
+
+// The bug this fixes: a task swarm INTENDS to run but which has not started —
+// pending on an unsatisfiable placement constraint, or still pulling an image —
+// was counted as if it were up, so the column read 3/3 where `docker service ls`
+// read 1/3 and the service never converged (issue #480).
+func TestCountTasksForNode_SkipsScheduledButNotYetRunning(t *testing.T) {
+	scheduled := func(state swarm.TaskState) swarm.Task {
+		t := runningTask("svc1", "n1")
+		t.Status.State = state // still intended to run, not there yet
+		return t
+	}
 	snap := &SwarmSnapshot{
 		Tasks: []swarm.Task{
-			{ServiceID: "svc1", NodeID: "n1", DesiredState: swarm.TaskStateRunning},
-			{ServiceID: "svc1", NodeID: "n1", DesiredState: swarm.TaskStateShutdown},
+			runningTask("svc1", "n1"),
+			scheduled(swarm.TaskStatePending),
+			scheduled(swarm.TaskStateStarting),
+			scheduled(swarm.TaskStatePreparing),
 		},
 	}
 	require.Equal(t, 1, countTasksForNode("svc1", "", snap))
+}
+
+// A superseded task is still counted while it runs, matching `docker service
+// ls`. Up-to-dateness is a separate question, and LoadStackConvergence is where
+// --wait asks it.
+func TestCountTasksForNode_CountsSupersededTasksStillRunning(t *testing.T) {
+	outgoing := runningTask("svc1", "n1")
+	outgoing.DesiredState = swarm.TaskStateShutdown // superseded, container still up
+
+	snap := &SwarmSnapshot{Tasks: []swarm.Task{runningTask("svc1", "n2"), outgoing}}
+	require.Equal(t, 2, countTasksForNode("svc1", "", snap))
 }
 
 func TestSortEntries(t *testing.T) {


### PR DESCRIPTION
Closes #480. Split out of #473, which fixed the same root cause for the chart-convergence path only.

The REPLICAS column counted tasks by `DesiredState`. Tasks are created with `DesiredState=running` and only *then* walk `new → pending → assigned → preparing → starting → running`, so a task that had never started was counted as if it were up.

```
                        rollout in flight, 3 replicas, 1 new task up
  docker service ls     3/3
  swarmcli (before)     3/3   ← right number, wrong reason
  swarmcli (after)      3/3   ← old generation still running, same as docker

                        node down, 1 task stuck pending
  docker service ls     2/3
  swarmcli (before)     3/3   ← the bug
  swarmcli (after)      2/3
```

Worst case: a service wedged on an unsatisfiable placement constraint displayed as **fully converged forever** — misleading exactly when the operator most needs the truth.

## Converging on `docker service ls`, not overshooting

`countTasksForNode` now counts by `Status.State`. A **superseded task is still counted while its container runs**, matching docker.

That is a deliberate choice against sharing the convergence helper verbatim. `LoadStackConvergence` additionally requires `DesiredState==running`, which drops the outgoing generation — strictly more informative, but it would make swarmcli read `1/3` where `docker service ls` reads `3/3`, and the operator would have to know which is lying. The issue's complaint is that we *diverge* from docker; the fix should converge, not overshoot in the other direction. Kubernetes draws the same line: `kubectl get deploy` keeps `READY` and `UP-TO-DATE` as separate columns rather than folding staleness into the ready count.

Up-to-dateness is still asked where it matters — `--wait` goes through `LoadStackConvergence`, unchanged.

## Denominator

`getServiceStackAndDesired` now derives a global service's target from `desiredOverActiveNodes(svc, len(activeNodeIDs(snap)))` instead of `len(snap.Nodes)`. Shared with the convergence path rather than duplicated, and it deletes the duplicated mode switch. A drained or down node now lowers the target, instead of making a fully healthy global service read permanently short — the same class of lie the numerator had.

## Scope

`ReplicasOnNode` / `ReplicasTotal` back the services view (`views/services/columns.go`) and `charts` release status. The scale dialog pre-fills from `ReplicasTotal`, which is unchanged for replicated services (it reads `Spec.Mode.Replicated.Replicas` either way).

## Verification

`gofmt`, `go vet ./...`, `go test -race -count=1 ./...`, `golangci-lint run ./... --build-tags=integration` → 0 issues.

Four existing tests encoded the old semantics and were rewritten against real task fixtures (`DesiredState` *and* `Status.State`). New tests cover: a scheduled-but-not-started task in each of `pending`/`starting`/`preparing` is not counted; a superseded-but-running task *is*; and a global service's denominator ignores drained and down nodes.