### PR TITLE
perf(configs): answer "which services use this config" in one listing

### DIFF
--- a/docker/config.go
+++ b/docker/config.go
@@ -387,3 +387,50 @@ func listServicesUsingConfigName(ctx context.Context, client *client.Client, nam
 	}
 	return filtered, nil
 }
+
+// ServicesUsingConfigs indexes services by the configs they reference.
+//
+// The single-config lookups above each list every service and filter, which is
+// right for one question and wrong for many: asking about N configs costs N full
+// service listings. This asks once and answers all of them.
+//
+// Keyed by both ConfigID and ConfigName, because a reference carries both and
+// callers hold one or the other. A service appears once per key it references,
+// even if it mounts the same config at several paths.
+func ServicesUsingConfigs(ctx context.Context) (map[string][]swarm.Service, error) {
+	cli, err := GetClient()
+	if err != nil {
+		return nil, err
+	}
+	return ServicesUsingConfigsWith(ctx, cli)
+}
+
+// ServicesUsingConfigsWith is ServicesUsingConfigs against an explicit client.
+func ServicesUsingConfigsWith(ctx context.Context, cli *client.Client) (map[string][]swarm.Service, error) {
+	services, err := cli.ServiceList(ctx, swarm.ServiceListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list services: %w", err)
+	}
+
+	idx := make(map[string][]swarm.Service)
+	for _, s := range services {
+		if s.Spec.TaskTemplate.ContainerSpec == nil {
+			continue
+		}
+		keys := make(map[string]struct{})
+		for _, c := range s.Spec.TaskTemplate.ContainerSpec.Configs {
+			if c.ConfigID != "" {
+				keys[c.ConfigID] = struct{}{}
+			}
+			if c.ConfigName != "" {
+				keys[c.ConfigName] = struct{}{}
+			}
+		}
+		for k := range keys {
+			idx[k] = append(idx[k], s)
+		}
+	}
+
+	l().Debugf("[ServicesUsingConfigs] Indexed %d services under %d config keys", len(services), len(idx))
+	return idx, nil
+}

--- a/docker/config_ops.go
+++ b/docker/config_ops.go
@@ -17,8 +17,14 @@ type ConfigOps interface {
 	CreateConfigVersion(ctx context.Context, baseConfig swarm.Config, newData []byte) (swarm.Config, error)
 	RotateConfigInServices(ctx context.Context, oldCfg *swarm.Config, newCfg swarm.Config) error
 	DeleteConfig(ctx context.Context, nameOrID string) error
-	ListServicesUsingConfigID(ctx context.Context, configID string) ([]swarm.Service, error)
-	ListServicesUsingConfigName(ctx context.Context, name string) ([]swarm.Service, error)
+	// ServicesUsingConfigs answers "which services reference this config" for
+	// every config at once, keyed by config ID and name.
+	//
+	// It replaces per-config lookups in this seam. ListServicesUsingConfigID and
+	// ListServicesUsingConfigName still exist on the package for a caller with a
+	// single config, but each lists every service and filters, so a loop over
+	// them scales the whole service listing by the number of configs.
+	ServicesUsingConfigs(ctx context.Context) (map[string][]swarm.Service, error)
 }
 
 type defaultConfigOps struct{}
@@ -41,9 +47,6 @@ func (defaultConfigOps) RotateConfigInServices(ctx context.Context, oldCfg *swar
 func (defaultConfigOps) DeleteConfig(ctx context.Context, nameOrID string) error {
 	return DeleteConfig(ctx, nameOrID)
 }
-func (defaultConfigOps) ListServicesUsingConfigID(ctx context.Context, configID string) ([]swarm.Service, error) {
-	return ListServicesUsingConfigID(ctx, configID)
-}
-func (defaultConfigOps) ListServicesUsingConfigName(ctx context.Context, name string) ([]swarm.Service, error) {
-	return ListServicesUsingConfigName(ctx, name)
+func (defaultConfigOps) ServicesUsingConfigs(ctx context.Context) (map[string][]swarm.Service, error) {
+	return ServicesUsingConfigs(ctx)
 }

--- a/docker/config_test.go
+++ b/docker/config_test.go
@@ -75,3 +75,53 @@ func TestListConfigsDoesNotInspectEachOne(t *testing.T) {
 	require.Equal(t, map[string]string{"k": "v"}, beta.Spec.Labels)
 	require.Equal(t, []byte("hi"), beta.Spec.Data)
 }
+
+// The reference question answered for every config in one service listing.
+//
+// ListServicesUsingConfigID/Name each list every service and filter, so asking
+// about N configs costs N listings — which is what the configs view did on every
+// load and every poll.
+func TestServicesUsingConfigsIndexesInOneListing(t *testing.T) {
+	var lists int
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/v1.44/services", r.URL.Path)
+		lists++
+		w.Header().Set("Content-Type", "application/json")
+		// web mounts the same config at two paths; db mounts another; noop has no
+		// ContainerSpec at all, which a real swarm does produce.
+		_, _ = w.Write([]byte(`[
+			{"ID":"web","Spec":{"Name":"web","TaskTemplate":{"ContainerSpec":{"Configs":[
+				{"ConfigID":"c1","ConfigName":"alpha"},
+				{"ConfigID":"c1","ConfigName":"alpha"}
+			]}}}},
+			{"ID":"db","Spec":{"Name":"db","TaskTemplate":{"ContainerSpec":{"Configs":[
+				{"ConfigID":"c2","ConfigName":"beta"}
+			]}}}},
+			{"ID":"noop","Spec":{"Name":"noop","TaskTemplate":{}}}
+		]`))
+	}))
+	defer ts.Close()
+
+	cli, err := client.NewClientWithOpts(client.WithHost(ts.URL), client.WithVersion("1.44"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = cli.Close() })
+
+	idx, err := ServicesUsingConfigsWith(context.Background(), cli)
+	require.NoError(t, err)
+	require.Equal(t, 1, lists, "one listing answers every config")
+
+	// Reachable by ID and by name, because a caller may hold either.
+	require.Len(t, idx["c1"], 1)
+	require.Equal(t, "web", idx["c1"][0].ID)
+	require.Len(t, idx["alpha"], 1, "mounting one config twice must not list the service twice")
+	require.Equal(t, "web", idx["alpha"][0].ID)
+
+	require.Len(t, idx["c2"], 1)
+	require.Equal(t, "db", idx["c2"][0].ID)
+	require.Len(t, idx["beta"], 1)
+
+	// A config nothing references is simply absent, so len() on the miss is 0.
+	require.Empty(t, idx["c3"])
+	// The service with no ContainerSpec contributed no keys and did not panic.
+	require.Len(t, idx, 4)
+}

--- a/views/configs/actions.go
+++ b/views/configs/actions.go
@@ -41,18 +41,24 @@ func (m *Model) loadConfigsCmd() tea.Cmd {
 
 // computeConfigUsedCmd checks which configs are used by services in background
 // and returns a usedStatusUpdatedMsg containing a map[id]bool.
+//
+// One indexed lookup, not one service listing per config. This runs after every
+// load and after every poll that sees a change, so the per-config version cost a
+// full ServiceList times the number of configs on the swarm each time.
 func (m *Model) computeConfigUsedCmd(cfgs []docker.ConfigWithDecodedData) tea.Cmd {
 	configOps := m.deps.Configs
 	return func() tea.Msg {
-		usedMap := make(map[string]bool, len(cfgs))
 		ctx, cancel := context.WithTimeout(context.Background(), pollTimeout)
 		defer cancel()
+
+		usedBy, err := configOps.ServicesUsingConfigs(ctx)
+		if err != nil {
+			l().Errorf("computeConfigUsedCmd: ServicesUsingConfigs failed: %v", err)
+		}
+
+		usedMap := make(map[string]bool, len(cfgs))
 		for _, c := range cfgs {
-			usedMap[c.Config.ID] = false
-			svcs, err := configOps.ListServicesUsingConfigID(ctx, c.Config.ID)
-			if err == nil && len(svcs) > 0 {
-				usedMap[c.Config.ID] = true
-			}
+			usedMap[c.Config.ID] = len(usedBy[c.Config.ID]) > 0
 		}
 		return usedStatusUpdatedMsg(usedMap)
 	}
@@ -333,24 +339,19 @@ func (m *Model) getUsedByStacksCmd(configName string) tea.Cmd {
 			return usedByMsg{ConfigName: configName, UsedBy: nil, Error: err}
 		}
 
-		// Get services by config name and ID
-		servicesByName, err := configOps.ListServicesUsingConfigName(ctx, configName)
+		// Services referencing this config by either name or ID. The index holds
+		// both keys, so one listing replaces the two this used to merge by hand.
+		svcsByConfig, err := configOps.ServicesUsingConfigs(ctx)
 		if err != nil {
-			l().Errorf("Failed to list services using config name %s: %v", configName, err)
-			return usedByMsg{ConfigName: configName, UsedBy: nil, Error: err}
-		}
-		servicesByID, err := configOps.ListServicesUsingConfigID(ctx, cfg.Config.ID)
-		if err != nil {
-			l().Errorf("Failed to list services using config ID %s: %v", cfg.Config.ID, err)
+			l().Errorf("Failed to index services by config: %v", err)
 			return usedByMsg{ConfigName: configName, UsedBy: nil, Error: err}
 		}
 
-		// Merge services, avoid duplicates
 		svcMap := make(map[string]swarm.Service)
-		for _, svc := range servicesByName {
+		for _, svc := range svcsByConfig[configName] {
 			svcMap[svc.ID] = svc
 		}
-		for _, svc := range servicesByID {
+		for _, svc := range svcsByConfig[cfg.Config.ID] {
 			svcMap[svc.ID] = svc
 		}
 

--- a/views/configs/actions_test.go
+++ b/views/configs/actions_test.go
@@ -115,11 +115,8 @@ func TestInspectRawConfigCmd_NavigatesToInspect(t *testing.T) {
 
 func TestComputeConfigUsedCmd_SetsUsedMap(t *testing.T) {
 	mock := noopConfigOps()
-	mock.listServicesUsingConfigIDFn = func(_ context.Context, configID string) ([]swarm.Service, error) {
-		if configID == "id-used" {
-			return []swarm.Service{{ID: "svc1"}}, nil
-		}
-		return nil, nil
+	mock.servicesUsingConfigsFn = func(_ context.Context) (map[string][]swarm.Service, error) {
+		return map[string][]swarm.Service{"id-used": {{ID: "svc1"}}}, nil
 	}
 	m := testModel(func(m *Model) { m.deps.Configs = mock })
 
@@ -133,6 +130,27 @@ func TestComputeConfigUsedCmd_SetsUsedMap(t *testing.T) {
 	require.True(t, ok)
 	require.True(t, usedMap["id-used"])
 	require.False(t, usedMap["id-unused"])
+	// The point of the index: one lookup regardless of how many configs the
+	// swarm holds. Per-config lookups each list every service.
+	require.Equal(t, 1, mock.servicesUsingConfigsCalls)
+}
+
+// A config the view has just created cannot be referenced yet, so building its
+// row asks the daemon nothing at all.
+func TestAddConfigDoesNotQueryServices(t *testing.T) {
+	mock := noopConfigOps()
+	m := testModel(func(m *Model) { m.deps.Configs = mock })
+
+	m.addConfig(docker.ConfigWithDecodedData{
+		Config: swarm.Config{ID: "fresh", Spec: swarm.ConfigSpec{Annotations: swarm.Annotations{Name: "c-v2"}}},
+	})
+
+	require.Zero(t, mock.servicesUsingConfigsCalls)
+	require.NotEmpty(t, m.configsList.Items)
+	item := m.configsList.Items[len(m.configsList.Items)-1]
+	require.Equal(t, "c-v2", item.Name)
+	require.False(t, item.Used)
+	require.True(t, item.UsedKnown)
 }
 
 func TestGetUsedByStacksCmd_ReturnsUsedByMsg(t *testing.T) {
@@ -142,13 +160,17 @@ func TestGetUsedByStacksCmd_ReturnsUsedByMsg(t *testing.T) {
 			Config: swarm.Config{ID: "cfg-id", Spec: swarm.ConfigSpec{Annotations: swarm.Annotations{Name: "c1"}}},
 		}, nil
 	}
-	mock.listServicesUsingConfigNameFn = func(_ context.Context, _ string) ([]swarm.Service, error) {
-		return []swarm.Service{
-			{ID: "svc1", Spec: swarm.ServiceSpec{Annotations: swarm.Annotations{Name: "web", Labels: map[string]string{"com.docker.stack.namespace": "mystack"}}}},
+	// One service reachable by name, another by ID: the index carries both keys,
+	// which is what lets a single listing replace the two this used to merge.
+	mock.servicesUsingConfigsFn = func(_ context.Context) (map[string][]swarm.Service, error) {
+		return map[string][]swarm.Service{
+			"c1": {
+				{ID: "svc1", Spec: swarm.ServiceSpec{Annotations: swarm.Annotations{Name: "web", Labels: map[string]string{"com.docker.stack.namespace": "mystack"}}}},
+			},
+			"cfg-id": {
+				{ID: "svc2", Spec: swarm.ServiceSpec{Annotations: swarm.Annotations{Name: "api", Labels: map[string]string{"com.docker.stack.namespace": "mystack"}}}},
+			},
 		}, nil
-	}
-	mock.listServicesUsingConfigIDFn = func(_ context.Context, _ string) ([]swarm.Service, error) {
-		return nil, nil
 	}
 
 	m := testModel(func(m *Model) { m.deps.Configs = mock })
@@ -157,8 +179,11 @@ func TestGetUsedByStacksCmd_ReturnsUsedByMsg(t *testing.T) {
 	used, ok := msg.(usedByMsg)
 	require.True(t, ok)
 	require.Equal(t, "c1", used.ConfigName)
-	require.Len(t, used.UsedBy, 1)
+	require.Len(t, used.UsedBy, 2)
 	require.Equal(t, "mystack", used.UsedBy[0].StackName)
+	require.Equal(t, "api", used.UsedBy[0].ServiceName, "sorted by stack then service")
+	require.Equal(t, "web", used.UsedBy[1].ServiceName)
+	require.Equal(t, 1, mock.servicesUsingConfigsCalls)
 }
 
 func TestCreateConfigFromContentCmd_Success(t *testing.T) {

--- a/views/configs/model.go
+++ b/views/configs/model.go
@@ -4,7 +4,6 @@
 package configsview
 
 import (
-	"context"
 	"fmt"
 	"github.com/Eldara-Tech/swarmcli/docker"
 	filterlist "github.com/Eldara-Tech/swarmcli/ui/components/filterable/list"
@@ -241,8 +240,10 @@ func (m *Model) findConfigByName(name string) (*docker.ConfigWithDecodedData, er
 
 func (m *Model) addConfig(cfg docker.ConfigWithDecodedData) {
 	m.configs = append(m.configs, cfg)
-	ctx := context.Background()
-	m.configsList.Items = append(m.configsList.Items, configItemFromSwarm(ctx, cfg.Config))
+	// No index: this is a config this view has just created, so no service can
+	// reference it yet. The rotation that will point services at it is still
+	// behind a confirmation dialog.
+	m.configsList.Items = append(m.configsList.Items, configItemFromSwarm(cfg.Config, nil))
 	m.configsList.ApplyFilter()
 }
 

--- a/views/configs/model_test.go
+++ b/views/configs/model_test.go
@@ -18,14 +18,16 @@ import (
 // --- mocks ---
 
 type mockConfigOps struct {
-	listConfigsFn                 func(ctx context.Context) ([]swarm.Config, error)
-	inspectConfigFn               func(ctx context.Context, nameOrID string) (*docker.ConfigWithDecodedData, error)
-	createConfigFn                func(ctx context.Context, name string, data []byte, labels map[string]string) (swarm.Config, error)
-	createConfigVersionFn         func(ctx context.Context, baseConfig swarm.Config, newData []byte) (swarm.Config, error)
-	rotateConfigInServicesFn      func(ctx context.Context, oldCfg *swarm.Config, newCfg swarm.Config) error
-	deleteConfigFn                func(ctx context.Context, nameOrID string) error
-	listServicesUsingConfigIDFn   func(ctx context.Context, configID string) ([]swarm.Service, error)
-	listServicesUsingConfigNameFn func(ctx context.Context, name string) ([]swarm.Service, error)
+	listConfigsFn            func(ctx context.Context) ([]swarm.Config, error)
+	inspectConfigFn          func(ctx context.Context, nameOrID string) (*docker.ConfigWithDecodedData, error)
+	createConfigFn           func(ctx context.Context, name string, data []byte, labels map[string]string) (swarm.Config, error)
+	createConfigVersionFn    func(ctx context.Context, baseConfig swarm.Config, newData []byte) (swarm.Config, error)
+	rotateConfigInServicesFn func(ctx context.Context, oldCfg *swarm.Config, newCfg swarm.Config) error
+	deleteConfigFn           func(ctx context.Context, nameOrID string) error
+	servicesUsingConfigsFn   func(ctx context.Context) (map[string][]swarm.Service, error)
+	// servicesUsingConfigsCalls counts the indexed lookups, so a test can assert
+	// the view asks once rather than once per config.
+	servicesUsingConfigsCalls int
 }
 
 func (m *mockConfigOps) ListConfigs(ctx context.Context) ([]swarm.Config, error) {
@@ -52,11 +54,12 @@ func (m *mockConfigOps) RotateConfigInServices(ctx context.Context, oldCfg *swar
 func (m *mockConfigOps) DeleteConfig(ctx context.Context, nameOrID string) error {
 	return m.deleteConfigFn(ctx, nameOrID)
 }
-func (m *mockConfigOps) ListServicesUsingConfigID(ctx context.Context, configID string) ([]swarm.Service, error) {
-	return m.listServicesUsingConfigIDFn(ctx, configID)
-}
-func (m *mockConfigOps) ListServicesUsingConfigName(ctx context.Context, name string) ([]swarm.Service, error) {
-	return m.listServicesUsingConfigNameFn(ctx, name)
+func (m *mockConfigOps) ServicesUsingConfigs(ctx context.Context) (map[string][]swarm.Service, error) {
+	m.servicesUsingConfigsCalls++
+	if m.servicesUsingConfigsFn != nil {
+		return m.servicesUsingConfigsFn(ctx)
+	}
+	return nil, nil
 }
 
 // --- helpers ---
@@ -106,12 +109,6 @@ func noopConfigOps() *mockConfigOps {
 		},
 		deleteConfigFn: func(_ context.Context, _ string) error {
 			return nil
-		},
-		listServicesUsingConfigIDFn: func(_ context.Context, _ string) ([]swarm.Service, error) {
-			return nil, nil
-		},
-		listServicesUsingConfigNameFn: func(_ context.Context, _ string) ([]swarm.Service, error) {
-			return nil, nil
 		},
 	}
 }

--- a/views/configs/view.go
+++ b/views/configs/view.go
@@ -4,9 +4,7 @@
 package configsview
 
 import (
-	"context"
 	"fmt"
-	"github.com/Eldara-Tech/swarmcli/docker"
 	"github.com/Eldara-Tech/swarmcli/ui"
 	"github.com/Eldara-Tech/swarmcli/ui/components/errordialog"
 	"github.com/Eldara-Tech/swarmcli/ui/dialog"
@@ -51,19 +49,19 @@ func (i usedByItem) FilterValue() string { return i.StackName + " " + i.ServiceN
 func (i usedByItem) Title() string       { return fmt.Sprintf("%-24s %-24s", i.StackName, i.ServiceName) }
 func (i usedByItem) Description() string { return "Service: " + i.ServiceName }
 
-func configItemFromSwarm(ctx context.Context, c swarm.Config) configItem {
-	used := false
-	services, err := docker.ListServicesUsingConfigID(ctx, c.ID)
-	if err == nil && len(services) > 0 {
-		used = true
-	}
+// configItemFromSwarm builds a list row for one config. usedBy is the
+// config-to-services index from docker.ServicesUsingConfigs, looked up by both
+// ID and name because a service reference may carry either. A nil index means
+// nothing references this config — which is the case for one just created, and
+// is why this no longer reaches for the daemon itself.
+func configItemFromSwarm(c swarm.Config, usedBy map[string][]swarm.Service) configItem {
 	return configItem{
 		Name:      c.Spec.Name,
 		ID:        c.ID,
 		CreatedAt: c.CreatedAt,
 		UpdatedAt: c.UpdatedAt,
 		Labels:    c.Spec.Labels,
-		Used:      used,
+		Used:      len(usedBy[c.ID]) > 0 || len(usedBy[c.Spec.Name]) > 0,
 		UsedKnown: true,
 	}
 }


### PR DESCRIPTION
Found while fixing #510, which removed the sibling N+1 on this same view. This is the larger of the two.

## The loop

`docker.ListServicesUsingConfigID` and `...ByName` each call `ServiceList` for the whole swarm and filter client-side. Correct for one config; the configs view asked in a loop:

| site | calls | when |
|---|---|---|
| `computeConfigUsedCmd` | one full `ServiceList` **per config** | after every load, and every poll that sees a change |
| `getUsedByStacksCmd` | two (by name, by ID) then merged by hand | user opens "used by" |
| `configItemFromSwarm` | one | per config added |

So painting the USED column on a swarm with N configs meant N full service listings, repeatedly. `configItemFromSwarm` also called `docker.` directly instead of going through the view's `deps`, so the view's own mock could not intercept that path.

## One listing, indexed

`docker.ServicesUsingConfigs` lists services once and returns `map[string][]swarm.Service` keyed by **both** `ConfigID` and `ConfigName` — a reference carries both and callers hold one or the other. A service appears once per key even when it mounts the same config at several paths, which is exactly the dedup `getUsedByStacksCmd` was performing by hand.

- `computeConfigUsedCmd`: N listings → 1.
- `getUsedByStacksCmd`: 3 calls → 2 (the `InspectConfig` stays; it resolves the ID so a reference carrying only an ID is still matched, preserving today's behaviour).
- `configItemFromSwarm`: takes the index rather than fetching. `addConfig` passes none — it is adding a config this view just created, so nothing can reference it yet and the rotation that will is still behind a confirmation dialog. Zero calls where there was one.

Errors are now logged rather than silently swallowed per config; the resulting used-map is all-false either way, as before.

## API surface

`ServicesUsingConfigs` joins `ConfigOps`; the two single-config lookups leave it, since no view calls them any more. They stay exported on the package for callers holding a single config, and mirror the `ListServicesUsingSecretID/Name` pair the secrets view still uses.

Not breaking: shrinking an interface cannot break an implementor, and nothing outside this repo implements `ConfigOps` — swarmcli-be consumes `docker.Deps` in its view factories but never implements the ops interfaces.

## Verification

- `TestServicesUsingConfigsIndexesInOneListing` (`docker/config_test.go`) — httptest daemon: asserts exactly one `GET /services`, both keys resolving, a twice-mounted config listing its service once, and a service with a nil `ContainerSpec` neither contributing keys nor panicking.
- `TestComputeConfigUsedCmd_SetsUsedMap` — now also asserts the view asks **once**, via a call counter on the mock.
- `TestGetUsedByStacksCmd_ReturnsUsedByMsg` — extended to cover a service reachable by name *and* one by ID, which is what makes a single listing able to replace the two.
- `TestAddConfigDoesNotQueryServices` — new; the freshly created row asks the daemon nothing.

`go test ./...` green, `golangci-lint run ./... --build-tags=integration` reports 0 issues.

## Note

`views/secrets` has the identical pattern (`actions.go:54` loop, `:308` double call). Left alone deliberately — it is a separate view and was not in scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)