### PR TITLE
fix(charts): measure the stability window from task creation, as swarm does

### DIFF
--- a/charts/backend_docker.go
+++ b/charts/backend_docker.go
@@ -173,6 +173,7 @@ func (b *dockerBackend) StackServices(name string) []ServiceState {
 			st.Desired = c.Desired
 			st.UpdateState = c.UpdateState
 			st.Monitor = c.Monitor
+			st.NewestTaskAge = c.NewestTaskAge
 		}
 		out = append(out, st)
 	}

--- a/charts/release.go
+++ b/charts/release.go
@@ -51,6 +51,9 @@ type ServiceState struct {
 	// Monitor is UpdateConfig.Monitor: the window after a task is created in
 	// which its failure still counts against the rollout.
 	Monitor time.Duration
+	// NewestTaskAge is how much of that window the newest running task has
+	// already lived through, measured from task creation as swarm measures it.
+	NewestTaskAge time.Duration
 }
 
 // Backend abstracts the Docker operations the release engine needs, so the
@@ -903,23 +906,18 @@ func (e *Engine) waitReady(release string, timeout time.Duration) error {
 		timeout = 5 * time.Minute
 	}
 	deadline := e.now().Add(timeout)
-	var convergedAt time.Time
 	for {
 		states := e.Backend.StackServices(release)
 		if err := rolloutWedged(states); err != nil {
 			return fmt.Errorf("release %q: %w", release, err)
 		}
-		if len(states) > 0 && allConverged(states) {
-			if convergedAt.IsZero() {
-				convergedAt = e.now()
-			}
-			if !e.now().Before(convergedAt.Add(stabilityWindow(states))) {
-				return nil
-			}
-		} else {
-			// Lost parity — a task died inside the window. Start it again rather
-			// than counting the earlier, now-invalidated stretch.
-			convergedAt = time.Time{}
+		// Parity is necessary but not sufficient: a task that starts and then
+		// dies inside the monitor window is a rollout failure, so hold until
+		// swarm's own window has closed. Losing parity needs no special case —
+		// the replacement task is newer, so the window it has left grows back on
+		// its own.
+		if len(states) > 0 && allConverged(states) && stabilityRemaining(states) <= 0 {
+			return nil
 		}
 		if !e.now().Before(deadline) {
 			return fmt.Errorf("timed out after %s waiting for release %q to converge", timeout, release)
@@ -928,16 +926,32 @@ func (e *Engine) waitReady(release string, timeout time.Duration) error {
 	}
 }
 
-// stabilityWindow is the longest monitor period across the release's services,
-// so the slowest service governs. Services declaring none use the CLI default.
-func stabilityWindow(states []ServiceState) time.Duration {
-	window := defaultStabilityWindow
+// stabilityRemaining is how much of the monitor window is still outstanding
+// across the release's services — the slowest governs, and <= 0 means every
+// service has held parity for as long as swarm itself would watch.
+//
+// The remainder is measured from TASK CREATION, not from the moment parity was
+// reached. Swarm starts the monitor when it creates the task, and a task only
+// reports running once its healthcheck passes, so start_period and the checks
+// that followed have already burned part of the window — for a service with a
+// long start_period, usually all of it. Restarting a full window at parity
+// instead made --wait sit for the monitor period on top of the time the service
+// took to come up, which is strictly more conservative than swarm and turns an
+// honest `monitor: 8m` into an eight-minute install.
+//
+// Services declaring no monitor use the CLI default, matching swarm's own.
+func stabilityRemaining(states []ServiceState) time.Duration {
+	var worst time.Duration
 	for _, s := range states {
-		if s.Monitor > window {
-			window = s.Monitor
+		window := s.Monitor
+		if window < defaultStabilityWindow {
+			window = defaultStabilityWindow
+		}
+		if remaining := window - s.NewestTaskAge; remaining > worst {
+			worst = remaining
 		}
 	}
-	return window
+	return worst
 }
 
 // rolloutWedged reports a rollout swarm has given up on.

--- a/charts/release_test.go
+++ b/charts/release_test.go
@@ -372,12 +372,32 @@ func TestAllConvergedGlobalTracksActiveNodes(t *testing.T) {
 	require.False(t, allConverged([]ServiceState{{Mode: "global", Running: 1, Desired: 2}}))
 }
 
-func TestStabilityWindowTakesTheLongestMonitor(t *testing.T) {
-	require.Equal(t, defaultStabilityWindow, stabilityWindow(nil))
+func TestStabilityRemainingTakesTheLongestOutstandingWindow(t *testing.T) {
+	require.Equal(t, time.Duration(0), stabilityRemaining(nil))
 	require.Equal(t, defaultStabilityWindow,
-		stabilityWindow([]ServiceState{{Monitor: time.Second}}), "a shorter monitor must not weaken the default")
+		stabilityRemaining([]ServiceState{{Monitor: time.Second}}), "a shorter monitor must not weaken the default")
 	require.Equal(t, 30*time.Second,
-		stabilityWindow([]ServiceState{{Monitor: 10 * time.Second}, {Monitor: 30 * time.Second}}))
+		stabilityRemaining([]ServiceState{{Monitor: 10 * time.Second}, {Monitor: 30 * time.Second}}))
+}
+
+// The window is measured from task creation, the same instant swarm measures it
+// from — so a task that has already lived through it is stable NOW.
+//
+// This is the whole point. A task only reports running once its healthcheck
+// passes, so start_period and the checks that followed are already spent by the
+// time parity is observed. Restarting a full window at parity made --wait sit
+// out the monitor period on top of however long the service took to come up,
+// which is strictly more conservative than swarm and turns an honest
+// `monitor: 8m` into an eight-minute install.
+func TestStabilityRemainingCountsTimeTheTaskHasAlreadyLived(t *testing.T) {
+	monitor := 90 * time.Second
+
+	require.Equal(t, 30*time.Second,
+		stabilityRemaining([]ServiceState{{Monitor: monitor, NewestTaskAge: 60 * time.Second}}))
+	require.LessOrEqual(t, stabilityRemaining([]ServiceState{{Monitor: monitor, NewestTaskAge: monitor}}),
+		time.Duration(0), "a task that has outlived its monitor is already stable")
+	require.LessOrEqual(t, stabilityRemaining([]ServiceState{{Monitor: monitor, NewestTaskAge: 10 * time.Minute}}),
+		time.Duration(0), "an over-aged task must not produce a negative wait either")
 }
 
 // paused and rollback_paused are terminal: swarmkit never rolls back a
@@ -470,34 +490,33 @@ func TestWaitReadyReturnsOnceTheWindowElapses(t *testing.T) {
 	waitPollInterval = time.Millisecond
 	defer func() { waitPollInterval = prev }()
 
-	b := &convergenceBackend{states: []ServiceState{{Name: "api", Running: 1, Desired: 1}}}
-	clock := time.Now()
-	e := &Engine{Backend: b, now: func() time.Time {
-		clock = clock.Add(2 * time.Second) // clears defaultStabilityWindow quickly
-		return clock
-	}}
+	young := []ServiceState{{Name: "api", Running: 1, Desired: 1, NewestTaskAge: time.Second}}
+	aged := []ServiceState{{Name: "api", Running: 1, Desired: 1, NewestTaskAge: time.Minute}}
+
+	b := &scriptedBackend{script: [][]ServiceState{young, young, aged}}
+	e := &Engine{Backend: b, now: time.Now}
+
 	require.NoError(t, e.waitReady("rel", time.Hour))
+	require.Equal(t, 3, b.calls, "must wait for the task to outlive the window, not return at parity")
 }
 
-// Losing parity inside the window restarts it, rather than counting the earlier
-// stretch that a task failure has invalidated.
-func TestWaitReadyRestartsWindowOnLostParity(t *testing.T) {
+// A replacement task after a lost rollout is newer, so the window it has left
+// grows back and waitReady must keep waiting rather than treating regained
+// parity as already-stable.
+func TestWaitReadyWaitsOutAReplacementTasksFreshWindow(t *testing.T) {
 	prev := waitPollInterval
 	waitPollInterval = time.Millisecond
 	defer func() { waitPollInterval = prev }()
 
-	converged := []ServiceState{{Name: "api", Running: 1, Desired: 1}}
+	young := []ServiceState{{Name: "api", Running: 1, Desired: 1, NewestTaskAge: time.Second}}
 	lost := []ServiceState{{Name: "api", Running: 0, Desired: 1}}
+	aged := []ServiceState{{Name: "api", Running: 1, Desired: 1, NewestTaskAge: time.Minute}}
 
-	b := &scriptedBackend{script: [][]ServiceState{converged, lost, converged}}
-	clock := time.Now()
-	e := &Engine{Backend: b, now: func() time.Time {
-		clock = clock.Add(3 * time.Second)
-		return clock
-	}}
+	b := &scriptedBackend{script: [][]ServiceState{young, lost, young, aged}}
+	e := &Engine{Backend: b, now: time.Now}
+
 	require.NoError(t, e.waitReady("rel", time.Hour))
-	// Had the window not restarted, it would have returned on the 2nd poll.
-	require.GreaterOrEqual(t, b.calls, 3, "losing parity must restart the stability window")
+	require.Equal(t, 4, b.calls, "the fresh task's remaining window must still be waited out")
 }
 
 // A wedged rollout is reported immediately rather than after the full timeout.

--- a/docker/convergence.go
+++ b/docker/convergence.go
@@ -28,6 +28,14 @@ type ServiceConvergence struct {
 	// Monitor is UpdateConfig.Monitor: the window after a task is created during
 	// which its failure still counts against the rollout. Zero when unset.
 	Monitor time.Duration
+	// NewestTaskAge is how long the newest running task has been alive, measured
+	// from task creation — the same instant swarm measures Monitor from.
+	//
+	// A caller waiting out the monitor window needs it: a task only reports
+	// running once its healthcheck passes, so by then start_period and the
+	// checks that followed have already consumed part of the window, and
+	// sometimes all of it. Zero when nothing is running.
+	NewestTaskAge time.Duration
 }
 
 // activeNodeIDs returns the nodes that can currently run tasks. A task pinned to
@@ -71,6 +79,7 @@ func (snap *SwarmSnapshot) StackConvergence(stackName string) []ServiceConvergen
 		}
 
 		running := 0
+		var newest time.Time
 		for _, t := range snap.Tasks {
 			if t.ServiceID != svc.ID {
 				continue
@@ -87,18 +96,38 @@ func (snap *SwarmSnapshot) StackConvergence(stackName string) []ServiceConvergen
 				continue
 			}
 			running++
+			// The window is outstanding until the LAST task created has survived
+			// it, so the newest task governs.
+			if t.CreatedAt.After(newest) {
+				newest = t.CreatedAt
+			}
 		}
 
 		out = append(out, ServiceConvergence{
-			Name:        svc.Spec.Name,
-			Mode:        getServiceMode(svc),
-			Running:     running,
-			Desired:     desiredOverActiveNodes(svc, len(active)),
-			UpdateState: updateState(svc),
-			Monitor:     monitorWindow(svc),
+			Name:          svc.Spec.Name,
+			Mode:          getServiceMode(svc),
+			Running:       running,
+			Desired:       desiredOverActiveNodes(svc, len(active)),
+			UpdateState:   updateState(svc),
+			Monitor:       monitorWindow(svc),
+			NewestTaskAge: ageSince(newest),
 		})
 	}
 	return out
+}
+
+// ageSince is how long ago t was, clamped at zero. CreatedAt comes off the
+// manager's clock and is compared against this host's, so skew can put it in the
+// future; reporting a negative age would credit the caller with time that has
+// not passed. A zero timestamp (nothing running) is likewise zero age.
+func ageSince(t time.Time) time.Duration {
+	if t.IsZero() {
+		return 0
+	}
+	if age := time.Since(t); age > 0 {
+		return age
+	}
+	return 0
 }
 
 // desiredOverActiveNodes is the target task count. For a global service that is


### PR DESCRIPTION
Closes #491. Found while costing the chart-side remediation for #488.

`waitReady` held parity for the full `UpdateConfig.Monitor` **starting at the moment parity was observed**. Swarm starts that window when it **creates** the task — and a task only reports `running` once its healthcheck passes, so `start_period` and the checks that followed are already spent by then. `--wait` sat out the monitor period *on top of* however long the service took to come up: strictly more conservative than swarm itself.

## Why it was invisible, and why it stops being

Every chart in `swarmcli-charts` inherits swarm's 5s default, so the double-count is 5s and nobody notices. It stops being invisible the moment a chart sets an honest monitor covering its healthcheck — which is exactly what `charts lint` now tells people to do (#488).

| chart | honest monitor | `--wait` blocks after parity, before | after |
|---|---|---|---|
| mariadb, redis | 80s | 80s | ≤50s |
| postgres | 110s | ~2m | ≤50s |
| keycloak | 165s | ~2m45s | ≤75s |
| superset | 270s | ~4m30s | ≤90s |
| zammad | 450s | **~7m30s** | **≤150s** |

I hit this while computing the per-chart `monitor:` values for #488's remediation. Landing that PR first would have made `charts install zammad --wait` take seven minutes, and anyone who hit it would reasonably have concluded `--wait` was broken.

## The change

`ServiceConvergence` gains `NewestTaskAge` — how long the newest running task has been alive, from `swarm.Task.CreatedAt`. The *newest* task governs because the window is outstanding until the last one created has survived it. Clamped at zero: `CreatedAt` is the manager's clock compared against this host's, and skew must not credit the caller with time that has not passed.

`stabilityWindow` becomes `stabilityRemaining` — what is still outstanding rather than what the total is:

```go
if len(states) > 0 && allConverged(states) && stabilityRemaining(states) <= 0 {
    return nil
}
```

**The explicit lost-parity reset goes away with it.** It is no longer needed: a replacement task is newer, so its remaining window grows back on its own. That is both simpler and more faithful than restarting a full window on a task that may have been up for minutes.

## #481's guarantee is unchanged

A task that starts and then dies inside swarm's window is still a rollout failure, and `--wait` still refuses to return at first parity. The only thing that changed is that the window is no longer counted twice.

## Verification

`gofmt`, `go vet ./...`, `go test -race -count=1 ./...`, `golangci-lint run ./... --build-tags=integration` → 0 issues.

`TestWaitReadyHoldsTheStabilityWindow` and the wedged-rollout test pass unchanged. `TestWaitReadyReturnsOnceTheWindowElapses` and the lost-parity test now drive the window through task age instead of a fake clock, and assert the exact poll count. New unit tests cover the arithmetic directly: partial credit for a task mid-window, zero remaining for one that has outlived its monitor, and no negative wait for an over-aged task.