### PR TITLE
cli: remove the dead --debug flag

### DIFF
--- a/cli/args.go
+++ b/cli/args.go
@@ -20,7 +20,6 @@ type flags struct {
 	version      string   // --version, chart version selector
 	dryRun       bool
 	wait         bool
-	debug        bool
 	requirements bool          // --requirements (template): emit rendered requirements.yaml
 	purge        bool          // --purge-volumes
 	install      bool          // --install (upgrade)
@@ -138,8 +137,6 @@ func parseArgs(args []string) ([]string, flags, error) {
 			f.wait = true
 		case "--requirements":
 			f.requirements = true
-		case "--debug":
-			f.debug = true
 		case "--purge-volumes":
 			f.purge = true
 		case "--install":

--- a/cli/charts_test.go
+++ b/cli/charts_test.go
@@ -136,6 +136,15 @@ func TestParseArgsRequirements(t *testing.T) {
 	require.True(t, f.requirements)
 }
 
+// --debug was parsed into a field nothing ever read, so it was accepted and did
+// nothing — the exact "reads as if it worked" shape #451 is about. It is gone,
+// which means it now falls through to the unknown-flag error like any other
+// name the CLI does not know.
+func TestParseArgsRejectsDebug(t *testing.T) {
+	_, _, err := parseArgs([]string{"--debug"})
+	require.EqualError(t, err, `unknown flag "--debug"`)
+}
+
 func TestParseIntRejectsGarbage(t *testing.T) {
 	n, err := parseInt("3")
 	require.NoError(t, err)


### PR DESCRIPTION
Refs #451 (the smaller half; the issue stays open for the rest).

## What

`cli/args.go` parsed `--debug` into `f.debug`, and nothing ever read it — the only occurrence of the field in the tree was its own assignment.

So it was accepted and did nothing, which is the exact shape #451 is about: an *unknown* flag is rejected, but a flag the CLI knows and never acts on reads as "it worked". Someone passing `--debug` to get more output got silence, with no indication the flag was inert.

Removing it makes `--debug` fall through to the existing unknown-flag error, which is the honest answer.

## On the label

**C0-breaks-nothing, deliberately.** No behaviour of swarmcli changes, because the flag had none — the only observable difference is that an incantation which was silently accepted is now refused, and that is the fix rather than a regression. A script passing `--debug` was already not getting what it asked for.

Flagging it explicitly because `CLAUDE.md` makes a `C1-breaking-change` merged since the last GA force a major tag, and this does not warrant one.

## Not in scope

The larger half of #451 — a per-subcommand allow-list so that e.g. `charts list --purge-volumes` is refused rather than parsed and ignored — is not here. It tightens acceptance across 16 subcommands and is the change most likely to generate "this worked yesterday" reports, so it wants its own review.

## Tests

`TestParseArgsRejectsDebug`. `go test ./...` and `golangci-lint run ./cli/...` clean.