### PR TITLE
chore: pin docker/cli to v28.5.1 so compose/convert speaks our API types

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,11 @@ updates:
       go-minor-patch:
         patterns: ["*"]
         update-types: [minor, patch]
+    ignore:
+      # Pinned to v28.5.1 — see the comment in go.mod and issue #504. At v29 its
+      # cli/compose/convert moved to github.com/moby/moby's API types, which are
+      # distinct Go types from the github.com/docker/docker ones used here.
+      - dependency-name: "github.com/docker/cli"
     labels:
       - B0-low-priority
       - C0-breaks-nothing

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,13 @@ require (
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/charmbracelet/x/ansi v0.11.7
-	github.com/docker/cli v29.6.2+incompatible
+	// Pinned, do not bump without reading Eldara-Tech/swarmcli#504. We import
+	// exactly one package from this module (cli/connhelper), but at v29 its
+	// cli/compose/convert moved to github.com/moby/moby's API types, which are
+	// distinct Go types from the github.com/docker/docker ones this module uses
+	// everywhere. swarmcli-cd builds its applier on that convert package, so the
+	// bump would silently make its output untypeable against ours.
+	github.com/docker/cli v28.5.1+incompatible
 	github.com/docker/docker v28.5.2+incompatible
 	github.com/mitchellh/hashstructure/v2 v2.0.2
 	github.com/muesli/reflow v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -49,8 +49,8 @@ github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5Qvfr
 github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
 github.com/dlclark/regexp2 v1.11.0 h1:G/nrcoOa7ZXlpoa/91N3X7mM3r8eIlMBBJZvsz/mxKI=
 github.com/dlclark/regexp2 v1.11.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
-github.com/docker/cli v29.6.2+incompatible h1:/bjePvcbbFTnRrMfWJBY7AjfICdsiLVgHn6LwTVOcqw=
-github.com/docker/cli v29.6.2+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
+github.com/docker/cli v28.5.1+incompatible h1:ESutzBALAD6qyCLqbQSEf1a/U8Ybms5agw59yGVc+yY=
+github.com/docker/cli v28.5.1+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/docker v28.5.2+incompatible h1:DBX0Y0zAjZbSrm1uzOkdr1onVghKaftjlSWt4AFexzM=
 github.com/docker/docker v28.5.2+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/go-connections v0.6.0 h1:LlMG9azAe1TqfR7sO+NJttz1gy6KO7VJBh+pMmjSD94=


### PR DESCRIPTION
We require `github.com/docker/cli` for exactly one package — `cli/connhelper`, added in #493 as latest-at-the-time rather than as a required floor. But `Eldara-Tech/swarmcli-cd` builds its applier on the same module's exported `cli/compose/{loader,schema,convert}` (which swarmcli-cd#1 mandates in place of `docker stack deploy`), and those changed Docker API module between v28 and v29:

| `docker/cli` | `cli/compose/convert` imports |
|---|---|
| **v28.5.1** | `github.com/docker/docker/api/types/swarm` |
| **v29.6.2** (today) | `github.com/moby/moby/api/types/swarm` |

Distinct Go types even where the source is identical, so at v29.6.2 a `convert.Services` result cannot be handed to anything typed against the `github.com/docker/docker` v28.5.2 this module uses everywhere.

## Verified

- `go build ./...`, `go vet ./...`, `go test -race ./...`, `golangci-lint` (0 issues) and `check-spdx.sh` all pass on the pin.
- A probe module on `docker/cli v28.5.1` + `docker/docker v28.5.2` compiles `convert.Services(...)` straight into `[]swarm.ServiceSpec` of **our** swarm package — the property this pin exists to preserve.
- The ssh:// connection-helper path #493 added is unaffected; `cli/connhelper` is unchanged between these versions.

## Why not migrate this module instead

Priced by attempting it, then reverted. Worth recording because the premise is not obvious: **there is no `github.com/moby/moby` v29 module.** `go list -m -versions` stops at `v28.5.2+incompatible` and `@latest` resolves to it — the v29 API lives in independently versioned submodules, `github.com/moby/moby/api` v1.55.0 and `github.com/moby/moby/client` v0.5.0. So the migration is:

- a genuine v28→v29 API move onto two new modules, not an import rename, pulling in `github.com/moby/swarmkit/v2` and a grpc/genproto set that already collides;
- unbuildable without `exclude` directives, because the umbrella `github.com/moby/moby@v28.5.2+incompatible` keeps re-resolving the same import paths and every `api/types/*` import goes ambiguous against `moby/moby/api@v1.55.0`;
- a break of our exported `docker` package (`SnapshotWith`, `SwarmSnapshot`, …), so `swarmcli-be` needs a lockstep change across 39 files;
- `C1-breaking-change`, which by our own rule forces the next GA to `v2.0.0` while `v1.13.0` is still held for #497.

## This is a freeze, not a fix

It carries a `go.mod` comment and a `dependabot.yml` ignore, or the next weekly bump undoes it silently. Revisit when moby publishes a coherent v29 story and a migration is worth its own release.

Closes #504