### PR TITLE
perf(charts): read release history without inspecting every config

### DIFF
--- a/charts/backend_docker.go
+++ b/charts/backend_docker.go
@@ -116,7 +116,7 @@ func (b *dockerBackend) ListConfigs(ctx context.Context) ([]ConfigMeta, error) {
 	}
 	out := make([]ConfigMeta, 0, len(configs))
 	for _, c := range configs {
-		out = append(out, ConfigMeta{Name: c.Spec.Name, Labels: c.Spec.Labels})
+		out = append(out, ConfigMeta{Name: c.Spec.Name, Labels: c.Spec.Labels, Data: c.Spec.Data})
 	}
 	return out, nil
 }

--- a/charts/release.go
+++ b/charts/release.go
@@ -27,6 +27,12 @@ const maxConfigPayload = 500 << 10 // 500 KiB
 type ConfigMeta struct {
 	Name   string
 	Labels map[string]string
+	// Data is the config payload, set when the Backend's listing already
+	// carried it. Docker returns a config's payload in the list response, not
+	// only on inspect, so a Backend that passes it through spares allRevisions
+	// one inspect per stored revision — which is the entire cost of reading
+	// release history. Leaving it nil is valid and costs exactly that inspect.
+	Data []byte
 }
 
 // ServiceState is a live status line for a release's services, plus the facts
@@ -665,9 +671,13 @@ func (e *Engine) allRevisions(ctx context.Context) (map[string][]Release, error)
 		if m.Labels[LabelType] != TypeRelease {
 			continue
 		}
-		data, err := e.Backend.InspectConfig(ctx, m.Name)
-		if err != nil {
-			return nil, fmt.Errorf("read release config %q: %w", m.Name, err)
+		data := m.Data
+		if data == nil {
+			d, err := e.Backend.InspectConfig(ctx, m.Name)
+			if err != nil {
+				return nil, fmt.Errorf("read release config %q: %w", m.Name, err)
+			}
+			data = d
 		}
 		rel, err := decodeRelease(data)
 		if err != nil {

--- a/charts/release_test.go
+++ b/charts/release_test.go
@@ -29,6 +29,11 @@ type fakeBackend struct {
 	secretsErr    error                   // error to return from SecretNames
 	onCreate      func(name string) error // hook to simulate concurrent config creation
 	deleteCfgErr  map[string]error        // config name -> error to return on delete
+	// listData makes ListConfigs carry each payload, as the Docker backend
+	// does. Off by default so the rest of the suite keeps exercising the
+	// inspect fallback a Backend that omits it relies on.
+	listData bool
+	inspects int // InspectConfig calls, to prove the payload came from the list
 }
 
 type fakeConfig struct {
@@ -84,11 +89,16 @@ func (f *fakeBackend) CreateConfig(_ context.Context, name string, data []byte, 
 func (f *fakeBackend) ListConfigs(context.Context) ([]ConfigMeta, error) {
 	var out []ConfigMeta
 	for name, c := range f.configs {
-		out = append(out, ConfigMeta{Name: name, Labels: c.labels})
+		m := ConfigMeta{Name: name, Labels: c.labels}
+		if f.listData {
+			m.Data = c.data
+		}
+		out = append(out, m)
 	}
 	return out, nil
 }
 func (f *fakeBackend) InspectConfig(_ context.Context, name string) ([]byte, error) {
+	f.inspects++
 	c, ok := f.configs[name]
 	if !ok {
 		return nil, fmt.Errorf("not found")
@@ -287,6 +297,46 @@ func TestListReturnsCurrentRevisions(t *testing.T) {
 	require.Len(t, list, 2)
 	require.Equal(t, "a", list[0].Name)
 	require.Equal(t, "b", list[1].Name)
+}
+
+// Reading release history is the engine's hottest path — every List, Status,
+// Install, Upgrade, Rollback and GetRevision walks it, and a GitOps controller
+// walks it on a timer. When the Backend's listing carries the payload, that walk
+// is one API call rather than one per stored revision (issue #510).
+func TestAllRevisionsReadsThePayloadFromTheListing(t *testing.T) {
+	fb := newFakeBackend()
+	fb.listData = true
+	e := testEngine(fb)
+	ctx := context.Background()
+	_, err := e.Install(ctx, "a", ReleaseChart{Name: "ca", Version: "1"}, nil, "services:\n  s:\n    image: x\n", InstallOptions{})
+	require.NoError(t, err)
+	_, err = e.Upgrade(ctx, "a", ReleaseChart{Name: "ca", Version: "2"}, nil, "services:\n  s:\n    image: y\n", InstallOptions{})
+	require.NoError(t, err)
+
+	fb.inspects = 0
+	list, err := e.List(ctx)
+	require.NoError(t, err)
+	require.Len(t, list, 1)
+	require.Equal(t, 2, list[0].Revision, "the payload from the listing must decode to the same release")
+	require.Zero(t, fb.inspects, "the payload was in the listing; inspecting again is a wasted round trip per revision")
+}
+
+// A Backend that lists names and labels but not payloads stays correct: the
+// field is additive, so an implementation written before it existed keeps
+// working through the inspect it always did.
+func TestAllRevisionsInspectsWhenTheListingOmitsThePayload(t *testing.T) {
+	fb := newFakeBackend() // listData off
+	e := testEngine(fb)
+	ctx := context.Background()
+	_, err := e.Install(ctx, "a", ReleaseChart{Name: "ca", Version: "1"}, nil, "services:\n  s:\n    image: x\n", InstallOptions{})
+	require.NoError(t, err)
+
+	fb.inspects = 0
+	list, err := e.List(ctx)
+	require.NoError(t, err)
+	require.Len(t, list, 1)
+	require.Equal(t, 1, list[0].Revision)
+	require.Equal(t, 1, fb.inspects, "the payload was not in the listing, so it had to be inspected")
 }
 
 func TestUninstallRemovesStackAndConfigsKeepsVolumes(t *testing.T) {

--- a/docker/config.go
+++ b/docker/config.go
@@ -129,26 +129,18 @@ func ListConfigsWith(ctx context.Context, cli *client.Client) ([]swarm.Config, e
 		return nil, fmt.Errorf("failed to list configs: %w", err)
 	}
 
-	// ConfigList doesn't populate all metadata like CreatedAt, so we need to inspect each config
-	fullConfigs := make([]swarm.Config, len(configs))
-	for i, cfg := range configs {
-		fullCfg, _, err := cli.ConfigInspectWithRaw(ctx, cfg.ID)
-		if err != nil {
-			l().Warnf("[ListConfigs] Failed to inspect config %s: %v", cfg.Spec.Name, err)
-			// Use the list result as fallback
-			fullConfigs[i] = cfg
-			continue
-		}
-		fullConfigs[i] = fullCfg
-	}
+	// No inspect per config. GET /configs and GET /configs/{id} are converted by
+	// the same daemon-side function, so the list already carries CreatedAt,
+	// UpdatedAt, Version and Spec.Data. Unlike secrets — where the list response
+	// deliberately omits Spec.Data — nothing about a config is withheld.
 
 	// 🔠 Sort configs alphabetically by name
-	sort.Slice(fullConfigs, func(i, j int) bool {
-		return fullConfigs[i].Spec.Name < fullConfigs[j].Spec.Name
+	sort.Slice(configs, func(i, j int) bool {
+		return configs[i].Spec.Name < configs[j].Spec.Name
 	})
 
-	l().Infof("[ListConfigs] Found %d configs", len(fullConfigs))
-	return fullConfigs, nil
+	l().Infof("[ListConfigs] Found %d configs", len(configs))
+	return configs, nil
 }
 
 // InspectConfig fetches and returns the config data.

--- a/docker/config_test.go
+++ b/docker/config_test.go
@@ -6,8 +6,12 @@ package docker
 import (
 	"bytes"
 	"compress/gzip"
+	"context"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
+	"github.com/docker/docker/client"
 	"github.com/stretchr/testify/require"
 )
 
@@ -26,4 +30,48 @@ func TestConfigDisplayData(t *testing.T) {
 	// non-gzip payloads are returned unchanged.
 	raw := &ConfigWithDecodedData{Data: []byte("plain config text")}
 	require.Equal(t, []byte("plain config text"), raw.DisplayData())
+}
+
+// One list call, not a list plus an inspect per config.
+//
+// The daemon converts a listed config and an inspected one with the same
+// function, so the listing already carries every field a caller can read. The
+// inspect loop this replaces cost one round trip per config on every read of
+// release history and on every poll of the configs view (issue #510).
+func TestListConfigsDoesNotInspectEachOne(t *testing.T) {
+	var lists, inspects int
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1.44/configs" {
+			inspects++
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		lists++
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[
+			{"ID":"c2","Version":{"Index":7},"CreatedAt":"2026-01-02T03:04:05Z","Spec":{"Name":"beta","Labels":{"k":"v"},"Data":"aGk="}},
+			{"ID":"c1","Spec":{"Name":"alpha"}}
+		]`))
+	}))
+	defer ts.Close()
+
+	cli, err := client.NewClientWithOpts(client.WithHost(ts.URL), client.WithVersion("1.44"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = cli.Close() })
+
+	got, err := ListConfigsWith(context.Background(), cli)
+	require.NoError(t, err)
+	require.Equal(t, 1, lists)
+	require.Zero(t, inspects, "the listing already holds what an inspect would return")
+
+	require.Len(t, got, 2)
+	require.Equal(t, "alpha", got[0].Spec.Name, "results stay sorted by name")
+	require.Equal(t, "beta", got[1].Spec.Name)
+
+	// The fields the callers actually read, all from the list response.
+	beta := got[1]
+	require.Equal(t, "2026-01-02T03:04:05Z", beta.CreatedAt.UTC().Format("2006-01-02T15:04:05Z"))
+	require.Equal(t, uint64(7), beta.Version.Index)
+	require.Equal(t, map[string]string{"k": "v"}, beta.Spec.Labels)
+	require.Equal(t, []byte("hi"), beta.Spec.Data)
 }

--- a/integration-tests/docker/config/config_lifecycle_test.go
+++ b/integration-tests/docker/config/config_lifecycle_test.go
@@ -25,6 +25,31 @@ func TestConfigLifecycle(t *testing.T) {
 		require.NoError(t, err, "ListConfigs should not fail")
 	})
 
+	// ListConfigs does not inspect each config, because a real daemon returns
+	// every field in the list response already. That is a claim about the
+	// daemon, so only a real one can hold it: if it ever stopped being true the
+	// configs view would lose its CREATED AT column and the chart engine would
+	// decode empty release payloads (issue #510).
+	t.Run("ListConfigsCarriesMetadataAndPayload", func(t *testing.T) {
+		name := uniqueName("demo_config-listed")
+		created := e.createConfig(t, name, "listed payload")
+
+		cfgs, err := docker.ListConfigs(e.ctx)
+		require.NoError(t, err)
+
+		var found *swarm.Config
+		for i, c := range cfgs {
+			if c.ID == created.ID {
+				found = &cfgs[i]
+				break
+			}
+		}
+		require.NotNil(t, found, "the config just created should be listed")
+		require.False(t, found.CreatedAt.IsZero(), "the list response should carry CreatedAt")
+		require.NotZero(t, found.Version.Index, "the list response should carry Version")
+		require.Equal(t, []byte("listed payload"), found.Spec.Data, "the list response should carry the payload")
+	})
+
 	t.Run("CreateConfigVersion", func(t *testing.T) {
 		orig := e.createConfig(t, uniqueName("demo_config-v1"), "hello world")
 


### PR DESCRIPTION
Fixes #510.

## The premise was wrong

`docker.ListConfigsWith` listed the swarm's configs and then inspected each one:

> `// ConfigList doesn't populate all metadata like CreatedAt, so we need to inspect each config`

It does populate it. The daemon converts a listed config and an inspected one with the **same** function — `daemon/cluster/convert.ConfigFromGRPC`, reached from both `GetConfigs` and `GetConfig`, byte-identical across moby v27.1.1 and docker v28.5.2 — and the router writes the result straight to JSON. Below it, swarmkit's `ListConfigs` returns store objects untouched; contrast `ListSecrets`, which explicitly does `secret.Spec.Data = nil`. A config listing withholds nothing.

The comment arrived with the loop in #133 and was never load-bearing: the code already fell back to the list entry whenever an inspect failed.

## Why it mattered

`allRevisions` is how the engine finds releases at all — `List`, `Status`, `Install`, `Upgrade`, `Rollback`, `GetRevision` — and `swarmcli-cd` walks it on a timer, per application. The configs view polled through it, and `stackDeleteIntentCmd` paid a full inspect sweep to read labels.

Since the payload is in the listing too, `ConfigMeta` now carries it and `allRevisions` decodes from it directly. On a swarm with N configs and R stored revisions, one read of release history goes from **1+N+R round trips to 1**. A 50-release × 10-revision swarm: 501 → 1.

`ConfigMeta.Data` is additive. A `charts.Backend` that leaves it nil keeps working through the inspect it always did, so this is not a breaking interface change.

## What this deliberately does not do

The issue's second proposal — filter the listing by `com.swarmcli.type=release` — is not implemented. There are two callers of `Backend.ListConfigs`, and the second wants the opposite: `ensureExternalSecretsConfigs` (`charts/release.go:492`) builds the set of config names on the swarm to validate a manifest's `external:` references, and an external config carries no `com.swarmcli.*` label. Filtering would report `config "foo" does not exist` with the config sitting right there, refusing installs on the apply path.

Worth stating: `fakeBackend.ListConfigs` does not model server-side filtering, so that regression would have passed CI and surfaced only against a live swarm.

## Verification

- `TestListConfigsDoesNotInspectEachOne` (`docker/config_test.go`) — httptest daemon counting round trips: one `GET /configs`, zero inspects, and `CreatedAt` / `Version` / `Labels` / `Spec.Data` all decoded from the list body.
- `TestAllRevisionsReadsThePayloadFromTheListing` / `...InspectsWhenTheListingOmitsThePayload` (`charts/release_test.go`) — both sides of the additive field.
- `ListConfigsCarriesMetadataAndPayload` (`integration-tests/docker/config/`) — the claim is about a real daemon, so a real daemon asserts it. Needs `./test-setup/testenv.sh integration`.

`go test ./...` green, `golangci-lint run ./... --build-tags=integration` reports 0 issues.

## Follow-ups (not here)

- `swarmcli-cd` gains the same win by populating `ConfigMeta.Data` once it bumps its pin — its reconcile is where the timer cost lives.
- `views/configs` runs a full `ServiceList` **per config** in `computeConfigUsedCmd` and `configItemFromSwarm`. That is a strictly worse N+1 than this one and wants its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)