### PR TITLE
fix(charts): honour a top-level name: on an external resource

### DIFF
--- a/charts/networks.go
+++ b/charts/networks.go
@@ -4,7 +4,9 @@
 package charts
 
 import (
+	"fmt"
 	"sort"
+	"strings"
 
 	"gopkg.in/yaml.v3"
 )
@@ -14,7 +16,7 @@ import (
 // without a networks block (or invalid YAML) yields no names and no error —
 // deploy validation handles that.
 func externalNetworks(manifest string) ([]string, error) {
-	return externalResourceNames(manifest, "networks"), nil
+	return externalResourceNames(manifest, "networks")
 }
 
 // externalResourceNames returns the real names of the entries under the given
@@ -23,50 +25,75 @@ func externalNetworks(manifest string) ([]string, error) {
 //
 //	<key>:
 //	  alias:
-//	    external: true            # real name == map key
+//	    external: true
+//	    name: actual-resource   # real name == name, else the map key
 //	  other:
 //	    external:
-//	      name: actual-resource   # real name == external.name
+//	      name: actual-resource # deprecated form; real name == external.name
+//
+// Precedence follows docker/cli's compose loader, which is what
+// `docker stack deploy` runs against the very same manifest: a sibling name:
+// wins, the deprecated external.name is still honoured, and the map key is only
+// the fallback. Reading the key when a name: was given is what made a chart
+// written to the current spec impossible to deploy (#513) — the pre-flight
+// looked for something nothing was ever going to be called.
+//
+// Declaring both forms is an error in the loader, so it is one here too:
+// accepting it would let a manifest clear the pre-flight that the deploy then
+// rejects, which is the opposite of what a pre-flight is for.
 //
 // Non-external entries are ignored. A manifest without that block, or invalid
 // YAML, yields no names. The block is decoded in isolation so unrelated
 // top-level keys (services, volumes, …) of any shape do not interfere.
-func externalResourceNames(manifest, topLevelKey string) []string {
+func externalResourceNames(manifest, topLevelKey string) ([]string, error) {
 	var top map[string]yaml.Node
 	if err := yaml.Unmarshal([]byte(manifest), &top); err != nil {
-		return nil
+		return nil, nil
 	}
 	node, ok := top[topLevelKey]
 	if !ok {
-		return nil
+		return nil, nil
 	}
 	var block map[string]struct {
 		External yaml.Node `yaml:"external"`
+		Name     string    `yaml:"name"`
 	}
 	if err := node.Decode(&block); err != nil {
-		return nil
+		return nil, nil
 	}
 	var names []string
 	for key, res := range block {
+		// deprecated holds external.name, set only by the long form.
+		var deprecated string
 		switch res.External.Kind {
 		case yaml.ScalarNode:
 			var b bool
-			if err := res.External.Decode(&b); err == nil && b {
-				names = append(names, key)
+			if err := res.External.Decode(&b); err != nil || !b {
+				continue
 			}
 		case yaml.MappingNode:
 			var m struct {
 				Name string `yaml:"name"`
 			}
-			if err := res.External.Decode(&m); err == nil {
-				if m.Name != "" {
-					names = append(names, m.Name)
-				} else {
-					names = append(names, key)
-				}
+			if err := res.External.Decode(&m); err != nil {
+				continue
 			}
+			deprecated = m.Name
+		default:
+			continue
+		}
+		switch {
+		case res.Name != "" && deprecated != "":
+			return nil, fmt.Errorf("%s %q: external.name and name conflict; use only name",
+				strings.TrimSuffix(topLevelKey, "s"), key)
+		case res.Name != "":
+			names = append(names, res.Name)
+		case deprecated != "":
+			names = append(names, deprecated)
+		default:
+			names = append(names, key)
 		}
 	}
 	sort.Strings(names)
-	return names
+	return names, nil
 }

--- a/charts/networks_test.go
+++ b/charts/networks_test.go
@@ -45,6 +45,11 @@ func TestExternalNetworks(t *testing.T) {
 			manifest: "networks:\n  b-net:\n    external: true\n  a-net:\n    external: true\n",
 			want:     []string{"a-net", "b-net"},
 		},
+		{
+			name:     "sibling name wins over the map key",
+			manifest: "networks:\n  alias:\n    external: true\n    name: traefik-public\n",
+			want:     []string{"traefik-public"},
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -53,4 +58,9 @@ func TestExternalNetworks(t *testing.T) {
 			require.Equal(t, tc.want, got)
 		})
 	}
+}
+
+func TestExternalNetworksRejectsBothForms(t *testing.T) {
+	_, err := externalNetworks("networks:\n  alias:\n    external:\n      name: deprecated\n    name: current\n")
+	require.EqualError(t, err, `network "alias": external.name and name conflict; use only name`)
 }

--- a/charts/release.go
+++ b/charts/release.go
@@ -464,8 +464,14 @@ func describe(desc string) string {
 // every external secret/config the manifest references must be declared there
 // (else a hard error), and a declared description enriches the remediation.
 func (e *Engine) ensureExternalSecretsConfigs(ctx context.Context, manifest string, req *Requirements) error {
-	secrets := externalResourceNames(manifest, "secrets")
-	configs := externalResourceNames(manifest, "configs")
+	secrets, err := externalResourceNames(manifest, "secrets")
+	if err != nil {
+		return err
+	}
+	configs, err := externalResourceNames(manifest, "configs")
+	if err != nil {
+		return err
+	}
 	if len(secrets) == 0 && len(configs) == 0 {
 		return nil
 	}

--- a/charts/requirements_test.go
+++ b/charts/requirements_test.go
@@ -42,6 +42,7 @@ func TestExternalResourceNames(t *testing.T) {
 		manifest string
 		key      string
 		want     []string
+		wantErr  string
 	}{
 		{
 			name:     "external true uses the map key",
@@ -54,6 +55,40 @@ func TestExternalResourceNames(t *testing.T) {
 			manifest: "configs:\n  alias:\n    external:\n      name: real-config\n",
 			key:      "configs",
 			want:     []string{"real-config"},
+		},
+		// The current compose spec: external: true with a sibling name:. All
+		// three kinds share this function, so all three are covered — only
+		// secrets and configs reach an existence check, but a network resolved
+		// to its map key would be auto-created under the wrong name.
+		{
+			name:     "sibling name wins over the map key for a secret",
+			manifest: "secrets:\n  alias:\n    external: true\n    name: real-secret\n",
+			key:      "secrets",
+			want:     []string{"real-secret"},
+		},
+		{
+			name:     "sibling name wins over the map key for a config",
+			manifest: "configs:\n  stolen:\n    external: true\n    name: swarmcli.release.my-app.v1\n",
+			key:      "configs",
+			want:     []string{"swarmcli.release.my-app.v1"},
+		},
+		{
+			name:     "sibling name wins over the map key for a network",
+			manifest: "networks:\n  alias:\n    external: true\n    name: real-net\n",
+			key:      "networks",
+			want:     []string{"real-net"},
+		},
+		{
+			name:     "a name on a non-external resource is not a reference",
+			manifest: "networks:\n  internal:\n    driver: overlay\n    name: renamed\n",
+			key:      "networks",
+			want:     nil,
+		},
+		{
+			name:     "declaring both forms is refused",
+			manifest: "configs:\n  alias:\n    external:\n      name: deprecated\n    name: current\n",
+			key:      "configs",
+			wantErr:  `config "alias": external.name and name conflict; use only name`,
 		},
 		{
 			name:     "non-external and external:false are ignored",
@@ -82,7 +117,13 @@ func TestExternalResourceNames(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			require.Equal(t, tc.want, externalResourceNames(tc.manifest, tc.key))
+			got, err := externalResourceNames(tc.manifest, tc.key)
+			if tc.wantErr != "" {
+				require.EqualError(t, err, tc.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
 		})
 	}
 }
@@ -127,6 +168,50 @@ func TestEnsureExternalSecretsConfigs(t *testing.T) {
 		// alias maps to real-secret, which exists -> passes
 		require.NoError(t, e.ensureExternalSecretsConfigs(ctx,
 			"secrets:\n  alias:\n    external:\n      name: real-secret\n", nil))
+	})
+
+	// The reproduction from #513: the config exists under the name the chart
+	// declares, and the pre-flight has to look for that name rather than the
+	// compose key. Before the fix this failed, naming something the chart never
+	// asked for and suggesting the user create a second, unrelated config.
+	t.Run("sibling name is resolved and its absence is reported by that name", func(t *testing.T) {
+		fb := newFakeBackend()
+		fb.configs["swarmcli.release.my-app.v1"] = fakeConfig{}
+		e := testEngine(fb)
+		m := "configs:\n  stolen:\n    external: true\n    name: swarmcli.release.my-app.v1\n"
+		require.NoError(t, e.ensureExternalSecretsConfigs(ctx, m, nil))
+
+		err := e.ensureExternalSecretsConfigs(ctx,
+			"configs:\n  stolen:\n    external: true\n    name: absent-config\n", nil)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), `config "absent-config" does not exist`)
+		require.Contains(t, err.Error(), "docker config create absent-config <file>")
+		require.NotContains(t, err.Error(), "stolen")
+	})
+
+	// requirements.yaml is authoritative over the *resolved* name: a requirement
+	// is about a resource on the swarm, not about a template-local alias.
+	t.Run("a requirement must declare the resolved name, not the compose key", func(t *testing.T) {
+		fb := newFakeBackend()
+		fb.secrets["real-secret"] = struct{}{}
+		e := testEngine(fb)
+		m := "secrets:\n  alias:\n    external: true\n    name: real-secret\n"
+
+		req := &Requirements{Secrets: []ResourceRequirement{{Name: "alias"}}}
+		err := e.ensureExternalSecretsConfigs(ctx, m, req)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "not declared in requirements.yaml")
+		require.Contains(t, err.Error(), "real-secret")
+
+		req = &Requirements{Secrets: []ResourceRequirement{{Name: "real-secret"}}}
+		require.NoError(t, e.ensureExternalSecretsConfigs(ctx, m, req))
+	})
+
+	t.Run("declaring both external forms is refused", func(t *testing.T) {
+		e := testEngine(newFakeBackend())
+		err := e.ensureExternalSecretsConfigs(ctx,
+			"configs:\n  alias:\n    external:\n      name: deprecated\n    name: current\n", nil)
+		require.EqualError(t, err, `config "alias": external.name and name conflict; use only name`)
 	})
 
 	t.Run("backend error is surfaced", func(t *testing.T) {

--- a/integration-tests/charts/charts_external_name_test.go
+++ b/integration-tests/charts/charts_external_name_test.go
@@ -1,0 +1,162 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+//go:build integration
+
+package charts
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/Eldara-Tech/swarmcli/charts"
+	"github.com/Eldara-Tech/swarmcli/docker"
+	swarmlog "github.com/Eldara-Tech/swarmcli/utils/log"
+)
+
+// writeExtConfigChart writes a chart whose service mounts a config declared
+// external under `key`, optionally with a sibling `name:` naming the real
+// resource. A nil name yields the historical key-as-name form.
+func writeExtConfigChart(t *testing.T, key, name string) string {
+	t.Helper()
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "Chart.yaml"),
+		[]byte("apiVersion: v1\nname: extname\nversion: 0.1.0\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "values.yaml"), []byte("{}\n"), 0o644))
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "templates"), 0o755))
+
+	decl := "configs:\n  " + key + ":\n    external: true\n"
+	if name != "" {
+		decl = "configs:\n  " + key + ":\n    external: true\n    name: " + name + "\n"
+	}
+	stack := "version: \"3.9\"\n\nservices:\n  app:\n" +
+		"    image: traefik/whoami:v1.10\n" +
+		"    configs:\n      - " + key + "\n" +
+		"    deploy:\n      replicas: 1\n" +
+		"      labels:\n        com.swarmcli.release: {{ .Release.Name }}\n\n" + decl
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "templates", "stack.yaml"), []byte(stack), 0o644))
+	return dir
+}
+
+// A chart declaring an external config the way the Compose specification
+// currently documents — `external: true` with a sibling `name:` — must install.
+//
+// This is the one thing the unit tests cannot prove. They check that swarmcli
+// resolves the reference to the sibling name, against a fake backend. What
+// makes the fix correct is that swarmcli's pre-flight and the *deploy* agree on
+// which resource is meant, and the deploy is `docker stack deploy` shelled out
+// to whatever `docker` binary is on PATH — not the docker/cli the module pins.
+// Reading that loader's source establishes the intent; only a real swarm
+// establishes that the binary in front of it behaves the same way.
+//
+// Before the fix the pre-flight refused this chart outright, naming the compose
+// key and suggesting the operator create a second, unrelated config (#513).
+func TestChartsExternalConfigResolvesASiblingName(t *testing.T) {
+	swarmlog.InitTestIfTestLogEnv()
+
+	ctx := context.Background()
+	release := fmt.Sprintf("itest-extname-%d", time.Now().UnixNano())
+	realName := release + "-real-config"
+
+	_, err := docker.CreateConfig(ctx, realName, []byte("payload\n"), nil)
+	require.NoError(t, err)
+
+	eng := charts.NewEngine()
+	defer func() {
+		_, _ = eng.Uninstall(ctx, release, true)
+		_ = docker.DeleteConfig(ctx, realName)
+	}()
+
+	// The compose key is deliberately NOT the name of anything on the swarm, so
+	// resolving to the key cannot accidentally pass.
+	chartDir := writeExtConfigChart(t, "alias", realName)
+	ch, err := charts.LoadChartDir(chartDir)
+	require.NoError(t, err)
+	rctx := charts.RenderContext{
+		Values:  ch.Values,
+		Release: charts.ReleaseMeta{Name: release, Namespace: release, Revision: 1},
+		Chart:   charts.ChartMeta{Name: ch.Metadata.Name, Version: ch.Metadata.Version},
+	}
+	manifest, err := charts.Render(ch, rctx)
+	require.NoError(t, err)
+
+	rel, err := eng.Install(ctx, release,
+		charts.ReleaseChart{Name: ch.Metadata.Name, Version: ch.Metadata.Version},
+		ch.Values, manifest, charts.InstallOptions{Wait: true, Timeout: 90 * time.Second})
+	require.NoError(t, err, "a chart declaring an external config by name: must install")
+	require.Equal(t, charts.StatusDeployed, rel.Status)
+}
+
+// The absent case, on a real swarm: the resource is reported and remediated by
+// the name the chart asked for, never by the compose key. Getting this wrong is
+// how #513 sent operators to create a second config that would not have helped.
+func TestChartsExternalConfigMissingIsReportedByItsResolvedName(t *testing.T) {
+	swarmlog.InitTestIfTestLogEnv()
+
+	ctx := context.Background()
+	release := fmt.Sprintf("itest-extmissing-%d", time.Now().UnixNano())
+	absent := release + "-absent-config"
+
+	eng := charts.NewEngine()
+	defer func() { _, _ = eng.Uninstall(ctx, release, true) }()
+
+	chartDir := writeExtConfigChart(t, "alias", absent)
+	ch, err := charts.LoadChartDir(chartDir)
+	require.NoError(t, err)
+	manifest, err := charts.Render(ch, charts.RenderContext{
+		Values:  ch.Values,
+		Release: charts.ReleaseMeta{Name: release, Namespace: release, Revision: 1},
+		Chart:   charts.ChartMeta{Name: ch.Metadata.Name, Version: ch.Metadata.Version},
+	})
+	require.NoError(t, err)
+
+	_, err = eng.Install(ctx, release,
+		charts.ReleaseChart{Name: ch.Metadata.Name, Version: ch.Metadata.Version},
+		ch.Values, manifest, charts.InstallOptions{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), absent)
+	require.Contains(t, err.Error(), "docker config create "+absent)
+	require.NotContains(t, err.Error(), "alias", "the compose key is not the name of anything")
+}
+
+// The historical form still works, against the same real swarm. Every chart in
+// Eldara-Tech/swarmcli-charts is written this way, so a regression here breaks
+// every published chart at once.
+func TestChartsExternalConfigStillResolvesTheMapKey(t *testing.T) {
+	swarmlog.InitTestIfTestLogEnv()
+
+	ctx := context.Background()
+	release := fmt.Sprintf("itest-extkey-%d", time.Now().UnixNano())
+	key := release + "-keyed-config"
+
+	_, err := docker.CreateConfig(ctx, key, []byte("payload\n"), nil)
+	require.NoError(t, err)
+
+	eng := charts.NewEngine()
+	defer func() {
+		_, _ = eng.Uninstall(ctx, release, true)
+		_ = docker.DeleteConfig(ctx, key)
+	}()
+
+	chartDir := writeExtConfigChart(t, key, "")
+	ch, err := charts.LoadChartDir(chartDir)
+	require.NoError(t, err)
+	manifest, err := charts.Render(ch, charts.RenderContext{
+		Values:  ch.Values,
+		Release: charts.ReleaseMeta{Name: release, Namespace: release, Revision: 1},
+		Chart:   charts.ChartMeta{Name: ch.Metadata.Name, Version: ch.Metadata.Version},
+	})
+	require.NoError(t, err)
+
+	rel, err := eng.Install(ctx, release,
+		charts.ReleaseChart{Name: ch.Metadata.Name, Version: ch.Metadata.Version},
+		ch.Values, manifest, charts.InstallOptions{Wait: true, Timeout: 90 * time.Second})
+	require.NoError(t, err, "the key-as-name form must keep working")
+	require.Equal(t, charts.StatusDeployed, rel.Status)
+}


### PR DESCRIPTION
Closes #513.

## Problem

A chart declaring an external config the way the Compose specification currently documents is refused by the pre-flight, with an error naming something that was never the name:

```yaml
configs:
  stolen:
    external: true
    name: swarmcli.release.my-app.v1
```

```
external secret(s)/config(s) required by this chart do not exist:
  config "stolen" does not exist
create them on a swarm manager, then retry:
  docker config create stolen <file>
```

The config exists. `stolen` is the compose key; `swarmcli.release.my-app.v1` is the name. Following the remedy creates a second, unrelated config and does not fix it.

## Cause

`externalResourceNames` branched on the *kind* of the `external` node — scalar `external: true` → the map key, mapping `external: {name: X}` → `X` — and never read the sibling `name:`. So the **deprecated** form was handled and the current one was not. Compose deprecated `external.name` in favour of a top-level `name:`, and `docker/cli`'s compose loader honours the latter; since swarmcli deploys by shelling out to `docker stack deploy`, the deploy would have worked had it got that far.

## Fix

Precedence now follows the loader: a sibling `name:` wins, the deprecated `external.name` is still honoured, the map key is only the fallback. Declaring both is an error in the loader, so it is one here too — accepting it would let a manifest clear the pre-flight that the deploy then rejects, which is the opposite of what a pre-flight is for. That needed `externalResourceNames` to return an error; `externalNetworks` already had the signature for it.

All three resource kinds go through this function and all three are covered. Only configs and secrets reach an existence check, but a network resolved to its map key would be **auto-created under the wrong name**.

## Consequence worth reviewing

`requirements.yaml` is matched against the *resolved* name, so a chart using the `name:` form must declare the real resource rather than the template-local alias. That is the consistent reading — a requirement is about something on the swarm, not a template-local alias — and there is nothing to migrate, because no chart could use this form before. Covered by a test.

## Risk

Low. All 32 external declarations across the 12 charts in `Eldara-Tech/swarmcli-charts` use the key-as-name form; none uses a top-level `name:` or the mapping form, so nothing the chart repo ships changes behaviour.

## Tests

- `TestExternalResourceNames` — sibling `name:` per resource kind (secrets, configs, networks), a `name:` on a *non-external* resource is not a reference, both-forms conflict.
- `TestExternalNetworksRejectsBothForms`.
- `TestEnsureExternalSecretsConfigs` — the #513 reproduction end to end: resolved name found; resolved name absent reports and remediates by *that* name and never mentions the compose key; requirements must declare the resolved name; both-forms refused.

`go test ./...` and `golangci-lint run ./charts/...` clean.