### PR TITLE
charts: export the convergence predicate over []ServiceState

### DIFF
--- a/charts/release.go
+++ b/charts/release.go
@@ -913,16 +913,10 @@ func (e *Engine) waitReady(release string, timeout time.Duration) error {
 	}
 	deadline := e.now().Add(timeout)
 	for {
-		states := e.Backend.StackServices(release)
-		if err := rolloutWedged(states); err != nil {
-			return fmt.Errorf("release %q: %w", release, err)
-		}
-		// Parity is necessary but not sufficient: a task that starts and then
-		// dies inside the monitor window is a rollout failure, so hold until
-		// swarm's own window has closed. Losing parity needs no special case —
-		// the replacement task is newer, so the window it has left grows back on
-		// its own.
-		if len(states) > 0 && allConverged(states) && stabilityRemaining(states) <= 0 {
+		switch c := Rollup(e.Backend.StackServices(release)); c.Phase {
+		case PhaseWedged:
+			return fmt.Errorf("release %q: %s", release, c.Reason)
+		case PhaseConverged:
 			return nil
 		}
 		if !e.now().Before(deadline) {
@@ -932,9 +926,74 @@ func (e *Engine) waitReady(release string, timeout time.Duration) error {
 	}
 }
 
-// stabilityRemaining is how much of the monitor window is still outstanding
-// across the release's services — the slowest governs, and <= 0 means every
-// service has held parity for as long as swarm itself would watch.
+// Phase is how far a rollout has got.
+type Phase string
+
+const (
+	// PhaseConverged means every task is up and has outlived the window in
+	// which swarm would still hold its failure against the rollout.
+	PhaseConverged Phase = "converged"
+	// PhaseProgressing means not yet — and, so far, not a failure either.
+	PhaseProgressing Phase = "progressing"
+	// PhaseWedged means swarm has given up and will not continue on its own.
+	PhaseWedged Phase = "wedged"
+)
+
+// Convergence is a phase and, when it is not converged, why.
+//
+// The reason is written for display: it is the sentence a status view or an API
+// response puts next to the phase, so it says what is outstanding rather than
+// naming an internal state.
+type Convergence struct {
+	Phase  Phase  `json:"phase"`
+	Reason string `json:"reason,omitempty"`
+}
+
+// Convergence classifies one service.
+//
+// Every rule here has been wrong once, which is why interpreting a ServiceState
+// belongs to this package rather than to each caller that holds one.
+func (s ServiceState) Convergence() Convergence {
+	switch s.UpdateState {
+	// Swarm never rolls back a rollback, so a paused rollout needs a human;
+	// waiting it out only delays the report.
+	case "paused":
+		return Convergence{PhaseWedged, "update paused after a task failure; swarm will not continue without intervention"}
+	case "rollback_paused":
+		return Convergence{PhaseWedged, "rollback paused; swarm never rolls back a rollback, so this needs manual recovery"}
+	// A rolling update in flight is not converged even if the task count
+	// already reads N/N: the count may still be the outgoing generation.
+	case "updating":
+		return Convergence{PhaseProgressing, "rolling update in progress"}
+	case "rollback_started":
+		return Convergence{PhaseProgressing, "rolling back"}
+	}
+	// Parity is measured from the actual running count, not the Replicas display
+	// string. That string counts tasks by DESIRED state, so it reaches parity
+	// the instant swarm schedules the tasks — before any container is up — which
+	// made --wait return immediately on a fresh install, where UpdateState is
+	// empty and the in-flight arm above cannot fire either (issue #473).
+	//
+	// A job's task ends Complete and is never replaced, so requiring a running
+	// task would report a step that succeeded as one that never came up. A
+	// completed task fills its slot; a failed one ends in state Failed and is
+	// not counted, so a broken job still blocks (issue #443).
+	if up := s.Running + s.Completed; up < s.Desired {
+		return Convergence{PhaseProgressing, fmt.Sprintf("%d/%d tasks running", up, s.Desired)}
+	}
+	// Parity is necessary but not sufficient: a task that starts and then dies
+	// inside the monitor window is a rollout failure, so hold until swarm's own
+	// window has closed. Losing parity needs no special case — the replacement
+	// task is newer, so the window it has left grows back on its own.
+	if left := s.stabilityRemaining(); left > 0 {
+		return Convergence{PhaseProgressing, fmt.Sprintf("%s of the stability window remains", left.Round(time.Millisecond))}
+	}
+	return Convergence{Phase: PhaseConverged}
+}
+
+// stabilityRemaining is how much of the monitor window this service still has
+// outstanding; <= 0 means it has held parity for as long as swarm itself would
+// watch.
 //
 // The remainder is measured from TASK CREATION, not from the moment parity was
 // reached. Swarm starts the monitor when it creates the task, and a task only
@@ -945,58 +1004,46 @@ func (e *Engine) waitReady(release string, timeout time.Duration) error {
 // took to come up, which is strictly more conservative than swarm and turns an
 // honest `monitor: 8m` into an eight-minute install.
 //
-// Services declaring no monitor use the CLI default, matching swarm's own.
-func stabilityRemaining(states []ServiceState) time.Duration {
-	var worst time.Duration
+// A service declaring no monitor uses the CLI default, matching swarm's own.
+func (s ServiceState) stabilityRemaining() time.Duration {
+	window := s.Monitor
+	if window < defaultStabilityWindow {
+		window = defaultStabilityWindow
+	}
+	return window - s.NewestTaskAge
+}
+
+// Rollup reduces a release's services to one answer: the worst phase wins, and
+// the reason names the service that produced it.
+//
+// No services is progressing rather than converged. A release whose stack
+// reports nothing has not finished coming up — and reporting it converged would
+// let --wait return the instant a deploy was accepted.
+func Rollup(states []ServiceState) Convergence {
+	if len(states) == 0 {
+		return Convergence{PhaseProgressing, "no services are running yet"}
+	}
+	worst := Convergence{Phase: PhaseConverged}
 	for _, s := range states {
-		window := s.Monitor
-		if window < defaultStabilityWindow {
-			window = defaultStabilityWindow
-		}
-		if remaining := window - s.NewestTaskAge; remaining > worst {
-			worst = remaining
+		c := s.Convergence()
+		if phaseRank(c.Phase) > phaseRank(worst.Phase) {
+			worst = Convergence{c.Phase, fmt.Sprintf("service %q: %s", s.Name, c.Reason)}
 		}
 	}
 	return worst
 }
 
-// rolloutWedged reports a rollout swarm has given up on.
-func rolloutWedged(states []ServiceState) error {
-	for _, s := range states {
-		switch s.UpdateState {
-		case "paused":
-			return fmt.Errorf("service %q: update paused after a task failure; swarm will not continue without intervention", s.Name)
-		case "rollback_paused":
-			return fmt.Errorf("service %q: rollback paused; swarm never rolls back a rollback, so this needs manual recovery", s.Name)
-		}
+// phaseRank orders phases by how much they should worry the reader, so that one
+// wedged service is not masked by another that is merely slow.
+func phaseRank(p Phase) int {
+	switch p {
+	case PhaseWedged:
+		return 2
+	case PhaseProgressing:
+		return 1
+	default:
+		return 0
 	}
-	return nil
-}
-
-// allConverged reports whether every service is running its target task count.
-//
-// It uses the actual running count rather than the Replicas display string.
-// That string counts tasks by DESIRED state, so it reaches parity the instant
-// swarm schedules the tasks — before any container is up — which made --wait
-// return immediately on a fresh install, where UpdateState is empty and the
-// in-flight guard below cannot fire either (issue #473).
-func allConverged(states []ServiceState) bool {
-	for _, s := range states {
-		// A rolling update in flight is not converged even if the task count
-		// already reads N/N: the count may still be the outgoing generation.
-		switch s.UpdateState {
-		case "updating", "rollback_started":
-			return false
-		}
-		// A job's task ends Complete and is never replaced, so requiring a
-		// running task would hold --wait until the timeout for a step that
-		// succeeded. A completed task fills its slot; a failed one ends in
-		// state Failed and is not counted, so a broken job still blocks.
-		if s.Running+s.Completed < s.Desired {
-			return false
-		}
-	}
-	return true
 }
 
 func releaseConfigName(release string, rev int) string {

--- a/charts/release_test.go
+++ b/charts/release_test.go
@@ -340,66 +340,81 @@ func mustGzipRelease(t *testing.T, rel *Release) []byte {
 	return gz
 }
 
-// A converged service whose update is still in flight must not count as ready.
-func TestAllConvergedRejectsInProgress(t *testing.T) {
-	require.True(t, allConverged([]ServiceState{{Running: 2, Desired: 2}}))
-	require.True(t, allConverged([]ServiceState{{Running: 1, Desired: 1, UpdateState: "completed"}}))
-	require.False(t, allConverged([]ServiceState{{Running: 2, Desired: 2, UpdateState: "updating"}}))
-	require.False(t, allConverged([]ServiceState{{Running: 1, Desired: 1, UpdateState: "rollback_started"}}))
-	require.False(t, allConverged([]ServiceState{{Running: 1, Desired: 2}}))
+// stableAge outlives any monitor window these tests declare, so a service
+// carrying it has already served out its stability window and parity is the only
+// thing left to decide.
+const stableAge = time.Hour
+
+func phaseOf(s ServiceState) Phase { return s.Convergence().Phase }
+
+// A service at parity whose update is still in flight must not count as ready.
+func TestConvergenceRejectsInProgress(t *testing.T) {
+	require.Equal(t, PhaseConverged, phaseOf(ServiceState{Running: 2, Desired: 2, NewestTaskAge: stableAge}))
+	require.Equal(t, PhaseConverged, phaseOf(ServiceState{Running: 1, Desired: 1, UpdateState: "completed", NewestTaskAge: stableAge}))
+	require.Equal(t, PhaseProgressing, phaseOf(ServiceState{Running: 2, Desired: 2, UpdateState: "updating", NewestTaskAge: stableAge}))
+	require.Equal(t, PhaseProgressing, phaseOf(ServiceState{Running: 1, Desired: 1, UpdateState: "rollback_started", NewestTaskAge: stableAge}))
+	require.Equal(t, PhaseProgressing, phaseOf(ServiceState{Running: 1, Desired: 2, NewestTaskAge: stableAge}))
 }
 
 // The bug in #473: a fresh install has no UpdateStatus, so the in-flight guard
 // cannot fire, and the old check compared a Replicas string counting tasks by
 // DESIRED state — which reaches parity the moment swarm schedules them. A
 // release whose tasks are all still pending must not read as converged.
-func TestAllConvergedRejectsScheduledButNotRunning(t *testing.T) {
-	scheduled := []ServiceState{{
-		Name:        "api",
-		Replicas:    "3/3", // what the old check saw: 3 tasks DESIRED running
-		Status:      "active",
-		Running:     0, // ...none of which had actually started
-		Desired:     3,
-		UpdateState: "", // fresh install: never updated
-	}}
-	require.False(t, allConverged(scheduled), "tasks that are merely scheduled must not count as converged")
+func TestConvergenceRejectsScheduledButNotRunning(t *testing.T) {
+	scheduled := ServiceState{
+		Name:          "api",
+		Replicas:      "3/3", // what the old check saw: 3 tasks DESIRED running
+		Status:        "active",
+		Running:       0, // ...none of which had actually started
+		Desired:       3,
+		UpdateState:   "", // fresh install: never updated
+		NewestTaskAge: stableAge,
+	}
+	c := scheduled.Convergence()
+	require.Equal(t, PhaseProgressing, c.Phase, "tasks that are merely scheduled must not count as converged")
+	require.Equal(t, "0/3 tasks running", c.Reason)
 }
 
 // The bug in #443: a one-shot init or migration step ends with its task
 // Complete and nothing running, which is its SUCCESS state. Requiring a running
 // task held --wait until the timeout for a job that had already done its work,
 // and showed the release as 0/1 forever.
-func TestAllConvergedAcceptsACompletedJob(t *testing.T) {
-	done := []ServiceState{{
-		Name:      "superset_init",
-		Running:   0, // the task exited; swarm will not replace it
-		Completed: 1,
-		Desired:   1,
-		Job:       true,
-	}}
-	require.True(t, allConverged(done), "a job that ran to completion is converged")
+func TestConvergenceAcceptsACompletedJob(t *testing.T) {
+	done := ServiceState{
+		Name:          "superset_init",
+		Running:       0, // the task exited; swarm will not replace it
+		Completed:     1,
+		Desired:       1,
+		Job:           true,
+		NewestTaskAge: stableAge,
+	}
+	require.Equal(t, PhaseConverged, phaseOf(done), "a job that ran to completion is converged")
 
 	// A job whose task has not finished yet is still not converged.
-	require.False(t, allConverged([]ServiceState{{Running: 0, Completed: 0, Desired: 1, Job: true}}))
+	require.Equal(t, PhaseProgressing, phaseOf(ServiceState{Running: 0, Completed: 0, Desired: 1, Job: true, NewestTaskAge: stableAge}))
 
 	// The distinction that matters: a task that failed ends in state Failed, so
 	// it is never counted as Completed and a broken job still blocks the wait.
-	require.False(t, allConverged([]ServiceState{{Running: 0, Completed: 0, Desired: 1, Job: true, Status: "active"}}))
+	require.Equal(t, PhaseProgressing, phaseOf(ServiceState{Running: 0, Completed: 0, Desired: 1, Job: true, Status: "active", NewestTaskAge: stableAge}))
 }
 
 // A global service on a drained node lowers the target rather than leaving the
 // release permanently short of a replica that can never be scheduled.
-func TestAllConvergedGlobalTracksActiveNodes(t *testing.T) {
-	require.True(t, allConverged([]ServiceState{{Mode: "global", Running: 2, Desired: 2}}))
-	require.False(t, allConverged([]ServiceState{{Mode: "global", Running: 1, Desired: 2}}))
+func TestConvergenceGlobalTracksActiveNodes(t *testing.T) {
+	require.Equal(t, PhaseConverged, phaseOf(ServiceState{Mode: "global", Running: 2, Desired: 2, NewestTaskAge: stableAge}))
+	require.Equal(t, PhaseProgressing, phaseOf(ServiceState{Mode: "global", Running: 1, Desired: 2, NewestTaskAge: stableAge}))
 }
 
-func TestStabilityRemainingTakesTheLongestOutstandingWindow(t *testing.T) {
-	require.Equal(t, time.Duration(0), stabilityRemaining(nil))
-	require.Equal(t, defaultStabilityWindow,
-		stabilityRemaining([]ServiceState{{Monitor: time.Second}}), "a shorter monitor must not weaken the default")
-	require.Equal(t, 30*time.Second,
-		stabilityRemaining([]ServiceState{{Monitor: 10 * time.Second}, {Monitor: 30 * time.Second}}))
+// Parity is necessary but not sufficient: a task that starts and then dies
+// inside the monitor window is a rollout failure, so a service that has reached
+// its target but not yet served out the window is still progressing.
+func TestConvergenceHoldsUntilTheStabilityWindowCloses(t *testing.T) {
+	c := ServiceState{Running: 1, Desired: 1, Monitor: 90 * time.Second, NewestTaskAge: 60 * time.Second}.Convergence()
+	require.Equal(t, PhaseProgressing, c.Phase)
+	require.Equal(t, "30s of the stability window remains", c.Reason)
+
+	require.Equal(t, defaultStabilityWindow, ServiceState{Monitor: time.Second}.stabilityRemaining(),
+		"a shorter monitor must not weaken the default")
 }
 
 // The window is measured from task creation, the same instant swarm measures it
@@ -415,26 +430,53 @@ func TestStabilityRemainingCountsTimeTheTaskHasAlreadyLived(t *testing.T) {
 	monitor := 90 * time.Second
 
 	require.Equal(t, 30*time.Second,
-		stabilityRemaining([]ServiceState{{Monitor: monitor, NewestTaskAge: 60 * time.Second}}))
-	require.LessOrEqual(t, stabilityRemaining([]ServiceState{{Monitor: monitor, NewestTaskAge: monitor}}),
+		ServiceState{Monitor: monitor, NewestTaskAge: 60 * time.Second}.stabilityRemaining())
+	require.LessOrEqual(t, ServiceState{Monitor: monitor, NewestTaskAge: monitor}.stabilityRemaining(),
 		time.Duration(0), "a task that has outlived its monitor is already stable")
-	require.LessOrEqual(t, stabilityRemaining([]ServiceState{{Monitor: monitor, NewestTaskAge: 10 * time.Minute}}),
+	require.LessOrEqual(t, ServiceState{Monitor: monitor, NewestTaskAge: 10 * time.Minute}.stabilityRemaining(),
 		time.Duration(0), "an over-aged task must not produce a negative wait either")
 }
 
 // paused and rollback_paused are terminal: swarmkit never rolls back a
 // rollback, so waiting out the timeout only delays the report.
-func TestRolloutWedged(t *testing.T) {
-	require.NoError(t, rolloutWedged([]ServiceState{{Name: "api", UpdateState: "updating"}}))
-	require.NoError(t, rolloutWedged([]ServiceState{{Name: "api", UpdateState: ""}}))
+func TestConvergenceWedged(t *testing.T) {
+	require.Equal(t, PhaseProgressing, phaseOf(ServiceState{Name: "api", UpdateState: "updating"}))
+	require.Equal(t, PhaseProgressing, phaseOf(ServiceState{Name: "api", UpdateState: ""}))
 
-	err := rolloutWedged([]ServiceState{{Name: "api", UpdateState: "paused"}})
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "api")
+	c := Rollup([]ServiceState{{Name: "api", UpdateState: "paused"}})
+	require.Equal(t, PhaseWedged, c.Phase)
+	require.Contains(t, c.Reason, "api")
 
-	err = rolloutWedged([]ServiceState{{Name: "api", UpdateState: "rollback_paused"}})
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "manual recovery")
+	c = Rollup([]ServiceState{{Name: "api", UpdateState: "rollback_paused"}})
+	require.Equal(t, PhaseWedged, c.Phase)
+	require.Contains(t, c.Reason, "manual recovery")
+}
+
+// The rollup is what a caller reads, so the phase that should worry it most has
+// to win regardless of where in the list it appears — one wedged service must
+// not be masked by another that is merely slow.
+func TestRollupTakesTheWorstPhase(t *testing.T) {
+	states := []ServiceState{
+		{Name: "web", Running: 1, Desired: 1, NewestTaskAge: stableAge},
+		{Name: "api", Running: 0, Desired: 1, NewestTaskAge: stableAge},
+		{Name: "db", UpdateState: "paused"},
+	}
+	c := Rollup(states)
+	require.Equal(t, PhaseWedged, c.Phase)
+	require.Contains(t, c.Reason, `service "db"`)
+
+	// Progressing wins over converged the same way, and names the service.
+	c = Rollup(states[:2])
+	require.Equal(t, PhaseProgressing, c.Phase)
+	require.Equal(t, `service "api": 0/1 tasks running`, c.Reason)
+
+	require.Equal(t, PhaseConverged, Rollup(states[:1]).Phase)
+}
+
+// A release whose stack reports nothing has not finished coming up. Reporting it
+// converged would let --wait return the instant a deploy was accepted.
+func TestRollupOfNoServicesIsProgressing(t *testing.T) {
+	require.Equal(t, PhaseProgressing, Rollup(nil).Phase)
 }
 
 // When a concurrent actor claims the next revision number between read and


### PR DESCRIPTION
`ServiceState` is exported and `Engine.Status` hands out a `[]ServiceState`, but every predicate that interpreted them — `allConverged`, `stabilityRemaining`, `rolloutWedged` — was unexported. The only way a library consumer could reach convergence logic was `InstallOptions.Wait` during an install or upgrade; asking "is this release healthy *right now*", outside a deploy, meant reimplementing it.

The rules are not obvious, and four of them exist because they were wrong once: the actual running count rather than the `Replicas` display string (#473), `Desired` over active nodes (#481), a completed one-shot job converging rather than reading `0/N` (#494), the stability window measured from newest **task creation**, and `paused`/`rollback_paused` as wedged rather than merely slow. A second copy would drift, and the failure is silent in both directions — healthy while `charts` would still be waiting, or degraded on a stack that is fine.

## What this exports

```go
type Phase string   // PhaseConverged | PhaseProgressing | PhaseWedged

type Convergence struct {
    Phase  Phase  `json:"phase"`
    Reason string `json:"reason,omitempty"`
}

func (s ServiceState) Convergence() Convergence
func Rollup(states []ServiceState) Convergence
```

One type rather than three predicates, because **combining them is itself part of the rule**: converged means at parity AND past the stability window AND not wedged, in that order. A consumer left to `&&` them together is a consumer that can get the order wrong, which is the divergence this issue exists to prevent.

The per-service classifier is the reusable unit — a caller wanting health per service *and* per stack needs both — so `Rollup` is a worst-phase-wins reduction over `ServiceState.Convergence` rather than a second implementation of the same rules. `Reason` is written for display: the sentence a status view or an API response puts beside the phase.

## No behaviour change

`waitReady` reads the rollup and produces the same verdict and the same wedged message as before. Two things fall out:

- the slice-level `stabilityRemaining` is gone — "the slowest governs" is what worst-wins already means, and nothing used the duration itself;
- `waitReady`'s `len(states) > 0` guard is now `Rollup(nil)` returning *progressing*, since a release whose stack reports nothing has not finished coming up.

The existing tests are rewritten against the new surface with every assertion's intent preserved, plus coverage of worst-wins ordering and the empty case.

## Consumer

`Eldara-Tech/swarmcli-cd` needs per-stack and per-service health for its Phase 1 health rollup, which is one of the things nothing else in the Swarm GitOps field does. It reads `Engine.Status` and has `[]ServiceState` in hand; it should not have to guess what they mean.

Closes #500