### PR TITLE
charts: let a caller supply the owner id and values reader PlanApply uses

### DIFF
--- a/charts/README.md
+++ b/charts/README.md
@@ -111,7 +111,9 @@ for it to count. A bare owner string cannot tell a release this file installed
 from a copy of one — ArgoCD shipped exactly that as `app.kubernetes.io/instance`
 and replaced it in 3.0 for the same reason. The `apply/` prefix keeps a manifest
 applied from the command line from colliding with a controller that happened to
-pick the same name.
+pick the same name. The controller is the other side of that: a library consumer
+passes its own id as `PlanOptions.Owner` and plans against it instead, so the
+releases it installed under `cd/<app>` read back as its own.
 
 `owner:` is optional and has **no default**. A derived one would either change
 between a laptop and a CI checkout (a path hash) or be shared by every repository

--- a/charts/apply.go
+++ b/charts/apply.go
@@ -45,9 +45,14 @@ type ReleasePlan struct {
 
 // Plan is what apply would do to the whole swarm.
 type Plan struct {
-	// Owner is the owner id this plan was classified against, from the release
-	// file's `owner:` key. Empty when the file declares none, in which case
-	// nothing on the swarm is claimable and Orphaned is always empty.
+	// Owner is the owner id this plan was classified against: PlanOptions.Owner
+	// when the caller supplied one, otherwise "apply/" and the release file's
+	// `owner:` key. Empty when neither names an owner, in which case nothing on
+	// the swarm is claimable and Orphaned is always empty.
+	//
+	// It is also the id Apply should stamp on what it writes — pass it as
+	// InstallOptions.Owner — so that the next plan recognises these releases as
+	// its own rather than as somebody else's.
 	Owner string `json:"owner,omitempty"`
 	// Releases, in file order.
 	Releases []ReleasePlan `json:"releases"`
@@ -77,13 +82,49 @@ func (p *Plan) Counts() (install, upgrade, unchanged int) {
 	return install, upgrade, unchanged
 }
 
+// PlanOptions tune planning. The zero value is what `swarmcli charts apply`
+// uses, and reproduces the behaviour of every release before these existed.
+type PlanOptions struct {
+	// Owner is the owner id the plan classifies deployed releases against,
+	// overriding the "apply/<owner>" the release file would imply. A controller
+	// installs under an id of its own — InstallOptions.Owner documents "cd/edge"
+	// — and without this its own releases fail the ownership check and report as
+	// Unmanaged from the first reconcile.
+	//
+	// Empty derives the id from the release file, which is what keeps a manifest
+	// applied from the command line and a controller that happened to pick the
+	// same name from claiming each other's releases. Set, it replaces that
+	// derivation entirely: the file's `owner:` key is not consulted.
+	Owner string
+	// ReadFile reads one values file named by the release file, by the resolved
+	// path ReleaseFile.ValuesPaths produced. Nil is os.ReadFile.
+	//
+	// It exists so that a caller can see and transform the bytes between "this
+	// path was named" and "these values were merged" — decrypting a values file
+	// committed encrypted, or serving it from a git object rather than a local
+	// path at all — without the material having to reach a filesystem first.
+	ReadFile func(path string) ([]byte, error)
+}
+
 // PlanApply computes what Apply would do, without writing anything.
 //
 // Every release is resolved, merged, schema-validated and rendered BEFORE any of
 // them is deployed. A bad value in the third release therefore aborts the whole
 // apply instead of leaving the swarm half-converged — and `--dry-run` is just
 // "stop after planning".
-func (e *Engine) PlanApply(ctx context.Context, rf *ReleaseFile, src ChartSource) (*Plan, error) {
+func (e *Engine) PlanApply(ctx context.Context, rf *ReleaseFile, src ChartSource, opts PlanOptions) (*Plan, error) {
+	owner := rf.ownerID()
+	if opts.Owner != "" {
+		if err := validateOwnerID(opts.Owner); err != nil {
+			return nil, err
+		}
+		owner = opts.Owner
+	}
+	read := opts.ReadFile
+	if read == nil {
+		read = os.ReadFile
+	}
+
 	current, err := e.List(ctx)
 	if err != nil {
 		return nil, err
@@ -93,13 +134,13 @@ func (e *Engine) PlanApply(ctx context.Context, rf *ReleaseFile, src ChartSource
 		deployed[rel.Name] = rel
 	}
 
-	plan := &Plan{Owner: rf.ownerID()}
+	plan := &Plan{Owner: owner}
 	managed := map[string]bool{}
 
 	for _, spec := range rf.Releases {
 		managed[spec.Name] = true
 
-		rp, err := e.planRelease(rf, spec, src, deployed)
+		rp, err := e.planRelease(rf, spec, src, deployed, read)
 		if err != nil {
 			return nil, err
 		}
@@ -134,7 +175,7 @@ func ownedBy(rel Release, id string) bool {
 	return own == OwnerRef{ID: id, Kind: OwnerKindRelease, Name: rel.Name}
 }
 
-func (e *Engine) planRelease(rf *ReleaseFile, spec ReleaseSpec, src ChartSource, deployed map[string]Release) (ReleasePlan, error) {
+func (e *Engine) planRelease(rf *ReleaseFile, spec ReleaseSpec, src ChartSource, deployed map[string]Release, read func(string) ([]byte, error)) (ReleasePlan, error) {
 	ref := rf.ChartRef(spec)
 
 	ch, err := src.Load(ref, spec.Version)
@@ -143,7 +184,7 @@ func (e *Engine) planRelease(rf *ReleaseFile, spec ReleaseSpec, src ChartSource,
 	}
 	compat := CheckCompat(ch.Metadata)
 
-	files, err := readFiles(rf.ValuesPaths(spec))
+	files, err := readFiles(rf.ValuesPaths(spec), read)
 	if err != nil {
 		return ReleasePlan{}, fmt.Errorf("%s: release %q: %w", rf.Path, spec.Name, err)
 	}
@@ -306,10 +347,10 @@ func canonicalValues(v map[string]any) (string, error) {
 	return string(second), nil
 }
 
-func readFiles(paths []string) ([][]byte, error) {
+func readFiles(paths []string, read func(string) ([]byte, error)) ([][]byte, error) {
 	var out [][]byte
 	for _, p := range paths {
-		b, err := os.ReadFile(p)
+		b, err := read(p)
 		if err != nil {
 			return nil, fmt.Errorf("read values file %q: %w", p, err)
 		}

--- a/charts/apply_test.go
+++ b/charts/apply_test.go
@@ -5,6 +5,7 @@ package charts
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -79,7 +80,7 @@ func TestPlanApplyRecordsCompatFinding(t *testing.T) {
 	ch.Metadata.SwarmcliVersion = ">= 1.13.0"
 	src.charts["swarmcli-charts/demo@0.1.0"] = ch
 
-	plan, err := e.PlanApply(context.Background(), rf, src)
+	plan, err := e.PlanApply(context.Background(), rf, src, PlanOptions{})
 	require.NoError(t, err, "an incompatible chart must still plan; refusing is the caller's call")
 	require.Len(t, plan.Releases, 1)
 	require.Equal(t, ActionInstall, plan.Releases[0].Action)
@@ -99,7 +100,7 @@ func TestPlanApplyRenderErrorNamesTheEngineRequirement(t *testing.T) {
 	broken.Templates = map[string]string{"templates/stack.yaml": "{{ toYamlPretty .Values }}"}
 	src.charts["swarmcli-charts/demo@0.1.0"] = broken
 
-	_, err := e.PlanApply(context.Background(), rf, src)
+	_, err := e.PlanApply(context.Background(), rf, src, PlanOptions{})
 	require.Error(t, err)
 	require.ErrorContains(t, err, "toYamlPretty", "the underlying failure must survive")
 	require.ErrorContains(t, err, "requires swarmcli >= 1.13.0", "and be diagnosed")
@@ -116,7 +117,7 @@ func TestPlanApplyRenderErrorUnannotatedWhenNothingDeclared(t *testing.T) {
 	broken.Templates = map[string]string{"templates/stack.yaml": "{{ toYamlPretty .Values }}"}
 	src.charts["swarmcli-charts/demo@0.1.0"] = broken
 
-	_, err := e.PlanApply(context.Background(), rf, src)
+	_, err := e.PlanApply(context.Background(), rf, src, PlanOptions{})
 	require.Error(t, err)
 	require.ErrorContains(t, err, "toYamlPretty")
 	require.NotContains(t, err.Error(), "likely a consequence")
@@ -126,7 +127,7 @@ func TestApplyInstallsThenIsIdempotent(t *testing.T) {
 	e, fb, src, rf := applyEnv(t, oneRelease, "0.1.0")
 	ctx := context.Background()
 
-	plan, err := e.PlanApply(ctx, rf, src)
+	plan, err := e.PlanApply(ctx, rf, src, PlanOptions{})
 	require.NoError(t, err)
 	require.Len(t, plan.Releases, 1)
 	require.Equal(t, ActionInstall, plan.Releases[0].Action)
@@ -142,7 +143,7 @@ func TestApplyInstallsThenIsIdempotent(t *testing.T) {
 	// write nothing at all. Do not delete this test.
 	before := len(fb.configs)
 
-	plan2, err := e.PlanApply(ctx, rf, src)
+	plan2, err := e.PlanApply(ctx, rf, src, PlanOptions{})
 	require.NoError(t, err)
 	require.Equal(t, ActionUnchanged, plan2.Releases[0].Action)
 
@@ -157,7 +158,7 @@ func TestApplyUpgradesOnVersionBump(t *testing.T) {
 	e, _, src, rf := applyEnv(t, oneRelease, "0.1.0")
 	ctx := context.Background()
 
-	plan, err := e.PlanApply(ctx, rf, src)
+	plan, err := e.PlanApply(ctx, rf, src, PlanOptions{})
 	require.NoError(t, err)
 	_, err = e.Apply(ctx, plan, InstallOptions{})
 	require.NoError(t, err)
@@ -169,7 +170,7 @@ func TestApplyUpgradesOnVersionBump(t *testing.T) {
 	}
 	src.charts["swarmcli-charts/demo@0.2.0"] = demoChart(t, "0.2.0")
 
-	plan2, err := e.PlanApply(ctx, bumped, src)
+	plan2, err := e.PlanApply(ctx, bumped, src, PlanOptions{})
 	require.NoError(t, err)
 	require.Equal(t, ActionUpgrade, plan2.Releases[0].Action)
 	require.Equal(t, "0.1.0", plan2.Releases[0].FromVersion)
@@ -191,7 +192,7 @@ func TestApplyDetectsValuesOnlyChange(t *testing.T) {
 	e, _, src, rf := applyEnv(t, oneRelease, "0.1.0")
 	ctx := context.Background()
 
-	plan, err := e.PlanApply(ctx, rf, src)
+	plan, err := e.PlanApply(ctx, rf, src, PlanOptions{})
 	require.NoError(t, err)
 	_, err = e.Apply(ctx, plan, InstallOptions{})
 	require.NoError(t, err)
@@ -206,7 +207,7 @@ func TestApplyDetectsValuesOnlyChange(t *testing.T) {
 		}},
 	}
 
-	plan2, err := e.PlanApply(ctx, withValues, src)
+	plan2, err := e.PlanApply(ctx, withValues, src, PlanOptions{})
 	require.NoError(t, err)
 	require.Equal(t, ActionUpgrade, plan2.Releases[0].Action)
 }
@@ -249,7 +250,7 @@ func TestApplyNeverRemovesUnmanagedReleases(t *testing.T) {
 	_, err := e.Install(ctx, "legacy", ReleaseChartOf(ch), ch.Values, "services: {}\n", InstallOptions{})
 	require.NoError(t, err)
 
-	plan, err := e.PlanApply(ctx, rf, src)
+	plan, err := e.PlanApply(ctx, rf, src, PlanOptions{})
 	require.NoError(t, err)
 	require.Equal(t, []string{"legacy"}, plan.Unmanaged)
 
@@ -272,7 +273,7 @@ func TestPlanApplyValidatesEverythingBeforeDeployingAnything(t *testing.T) {
 `
 	e, fb, src, rf := applyEnv(t, body, "0.1.0")
 
-	_, err := e.PlanApply(context.Background(), rf, src)
+	_, err := e.PlanApply(context.Background(), rf, src, PlanOptions{})
 	require.ErrorContains(t, err, "bad")
 	require.Empty(t, fb.deployed, "the first release must not deploy when a later one fails to plan")
 }
@@ -290,7 +291,7 @@ func TestApplyFailsFastAndReportsPartialProgress(t *testing.T) {
 	e, fb, src, rf := applyEnv(t, body, "0.1.0")
 	ctx := context.Background()
 
-	plan, err := e.PlanApply(ctx, rf, src)
+	plan, err := e.PlanApply(ctx, rf, src, PlanOptions{})
 	require.NoError(t, err)
 
 	fb.failNext = true // first DeployStack fails
@@ -307,7 +308,7 @@ func TestApplyToleratesReleaseAppearingAfterPlan(t *testing.T) {
 	e, fb, src, rf := applyEnv(t, oneRelease, "0.1.0")
 	ctx := context.Background()
 
-	plan, err := e.PlanApply(ctx, rf, src)
+	plan, err := e.PlanApply(ctx, rf, src, PlanOptions{})
 	require.NoError(t, err)
 	require.Equal(t, ActionInstall, plan.Releases[0].Action)
 
@@ -376,7 +377,7 @@ func TestPlanApplyAgainstARealRepository(t *testing.T) {
 	require.NoError(t, fresh.EnsureRepos(rf.Repositories))
 
 	e := NewEngineWith(newFakeBackend())
-	plan, err := e.PlanApply(context.Background(), rf, NewChartSource(fresh))
+	plan, err := e.PlanApply(context.Background(), rf, NewChartSource(fresh), PlanOptions{})
 	require.NoError(t, err)
 	require.Len(t, plan.Releases, 1)
 	require.Equal(t, ActionInstall, plan.Releases[0].Action)
@@ -394,7 +395,7 @@ func TestPlanApplyReinstallsAnUninstalledRelease(t *testing.T) {
 	e, fb, src, rf := applyEnv(t, oneRelease, "0.1.0")
 	ctx := context.Background()
 
-	plan, err := e.PlanApply(ctx, rf, src)
+	plan, err := e.PlanApply(ctx, rf, src, PlanOptions{})
 	require.NoError(t, err)
 	_, err = e.Apply(ctx, plan, InstallOptions{})
 	require.NoError(t, err)
@@ -403,7 +404,7 @@ func TestPlanApplyReinstallsAnUninstalledRelease(t *testing.T) {
 	require.NoError(t, err)
 	require.NotContains(t, fb.deployed, "hello")
 
-	plan2, err := e.PlanApply(ctx, rf, src)
+	plan2, err := e.PlanApply(ctx, rf, src, PlanOptions{})
 	require.NoError(t, err)
 	require.Equal(t, ActionInstall, plan2.Releases[0].Action,
 		"an uninstalled release must be reinstalled, not reported unchanged")
@@ -420,7 +421,7 @@ func TestPlanApplyDetectsManifestOnlyChange(t *testing.T) {
 	e, _, src, rf := applyEnv(t, oneRelease, "0.1.0")
 	ctx := context.Background()
 
-	plan, err := e.PlanApply(ctx, rf, src)
+	plan, err := e.PlanApply(ctx, rf, src, PlanOptions{})
 	require.NoError(t, err)
 	_, err = e.Apply(ctx, plan, InstallOptions{})
 	require.NoError(t, err)
@@ -433,7 +434,7 @@ func TestPlanApplyDetectsManifestOnlyChange(t *testing.T) {
 	edited.Templates["stack.yaml"] += "    stop_grace_period: 42s\n"
 	src.charts["swarmcli-charts/demo@0.1.0"] = edited
 
-	plan2, err := e.PlanApply(ctx, rf, src)
+	plan2, err := e.PlanApply(ctx, rf, src, PlanOptions{})
 	require.NoError(t, err)
 	require.Equal(t, ActionUpgrade, plan2.Releases[0].Action)
 }
@@ -449,7 +450,7 @@ func TestPlanApplyMissingValuesFileFailsBeforeDeploying(t *testing.T) {
 `
 	e, fb, src, rf := applyEnv(t, body, "0.1.0")
 
-	_, err := e.PlanApply(context.Background(), rf, src)
+	_, err := e.PlanApply(context.Background(), rf, src, PlanOptions{})
 	require.ErrorContains(t, err, "absent.yaml")
 	require.ErrorContains(t, err, "hello")
 	require.Empty(t, fb.deployed)
@@ -462,7 +463,7 @@ func TestPlanApplyErrorsNameTheFileAndRelease(t *testing.T) {
 
 	// A chart version the source cannot serve.
 	rf.Releases[0].Version = "9.9.9"
-	_, err := e.PlanApply(context.Background(), rf, src)
+	_, err := e.PlanApply(context.Background(), rf, src, PlanOptions{})
 	require.ErrorContains(t, err, rf.Path)
 	require.ErrorContains(t, err, `release "hello"`)
 }
@@ -477,7 +478,7 @@ func TestPlanApplyRejectsSchemaViolationBeforeDeploying(t *testing.T) {
 	require.NoError(t, os.WriteFile(bad, []byte("replicas: 0\n"), 0o600)) // schema: minimum 1
 	rf.Releases[0].Values = []string{"./bad.yaml"}
 
-	_, err := e.PlanApply(context.Background(), rf, src)
+	_, err := e.PlanApply(context.Background(), rf, src, PlanOptions{})
 	require.Error(t, err)
 	require.ErrorContains(t, err, rf.Path)
 	require.ErrorContains(t, err, `release "hello"`)
@@ -490,7 +491,7 @@ func TestPlanApplyDetectsChartNameChange(t *testing.T) {
 	e, _, src, rf := applyEnv(t, oneRelease, "0.1.0")
 	ctx := context.Background()
 
-	plan, err := e.PlanApply(ctx, rf, src)
+	plan, err := e.PlanApply(ctx, rf, src, PlanOptions{})
 	require.NoError(t, err)
 	_, err = e.Apply(ctx, plan, InstallOptions{})
 	require.NoError(t, err)
@@ -500,7 +501,7 @@ func TestPlanApplyDetectsChartNameChange(t *testing.T) {
 	src.charts["swarmcli-charts/other@0.1.0"] = other
 	rf.Releases[0].Chart = "swarmcli-charts/other"
 
-	plan2, err := e.PlanApply(ctx, rf, src)
+	plan2, err := e.PlanApply(ctx, rf, src, PlanOptions{})
 	require.NoError(t, err)
 	require.Equal(t, ActionUpgrade, plan2.Releases[0].Action)
 }
@@ -544,7 +545,7 @@ func TestPlanApplySeparatesItsOwnOrphansFromUnmanagedReleases(t *testing.T) {
 	storeRelease(t, fb, Release{Name: "theirs", Revision: 1, Status: StatusDeployed, Owner: "apply/other-swarm:release/theirs"})
 	storeRelease(t, fb, Release{Name: "byhand", Revision: 1, Status: StatusDeployed})
 
-	plan, err := e.PlanApply(ctx, rf, src)
+	plan, err := e.PlanApply(ctx, rf, src, PlanOptions{})
 	require.NoError(t, err)
 	require.Equal(t, "apply/prod-swarm", plan.Owner)
 	require.Equal(t, []string{"ours"}, plan.Orphaned)
@@ -564,7 +565,7 @@ func TestPlanApplyIgnoresAStampNamingAnotherRelease(t *testing.T) {
 	// Right owner, unparseable stamp.
 	storeRelease(t, fb, Release{Name: "garbled", Revision: 1, Status: StatusDeployed, Owner: "apply/prod-swarm"})
 
-	plan, err := e.PlanApply(context.Background(), rf, src)
+	plan, err := e.PlanApply(context.Background(), rf, src, PlanOptions{})
 	require.NoError(t, err)
 	require.Empty(t, plan.Orphaned, "an unverifiable stamp is not ownership")
 	require.ElementsMatch(t, []string{"copy", "garbled"}, plan.Unmanaged)
@@ -578,7 +579,7 @@ func TestPlanApplyWithoutAnOwnerClaimsNothing(t *testing.T) {
 
 	storeRelease(t, fb, Release{Name: "stamped", Revision: 1, Status: StatusDeployed, Owner: "apply/prod-swarm:release/stamped"})
 
-	plan, err := e.PlanApply(context.Background(), rf, src)
+	plan, err := e.PlanApply(context.Background(), rf, src, PlanOptions{})
 	require.NoError(t, err)
 	require.Empty(t, plan.Owner)
 	require.Empty(t, plan.Orphaned)
@@ -591,7 +592,7 @@ func TestApplyStampsTheOwnerItPlannedWith(t *testing.T) {
 	e, _, src, rf := applyEnv(t, ownedRelease, "0.1.0")
 	ctx := context.Background()
 
-	plan, err := e.PlanApply(ctx, rf, src)
+	plan, err := e.PlanApply(ctx, rf, src, PlanOptions{})
 	require.NoError(t, err)
 	_, err = e.Apply(ctx, plan, InstallOptions{Owner: plan.Owner})
 	require.NoError(t, err)
@@ -608,7 +609,7 @@ releases:
     chart: swarmcli-charts/demo
     version: "0.1.0"
 `, "0.1.0")
-	plan2, err := e.PlanApply(ctx, rf2, src2)
+	plan2, err := e.PlanApply(ctx, rf2, src2, PlanOptions{})
 	require.NoError(t, err)
 	require.Equal(t, []string{"hello"}, plan2.Orphaned)
 }
@@ -624,7 +625,7 @@ func TestApplyDoesNotRemoveItsOwnOrphans(t *testing.T) {
 		InstallOptions{Owner: "apply/prod-swarm"})
 	require.NoError(t, err)
 
-	plan, err := e.PlanApply(ctx, rf, src)
+	plan, err := e.PlanApply(ctx, rf, src, PlanOptions{})
 	require.NoError(t, err)
 	require.Equal(t, []string{"obsolete"}, plan.Orphaned)
 
@@ -632,4 +633,102 @@ func TestApplyDoesNotRemoveItsOwnOrphans(t *testing.T) {
 	require.NoError(t, err)
 	require.Contains(t, fb.deployed, "obsolete")
 	require.Contains(t, fb.configs, "swarmcli.release.obsolete.v1")
+}
+
+// A controller installs under an id of its own — "cd/<app>" — and must be able to
+// plan against that same id. Deriving "apply/<owner>" from the file regardless
+// classified the controller's own releases as Unmanaged from the first reconcile:
+// "I do not recognise this", about releases this exact caller installed.
+func TestPlanApplyClassifiesAgainstTheOwnerTheCallerSupplied(t *testing.T) {
+	e, fb, src, rf := applyEnv(t, ownedRelease, "0.1.0")
+	ctx := context.Background()
+
+	storeRelease(t, fb, Release{Name: "ours", Revision: 1, Status: StatusDeployed, Owner: "cd/edge:release/ours"})
+	// What the file would have claimed, had the caller not overridden it.
+	storeRelease(t, fb, Release{Name: "theirs", Revision: 1, Status: StatusDeployed, Owner: "apply/prod-swarm:release/theirs"})
+
+	plan, err := e.PlanApply(ctx, rf, src, PlanOptions{Owner: "cd/edge"})
+	require.NoError(t, err)
+	require.Equal(t, "cd/edge", plan.Owner)
+	require.Equal(t, []string{"ours"}, plan.Orphaned)
+	require.Equal(t, []string{"theirs"}, plan.Unmanaged,
+		"the file's own owner must not keep claiming once a caller has supplied one")
+}
+
+// The supplied id goes on to be stamped through Plan.Owner, so a plan and the
+// apply that follows it agree — the whole point of classifying against it.
+func TestPlanApplyRoundTripsTheSuppliedOwnerThroughApply(t *testing.T) {
+	e, _, src, rf := applyEnv(t, oneRelease, "0.1.0")
+	ctx := context.Background()
+
+	plan, err := e.PlanApply(ctx, rf, src, PlanOptions{Owner: "cd/edge"})
+	require.NoError(t, err)
+	_, err = e.Apply(ctx, plan, InstallOptions{Owner: plan.Owner})
+	require.NoError(t, err)
+
+	// Drop it from the file; the next plan recognises its own work as an orphan
+	// rather than as a stranger, which is what makes a later prune safe.
+	_, _, src2, rf2 := applyEnv(t, `releases:
+  - name: other
+    chart: swarmcli-charts/demo
+    version: "0.1.0"
+`, "0.1.0")
+	plan2, err := e.PlanApply(ctx, rf2, src2, PlanOptions{Owner: "cd/edge"})
+	require.NoError(t, err)
+	require.Equal(t, []string{"hello"}, plan2.Orphaned)
+}
+
+// ":" separates the id from the resource half, so an id containing one would
+// decode as a different owner than it was written as. Install rejects it; so must
+// planning, and before reading anything off the swarm.
+func TestPlanApplyRejectsAnOwnerThatWouldNotSurviveTheEncoding(t *testing.T) {
+	e, _, src, rf := applyEnv(t, oneRelease, "0.1.0")
+
+	_, err := e.PlanApply(context.Background(), rf, src, PlanOptions{Owner: "cd:edge"})
+	require.ErrorContains(t, err, "must not contain ':'")
+}
+
+// The reader sees the bytes between "this path was named" and "these values were
+// merged", which is where a values file committed encrypted becomes plaintext
+// without ever reaching the controller's filesystem.
+func TestPlanApplyMergesValuesThroughTheSuppliedReader(t *testing.T) {
+	body := `releases:
+  - name: hello
+    chart: swarmcli-charts/demo
+    version: "0.1.0"
+    values: [./secret.yaml]
+`
+	e, _, src, rf := applyEnv(t, body, "0.1.0")
+	require.NoError(t, os.WriteFile(filepath.Join(rf.Dir, "secret.yaml"), []byte("ciphertext\n"), 0o600))
+
+	var seen []string
+	plan, err := e.PlanApply(context.Background(), rf, src, PlanOptions{
+		ReadFile: func(path string) ([]byte, error) {
+			seen = append(seen, path)
+			return []byte("injected: 1\n"), nil
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, []string{filepath.Join(rf.Dir, "secret.yaml")}, seen,
+		"the reader is given the resolved path, so it can decide by name")
+	require.Equal(t, 1, plan.Releases[0].Values["injected"])
+}
+
+// A reader that fails aborts the whole plan, exactly as an unreadable file does:
+// nothing is deployed on the strength of values that could not be resolved.
+func TestPlanApplyReaderErrorFailsBeforeDeploying(t *testing.T) {
+	body := `releases:
+  - name: hello
+    chart: swarmcli-charts/demo
+    version: "0.1.0"
+    values: [./secret.yaml]
+`
+	e, fb, src, rf := applyEnv(t, body, "0.1.0")
+
+	_, err := e.PlanApply(context.Background(), rf, src, PlanOptions{
+		ReadFile: func(string) ([]byte, error) { return nil, errors.New("no decryption key") },
+	})
+	require.ErrorContains(t, err, "no decryption key")
+	require.ErrorContains(t, err, "hello")
+	require.Empty(t, fb.deployed)
 }

--- a/cli/apply.go
+++ b/cli/apply.go
@@ -42,7 +42,7 @@ func chartsApply(args []string) int {
 	}
 
 	e := charts.NewEngine()
-	plan, err := e.PlanApply(context.Background(), rf, charts.NewChartSource(store))
+	plan, err := e.PlanApply(context.Background(), rf, charts.NewChartSource(store), charts.PlanOptions{})
 	if err != nil {
 		return fail(err)
 	}

--- a/integration-tests/charts/charts_apply_test.go
+++ b/integration-tests/charts/charts_apply_test.go
@@ -53,7 +53,7 @@ func TestChartsApplyIsIdempotentAgainstARealSwarm(t *testing.T) {
 	opts := charts.InstallOptions{Wait: true, Timeout: 90 * time.Second}
 
 	// First apply installs.
-	plan, err := eng.PlanApply(ctx, rf, src)
+	plan, err := eng.PlanApply(ctx, rf, src, charts.PlanOptions{})
 	require.NoError(t, err)
 	require.Len(t, plan.Releases, 1)
 	require.Equal(t, charts.ActionInstall, plan.Releases[0].Action)
@@ -68,7 +68,7 @@ func TestChartsApplyIsIdempotentAgainstARealSwarm(t *testing.T) {
 
 	// Second apply, nothing changed: it must plan `unchanged`, deploy nothing, and
 	// record NO new revision.
-	plan2, err := eng.PlanApply(ctx, rf, src)
+	plan2, err := eng.PlanApply(ctx, rf, src, charts.PlanOptions{})
 	require.NoError(t, err)
 	require.Equal(t, charts.ActionUnchanged, plan2.Releases[0].Action)
 
@@ -88,7 +88,7 @@ func TestChartsApplyIsIdempotentAgainstARealSwarm(t *testing.T) {
 
 	rf2, err := charts.LoadReleaseFile(relFile)
 	require.NoError(t, err)
-	plan3, err := eng.PlanApply(ctx, rf2, src)
+	plan3, err := eng.PlanApply(ctx, rf2, src, charts.PlanOptions{})
 	require.NoError(t, err)
 	require.Equal(t, charts.ActionUpgrade, plan3.Releases[0].Action)
 
@@ -140,7 +140,7 @@ func TestChartsApplyLeavesUnmanagedReleasesRunning(t *testing.T) {
 	rf, err := charts.LoadReleaseFile(relFile)
 	require.NoError(t, err)
 
-	plan, err := eng.PlanApply(ctx, rf, src)
+	plan, err := eng.PlanApply(ctx, rf, src, charts.PlanOptions{})
 	require.NoError(t, err)
 	require.Contains(t, plan.Unmanaged, byHand, "the hand-installed release must be reported")
 
@@ -192,7 +192,7 @@ func TestChartsApplyDiffDoesNotDeploy(t *testing.T) {
 	// simply testing a broken path.
 	rf, err := charts.LoadReleaseFile(relFile)
 	require.NoError(t, err)
-	plan, err := eng.PlanApply(ctx, rf, charts.NewChartSource(nil))
+	plan, err := eng.PlanApply(ctx, rf, charts.NewChartSource(nil), charts.PlanOptions{})
 	require.NoError(t, err)
 	_, err = eng.Apply(ctx, plan, charts.InstallOptions{Wait: true, Timeout: 90 * time.Second})
 	require.NoError(t, err)


### PR DESCRIPTION
`PlanApply` derived the owner id it classifies against from the release file, always as `apply/<owner>`, and read values files itself through an unexported `readFiles`. Both are right for `swarmcli charts apply`; both lock out a library consumer.

## What was wrong

**#499** — a controller stamps its releases with an id of its own (`InstallOptions.Owner` documents `cd/edge`), but `ownedBy` requires *both* halves of the stamp to match, so on the next plan its own releases failed the check and reported as **Unmanaged** — "I do not recognise this", about releases that exact caller installed. Wrong from the first reconcile, and load-bearing beyond reporting: the orphan/unmanaged split is what separates provably obsolete from merely unrecognised, and only the first is ever safe to delete.

**#501** — with no way in, a consumer that must transform a values file's bytes (one committed encrypted) has to decrypt it, write the plaintext to a scratch directory and repoint the release file at the copy. Decrypted material reaches the filesystem purely because there was nowhere to hand the engine bytes.

## What this does

One `PlanOptions` struct carrying both, since both are plan-time inputs and `ReadFile` is called only from `planRelease`. It follows the existing `InstallOptions` shape rather than introducing functional options, which appear nowhere in this codebase.

```go
plan, err := e.PlanApply(ctx, rf, src, charts.PlanOptions{
    Owner:    "cd/" + app,
    ReadFile: provider.ReadFile,
})
```

- The **zero value is today's behaviour**: `swarmcli charts apply` passes `PlanOptions{}` and keeps deriving `apply/<owner>` from the file; a file with no `owner:` still claims nothing.
- A supplied owner **replaces** that derivation entirely — the file's `owner:` is not consulted — and is validated with the same rule an installed one is (`:` would decode as a different owner), before anything is read off the swarm.
- `Plan.Owner` carries it on to `Apply` through `InstallOptions.Owner`, exactly as the CLI already does, so a plan and the apply that follows it cannot disagree about who owns what.

## On the label

`C0-breaks-nothing` despite the signature change: `charts/apply.go` landed after `v1.12.0` and exists only in `v1.13.0-rc1…rc4`, so `PlanApply` has never appeared in a GA tag and no released API changes. Labelling it `C1` would force a `v2.0.0` for a function no GA consumer can have. Updated call sites: `cli/apply.go` and the tests.

Closes #499
Closes #501