### PR TITLE
perf(secrets): answer "which services use this secret" in one listing

### DIFF
--- a/docker/secret.go
+++ b/docker/secret.go
@@ -334,3 +334,50 @@ func listServicesUsingSecretName(ctx context.Context, client *client.Client, nam
 	}
 	return filtered, nil
 }
+
+// ServicesUsingSecrets indexes services by the secrets they reference.
+//
+// The single-secret lookups above each list every service and filter, which is
+// right for one question and wrong for many: asking about N secrets costs N full
+// service listings. This asks once and answers all of them.
+//
+// Keyed by both SecretID and SecretName, because a reference carries both and
+// callers hold one or the other. A service appears once per key it references,
+// even if it mounts the same secret at several paths.
+func ServicesUsingSecrets(ctx context.Context) (map[string][]swarm.Service, error) {
+	cli, err := GetClient()
+	if err != nil {
+		return nil, err
+	}
+	return ServicesUsingSecretsWith(ctx, cli)
+}
+
+// ServicesUsingSecretsWith is ServicesUsingSecrets against an explicit client.
+func ServicesUsingSecretsWith(ctx context.Context, cli *client.Client) (map[string][]swarm.Service, error) {
+	services, err := cli.ServiceList(ctx, swarm.ServiceListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list services: %w", err)
+	}
+
+	idx := make(map[string][]swarm.Service)
+	for _, s := range services {
+		if s.Spec.TaskTemplate.ContainerSpec == nil {
+			continue
+		}
+		keys := make(map[string]struct{})
+		for _, sec := range s.Spec.TaskTemplate.ContainerSpec.Secrets {
+			if sec.SecretID != "" {
+				keys[sec.SecretID] = struct{}{}
+			}
+			if sec.SecretName != "" {
+				keys[sec.SecretName] = struct{}{}
+			}
+		}
+		for k := range keys {
+			idx[k] = append(idx[k], s)
+		}
+	}
+
+	l().Debugf("[ServicesUsingSecrets] Indexed %d services under %d secret keys", len(services), len(idx))
+	return idx, nil
+}

--- a/docker/secret_ops.go
+++ b/docker/secret_ops.go
@@ -17,8 +17,14 @@ type SecretOps interface {
 	CreateSecretVersion(ctx context.Context, baseSecret swarm.Secret, newData []byte) (swarm.Secret, error)
 	RotateSecretInServices(ctx context.Context, oldSec *swarm.Secret, newSec swarm.Secret) error
 	DeleteSecret(ctx context.Context, nameOrID string) error
-	ListServicesUsingSecretID(ctx context.Context, secretID string) ([]swarm.Service, error)
-	ListServicesUsingSecretName(ctx context.Context, name string) ([]swarm.Service, error)
+	// ServicesUsingSecrets answers "which services reference this secret" for
+	// every secret at once, keyed by secret ID and name.
+	//
+	// It replaces per-secret lookups in this seam. ListServicesUsingSecretID and
+	// ListServicesUsingSecretName still exist on the package for a caller with a
+	// single secret, but each lists every service and filters, so a loop over
+	// them scales the whole service listing by the number of secrets.
+	ServicesUsingSecrets(ctx context.Context) (map[string][]swarm.Service, error)
 }
 
 type defaultSecretOps struct{}
@@ -41,9 +47,6 @@ func (defaultSecretOps) RotateSecretInServices(ctx context.Context, oldSec *swar
 func (defaultSecretOps) DeleteSecret(ctx context.Context, nameOrID string) error {
 	return DeleteSecret(ctx, nameOrID)
 }
-func (defaultSecretOps) ListServicesUsingSecretID(ctx context.Context, secretID string) ([]swarm.Service, error) {
-	return ListServicesUsingSecretID(ctx, secretID)
-}
-func (defaultSecretOps) ListServicesUsingSecretName(ctx context.Context, name string) ([]swarm.Service, error) {
-	return ListServicesUsingSecretName(ctx, name)
+func (defaultSecretOps) ServicesUsingSecrets(ctx context.Context) (map[string][]swarm.Service, error) {
+	return ServicesUsingSecrets(ctx)
 }

--- a/docker/secret_test.go
+++ b/docker/secret_test.go
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package docker
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/docker/docker/client"
+	"github.com/stretchr/testify/require"
+)
+
+// The reference question answered for every secret in one service listing.
+//
+// ListServicesUsingSecretID/Name each list every service and filter, so asking
+// about N secrets costs N listings — which is what the secrets view did on every
+// load and every poll.
+func TestServicesUsingSecretsIndexesInOneListing(t *testing.T) {
+	var lists int
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/v1.44/services", r.URL.Path)
+		lists++
+		w.Header().Set("Content-Type", "application/json")
+		// web mounts the same secret at two paths; db mounts another; noop has no
+		// ContainerSpec at all, which a real swarm does produce.
+		_, _ = w.Write([]byte(`[
+			{"ID":"web","Spec":{"Name":"web","TaskTemplate":{"ContainerSpec":{"Secrets":[
+				{"SecretID":"s1","SecretName":"alpha"},
+				{"SecretID":"s1","SecretName":"alpha"}
+			]}}}},
+			{"ID":"db","Spec":{"Name":"db","TaskTemplate":{"ContainerSpec":{"Secrets":[
+				{"SecretID":"s2","SecretName":"beta"}
+			]}}}},
+			{"ID":"noop","Spec":{"Name":"noop","TaskTemplate":{}}}
+		]`))
+	}))
+	defer ts.Close()
+
+	cli, err := client.NewClientWithOpts(client.WithHost(ts.URL), client.WithVersion("1.44"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = cli.Close() })
+
+	idx, err := ServicesUsingSecretsWith(context.Background(), cli)
+	require.NoError(t, err)
+	require.Equal(t, 1, lists, "one listing answers every secret")
+
+	// Reachable by ID and by name, because a caller may hold either.
+	require.Len(t, idx["s1"], 1)
+	require.Equal(t, "web", idx["s1"][0].ID)
+	require.Len(t, idx["alpha"], 1, "mounting one secret twice must not list the service twice")
+	require.Equal(t, "web", idx["alpha"][0].ID)
+
+	require.Len(t, idx["s2"], 1)
+	require.Equal(t, "db", idx["s2"][0].ID)
+	require.Len(t, idx["beta"], 1)
+
+	// A secret nothing references is simply absent, so len() on the miss is 0.
+	require.Empty(t, idx["s3"])
+	// The service with no ContainerSpec contributed no keys and did not panic.
+	require.Len(t, idx, 4)
+}

--- a/views/secrets/actions.go
+++ b/views/secrets/actions.go
@@ -43,18 +43,24 @@ func (m *Model) loadSecretsCmd() tea.Cmd {
 
 // computeSecretUsedCmd checks which secrets are used by services in background
 // and returns a usedStatusUpdatedMsg containing a map[id]bool.
+//
+// One indexed lookup, not one service listing per secret. This runs after every
+// load and after every poll that sees a change, so the per-secret version cost a
+// full ServiceList times the number of secrets on the swarm each time.
 func (m *Model) computeSecretUsedCmd(secs []docker.SecretWithDecodedData) tea.Cmd {
 	secretOps := m.deps.Secrets
 	return func() tea.Msg {
-		usedMap := make(map[string]bool, len(secs))
 		ctx, cancel := context.WithTimeout(context.Background(), pollTimeout)
 		defer cancel()
+
+		usedBy, err := secretOps.ServicesUsingSecrets(ctx)
+		if err != nil {
+			l().Errorf("computeSecretUsedCmd: ServicesUsingSecrets failed: %v", err)
+		}
+
+		usedMap := make(map[string]bool, len(secs))
 		for _, s := range secs {
-			usedMap[s.Secret.ID] = false
-			svcs, err := secretOps.ListServicesUsingSecretID(ctx, s.Secret.ID)
-			if err == nil && len(svcs) > 0 {
-				usedMap[s.Secret.ID] = true
-			}
+			usedMap[s.Secret.ID] = len(usedBy[s.Secret.ID]) > 0
 		}
 		return usedStatusUpdatedMsg(usedMap)
 	}
@@ -304,24 +310,19 @@ func (m *Model) getUsedByStacksCmd(secretName string) tea.Cmd {
 			return errorMsg(err)
 		}
 
-		// Get services by secret name and ID
-		servicesByName, err := secretOps.ListServicesUsingSecretName(ctx, secretName)
+		// Services referencing this secret by either name or ID. The index holds
+		// both keys, so one listing replaces the two this used to merge by hand.
+		svcsBySecret, err := secretOps.ServicesUsingSecrets(ctx)
 		if err != nil {
-			l().Errorf("Failed to list services using secret name %s: %v", secretName, err)
-			return errorMsg(err)
-		}
-		servicesByID, err := secretOps.ListServicesUsingSecretID(ctx, sec.Secret.ID)
-		if err != nil {
-			l().Errorf("Failed to list services using secret ID %s: %v", sec.Secret.ID, err)
+			l().Errorf("Failed to index services by secret: %v", err)
 			return errorMsg(err)
 		}
 
-		// Merge services, avoid duplicates
 		svcMap := make(map[string]swarm.Service)
-		for _, svc := range servicesByName {
+		for _, svc := range svcsBySecret[secretName] {
 			svcMap[svc.ID] = svc
 		}
-		for _, svc := range servicesByID {
+		for _, svc := range svcsBySecret[sec.Secret.ID] {
 			svcMap[svc.ID] = svc
 		}
 

--- a/views/secrets/actions_test.go
+++ b/views/secrets/actions_test.go
@@ -95,11 +95,8 @@ func TestInspectSecretCmd_NavigatesToInspect(t *testing.T) {
 
 func TestComputeSecretUsedCmd_SetsUsedMap(t *testing.T) {
 	mock := noopSecretOps()
-	mock.listServicesUsingSecretIDFn = func(_ context.Context, secretID string) ([]swarm.Service, error) {
-		if secretID == "id-used" {
-			return []swarm.Service{{ID: "svc1"}}, nil
-		}
-		return nil, nil
+	mock.servicesUsingSecretsFn = func(_ context.Context) (map[string][]swarm.Service, error) {
+		return map[string][]swarm.Service{"id-used": {{ID: "svc1"}}}, nil
 	}
 	m := testModel(func(m *Model) { m.deps.Secrets = mock })
 
@@ -113,6 +110,27 @@ func TestComputeSecretUsedCmd_SetsUsedMap(t *testing.T) {
 	require.True(t, ok)
 	require.True(t, usedMap["id-used"])
 	require.False(t, usedMap["id-unused"])
+	// The point of the index: one lookup regardless of how many secrets the
+	// swarm holds. Per-secret lookups each list every service.
+	require.Equal(t, 1, mock.servicesUsingSecretsCalls)
+}
+
+// A secret the view has just created cannot be referenced yet, so building its
+// row asks the daemon nothing at all.
+func TestAddSecretDoesNotQueryServices(t *testing.T) {
+	mock := noopSecretOps()
+	m := testModel(func(m *Model) { m.deps.Secrets = mock })
+
+	m.addSecret(docker.SecretWithDecodedData{
+		Secret: swarm.Secret{ID: "fresh", Spec: swarm.SecretSpec{Annotations: swarm.Annotations{Name: "s-new"}}},
+	})
+
+	require.Zero(t, mock.servicesUsingSecretsCalls)
+	require.NotEmpty(t, m.secretsList.Items)
+	item := m.secretsList.Items[len(m.secretsList.Items)-1]
+	require.Equal(t, "s-new", item.Name)
+	require.False(t, item.Used)
+	require.True(t, item.UsedKnown)
 }
 
 func TestGetUsedByStacksCmd_ReturnsUsedByMsg(t *testing.T) {
@@ -122,13 +140,17 @@ func TestGetUsedByStacksCmd_ReturnsUsedByMsg(t *testing.T) {
 			Secret: swarm.Secret{ID: "sec-id", Spec: swarm.SecretSpec{Annotations: swarm.Annotations{Name: "s1"}}},
 		}, nil
 	}
-	mock.listServicesUsingSecretNameFn = func(_ context.Context, _ string) ([]swarm.Service, error) {
-		return []swarm.Service{
-			{ID: "svc1", Spec: swarm.ServiceSpec{Annotations: swarm.Annotations{Name: "web", Labels: map[string]string{"com.docker.stack.namespace": "mystack"}}}},
+	// One service reachable by name, another by ID: the index carries both keys,
+	// which is what lets a single listing replace the two this used to merge.
+	mock.servicesUsingSecretsFn = func(_ context.Context) (map[string][]swarm.Service, error) {
+		return map[string][]swarm.Service{
+			"s1": {
+				{ID: "svc1", Spec: swarm.ServiceSpec{Annotations: swarm.Annotations{Name: "web", Labels: map[string]string{"com.docker.stack.namespace": "mystack"}}}},
+			},
+			"sec-id": {
+				{ID: "svc2", Spec: swarm.ServiceSpec{Annotations: swarm.Annotations{Name: "api", Labels: map[string]string{"com.docker.stack.namespace": "mystack"}}}},
+			},
 		}, nil
-	}
-	mock.listServicesUsingSecretIDFn = func(_ context.Context, _ string) ([]swarm.Service, error) {
-		return nil, nil
 	}
 
 	m := testModel(func(m *Model) { m.deps.Secrets = mock })
@@ -137,8 +159,11 @@ func TestGetUsedByStacksCmd_ReturnsUsedByMsg(t *testing.T) {
 	used, ok := msg.(usedByMsg)
 	require.True(t, ok)
 	require.Equal(t, "s1", used.SecretName)
-	require.Len(t, used.UsedBy, 1)
+	require.Len(t, used.UsedBy, 2)
 	require.Equal(t, "mystack", used.UsedBy[0].StackName)
+	require.Equal(t, "api", used.UsedBy[0].ServiceName, "sorted by stack then service")
+	require.Equal(t, "web", used.UsedBy[1].ServiceName)
+	require.Equal(t, 1, mock.servicesUsingSecretsCalls)
 }
 
 func TestCheckSecretsCmd_NoChange_ReturnsPollRetry(t *testing.T) {

--- a/views/secrets/model.go
+++ b/views/secrets/model.go
@@ -4,7 +4,6 @@
 package secretsview
 
 import (
-	"context"
 	"fmt"
 	"github.com/Eldara-Tech/swarmcli/docker"
 	filterlist "github.com/Eldara-Tech/swarmcli/ui/components/filterable/list"
@@ -254,8 +253,9 @@ func (m *Model) findSecretByName(name string) (*docker.SecretWithDecodedData, er
 
 func (m *Model) addSecret(sec docker.SecretWithDecodedData) {
 	m.secrets = append(m.secrets, sec)
-	ctx := context.Background()
-	m.secretsList.Items = append(m.secretsList.Items, secretItemFromSwarm(ctx, sec.Secret))
+	// No index: this is a secret this view has just created, so no service can
+	// reference it yet.
+	m.secretsList.Items = append(m.secretsList.Items, secretItemFromSwarm(sec.Secret, nil))
 	m.secretsList.ApplyFilter()
 }
 

--- a/views/secrets/model_test.go
+++ b/views/secrets/model_test.go
@@ -18,14 +18,16 @@ import (
 // --- mocks ---
 
 type mockSecretOps struct {
-	listSecretsFn                 func(ctx context.Context) ([]swarm.Secret, error)
-	inspectSecretFn               func(ctx context.Context, nameOrID string) (*docker.SecretWithDecodedData, error)
-	createSecretFn                func(ctx context.Context, name string, data []byte, labels map[string]string) (swarm.Secret, error)
-	createSecretVersionFn         func(ctx context.Context, baseSecret swarm.Secret, newData []byte) (swarm.Secret, error)
-	rotateSecretInServicesFn      func(ctx context.Context, oldSec *swarm.Secret, newSec swarm.Secret) error
-	deleteSecretFn                func(ctx context.Context, nameOrID string) error
-	listServicesUsingSecretIDFn   func(ctx context.Context, secretID string) ([]swarm.Service, error)
-	listServicesUsingSecretNameFn func(ctx context.Context, name string) ([]swarm.Service, error)
+	listSecretsFn            func(ctx context.Context) ([]swarm.Secret, error)
+	inspectSecretFn          func(ctx context.Context, nameOrID string) (*docker.SecretWithDecodedData, error)
+	createSecretFn           func(ctx context.Context, name string, data []byte, labels map[string]string) (swarm.Secret, error)
+	createSecretVersionFn    func(ctx context.Context, baseSecret swarm.Secret, newData []byte) (swarm.Secret, error)
+	rotateSecretInServicesFn func(ctx context.Context, oldSec *swarm.Secret, newSec swarm.Secret) error
+	deleteSecretFn           func(ctx context.Context, nameOrID string) error
+	servicesUsingSecretsFn   func(ctx context.Context) (map[string][]swarm.Service, error)
+	// servicesUsingSecretsCalls counts the indexed lookups, so a test can assert
+	// the view asks once rather than once per secret.
+	servicesUsingSecretsCalls int
 }
 
 func (m *mockSecretOps) ListSecrets(ctx context.Context) ([]swarm.Secret, error) {
@@ -52,11 +54,12 @@ func (m *mockSecretOps) RotateSecretInServices(ctx context.Context, oldSec *swar
 func (m *mockSecretOps) DeleteSecret(ctx context.Context, nameOrID string) error {
 	return m.deleteSecretFn(ctx, nameOrID)
 }
-func (m *mockSecretOps) ListServicesUsingSecretID(ctx context.Context, secretID string) ([]swarm.Service, error) {
-	return m.listServicesUsingSecretIDFn(ctx, secretID)
-}
-func (m *mockSecretOps) ListServicesUsingSecretName(ctx context.Context, name string) ([]swarm.Service, error) {
-	return m.listServicesUsingSecretNameFn(ctx, name)
+func (m *mockSecretOps) ServicesUsingSecrets(ctx context.Context) (map[string][]swarm.Service, error) {
+	m.servicesUsingSecretsCalls++
+	if m.servicesUsingSecretsFn != nil {
+		return m.servicesUsingSecretsFn(ctx)
+	}
+	return nil, nil
 }
 
 // --- helpers ---
@@ -106,12 +109,6 @@ func noopSecretOps() *mockSecretOps {
 		},
 		deleteSecretFn: func(_ context.Context, _ string) error {
 			return nil
-		},
-		listServicesUsingSecretIDFn: func(_ context.Context, _ string) ([]swarm.Service, error) {
-			return nil, nil
-		},
-		listServicesUsingSecretNameFn: func(_ context.Context, _ string) ([]swarm.Service, error) {
-			return nil, nil
 		},
 	}
 }

--- a/views/secrets/view.go
+++ b/views/secrets/view.go
@@ -4,9 +4,7 @@
 package secretsview
 
 import (
-	"context"
 	"fmt"
-	"github.com/Eldara-Tech/swarmcli/docker"
 	"github.com/Eldara-Tech/swarmcli/ui"
 	"github.com/Eldara-Tech/swarmcli/ui/components/errordialog"
 	"github.com/Eldara-Tech/swarmcli/ui/dialog"
@@ -51,19 +49,19 @@ func (i usedByItem) FilterValue() string { return i.StackName + " " + i.ServiceN
 func (i usedByItem) Title() string       { return fmt.Sprintf("%-24s %-24s", i.StackName, i.ServiceName) }
 func (i usedByItem) Description() string { return "Service: " + i.ServiceName }
 
-func secretItemFromSwarm(ctx context.Context, s swarm.Secret) secretItem {
-	used := false
-	services, err := docker.ListServicesUsingSecretID(ctx, s.ID)
-	if err == nil && len(services) > 0 {
-		used = true
-	}
+// secretItemFromSwarm builds a list row for one secret. usedBy is the
+// secret-to-services index from docker.ServicesUsingSecrets, looked up by both
+// ID and name because a service reference may carry either. A nil index means
+// nothing references this secret — which is the case for one just created, and
+// is why this no longer reaches for the daemon itself.
+func secretItemFromSwarm(s swarm.Secret, usedBy map[string][]swarm.Service) secretItem {
 	return secretItem{
 		Name:      s.Spec.Name,
 		ID:        s.ID,
 		CreatedAt: s.CreatedAt,
 		UpdatedAt: s.UpdatedAt,
 		Labels:    s.Spec.Labels,
-		Used:      used,
+		Used:      len(usedBy[s.ID]) > 0 || len(usedBy[s.Spec.Name]) > 0,
 		UsedKnown: true,
 	}
 }


### PR DESCRIPTION
The same N+1 #516 removed from the configs view, in the view it was copied from. Last known instance of the pattern.

## The loop

`docker.ListServicesUsingSecretID` and `...ByName` each call `ServiceList` for the whole swarm and filter client-side. Correct for one secret; the secrets view asked in a loop:

| site | calls | when |
|---|---|---|
| `computeSecretUsedCmd` | one full `ServiceList` **per secret** | after every load, and every poll that sees a change |
| `getUsedByStacksCmd` | two (by name, by ID) then merged by hand | user opens "used by" |
| `secretItemFromSwarm` | one | per secret added |

`secretItemFromSwarm` also called `docker.` directly instead of going through the view's `deps`, so the view's own mock could not intercept that path.

## One listing, indexed

`docker.ServicesUsingSecrets` lists services once and returns `map[string][]swarm.Service` keyed by **both** `SecretID` and `SecretName` — a reference carries both and callers hold one or the other. A service appears once per key even when it mounts the same secret at several paths, which is exactly the dedup `getUsedByStacksCmd` was performing by hand.

- `computeSecretUsedCmd`: N listings → 1.
- `getUsedByStacksCmd`: 3 calls → 2 (the `InspectSecret` stays; it resolves the ID so a reference carrying only an ID is still matched, preserving today's behaviour).
- `secretItemFromSwarm`: takes the index rather than fetching. `addSecret` passes none — it runs from `secretCreatedMsg`, so the secret was created moments ago and nothing can reference it. Zero calls where there was one.

Errors are now logged rather than silently swallowed per secret; the resulting used-map is all-false either way, as before.

## API surface

`ServicesUsingSecrets` joins `SecretOps`; the two single-secret lookups leave it, since no view calls them any more. They stay exported on the package for callers holding a single secret.

Their **unexported** counterparts are untouched: `listServicesUsingSecret` and `listServicesUsingSecretName` are still used by `RotateSecretInServices` (`secret.go:211,213`) and the delete guard (`:261`), which really are single-secret questions. That is the one asymmetry with #516, where the config equivalents had no such callers.

Not breaking: shrinking an interface cannot break an implementor, and nothing outside this repo implements `SecretOps` — swarmcli-be consumes `docker.Deps` in its view factories but never implements the ops interfaces.

## Verification

- `TestServicesUsingSecretsIndexesInOneListing` (`docker/secret_test.go`, new file) — httptest daemon: asserts exactly one `GET /services`, both keys resolving, a twice-mounted secret listing its service once, and a service with a nil `ContainerSpec` neither contributing keys nor panicking.
- `TestComputeSecretUsedCmd_SetsUsedMap` — now also asserts the view asks **once**, via a call counter on the mock.
- `TestGetUsedByStacksCmd_ReturnsUsedByMsg` — extended to cover a service reachable by name *and* one by ID.
- `TestAddSecretDoesNotQueryServices` — new; the freshly created row asks the daemon nothing.

`go test ./...` green, `golangci-lint run ./... --build-tags=integration` reports 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)