### PR TITLE
charts: export the snapshot-to-ServiceState mapping, widen SnapshotWith

### DIFF
--- a/charts/backend_docker.go
+++ b/charts/backend_docker.go
@@ -146,6 +146,21 @@ func (b *dockerBackend) StackServices(name string) []ServiceState {
 	if err != nil {
 		return nil
 	}
+	return ServiceStatesFrom(snap, name)
+}
+
+// ServiceStatesFrom reads one stack's service states out of a swarm snapshot.
+//
+// It is exported for the sake of a caller implementing Backend itself, which
+// NewEngineWith exists to allow: producing []ServiceState is the one part of
+// that job with rules rather than plumbing, and a second copy of them would
+// diverge silently in both directions — reporting a release converged when this
+// package would still be waiting, or degraded when it is fine.
+//
+// The snapshot is the caller's: docker.SnapshotWith builds one against any
+// client without touching the process-wide cache, so a consumer serving several
+// swarms is not forced through the ambient one.
+func ServiceStatesFrom(snap *docker.SwarmSnapshot, name string) []ServiceState {
 	entries := snap.StackServices(name)
 	// Convergence facts come from a separate loader because ServiceEntry counts
 	// replicas by desired state, which is right for the services view but wrong

--- a/charts/backend_docker_test.go
+++ b/charts/backend_docker_test.go
@@ -5,6 +5,7 @@ package charts
 
 import (
 	"testing"
+	"time"
 
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/stretchr/testify/require"
@@ -51,4 +52,98 @@ func TestNamedBackendRefreshDoesNotTouchTheSharedCache(t *testing.T) {
 	require.NotNil(t, got)
 	require.Len(t, got.Services, 1)
 	require.Equal(t, "sentinel", got.Services[0].ID, "the shared cache must be untouched")
+}
+
+// --- ServiceStatesFrom ---
+
+func readyNode(id string) swarm.Node {
+	return swarm.Node{
+		ID:     id,
+		Status: swarm.NodeStatus{State: swarm.NodeStateReady},
+		Spec:   swarm.NodeSpec{Availability: swarm.NodeAvailabilityActive},
+	}
+}
+
+func stackService(id, stack string, replicas uint64) swarm.Service {
+	return swarm.Service{
+		ID: id,
+		Spec: swarm.ServiceSpec{
+			Annotations: swarm.Annotations{
+				Name:   id,
+				Labels: map[string]string{"com.docker.stack.namespace": stack},
+			},
+			Mode: swarm.ServiceMode{Replicated: &swarm.ReplicatedService{Replicas: &replicas}},
+		},
+	}
+}
+
+func runningTask(svcID, nodeID string) swarm.Task {
+	return swarm.Task{
+		ServiceID:    svcID,
+		NodeID:       nodeID,
+		DesiredState: swarm.TaskStateRunning,
+		Status:       swarm.TaskStatus{State: swarm.TaskStateRunning},
+	}
+}
+
+// The states a caller gets carry both halves: the display line from the service
+// entry, and the convergence facts --wait and a health rollup decide on.
+func TestServiceStatesFromCarriesBothHalves(t *testing.T) {
+	snap := &docker.SwarmSnapshot{
+		Nodes:    []swarm.Node{readyNode("n1")},
+		Services: []swarm.Service{stackService("api", "mystack", 2)},
+		Tasks:    []swarm.Task{runningTask("api", "n1"), runningTask("api", "n1")},
+	}
+
+	states := ServiceStatesFrom(snap, "mystack")
+	require.Len(t, states, 1)
+	require.Equal(t, "api", states[0].Name)
+	require.Equal(t, "replicated", states[0].Mode)
+	require.Equal(t, "2/2", states[0].Replicas)
+	require.Equal(t, 2, states[0].Running, "the running count is by ACTUAL state, not desired (#480)")
+	require.Equal(t, 2, states[0].Desired)
+}
+
+// The rule this function exists to keep one copy of. A one-shot step ends with
+// its task Complete and nothing running, which is its success state — without
+// this the release reads 0/1 forever and looks degraded when it is done (#443).
+func TestServiceStatesFromReportsAFinishedJobAsCompleted(t *testing.T) {
+	svc := stackService("init", "mystack", 1)
+	svc.Spec.TaskTemplate.RestartPolicy = &swarm.RestartPolicy{Condition: swarm.RestartPolicyConditionNone}
+
+	snap := &docker.SwarmSnapshot{
+		Nodes:    []swarm.Node{readyNode("n1")},
+		Services: []swarm.Service{svc},
+		Tasks: []swarm.Task{{
+			ServiceID: "init",
+			NodeID:    "n1",
+			// Old enough to have served out the stability window, which applies
+			// to a job's task as much as to a long-running one.
+			Meta:         swarm.Meta{CreatedAt: time.Now().Add(-time.Hour)},
+			DesiredState: swarm.TaskStateShutdown,
+			Status:       swarm.TaskStatus{State: swarm.TaskStateComplete},
+		}},
+	}
+
+	states := ServiceStatesFrom(snap, "mystack")
+	require.Len(t, states, 1)
+	require.True(t, states[0].Job)
+	require.Zero(t, states[0].Running, "a finished job has nothing running")
+	require.Equal(t, 1, states[0].Completed)
+	require.Equal(t, "1/1", states[0].Replicas, "a completed task counts toward the target")
+	require.Equal(t, "completed", states[0].Status)
+	require.Equal(t, PhaseConverged, Rollup(states).Phase, "and the release is converged, not degraded")
+}
+
+// A snapshot holding several stacks answers about one of them.
+func TestServiceStatesFromIsScopedToTheStack(t *testing.T) {
+	snap := &docker.SwarmSnapshot{
+		Nodes:    []swarm.Node{readyNode("n1")},
+		Services: []swarm.Service{stackService("mine", "a", 1), stackService("theirs", "b", 1)},
+		Tasks:    []swarm.Task{runningTask("mine", "n1"), runningTask("theirs", "n1")},
+	}
+
+	states := ServiceStatesFrom(snap, "a")
+	require.Len(t, states, 1)
+	require.Equal(t, "mine", states[0].Name)
 }

--- a/docker/snapshot.go
+++ b/docker/snapshot.go
@@ -104,7 +104,12 @@ func RefreshSnapshot() (*SwarmSnapshot, error) {
 // reconciles against different swarms sharing it would not merely read each
 // other's data, they would evict each other's. A caller holding an explicit
 // client owns its own freshness.
-func SnapshotWith(parent context.Context, c *client.Client) (*SwarmSnapshot, error) {
+//
+// It takes the interface rather than *client.Client because it only ever calls
+// NodeList, ServiceList, TaskList and Info, and a consumer that holds an
+// APIClient — normally for testability — should not have to write a second
+// snapshot builder that misses the locked-swarm handling below.
+func SnapshotWith(parent context.Context, c client.APIClient) (*SwarmSnapshot, error) {
 	ctx, cancel := context.WithTimeout(parent, 30*time.Second)
 	defer cancel()
 


### PR DESCRIPTION
`Engine.Status` hands out `[]ServiceState` and #500 exported the predicate that interprets them. The step *before* that — turning a swarm snapshot into those states — was unexported inside `dockerBackend.StackServices` (`charts/backend_docker.go:144`).

## Why it matters

A consumer implementing `charts.Backend` itself, which `NewEngineWith` exists to allow, has to produce `[]ServiceState` for its own swarm. The facts were already reachable: `docker.SwarmSnapshot`'s fields are exported, and `StackServices`/`StackConvergence` are exported snapshot-scoped methods. What was not reachable is the ~35 lines that combine them — and those are not purely mechanical. They carry the #443 rule:

```go
if c.Job && c.Completed > 0 {
    st.Replicas = fmt.Sprintf("%d/%d", c.Running+c.Completed, c.Desired)
    st.Status = "completed"
}
```

Without it a finished one-shot step reads `0/N` and the release looks degraded when it is done. A second copy in a downstream consumer diverges silently — the argument #500 was accepted on, applied to the facts rather than the predicate.

## Two changes

**`ServiceStatesFrom(snap *docker.SwarmSnapshot, name string) []ServiceState`** is that mapping, exported. `dockerBackend.StackServices` is now a call to it, so there is exactly one copy.

**`docker.SnapshotWith` takes `client.APIClient`** rather than `*client.Client`. It only ever calls `NodeList`, `ServiceList`, `TaskList` and `Info`, all on the interface, so widening is source-compatible — every `*client.Client` satisfies it. A consumer holding an `APIClient` for testability no longer has to write a second snapshot builder that would miss the locked-swarm handling and the cluster-id lookup below it.

No behaviour change in either.

## Tests

`ServiceStatesFrom` had no direct coverage before, since it was reachable only through a live backend. Three new cases: both halves carried through (display line plus convergence facts, with the running count by *actual* state per #480); a finished job reported as `1/1` and `"completed"` and rolling up to `PhaseConverged` rather than degraded; and scoping to one stack in a snapshot holding several.

Writing the second of those caught its own bug — the first draft's task had a zero `CreatedAt`, so the stability window was still open and the rollup said *progressing*. The assertion was wrong, not the code, but it is a fair demonstration that the window applies to a job's task as much as to a long-running one.

## Consumer

`Eldara-Tech/swarmcli-cd` #12. With both, its `StackServices` is:

```go
snap, err := docker.SnapshotWith(ctx, b.api)
if err != nil {
    return nil
}
return charts.ServiceStatesFrom(snap, name)
```

This became possible only because #505 kept both repositories on the same `github.com/docker/docker` — before that these were not even the same types.

Closes #508