### PR TITLE
feat(log): forward this package's output into a host program's slog handler

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,7 @@ registry/
   registry.go              Global command map: Register(), Get(), All(), Suggest()
 utils/log/
   logger.go                zap wrapper: Init(), L(), Sync(), SetLevel(), lumberjack rotation
+  slogcore.go              InitSlog(slog.Handler): forwards this package's output into a host program's log/slog handler instead of a file. For consumers importing swarmcli as a library (swarmcli-cd), where Init's lumberjack file is wrong and not initialising at all silently discards everything L()'s callers write
 ```
 
 ## Key Patterns

--- a/utils/log/slogcore.go
+++ b/utils/log/slogcore.go
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package swarmlog
+
+import (
+	"context"
+	"log/slog"
+	"slices"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+// InitSlog installs a logger that forwards everything to h instead of writing
+// a file, so that a program built on log/slog gets this package's output in
+// its own format, on its own stream, at its own level.
+//
+// It exists for consumers that import swarmcli as a library rather than
+// running the TUI. Init is wrong for them twice over: it opens a lumberjack
+// file under ~/.local/state, which in a container is a file nobody will ever
+// read, and it would put a second format on a stream the host program already
+// owns. Not calling it at all is worse — L() then returns the no-op logger and
+// everything this package's callers report is silently discarded. That was
+// swarmcli-cd#72.
+//
+// The level is h's. LOG_LEVEL and SetLevel do not apply, because the host
+// program's handler already decides what it keeps and having two answers to
+// that question is how logs go missing.
+func InitSlog(h slog.Handler) {
+	if raw != nil {
+		_ = raw.Sync()
+	}
+	raw = zap.New(&slogCore{handler: h}, zap.AddCaller())
+	logger = &SwarmLogger{raw.Sugar()}
+}
+
+// slogCore is a zapcore.Core that hands every entry to an slog.Handler.
+type slogCore struct {
+	handler slog.Handler
+	// attrs are what With accumulated, e.g. the ("docker", "client") pair
+	// docker.l() adds to every line it writes.
+	attrs []slog.Attr
+}
+
+// Enabled implements zapcore.Core. The handler is the only authority on what
+// is worth writing.
+func (c *slogCore) Enabled(l zapcore.Level) bool {
+	return c.handler.Enabled(context.Background(), slogLevel(l))
+}
+
+// With implements zapcore.Core.
+func (c *slogCore) With(fields []zapcore.Field) zapcore.Core {
+	// Clip so two loggers derived from the same parent cannot append into each
+	// other's backing array.
+	return &slogCore{
+		handler: c.handler,
+		attrs:   append(slices.Clip(c.attrs), attrs(fields)...),
+	}
+}
+
+// Check implements zapcore.Core.
+func (c *slogCore) Check(e zapcore.Entry, ce *zapcore.CheckedEntry) *zapcore.CheckedEntry {
+	if c.Enabled(e.Level) {
+		return ce.AddCore(e, c)
+	}
+	return ce
+}
+
+// Write implements zapcore.Core.
+func (c *slogCore) Write(e zapcore.Entry, fields []zapcore.Field) error {
+	// A zero PC rather than the entry's caller: slog resolves source from the
+	// PC of its own call site, which for a forwarded entry is this function.
+	// The caller travels as an attribute instead, below.
+	r := slog.NewRecord(e.Time, slogLevel(e.Level), e.Message, 0)
+	r.AddAttrs(c.attrs...)
+	r.AddAttrs(attrs(fields)...)
+	if e.LoggerName != "" {
+		r.AddAttrs(slog.String("logger", e.LoggerName))
+	}
+	if e.Caller.Defined {
+		r.AddAttrs(slog.String("caller", e.Caller.TrimmedPath()))
+	}
+	if e.Stack != "" {
+		r.AddAttrs(slog.String("stack", e.Stack))
+	}
+	return c.handler.Handle(context.Background(), r)
+}
+
+// Sync implements zapcore.Core. Nothing is buffered here; whether the
+// destination needs flushing is the host program's business.
+func (c *slogCore) Sync() error { return nil }
+
+// attrs converts zap fields to slog attributes. It goes through zap's own map
+// encoder rather than switching on Field.Type, so every field constructor zap
+// has — including the ones it grows later — is handled by construction.
+func attrs(fields []zapcore.Field) []slog.Attr {
+	if len(fields) == 0 {
+		return nil
+	}
+	enc := zapcore.NewMapObjectEncoder()
+	for _, f := range fields {
+		f.AddTo(enc)
+	}
+	out := make([]slog.Attr, 0, len(enc.Fields))
+	for k, v := range enc.Fields {
+		out = append(out, slog.Any(k, v))
+	}
+	// Map iteration order is random, and a log line whose fields shuffle
+	// between writes is one nothing can diff or test.
+	slices.SortFunc(out, func(a, b slog.Attr) int {
+		switch {
+		case a.Key < b.Key:
+			return -1
+		case a.Key > b.Key:
+			return 1
+		}
+		return 0
+	})
+	return out
+}
+
+// slogLevel maps a zap level to the nearest slog one. zap's three levels above
+// Error all describe a program that is about to stop, which slog spells Error.
+func slogLevel(l zapcore.Level) slog.Level {
+	switch l {
+	case zapcore.DebugLevel:
+		return slog.LevelDebug
+	case zapcore.InfoLevel:
+		return slog.LevelInfo
+	case zapcore.WarnLevel:
+		return slog.LevelWarn
+	default:
+		return slog.LevelError
+	}
+}

--- a/utils/log/slogcore_test.go
+++ b/utils/log/slogcore_test.go
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package swarmlog
+
+import (
+	"bytes"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"go.uber.org/zap/zapcore"
+)
+
+// bridge installs a slog-backed logger writing text into a buffer, and puts
+// the package's previous logger back afterwards.
+func bridge(t *testing.T, level slog.Level) *bytes.Buffer {
+	t.Helper()
+	previous, previousRaw := logger, raw
+	t.Cleanup(func() { logger, raw = previous, previousRaw })
+
+	var buf bytes.Buffer
+	InitSlog(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: level}))
+	return &buf
+}
+
+func TestInitSlogForwardsEveryLevel(t *testing.T) {
+	for _, tc := range []struct {
+		write func(*SwarmLogger)
+		want  string
+	}{
+		{func(l *SwarmLogger) { l.Debug("a message") }, "level=DEBUG"},
+		{func(l *SwarmLogger) { l.Info("a message") }, "level=INFO"},
+		{func(l *SwarmLogger) { l.Warn("a message") }, "level=WARN"},
+		{func(l *SwarmLogger) { l.Error("a message") }, "level=ERROR"},
+		// zap's levels above Error all mean the program is stopping, which slog
+		// spells Error. DPanic is the only one testable without dying.
+		{func(l *SwarmLogger) { l.DPanic("a message") }, "level=ERROR"},
+	} {
+		t.Run(tc.want, func(t *testing.T) {
+			buf := bridge(t, slog.LevelDebug)
+			tc.write(L())
+			got := buf.String()
+			if !strings.Contains(got, tc.want) || !strings.Contains(got, "a message") {
+				t.Errorf("wrote %q, want %q and the message", got, tc.want)
+			}
+		})
+	}
+}
+
+// The formatted variants are what this package's callers actually use.
+func TestInitSlogForwardsFormattedMessages(t *testing.T) {
+	buf := bridge(t, slog.LevelDebug)
+	L().Warnf("snapshot: cli.Info failed (%d attempts)", 3)
+	if !strings.Contains(buf.String(), "snapshot: cli.Info failed (3 attempts)") {
+		t.Errorf("wrote %q, want the formatted message", buf.String())
+	}
+}
+
+// docker.l() derives a logger with With on every call, so this is the shape
+// the real callers take.
+func TestWithAttributesReachTheHandler(t *testing.T) {
+	buf := bridge(t, slog.LevelDebug)
+	L().With("docker", "client").Info("connected")
+
+	got := buf.String()
+	if !strings.Contains(got, "docker=client") {
+		t.Errorf("wrote %q, want the With attribute", got)
+	}
+	if !strings.Contains(got, "msg=connected") {
+		t.Errorf("wrote %q, want the message", got)
+	}
+}
+
+// Two loggers derived from one parent must not see each other's attributes.
+func TestDerivedLoggersDoNotShareAttributes(t *testing.T) {
+	buf := bridge(t, slog.LevelDebug)
+	base := L().With("pkg", "docker")
+	base.With("view", "stacks").Info("one")
+	buf.Reset()
+	base.With("view", "nodes").Info("two")
+
+	got := buf.String()
+	if strings.Contains(got, "stacks") {
+		t.Errorf("wrote %q, want no trace of the sibling logger's attribute", got)
+	}
+	if !strings.Contains(got, "view=nodes") || !strings.Contains(got, "pkg=docker") {
+		t.Errorf("wrote %q, want its own attribute and the parent's", got)
+	}
+}
+
+// The handler decides what is kept — LOG_LEVEL and SetLevel do not apply once
+// the bridge is installed, and a level the handler drops must cost nothing.
+func TestTheHandlerLevelFilters(t *testing.T) {
+	buf := bridge(t, slog.LevelWarn)
+	L().Info("dropped")
+	L().Warn("kept")
+
+	got := buf.String()
+	if strings.Contains(got, "dropped") {
+		t.Errorf("wrote %q, want the info line dropped by the handler", got)
+	}
+	if !strings.Contains(got, "kept") {
+		t.Errorf("wrote %q, want the warn line", got)
+	}
+}
+
+func TestDroppedLevelsAreNotEnabled(t *testing.T) {
+	bridge(t, slog.LevelWarn)
+	if L().Desugar().Core().Enabled(zapcore.InfoLevel) {
+		t.Error("info is enabled, want the handler's level to disable it")
+	}
+	if !L().Desugar().Core().Enabled(zapcore.ErrorLevel) {
+		t.Error("error is disabled, want the handler's level to allow it")
+	}
+}
+
+// Typed zap fields go through zap's own encoder, so anything it can encode
+// arrives without this package knowing the type.
+func TestTypedFieldsAreConverted(t *testing.T) {
+	buf := bridge(t, slog.LevelDebug)
+	L().Infow("service created", "replicas", 3, "name", "whoami", "ok", true)
+
+	got := buf.String()
+	for _, want := range []string{"replicas=3", "name=whoami", "ok=true"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("wrote %q, want %q", got, want)
+		}
+	}
+}
+
+// Field order must be stable: the map encoder's iteration order is not.
+func TestFieldOrderIsStable(t *testing.T) {
+	buf := bridge(t, slog.LevelDebug)
+	for range 8 {
+		L().Infow("m", "zeta", 1, "alpha", 2, "mu", 3)
+	}
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	for _, l := range lines[1:] {
+		if fieldsOf(l) != fieldsOf(lines[0]) {
+			t.Fatalf("field order varies between writes:\n%s\n%s", lines[0], l)
+		}
+	}
+}
+
+// fieldsOf drops the timestamp, which is the one part that legitimately differs.
+func fieldsOf(line string) string {
+	_, rest, _ := strings.Cut(line, " ")
+	return rest
+}
+
+// zap.AddCaller is applied to the bridged logger, and the caller is only
+// useful if it survives the hop.
+func TestTheCallerIsCarried(t *testing.T) {
+	buf := bridge(t, slog.LevelDebug)
+	L().Info("a message")
+	if !strings.Contains(buf.String(), "caller=log/slogcore_test.go") {
+		t.Errorf("wrote %q, want the caller attribute", buf.String())
+	}
+}
+
+func TestInitSlogReplacesTheGlobalLogger(t *testing.T) {
+	buf := bridge(t, slog.LevelDebug)
+	// The package-level L(), not the returned one: every caller in this
+	// repository goes through it.
+	L().Info("through the global")
+	if !strings.Contains(buf.String(), "through the global") {
+		t.Errorf("wrote %q, want L() to be the bridged logger", buf.String())
+	}
+}


### PR DESCRIPTION
Half of Eldara-Tech/swarmcli-cd#72. The follow-up PR there bumps this dep and
calls it; nothing changes for the TUI.

## Why

swarmcli is imported as a library, not only run as a TUI, and today a consumer
doing so has no good option:

- **`Init(appName)`** opens a lumberjack rotating file under `~/.local/state`.
  Inside a container that is a file nobody will ever read, and it puts a second
  format on a stream the host program already owns.
- **Not calling it** leaves `L()` returning `noopLogger`, so everything this
  repository's own callers write is silently discarded.

swarmcli-cd does the second one. `docker/snapshot.go:139` (`snapshot: cli.Info
failed (cluster id unavailable)`) and `:173` (`background snapshot refresh
failed`) have therefore never reached an operator running the controller —
exactly the lines you would want when the applier starts misbehaving against
the daemon.

## What

`InitSlog(h slog.Handler)` installs a `zapcore.Core` that hands every entry to
`h`. The host program keeps one logger, one format and one stream; this
package's callers keep writing `l().Warnf(...)` exactly as they do now.

- **The level is the handler's.** `LOG_LEVEL` and `SetLevel` do not apply once
  the bridge is installed — two answers to "is this worth writing" is how logs
  go missing. `Enabled` and `Check` defer to the handler, so a dropped level
  costs nothing.
- **Fields go through zap's own `MapObjectEncoder`** rather than a type switch
  on `Field.Type`, so every field constructor zap has — including ones added
  later — is handled by construction. They are then sorted: the map's iteration
  order is random, and a line whose fields shuffle between writes is one
  nothing can diff or test.
- **`With` clips** before appending, so two loggers derived from one parent
  cannot append into each other's backing array. `docker.l()` derives on every
  call, so this is the common path, not a corner.
- **The caller travels as an attribute.** `slog` resolves source from the PC of
  its own call site, which for a forwarded entry would be the bridge itself, so
  the record carries PC 0 and `caller=` instead.
- zap's three levels above `Error` all describe a program about to stop, which
  slog spells `Error`.

## Verification

`go build ./... && go test ./... && gofmt -l . && golangci-lint run ./utils/...` — clean, 0 lint issues.

New unit tests cover every level including `DPanic`, the formatted (`Warnf`)
and structured (`Infow`) variants, `With` attributes reaching the handler,
sibling loggers not sharing attributes, handler-level filtering (both the
output and `Core.Enabled`), typed-field conversion, stable field order across
repeated writes, the caller attribute, and that `L()` — the global every caller
in this repo uses — is what gets replaced.

The TUI path is untouched: `Init`, `InitTestIfTestLogEnv`, `SetLevel` and the
lumberjack file all behave exactly as before, and nothing in this repository
calls the new function.

🤖 Generated with [Claude Code](https://claude.com/claude-code)