### PR TITLE
fix(charts): correct a stale owner stamp on an otherwise unchanged release

### DIFF
--- a/charts/apply.go
+++ b/charts/apply.go
@@ -140,7 +140,7 @@ func (e *Engine) PlanApply(ctx context.Context, rf *ReleaseFile, src ChartSource
 	for _, spec := range rf.Releases {
 		managed[spec.Name] = true
 
-		rp, err := e.planRelease(rf, spec, src, deployed, read)
+		rp, err := e.planRelease(rf, spec, src, deployed, read, owner)
 		if err != nil {
 			return nil, err
 		}
@@ -175,7 +175,9 @@ func ownedBy(rel Release, id string) bool {
 	return own == OwnerRef{ID: id, Kind: OwnerKindRelease, Name: rel.Name}
 }
 
-func (e *Engine) planRelease(rf *ReleaseFile, spec ReleaseSpec, src ChartSource, deployed map[string]Release, read func(string) ([]byte, error)) (ReleasePlan, error) {
+// owner is the id PlanApply resolved for the whole plan (opts.Owner over the
+// file's own), not rf.ownerID() — planRelease cannot re-derive it.
+func (e *Engine) planRelease(rf *ReleaseFile, spec ReleaseSpec, src ChartSource, deployed map[string]Release, read func(string) ([]byte, error), owner string) (ReleasePlan, error) {
 	ref := rf.ChartRef(spec)
 
 	ch, err := src.Load(ref, spec.Version)
@@ -234,7 +236,7 @@ func (e *Engine) planRelease(rf *ReleaseFile, spec ReleaseSpec, src ChartSource,
 	default:
 		rp.FromVersion = cur.Chart.Version
 		rp.CurrentManifest = cur.Manifest
-		same, err := unchanged(&cur, rc, values, manifest)
+		same, err := unchanged(&cur, rc, values, manifest, owner)
 		if err != nil {
 			return ReleasePlan{}, fmt.Errorf("%s: release %q: %w", rf.Path, spec.Name, err)
 		}
@@ -294,8 +296,26 @@ func (e *Engine) Apply(ctx context.Context, plan *Plan, opts InstallOptions) ([]
 }
 
 // unchanged reports whether the current revision already encodes the desired
-// state: same chart, same rendered manifest, same values.
-func unchanged(cur *Release, chart ReleaseChart, values map[string]any, manifest string) (bool, error) {
+// state: same chart, same rendered manifest, same values — and the ownership
+// this plan is being asked to establish.
+//
+// Ownership is part of the desired state because the stamp is the only evidence
+// prune has. deployAndRecord is the sole writer of rel.Owner, and Apply skips
+// ActionUnchanged without calling it, so leaving the owner out of this
+// comparison meant a handover between two manifests with byte-identical content
+// silently never happened: the plan reported "unchanged", which was true of the
+// deployed resources and false of the ownership, and every later plan kept
+// classifying the release under the departed owner (#511).
+//
+// A stamp is only *contradicted* when it names someone else. An absent stamp is
+// not a mismatch: an unowned release is already classified conservatively — it
+// falls to Plan.Unmanaged rather than Plan.Orphaned — so forcing a revision to
+// stamp it would buy no safety, and would re-deploy every release installed
+// before owner stamping existed on the first apply after upgrading. An
+// unparseable stamp is no evidence of anything, so it is a mismatch and gets
+// healed. An empty plan owner never forces: an apply that claims nothing must
+// not strip a stamp somebody else wrote.
+func unchanged(cur *Release, chart ReleaseChart, values map[string]any, manifest, owner string) (bool, error) {
 	if cur == nil || cur.Status == StatusUninstalled {
 		return false, nil
 	}
@@ -303,6 +323,9 @@ func unchanged(cur *Release, chart ReleaseChart, values map[string]any, manifest
 		return false, nil
 	}
 	if cur.Manifest != manifest {
+		return false, nil
+	}
+	if owner != "" && cur.Owner != "" && !ownedBy(*cur, owner) {
 		return false, nil
 	}
 	return sameValues(cur.Values, values)

--- a/charts/owner_test.go
+++ b/charts/owner_test.go
@@ -161,3 +161,108 @@ func TestRollbackStampsTheCurrentOwnerNotTheTargets(t *testing.T) {
 	require.Equal(t, "apply/b:release/hello", rel.Owner)
 	require.Equal(t, "services: {}\n", rel.Manifest, "rollback still restores the target's content")
 }
+
+// The owner is part of the desired state an apply establishes, so a plan
+// classified against one owner must not report "unchanged" for a release
+// stamped by another — that was #511, and it let a departed owner's stamp
+// survive for ever behind a byte-identical file.
+//
+// The table is the whole contract, including the two cases that must NOT force
+// a revision: an absent stamp (else every release predating owner stamping
+// re-deploys once on upgrade) and an absent plan owner (else an apply claiming
+// nothing strips a stamp somebody else wrote).
+func TestUnchangedComparesTheOwner(t *testing.T) {
+	const manifest = "services: {}\n"
+	chart := ReleaseChart{Name: "demo", Version: "0.1.0"}
+	rel := func(owner string) *Release {
+		return &Release{Name: "hello", Status: StatusDeployed, Chart: chart, Manifest: manifest, Owner: owner}
+	}
+
+	for _, tc := range []struct {
+		name  string
+		stamp string
+		owner string
+		want  bool
+	}{
+		{"same owner is unchanged", "apply/a:release/hello", "apply/a", true},
+		{"a different owner is a handover", "apply/a:release/hello", "apply/b", false},
+		{"an unstamped release is not a mismatch", "", "apply/a", true},
+		{"an empty plan owner never forces", "apply/a:release/hello", "", true},
+		{"neither stamped nor claimed", "", "", true},
+		// A stamp naming another release is not evidence this one is owned;
+		// same for one that does not parse. Both get corrected.
+		{"a stamp naming another release is a mismatch", "apply/a:release/elsewhere", "apply/a", false},
+		{"an unparseable stamp is healed", "not-a-stamp", "apply/a", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := unchanged(rel(tc.stamp), chart, nil, manifest, tc.owner)
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// End to end: taking a release over with an otherwise identical file writes one
+// revision and the stamp is corrected. Renaming the owner of an unchanged
+// release used to have no effect at all.
+func TestApplyTakesOverAnUnchangedReleaseUnderANewOwner(t *testing.T) {
+	e, fb, src, rf := applyEnv(t, oneRelease, "0.1.0")
+	ctx := context.Background()
+
+	plan, err := e.PlanApply(ctx, rf, src, PlanOptions{Owner: "cd/ctrl/old-app"})
+	require.NoError(t, err)
+	require.Equal(t, ActionInstall, plan.Releases[0].Action)
+	_, err = e.Apply(ctx, plan, InstallOptions{Owner: plan.Owner})
+	require.NoError(t, err)
+
+	// Same file, same chart, same values — only the owner differs.
+	plan2, err := e.PlanApply(ctx, rf, src, PlanOptions{Owner: "cd/ctrl/new-app"})
+	require.NoError(t, err)
+	require.Equal(t, ActionUpgrade, plan2.Releases[0].Action)
+
+	res, err := e.Apply(ctx, plan2, InstallOptions{Owner: plan2.Owner})
+	require.NoError(t, err)
+	require.Equal(t, 2, res[0].Revision, "the handover is one revision, like any other real change")
+
+	cur, err := e.GetRevision(ctx, "hello", 2)
+	require.NoError(t, err)
+	require.Equal(t, "cd/ctrl/new-app:release/hello", cur.Owner)
+
+	// And it settles: the new owner's next apply is a no-op again.
+	before := len(fb.configs)
+	plan3, err := e.PlanApply(ctx, rf, src, PlanOptions{Owner: "cd/ctrl/new-app"})
+	require.NoError(t, err)
+	require.Equal(t, ActionUnchanged, plan3.Releases[0].Action)
+	_, err = e.Apply(ctx, plan3, InstallOptions{Owner: plan3.Owner})
+	require.NoError(t, err)
+	require.Len(t, fb.configs, before, "a settled handover must not keep writing revisions")
+}
+
+// THE NO-MIGRATION GUARANTEE. A release installed before owner stamping existed
+// carries no stamp. Planning it against an owner must stay ActionUnchanged, or
+// the first apply after upgrading re-deploys every release on the swarm — every
+// spec re-pushed, and with --resolve-image always, every digest re-resolved —
+// to buy safety it already had, since an unstamped release is classified
+// Unmanaged rather than Orphaned. Do not delete this test.
+func TestApplyDoesNotChurnAnUnstampedRelease(t *testing.T) {
+	e, fb, src, rf := applyEnv(t, oneRelease, "0.1.0")
+	ctx := context.Background()
+
+	plan, err := e.PlanApply(ctx, rf, src, PlanOptions{})
+	require.NoError(t, err)
+	_, err = e.Apply(ctx, plan, InstallOptions{})
+	require.NoError(t, err)
+
+	cur, err := e.GetRevision(ctx, "hello", 1)
+	require.NoError(t, err)
+	require.Empty(t, cur.Owner, "the fixture has to be unstamped for this to test anything")
+
+	before := len(fb.configs)
+	plan2, err := e.PlanApply(ctx, rf, src, PlanOptions{Owner: "apply/prod"})
+	require.NoError(t, err)
+	require.Equal(t, ActionUnchanged, plan2.Releases[0].Action)
+
+	_, err = e.Apply(ctx, plan2, InstallOptions{Owner: plan2.Owner})
+	require.NoError(t, err)
+	require.Len(t, fb.configs, before, "an unstamped release must not be re-deployed to acquire a stamp")
+}

--- a/integration-tests/charts/charts_owner_test.go
+++ b/integration-tests/charts/charts_owner_test.go
@@ -1,0 +1,217 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+//go:build integration
+
+package charts
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/Eldara-Tech/swarmcli/charts"
+	"github.com/Eldara-Tech/swarmcli/docker"
+	swarmlog "github.com/Eldara-Tech/swarmcli/utils/log"
+)
+
+// writeOwnedReleaseFile writes a release file for one local chart, with the
+// given owner (empty for none), and loads it.
+func writeOwnedReleaseFile(t *testing.T, dir, release, chartDir, owner string) *charts.ReleaseFile {
+	t.Helper()
+	body := ""
+	if owner != "" {
+		body += "owner: " + owner + "\n"
+	}
+	body += fmt.Sprintf("releases:\n  - name: %s\n    chart: %s\n", release, chartDir)
+	path := filepath.Join(dir, "swarmcli-release.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(body), 0o600))
+	rf, err := charts.LoadReleaseFile(path)
+	require.NoError(t, err)
+	return rf
+}
+
+// ownerLabelOf reads the com.swarmcli.owner label off a revision's real Docker
+// Config. The stored record carries the owner too, but the label is what a
+// prune sweep actually classifies from, so that is what has to be right.
+func ownerLabelOf(t *testing.T, ctx context.Context, release string, rev int) (string, bool) {
+	t.Helper()
+	want := fmt.Sprintf("swarmcli.release.%s.v%d", release, rev)
+	cfgs, err := docker.ListConfigs(ctx)
+	require.NoError(t, err)
+	for _, c := range cfgs {
+		if c.Spec.Name == want {
+			v, ok := c.Spec.Labels[charts.LabelOwner]
+			return v, ok
+		}
+	}
+	t.Fatalf("no Docker Config %q on the swarm", want)
+	return "", false
+}
+
+// Taking a release over with an otherwise identical file must move the stamp,
+// on a real swarm and on the real Docker Config label.
+//
+// The unit tests prove the plan says "upgrade". They cannot prove the label
+// round-trips: the stamp is written as a Config label by deployAndRecord and
+// read back by List, and a prune sweep in swarmcli-cd classifies from that
+// label. Reproduced there as a would-be destructive delete of a running stack
+// (#511, swarmcli-cd#62).
+func TestChartsApplyCorrectsAStaleOwnerStampOnARealSwarm(t *testing.T) {
+	swarmlog.InitTestIfTestLogEnv()
+
+	ctx := context.Background()
+	release := fmt.Sprintf("itest-owner-%d", time.Now().UnixNano())
+	chartDir := writeDemoChart(t)
+	dir := t.TempDir()
+
+	eng := charts.NewEngine()
+	src := charts.NewChartSource(nil)
+	defer func() { _, _ = eng.Uninstall(ctx, release, true) }()
+
+	opts := charts.InstallOptions{Wait: true, Timeout: 90 * time.Second}
+
+	// Installed under the first owner.
+	rf := writeOwnedReleaseFile(t, dir, release, chartDir, "old-app")
+	plan, err := eng.PlanApply(ctx, rf, src, charts.PlanOptions{})
+	require.NoError(t, err)
+	require.Equal(t, charts.ActionInstall, plan.Releases[0].Action)
+	res, err := eng.Apply(ctx, plan, charts.InstallOptions{
+		Wait: opts.Wait, Timeout: opts.Timeout, Owner: plan.Owner})
+	require.NoError(t, err)
+	require.Equal(t, 1, res[0].Revision)
+
+	got, ok := ownerLabelOf(t, ctx, release, 1)
+	require.True(t, ok, "revision 1 must carry an owner label")
+	require.Equal(t, "apply/old-app:release/"+release, got)
+
+	// Only the owner changes. Chart, values and rendered manifest are identical,
+	// so before the fix this planned as unchanged and the stamp never moved.
+	rf2 := writeOwnedReleaseFile(t, dir, release, chartDir, "new-app")
+	plan2, err := eng.PlanApply(ctx, rf2, src, charts.PlanOptions{})
+	require.NoError(t, err)
+	require.Equal(t, charts.ActionUpgrade, plan2.Releases[0].Action,
+		"a handover is a real change even when the content is byte-identical")
+
+	res2, err := eng.Apply(ctx, plan2, charts.InstallOptions{
+		Wait: opts.Wait, Timeout: opts.Timeout, Owner: plan2.Owner})
+	require.NoError(t, err)
+	require.Equal(t, 2, res2[0].Revision)
+
+	got, ok = ownerLabelOf(t, ctx, release, 2)
+	require.True(t, ok)
+	require.Equal(t, "apply/new-app:release/"+release, got,
+		"the new revision is stamped with whoever wrote it")
+
+	// And it settles: the new owner's next apply is a no-op. A handover that
+	// re-applied for ever would be worse than the bug it fixes.
+	hist, err := eng.History(ctx, release)
+	require.NoError(t, err)
+	require.Len(t, hist, 2)
+
+	plan3, err := eng.PlanApply(ctx, rf2, src, charts.PlanOptions{})
+	require.NoError(t, err)
+	require.Equal(t, charts.ActionUnchanged, plan3.Releases[0].Action)
+	res3, err := eng.Apply(ctx, plan3, charts.InstallOptions{
+		Wait: opts.Wait, Timeout: opts.Timeout, Owner: plan3.Owner})
+	require.NoError(t, err)
+	require.Zero(t, res3[0].Revision)
+
+	hist3, err := eng.History(ctx, release)
+	require.NoError(t, err)
+	require.Len(t, hist3, 2, "a settled handover must not keep writing revisions")
+}
+
+// THE MIGRATION GUARANTEE, on a real swarm.
+//
+// A release installed before owner stamping existed carries no stamp. Planning
+// it against an owner must stay ActionUnchanged. If it does not, the first
+// `charts apply` after upgrading re-deploys every release on the swarm — every
+// spec re-pushed, and with --resolve-image always, every digest re-resolved —
+// to buy safety it already had, because an unstamped release is classified
+// Unmanaged rather than Orphaned and so was never a prune candidate.
+//
+// The unit test asserts the plan. This asserts the swarm: no new Config, and
+// the running service untouched. Do not delete this test.
+func TestChartsApplyDoesNotChurnAnUnstampedReleaseOnARealSwarm(t *testing.T) {
+	swarmlog.InitTestIfTestLogEnv()
+
+	ctx := context.Background()
+	release := fmt.Sprintf("itest-nochurn-%d", time.Now().UnixNano())
+	chartDir := writeDemoChart(t)
+	dir := t.TempDir()
+
+	eng := charts.NewEngine()
+	src := charts.NewChartSource(nil)
+	defer func() { _, _ = eng.Uninstall(ctx, release, true) }()
+
+	opts := charts.InstallOptions{Wait: true, Timeout: 90 * time.Second}
+
+	// Installed with no owner at all — what every release deployed before owner
+	// stamping shipped looks like.
+	rf := writeOwnedReleaseFile(t, dir, release, chartDir, "")
+	plan, err := eng.PlanApply(ctx, rf, src, charts.PlanOptions{})
+	require.NoError(t, err)
+	require.Empty(t, plan.Owner)
+	_, err = eng.Apply(ctx, plan, opts)
+	require.NoError(t, err)
+
+	_, ok := ownerLabelOf(t, ctx, release, 1)
+	require.False(t, ok, "the fixture has to be unstamped for this to test anything")
+
+	// Now an apply that DOES claim an owner. The content is identical.
+	rf2 := writeOwnedReleaseFile(t, dir, release, chartDir, "prod")
+	plan2, err := eng.PlanApply(ctx, rf2, src, charts.PlanOptions{})
+	require.NoError(t, err)
+	require.Equal(t, charts.ActionUnchanged, plan2.Releases[0].Action,
+		"an unstamped release must not be re-deployed just to acquire a stamp")
+
+	res2, err := eng.Apply(ctx, plan2, charts.InstallOptions{
+		Wait: opts.Wait, Timeout: opts.Timeout, Owner: plan2.Owner})
+	require.NoError(t, err)
+	require.Zero(t, res2[0].Revision)
+
+	hist, err := eng.History(ctx, release)
+	require.NoError(t, err)
+	require.Len(t, hist, 1, "no revision may be written on a real swarm")
+}
+
+// An apply that claims nothing must not strip a stamp somebody else wrote.
+func TestChartsApplyWithoutAnOwnerLeavesAnExistingStamp(t *testing.T) {
+	swarmlog.InitTestIfTestLogEnv()
+
+	ctx := context.Background()
+	release := fmt.Sprintf("itest-noclaim-%d", time.Now().UnixNano())
+	chartDir := writeDemoChart(t)
+	dir := t.TempDir()
+
+	eng := charts.NewEngine()
+	src := charts.NewChartSource(nil)
+	defer func() { _, _ = eng.Uninstall(ctx, release, true) }()
+
+	opts := charts.InstallOptions{Wait: true, Timeout: 90 * time.Second}
+
+	rf := writeOwnedReleaseFile(t, dir, release, chartDir, "someone-else")
+	plan, err := eng.PlanApply(ctx, rf, src, charts.PlanOptions{})
+	require.NoError(t, err)
+	_, err = eng.Apply(ctx, plan, charts.InstallOptions{
+		Wait: opts.Wait, Timeout: opts.Timeout, Owner: plan.Owner})
+	require.NoError(t, err)
+
+	rf2 := writeOwnedReleaseFile(t, dir, release, chartDir, "")
+	plan2, err := eng.PlanApply(ctx, rf2, src, charts.PlanOptions{})
+	require.NoError(t, err)
+	require.Equal(t, charts.ActionUnchanged, plan2.Releases[0].Action)
+	_, err = eng.Apply(ctx, plan2, opts)
+	require.NoError(t, err)
+
+	got, ok := ownerLabelOf(t, ctx, release, 1)
+	require.True(t, ok)
+	require.Equal(t, "apply/someone-else:release/"+release, got,
+		"an unowned apply must not strip another owner's stamp")
+}


### PR DESCRIPTION
Closes #511.

## Problem

`unchanged` compared chart, version, rendered manifest and values — not the owner. `Apply` skips `ActionUnchanged` outright, and `deployAndRecord` is the only writer of `rel.Owner`, so **a release's owner stamp was never corrected unless its content also changed.**

`deployAndRecord`'s own comment states the contract it was failing to keep:

> A revision is stamped with whoever wrote it, not with whoever wrote the previous one: an upgrade or rollback by a second manifest takes the release over, and the history shows exactly where the handover happened.

swarmcli-cd hit this on a real swarm: renaming an application left the release stamped `cd/<controller>/<departed app>`, its prune sweep classifies from that stamp, and it would have deleted a running stack — with volumes opted in, destructively. Worked around in Eldara-Tech/swarmcli-cd#62 by giving prune a second signal, but the stamp still lied and every consumer of `Plan.Owner` inherited the hazard.

## Fix

The owner is now part of `unchanged`, so a handover plans as `ActionUpgrade` and the revision it writes carries the new stamp. The resolved plan owner is threaded from `PlanApply` into `planRelease` (which has `rf` but not `opts`, so it cannot re-derive it).

## Deliberately narrower than the issue suggested

The issue proposed forcing an upgrade on *any* owner mismatch. Read literally that includes the **unstamped** case — and every release deployed before owner stamping existed (#485) has an empty stamp, so the first `charts apply` after this ships would re-deploy every managed release once: every spec re-pushed, and with `--resolve-image always`, every digest re-resolved.

That buys no safety. An unstamped release is *already* classified conservatively — it falls to `Plan.Unmanaged`, never `Plan.Orphaned`, so `Apply` leaves it alone and prune cannot claim it. The dangerous state is not "no stamp", it is "a stamp naming the wrong owner", because that is the only one that produces a false `Orphaned`.

So two cases deliberately do **not** force a revision:

| deployed stamp | plan owner | action |
|---|---|---|
| empty | any | unchanged — no migration churn |
| names this owner | same | unchanged |
| names another owner | set | **upgrade**, stamp corrected |
| names another release, or unparseable | set | **upgrade**, stamp healed |
| any | empty | unchanged — an apply claiming nothing must not strip someone else's stamp |

## Tests

- `TestUnchangedComparesTheOwner` — the table above, directly.
- `TestApplyTakesOverAnUnchangedReleaseUnderANewOwner` — end to end: one revision, stamp corrected, and the *next* apply settles back to unchanged.
- `TestApplyDoesNotChurnAnUnstampedRelease` — the no-migration guarantee, marked do-not-delete alongside the existing no-churn test.

Both guard tests were checked to be load-bearing: reverting to the issue's literal variant fails `TestApplyDoesNotChurnAnUnstampedRelease` and the `an unstamped release is not a mismatch` case.

`go test ./...` and `golangci-lint run ./charts/...` clean.

## Note for swarmcli-cd

No cd change depends on this, and the cd#62 workaround stays correct either way — do not remove it as part of a version bump.