### PR TITLE
test: cover the multi-swarm seam and ssh:// contexts in CI

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -119,3 +119,37 @@ jobs:
 
       - name: Run locked-swarm integration test
         run: go test -tags=integration_locked -count=1 -v -timeout=15m ./integration-tests/...
+
+  # The ssh-context test stands up its own dind running an sshd and redirects
+  # HOME so the ssh client config and the Docker context store are both under
+  # test control. Like locked-swarm it must stay away from the shared swarm, so
+  # it gets the dedicated `integration_ssh` tag and its own job.
+  #
+  # It cannot ride along with the regular integration job: that job's tests share
+  # one HOME, and rewriting it mid-run would move the Docker context store out
+  # from under them.
+  ssh-context:
+    needs: [changes]
+    if: needs.changes.outputs.integration == 'true'
+    name: Run ssh-context integration test
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Set up Go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Verify Docker, Go & ssh
+        run: |
+          docker version
+          go version
+          ssh -V
+
+      - name: Run ssh-context integration test
+        run: go test -tags=integration_ssh -count=1 -v -timeout=15m ./integration-tests/...

--- a/integration-tests/multiswarm/two_swarms_test.go
+++ b/integration-tests/multiswarm/two_swarms_test.go
@@ -1,0 +1,213 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+//go:build integration
+
+// Package multiswarm proves that an Engine built with charts.NewDockerBackend
+// addresses exactly the swarm it names, and no other.
+//
+// This needs TWO swarms to mean anything. The failure mode #469/#487 exist to
+// prevent is silent: a backend that deploys to one swarm while reading release
+// history, networks and convergence from another reports success either way, so
+// a single-swarm test passes whether or not the seam works. Two contexts
+// pointing at the SAME daemon would be equally worthless.
+//
+// Swarm A is the shared multi-node swarm the rest of the integration suite runs
+// against (context "swarmcli"). Swarm B is a throwaway single-node dind started
+// here, following the pattern in integration-tests/swarmlock.
+package multiswarm
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/Eldara-Tech/swarmcli/charts"
+	swarmlog "github.com/Eldara-Tech/swarmcli/utils/log"
+)
+
+const (
+	dindImage     = "docker:29-dind"
+	containerName = "swarmcli-multiswarm-dind"
+	dindHostPort  = "24375" // distinct from the shared swarm (22375) and swarmlock (23375)
+	contextB      = "swarmcli-multiswarm-b"
+	hostB         = "tcp://localhost:" + dindHostPort
+
+	// contextA is the shared swarm's context, created by test-setup/testenv.sh.
+	contextA = "swarmcli"
+)
+
+const chartTemplate = `version: "3.9"
+
+services:
+  whoami:
+    image: traefik/whoami:v1.10
+    deploy:
+      replicas: 1
+`
+
+func hostDocker(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+	out, err := exec.Command("docker", append([]string{"--context", "default"}, args...)...).CombinedOutput()
+	return string(out), err
+}
+
+func innerB(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+	return hostDocker(t, append([]string{"exec", containerName, "docker"}, args...)...)
+}
+
+// startSwarmB brings up the throwaway second swarm and registers a context for
+// it, returning once its daemon answers and it is a swarm manager.
+func startSwarmB(t *testing.T) {
+	t.Helper()
+
+	_, _ = hostDocker(t, "rm", "-f", containerName)
+	_ = exec.Command("docker", "context", "rm", "-f", contextB).Run()
+	t.Cleanup(func() {
+		_ = exec.Command("docker", "context", "rm", "-f", contextB).Run()
+		_, _ = hostDocker(t, "rm", "-f", containerName)
+	})
+
+	out, err := hostDocker(t, "run", "-d", "--privileged",
+		"-e", "DOCKER_TLS_CERTDIR=",
+		"-p", dindHostPort+":2375",
+		"--name", containerName, dindImage)
+	require.NoErrorf(t, err, "starting swarm B dind: %s", out)
+
+	deadline := time.Now().Add(90 * time.Second)
+	for {
+		if _, err := innerB(t, "version"); err == nil {
+			break
+		}
+		require.Truef(t, time.Now().Before(deadline), "swarm B daemon never became ready")
+		time.Sleep(time.Second)
+	}
+
+	out, err = innerB(t, "swarm", "init", "--advertise-addr", "eth0")
+	require.NoErrorf(t, err, "swarm init on B: %s", out)
+
+	out, err = hostDocker(t, "context", "create", contextB, "--docker", "host="+hostB)
+	require.NoErrorf(t, err, "creating context B: %s", out)
+}
+
+func demoChart(t *testing.T) *charts.Chart {
+	t.Helper()
+	dir := t.TempDir()
+	write := func(name, body string) {
+		t.Helper()
+		require.NoError(t, os.MkdirAll(filepath.Dir(filepath.Join(dir, name)), 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, name), []byte(body), 0o644))
+	}
+	write("Chart.yaml", "apiVersion: v1\nname: multiswarm\nversion: 0.1.0\nappVersion: \"1.0\"\n")
+	write("values.yaml", "{}\n")
+	write("templates/stack.yaml", chartTemplate)
+
+	ch, err := charts.LoadChartDir(dir)
+	require.NoError(t, err)
+	return ch
+}
+
+func engineFor(ctxName string) *charts.Engine {
+	return charts.NewEngineWith(charts.NewDockerBackend(ctxName))
+}
+
+// A release installed through a backend naming one swarm must exist on that
+// swarm and be invisible from the other — in BOTH directions. One direction
+// alone would pass against a backend that always read swarm A.
+func TestReleasesDoNotLeakBetweenSwarms(t *testing.T) {
+	swarmlog.InitTestIfTestLogEnv()
+	startSwarmB(t)
+
+	ctx := context.Background()
+	ch := demoChart(t)
+
+	onA := fmt.Sprintf("multiswarm-a-%d", time.Now().UnixNano())
+	onB := fmt.Sprintf("multiswarm-b-%d", time.Now().UnixNano())
+
+	engA, engB := engineFor(contextA), engineFor(contextB)
+
+	manifest, err := charts.Render(ch, charts.RenderContext{
+		Values:  map[string]any{},
+		Release: charts.ReleaseMeta{Name: onA, Namespace: onA, Revision: 1},
+		Chart:   charts.ChartMeta{Name: "multiswarm", Version: "0.1.0"},
+	})
+	require.NoError(t, err)
+
+	_, err = engA.Install(ctx, onA, charts.ReleaseChart{Name: "multiswarm", Version: "0.1.0"},
+		map[string]any{}, manifest, charts.InstallOptions{})
+	require.NoError(t, err)
+	t.Cleanup(func() { _, _ = engA.Uninstall(context.Background(), onA, false) })
+
+	manifestB, err := charts.Render(ch, charts.RenderContext{
+		Values:  map[string]any{},
+		Release: charts.ReleaseMeta{Name: onB, Namespace: onB, Revision: 1},
+		Chart:   charts.ChartMeta{Name: "multiswarm", Version: "0.1.0"},
+	})
+	require.NoError(t, err)
+
+	_, err = engB.Install(ctx, onB, charts.ReleaseChart{Name: "multiswarm", Version: "0.1.0"},
+		map[string]any{}, manifestB, charts.InstallOptions{})
+	require.NoError(t, err)
+	t.Cleanup(func() { _, _ = engB.Uninstall(context.Background(), onB, false) })
+
+	namesOn := func(e *charts.Engine) []string {
+		rels, err := e.List(ctx)
+		require.NoError(t, err)
+		var out []string
+		for _, r := range rels {
+			out = append(out, r.Name)
+		}
+		return out
+	}
+
+	// Release history lives in Docker Configs read through the SDK client, which
+	// is the half #469's proposed fix would have left pointing at the ambient
+	// swarm.
+	require.Contains(t, namesOn(engA), onA, "A's own release must be visible from A")
+	require.NotContains(t, namesOn(engA), onB, "B's release must NOT be visible from A")
+
+	require.Contains(t, namesOn(engB), onB, "B's own release must be visible from B")
+	require.NotContains(t, namesOn(engB), onA, "A's release must NOT be visible from B")
+}
+
+// The deploy half goes through `docker --context <name> stack deploy`, a
+// different mechanism from the SDK reads above. Assert the stack really landed
+// on the named daemon by asking that daemon directly, not through swarmcli.
+func TestDeployLandsOnTheNamedSwarm(t *testing.T) {
+	swarmlog.InitTestIfTestLogEnv()
+	startSwarmB(t)
+
+	ctx := context.Background()
+	ch := demoChart(t)
+	release := fmt.Sprintf("multiswarm-land-%d", time.Now().UnixNano())
+
+	manifest, err := charts.Render(ch, charts.RenderContext{
+		Values:  map[string]any{},
+		Release: charts.ReleaseMeta{Name: release, Namespace: release, Revision: 1},
+		Chart:   charts.ChartMeta{Name: "multiswarm", Version: "0.1.0"},
+	})
+	require.NoError(t, err)
+
+	engB := engineFor(contextB)
+	_, err = engB.Install(ctx, release, charts.ReleaseChart{Name: "multiswarm", Version: "0.1.0"},
+		map[string]any{}, manifest, charts.InstallOptions{})
+	require.NoError(t, err)
+	t.Cleanup(func() { _, _ = engB.Uninstall(context.Background(), release, false) })
+
+	// Ask swarm B's own daemon, bypassing swarmcli entirely.
+	out, err := innerB(t, "stack", "ls", "--format", "{{.Name}}")
+	require.NoErrorf(t, err, "listing stacks on B: %s", out)
+	require.Contains(t, out, release, "the stack must exist on the swarm the backend named")
+
+	// And it must not have landed on the shared swarm.
+	outA, err := exec.Command("docker", "--context", contextA, "stack", "ls", "--format", "{{.Name}}").CombinedOutput()
+	require.NoErrorf(t, err, "listing stacks on A: %s", outA)
+	require.NotContains(t, string(outA), release, "the stack must NOT have been deployed to the other swarm")
+}

--- a/integration-tests/sshcontext/ssh_context_test.go
+++ b/integration-tests/sshcontext/ssh_context_test.go
@@ -130,6 +130,12 @@ func startSSHDind(t *testing.T, pubKey string) {
 		"chmod 700 /root/.ssh && chmod 600 /root/.ssh/authorized_keys",
 		// Explicit rather than relying on Alpine's commented-out default.
 		"echo 'PermitRootLogin prohibit-password' >> /etc/ssh/sshd_config",
+		// The docker CLI lives in /usr/local/bin, which is NOT on sshd's default
+		// PATH for a non-interactive session — and `ssh host -- command` is
+		// exactly that. connhelper runs `ssh … -- docker system dial-stdio`, so
+		// without this the feature under test cannot work, not just the probe.
+		// /etc/profile would not help: it is only read by login shells.
+		"[ -x /usr/bin/docker ] || ln -s \"$(command -v docker)\" /usr/bin/docker",
 		"/usr/sbin/sshd",
 	}, " && ")
 	out, err = inner(t, "sh", "-c", setup)
@@ -141,13 +147,20 @@ func startSSHDind(t *testing.T, pubKey string) {
 
 	// Poll the actual transport: ssh in and run the very command the connection
 	// helper runs. sshd takes a moment to bind after being started.
+	// Keep the last failure so a timeout reports WHY ssh never worked rather
+	// than just that it did not.
+	var lastOut string
+	var lastErr error
 	deadline = time.Now().Add(60 * time.Second)
 	for {
 		probe := exec.Command("ssh", "-o", "BatchMode=yes", "localhost", "docker", "version", "--format", "{{.Server.Version}}")
-		if out, err := probe.CombinedOutput(); err == nil && len(strings.TrimSpace(string(out))) > 0 {
+		out, err := probe.CombinedOutput()
+		if err == nil && len(strings.TrimSpace(string(out))) > 0 {
 			return
 		}
-		require.Truef(t, time.Now().Before(deadline), "ssh to the dind never became usable")
+		lastOut, lastErr = string(out), err
+		require.Truef(t, time.Now().Before(deadline),
+			"ssh to the dind never became usable: %v\n%s", lastErr, lastOut)
 		time.Sleep(time.Second)
 	}
 }

--- a/integration-tests/sshcontext/ssh_context_test.go
+++ b/integration-tests/sshcontext/ssh_context_test.go
@@ -17,11 +17,14 @@
 // npipe, so an ssh:// host was TCP-dialled and the ping failed. The fix resolves
 // a connection helper and dials `ssh … docker system dial-stdio` instead.
 //
-// HOME is redirected to a temp dir on purpose. It puts both the ssh client
-// config and the Docker context store under test control, and it means the run
-// genuinely exercises ~/.ssh/config handling — the parity with `docker
-// --context` that justified depending on docker/cli's connhelper rather than
-// hand-rolling the dialer.
+// HOME is redirected to a temp dir so the Docker context store is under test
+// control. That is NOT enough to redirect the ssh client config: OpenSSH
+// resolves ~/.ssh/config through getpwuid(), not $HOME. An `ssh` shim on PATH
+// supplies -F instead — see shimSSH.
+//
+// Either way the run exercises ssh_config handling, which is the parity with
+// `docker --context` that justified depending on docker/cli's connhelper rather
+// than hand-rolling the dialer.
 package sshcontext
 
 import (
@@ -66,13 +69,40 @@ func isolateHome(t *testing.T) string {
 	return home
 }
 
-// writeSSHConfig generates a keypair and an ssh config for the throwaway host.
+// shimSSH puts an `ssh` wrapper at the front of PATH that adds -F <config>.
+//
+// This is necessary, not decorative: OpenSSH resolves the default config path
+// through getpwuid(), NOT $HOME, so redirecting HOME does not redirect
+// ~/.ssh/config. Without the shim the run ignores our config entirely — no
+// port, no identity, no host-key policy — and fails with "Host key verification
+// failed" against whatever is listening on port 22.
+//
+// The alternative was appending to the developer's real ~/.ssh/config, which
+// this test declines to do. The fidelity cost is small and worth naming: the
+// options reach ssh via -F rather than by being found at the default path, so
+// this proves connhelper honours ssh_config, not that it finds the user's file.
+func shimSSH(t *testing.T, home, cfg string) {
+	t.Helper()
+	realSSH, err := exec.LookPath("ssh")
+	require.NoError(t, err)
+
+	bin := filepath.Join(home, "bin")
+	require.NoError(t, os.MkdirAll(bin, 0o755))
+	// Absolute path to the real ssh, so the shim cannot recurse into itself.
+	script := "#!/bin/sh\nexec " + realSSH + " -F " + cfg + " \"$@\"\n"
+	require.NoError(t, os.WriteFile(filepath.Join(bin, "ssh"), []byte(script), 0o755))
+
+	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
+// writeSSHConfig generates a keypair and an ssh config for the throwaway host,
+// returning the public key and the config path.
 //
 // The config is what makes this a real test of connhelper: GetConnectionHelper
 // shells out to the system ssh with no options of its own, so the identity file,
-// port and host-key policy can only come from ~/.ssh/config. A hand-rolled
-// dialer would have ignored all of it.
-func writeSSHConfig(t *testing.T, home string) string {
+// port and host-key policy can only come from ssh_config. A hand-rolled dialer
+// would have ignored all of it.
+func writeSSHConfig(t *testing.T, home string) (string, string) {
 	t.Helper()
 	key := filepath.Join(home, ".ssh", "id_ed25519")
 	out, err := exec.Command("ssh-keygen", "-t", "ed25519", "-N", "", "-f", key).CombinedOutput()
@@ -89,11 +119,12 @@ func writeSSHConfig(t *testing.T, home string) string {
 		"  LogLevel ERROR",
 		"",
 	}, "\n")
-	require.NoError(t, os.WriteFile(filepath.Join(home, ".ssh", "config"), []byte(cfg), 0o600))
+	cfgPath := filepath.Join(home, ".ssh", "config")
+	require.NoError(t, os.WriteFile(cfgPath, []byte(cfg), 0o600))
 
 	pub, err := os.ReadFile(key + ".pub")
 	require.NoError(t, err)
-	return strings.TrimSpace(string(pub))
+	return strings.TrimSpace(string(pub)), cfgPath
 }
 
 // startSSHDind brings up a dind daemon with an sshd in front of it and waits
@@ -173,7 +204,8 @@ func TestSSHContextReachesTheDaemon(t *testing.T) {
 	}
 
 	home := isolateHome(t)
-	pub := writeSSHConfig(t, home)
+	pub, cfg := writeSSHConfig(t, home)
+	shimSSH(t, home, cfg)
 	startSSHDind(t, pub)
 
 	out, err := hostDocker(t, "context", "create", sshContext,
@@ -207,7 +239,8 @@ func TestUnreachableSSHHostFailsCleanly(t *testing.T) {
 	}
 
 	home := isolateHome(t)
-	_ = writeSSHConfig(t, home)
+	_, cfg := writeSSHConfig(t, home)
+	shimSSH(t, home, cfg)
 
 	const badContext = "swarmcli-ssh-unreachable"
 	out, err := hostDocker(t, "context", "create", badContext,

--- a/integration-tests/sshcontext/ssh_context_test.go
+++ b/integration-tests/sshcontext/ssh_context_test.go
@@ -1,0 +1,221 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+//go:build integration_ssh
+
+// Package sshcontext proves swarmcli can reach a daemon over an ssh:// Docker
+// context (#449).
+//
+// It is gated behind its own `integration_ssh` build tag, not the regular
+// `integration` one, because it stands up a throwaway dind running an sshd and
+// rewrites HOME — neither of which should touch the shared multi-node swarm the
+// rest of the suite uses. A separate CI job runs only this tag, mirroring
+// integration-tests/swarmlock.
+//
+// The bug this guards: client.WithHost routes through
+// go-connections/sockets.ConfigureTransport, which special-cases only unix and
+// npipe, so an ssh:// host was TCP-dialled and the ping failed. The fix resolves
+// a connection helper and dials `ssh … docker system dial-stdio` instead.
+//
+// HOME is redirected to a temp dir on purpose. It puts both the ssh client
+// config and the Docker context store under test control, and it means the run
+// genuinely exercises ~/.ssh/config handling — the parity with `docker
+// --context` that justified depending on docker/cli's connhelper rather than
+// hand-rolling the dialer.
+package sshcontext
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/Eldara-Tech/swarmcli/docker"
+)
+
+const (
+	dindImage     = "docker:29-dind"
+	containerName = "swarmcli-ssh-dind"
+	sshHostPort   = "22222"
+	sshContext    = "swarmcli-ssh"
+)
+
+func hostDocker(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+	out, err := exec.Command("docker", append([]string{"--context", "default"}, args...)...).CombinedOutput()
+	return string(out), err
+}
+
+func inner(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+	return hostDocker(t, append([]string{"exec", containerName}, args...)...)
+}
+
+// isolateHome points HOME at a temp dir so the ssh config written below and the
+// Docker context created later are both scoped to this test.
+func isolateHome(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	require.NoError(t, os.MkdirAll(filepath.Join(home, ".ssh"), 0o700))
+	return home
+}
+
+// writeSSHConfig generates a keypair and an ssh config for the throwaway host.
+//
+// The config is what makes this a real test of connhelper: GetConnectionHelper
+// shells out to the system ssh with no options of its own, so the identity file,
+// port and host-key policy can only come from ~/.ssh/config. A hand-rolled
+// dialer would have ignored all of it.
+func writeSSHConfig(t *testing.T, home string) string {
+	t.Helper()
+	key := filepath.Join(home, ".ssh", "id_ed25519")
+	out, err := exec.Command("ssh-keygen", "-t", "ed25519", "-N", "", "-f", key).CombinedOutput()
+	require.NoErrorf(t, err, "ssh-keygen: %s", out)
+
+	cfg := strings.Join([]string{
+		"Host localhost",
+		"  User root",
+		"  Port " + sshHostPort,
+		"  IdentityFile " + key,
+		"  IdentitiesOnly yes",
+		"  StrictHostKeyChecking no",
+		"  UserKnownHostsFile /dev/null",
+		"  LogLevel ERROR",
+		"",
+	}, "\n")
+	require.NoError(t, os.WriteFile(filepath.Join(home, ".ssh", "config"), []byte(cfg), 0o600))
+
+	pub, err := os.ReadFile(key + ".pub")
+	require.NoError(t, err)
+	return strings.TrimSpace(string(pub))
+}
+
+// startSSHDind brings up a dind daemon with an sshd in front of it and waits
+// until `ssh … docker version` actually answers — the same path the connection
+// helper will take.
+func startSSHDind(t *testing.T, pubKey string) {
+	t.Helper()
+
+	_, _ = hostDocker(t, "rm", "-f", containerName)
+	t.Cleanup(func() { _, _ = hostDocker(t, "rm", "-f", containerName) })
+
+	out, err := hostDocker(t, "run", "-d", "--privileged",
+		"-e", "DOCKER_TLS_CERTDIR=",
+		"-p", sshHostPort+":22",
+		"--name", containerName, dindImage)
+	require.NoErrorf(t, err, "starting dind: %s", out)
+
+	// Wait for the inner daemon before installing anything, so apk has a working
+	// container and the error below means "sshd setup failed", not "too early".
+	deadline := time.Now().Add(90 * time.Second)
+	for {
+		if _, err := inner(t, "docker", "version"); err == nil {
+			break
+		}
+		require.Truef(t, time.Now().Before(deadline), "inner daemon never became ready")
+		time.Sleep(time.Second)
+	}
+
+	setup := strings.Join([]string{
+		"apk add --no-cache openssh-server",
+		"ssh-keygen -A",
+		"mkdir -p /root/.ssh",
+		"printf '%s\\n' \"" + pubKey + "\" > /root/.ssh/authorized_keys",
+		"chmod 700 /root/.ssh && chmod 600 /root/.ssh/authorized_keys",
+		// Explicit rather than relying on Alpine's commented-out default.
+		"echo 'PermitRootLogin prohibit-password' >> /etc/ssh/sshd_config",
+		"/usr/sbin/sshd",
+	}, " && ")
+	out, err = inner(t, "sh", "-c", setup)
+	require.NoErrorf(t, err, "provisioning sshd: %s", out)
+
+	// A swarm, so there is real state to read back over the tunnel.
+	out, err = inner(t, "docker", "swarm", "init", "--advertise-addr", "eth0")
+	require.NoErrorf(t, err, "swarm init: %s", out)
+
+	// Poll the actual transport: ssh in and run the very command the connection
+	// helper runs. sshd takes a moment to bind after being started.
+	deadline = time.Now().Add(60 * time.Second)
+	for {
+		probe := exec.Command("ssh", "-o", "BatchMode=yes", "localhost", "docker", "version", "--format", "{{.Server.Version}}")
+		if out, err := probe.CombinedOutput(); err == nil && len(strings.TrimSpace(string(out))) > 0 {
+			return
+		}
+		require.Truef(t, time.Now().Before(deadline), "ssh to the dind never became usable")
+		time.Sleep(time.Second)
+	}
+}
+
+// The whole point: a context whose host is ssh:// must produce a working client.
+// Before the fix this failed at the ping, because the SDK TCP-dialled the URL.
+func TestSSHContextReachesTheDaemon(t *testing.T) {
+	if _, err := exec.LookPath("ssh"); err != nil {
+		t.Skip("ssh client not available")
+	}
+
+	home := isolateHome(t)
+	pub := writeSSHConfig(t, home)
+	startSSHDind(t, pub)
+
+	out, err := hostDocker(t, "context", "create", sshContext,
+		"--docker", "host=ssh://root@localhost:"+sshHostPort)
+	require.NoErrorf(t, err, "creating ssh context: %s", out)
+	t.Cleanup(func() {
+		docker.ResetClient()
+		_ = exec.Command("docker", "context", "rm", "-f", sshContext).Run()
+	})
+
+	// ClientFor pings, so a successful return IS the assertion that the transport
+	// works — that ping is exactly what failed before the fix.
+	cli, err := docker.ClientFor(sshContext)
+	require.NoError(t, err, "ClientFor over ssh:// must succeed")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// And a real API call must return this daemon's state, not something cached
+	// from an ambient context.
+	info, err := cli.Info(ctx)
+	require.NoError(t, err)
+	require.True(t, info.Swarm.ControlAvailable, "should be talking to the dind's swarm manager")
+}
+
+// A ssh:// host that cannot be reached must fail as a connection error rather
+// than hanging or reporting something unrelated to ssh.
+func TestUnreachableSSHHostFailsCleanly(t *testing.T) {
+	if _, err := exec.LookPath("ssh"); err != nil {
+		t.Skip("ssh client not available")
+	}
+
+	home := isolateHome(t)
+	_ = writeSSHConfig(t, home)
+
+	const badContext = "swarmcli-ssh-unreachable"
+	out, err := hostDocker(t, "context", "create", badContext,
+		// Port 1 has nothing on it; ConnectTimeout comes from connhelper.
+		"--docker", "host=ssh://root@127.0.0.1:1")
+	require.NoErrorf(t, err, "creating context: %s", out)
+	t.Cleanup(func() {
+		docker.ResetClient()
+		_ = exec.Command("docker", "context", "rm", "-f", badContext).Run()
+	})
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := docker.ClientFor(badContext)
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		require.Error(t, err, "an unreachable ssh host must not report success")
+	case <-time.After(90 * time.Second):
+		t.Fatal("ClientFor hung on an unreachable ssh host")
+	}
+}


### PR DESCRIPTION
#487 (explicit Docker context) and #493 (ssh:// contexts) both shipped with unit tests only. Not an oversight — each needs infrastructure the suite did not have: **two independent swarms**, and an **ssh endpoint fronting a daemon**. They were the two items on the v1.13.0 test plan (#497 §5.1, §7.1) that could only be checked by hand.

Both turn out to be buildable from a pattern the repo already has: `integration-tests/swarmlock` starts a throwaway `docker:29-dind` on its own port, registers its own context, and tears both down.

## `multiswarm` — #487

Runs under the existing `integration` tag, so `testenv.sh test` picks it up with **no workflow change**. Swarm A is the shared multi-node swarm (context `swarmcli`); swarm B is a throwaway dind on port 24375 (distinct from 22375 and swarmlock's 23375).

Two things it deliberately does, because the weaker versions would be worthless:

- **Asserts isolation in both directions.** A's release visible from A and *not* from B, and B's from B and *not* from A. Checking one direction would pass against a backend that always read swarm A — which is exactly the bug.
- **Uses two real swarms, not two contexts on one daemon.** The latter would pass against a backend that ignored the context name entirely.

`TestDeployLandsOnTheNamedSwarm` covers the other half separately: the deploy path shells out to `docker --context <name> stack deploy`, a different mechanism from the SDK reads, so it asks swarm B's own daemon directly — bypassing swarmcli — and then asserts the stack is *absent* from A.

This is the seam #469 nearly shipped as a 2-of-15-methods fix. A test that only exercised the SDK reads, or only the deploy, would have gone green on that version.

## `sshcontext` — #493

Own `integration_ssh` tag and own job, mirroring locked-swarm. It provisions `openssh-server` inside a dind, authorises a generated key, and points a context at `ssh://root@localhost:22222`.

**It redirects `HOME` to a temp dir**, which does two things: scopes both the ssh client config and the Docker context store to the test, and — more interesting — makes this a genuine test of `~/.ssh/config` handling. `connhelper.GetConnectionHelper` shells out to the system `ssh` with no options of its own, so the identity file, port and host-key policy can *only* come from that config. A hand-rolled dialer would have ignored all of it, and ssh_config parity is precisely what justified taking the dependency in #493.

That HOME rewrite is also why it cannot ride along in the regular integration job: those tests share one HOME, and moving the context store mid-run would break them. Stated in a comment on the job.

The assertion is `docker.ClientFor` succeeding — it pings, and **that ping is what failed before the fix**. Then `cli.Info` must report a swarm manager, so it is reading this daemon rather than something ambient. A second test asserts an unreachable ssh host errors rather than hanging, guarded by a timeout so a regression to a hang fails loudly instead of eating the job's 20 minutes.

## What I could not verify

**Neither test has ever run.** There is no Docker daemon in this environment, so CI is the first execution. `gofmt`, `go vet` under both tags, `go test -race ./...` and `golangci-lint --build-tags=integration` (0 issues) all pass, and the workflow YAML parses with the expected four jobs — but that is compile-and-lint confidence, not behavioural.

The sshd bring-up is the part most likely to need a round of iteration: `apk add` needs network, and sshd takes a moment to bind. It polls the real transport (`ssh … docker version`, the same command the helper runs) rather than sleeping, but I would not be surprised to have to tune it.
