### PR TITLE
docs(charts): state the manifest-storage limitation, and re-sync the command list

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ swarmcli charts diff upgrade <release> <repo/chart>  # preview upgrade changes
 swarmcli charts rollback <release> <revision>     # re-deploy a past revision
 swarmcli charts uninstall <release>               # remove a release
 swarmcli charts history <release>                 # revision history
+swarmcli charts get values|manifest <release>     # stored values or rendered manifest
+swarmcli charts prune [release]                   # delete old revisions beyond --history-max
 swarmcli charts list                              # list releases
 swarmcli charts status <release>                  # release status and services
 

--- a/charts/README.md
+++ b/charts/README.md
@@ -33,6 +33,7 @@ swarmcli charts status   my-traefik
 swarmcli charts diff upgrade my-traefik eldara/traefik --set replicas=3
 swarmcli charts upgrade  my-traefik eldara/traefik --set replicas=3
 swarmcli charts history  my-traefik
+swarmcli charts get manifest my-traefik      # also: get values
 swarmcli charts rollback my-traefik 1
 swarmcli charts list
 swarmcli charts uninstall my-traefik
@@ -324,10 +325,14 @@ window are the protections.
   but does not deploy. For fully offline rendering use `charts template`.
 - **`--purge-volumes`** removes volumes on the connected node only (the CE
   single-node volume scope); cross-node purge is a future extension.
-- **Secrets:** the rendered manifest is stored in a Docker Config, which is
-  readable by anyone with Docker access. Do **not** inline secret material in
-  templates — reference Docker secrets as separate objects instead. A redaction
-  pass is planned before charts ship broadly.
+- **Secrets:** the rendered manifest is stored **unredacted** in a Docker Config,
+  which is readable by anyone with Docker access — as are `charts get manifest`
+  and the TUI config viewer, which read it back. Do **not** inline secret
+  material in templates: reference Docker secrets as separate objects instead.
+  Nothing currently enforces that. A redaction pass is
+  [issue #465](https://github.com/Eldara-Tech/swarmcli/issues/465); treat this
+  as a limitation to design around rather than something the engine will catch
+  for you.
 - **Chart integrity** is only as good as the index: a repository that publishes
   no `digest` gets a warning, not a refusal (see [Integrity](#integrity)). Chart
   archives are capped at 20 MiB on the wire.


### PR DESCRIPTION
Refs #465, #452 — both stay open; this fixes only what the GA would otherwise ship wrong.

## 1. The redaction promise (#465)

`charts/README.md` said:

> A redaction pass is planned **before charts ship broadly**.

Shipping charts in a stable release *is* charts shipping broadly, so on tag day that sentence becomes a promise the release does not keep — in the security section of the charts reference.

Redaction is not a release-week change: it needs a definition of what counts as secret material in a rendered manifest, redaction on the write path **and** on every read-back path (`charts get manifest`, the TUI config viewer), and a fail-closed-vs-warn decision that can refuse charts which work today.

So the limitation is now stated as what it actually is — the manifest is stored **unredacted**, the read-back paths are named, and nothing enforces the "do not inline secret material" rule — pointing at #465, which stays open. The difference between a known limitation and a broken promise.

## 2. Command-list drift (#452)

The list is hand-maintained in three places and had drifted again:

| | `get` | `prune` |
|---|---|---|
| `chartsUsage` (`cli/charts.go`) | ✅ | ✅ |
| `README.md` | ❌ | ❌ |
| `charts/README.md` | ❌ | ✅ |

`prune` was the one that mattered: `charts/README.md` tells users in a call-out box that `swarmcli charts prune` is the **only** sanctioned way to delete release history and that raw `docker config rm` will corrupt it — while someone reading only the front-door README never learned the command exists.

Verified after the change: every top-level subcommand in the `chartsMain` dispatch switch now appears in both READMEs.

This is the drift, not its cause. #452 stays open for the de-duplication (generate the sections from `chartsUsage`, shell completion, or a man page).