### PR TITLE
docs(testing): manual test guide for v1.13.0-rc4 → rc5

### DIFF
--- a/docs/testing/v1.13.0-rc5.md
+++ b/docs/testing/v1.13.0-rc5.md
@@ -1,0 +1,420 @@
+<!--
+SPDX-License-Identifier: Apache-2.0
+Copyright © 2026 Eldara Tech
+-->
+
+# Manual test guide — v1.13.0-rc4 → v1.13.0-rc5
+
+What changed since `v1.13.0-rc4`, and how to convince yourself it works before
+`v1.13.0` GA is tagged.
+
+`rc4` is what swarmcli-be, swarmcli-cd and the swarmcli-charts nightly have all
+been validated against, so everything below is new risk that nothing downstream
+has exercised yet. Nine changes: three bug fixes, three performance changes that
+rewrote read paths, one new library seam, one flag removal, one docs change.
+
+**The performance changes carry the most risk and get the least attention** —
+they are the ones that replaced a working read path with a faster one, and a
+wrong answer there is silent. Sections D and E matter more than their commit
+messages suggest.
+
+## Contents
+
+- [Prerequisites](#prerequisites)
+- [Fast path — 20 minute smoke](#fast-path--20-minute-smoke)
+- [A. External `name:` on an external resource (#513)](#a-external-name-on-an-external-resource-513)
+- [B. Owner stamp on an unchanged release (#511)](#b-owner-stamp-on-an-unchanged-release-511)
+- [C. `--debug` removed (#451)](#c---debug-removed-451)
+- [D. Release history read without inspecting every config (#510)](#d-release-history-read-without-inspecting-every-config-510)
+- [E. Configs and secrets "used by" in one listing (#516, #517)](#e-configs-and-secrets-used-by-in-one-listing-516-517)
+- [F. `InitSlog` library seam (#512)](#f-initslog-library-seam-512)
+- [G. Docs (#465, #452)](#g-docs-465-452)
+- [Cross-repo checks before the GA](#cross-repo-checks-before-the-ga)
+- [Not covered here](#not-covered-here)
+- [Sign-off](#sign-off)
+
+---
+
+## Prerequisites
+
+A **real multi-node swarm**. The DinD environment is the reference:
+
+```bash
+./test-setup/testenv.sh up           # 1 manager on tcp://localhost:22375, 2 workers
+export DOCKER_CONTEXT=swarmcli
+```
+
+Do **not** use Docker Desktop for anything involving networks or port-forwarding;
+Desktop/WSL2 rewrites bind sources and the results do not mean what they appear
+to mean.
+
+Build the candidate and keep the previous release next to it — several checks
+below are "this used to do X":
+
+```bash
+go build -o /tmp/swarmcli-rc5 .
+curl -sfL https://github.com/Eldara-Tech/swarmcli/releases/download/v1.13.0-rc4/swarmcli_Linux_x86_64.tar.gz \
+  | tar -xzO swarmcli > /tmp/swarmcli-rc4 && chmod +x /tmp/swarmcli-rc4
+```
+
+For section B you also want a **v1.12.0** binary, because the migration case is
+"a release installed before owner stamping existed".
+
+---
+
+## Fast path — 20 minute smoke
+
+If time is short, these five catch the changes that would be worst to ship:
+
+1. **B3** — an unstamped release must plan as `unchanged`, not `upgrade`. The
+   single highest-risk regression: getting it wrong re-deploys every release on
+   every user's swarm on their first apply.
+2. **D2** — an external config carrying no swarmcli label is still found by the
+   pre-flight.
+3. **E1** — the `USED` column in `:configs` is still correct.
+4. **A1** — a chart with `external: true` + `name:` installs.
+5. **Release-asset check** from [Cross-repo](#cross-repo-checks-before-the-ga).
+
+---
+
+## A. External `name:` on an external resource (#513)
+
+PR #518. `externalResourceNames` now reads the sibling `name:`, matching
+docker/cli's loader. Precedence: `name:` wins → deprecated `external.name` →
+map key.
+
+**A1 — the reproduction (must now work).**
+
+```bash
+docker config create real-app-config /etc/hostname
+mkdir -p /tmp/nc/templates && cd /tmp/nc
+cat > Chart.yaml <<'EOF'
+apiVersion: v1
+name: namecheck
+version: 0.1.0
+EOF
+echo '{}' > values.yaml
+cat > templates/stack.yaml <<'EOF'
+services:
+  app:
+    image: busybox:1.36
+    command: ["sleep", "3600"]
+    configs: ["alias"]
+configs:
+  alias:
+    external: true
+    name: real-app-config
+EOF
+/tmp/swarmcli-rc5 charts install nc . --wait --timeout 2m
+```
+
+Expect: installs and converges.
+On rc4 the same chart fails with `config "alias" does not exist` and tells you
+to `docker config create alias <file>` — which would not have fixed it.
+
+**A2 — a missing resource is reported by its real name.** Change `name:` to
+`no-such-config` and re-run. The error must say `config "no-such-config" does
+not exist`, suggest `docker config create no-such-config <file>`, and **never
+mention `alias`**.
+
+**A3 — both forms is an error.**
+
+```yaml
+configs:
+  alias:
+    external:
+      name: deprecated
+    name: current
+```
+
+Expect: `config "alias": external.name and name conflict; use only name`, before
+anything is deployed.
+
+**A4 — regression, the old forms still work.** `external: true` alone (key is
+the name) and `external: {name: X}` (deprecated) must both behave exactly as on
+rc4. Every chart in `swarmcli-charts` uses the first form, so
+`scripts/e2e-test.sh` covers this — but run one by hand too.
+
+**A5 — networks.** Networks go through the same function and are the only kind
+swarmcli **auto-creates**, so a wrong name here creates a real object:
+
+```yaml
+networks:
+  alias:
+    external: true
+    name: my-real-net
+```
+
+With `my-real-net` absent and no `requirements.yaml`, install must create
+**`my-real-net`** — check `docker network ls` — and never a network called
+`alias`.
+
+**A6 — requirements.yaml matches the resolved name.** This is the behaviour
+change most likely to surprise a chart author. Give the chart a
+`requirements.yaml` declaring `alias`: install must fail with "not declared in
+requirements.yaml". Declare `real-app-config` instead: it must pass.
+
+---
+
+## B. Owner stamp on an unchanged release (#511)
+
+PR #519. `unchanged` now compares the owner, so a handover between two manifests
+with byte-identical content is an upgrade rather than a silent no-op.
+
+**B1 — the handover.** Apply a release file with `owner: old-app`, then change
+**only** the `owner:` key to `new-app` and re-apply.
+
+```bash
+/tmp/swarmcli-rc5 charts apply -f rel.yaml --dry-run   # expect: upgrade
+/tmp/swarmcli-rc5 charts apply -f rel.yaml
+/tmp/swarmcli-rc5 charts history hello                 # expect: revision 2
+```
+
+Revision 2 must carry `apply/new-app:release/hello`. Check the label directly:
+
+```bash
+docker config inspect swarmcli.release.hello.v2 \
+  --format '{{ index .Spec.Labels "com.swarmcli.owner" }}'
+```
+
+On rc4 this whole sequence reports `unchanged` and the stamp stays `old-app`
+for ever.
+
+**B2 — it settles.** Immediately re-apply the same file. Must report
+`unchanged` and write **no** revision 3. A handover that keeps re-applying is
+worse than the bug.
+
+**B3 — THE MIGRATION GUARANTEE.** Install a release with a **v1.12.0** binary
+(or any apply with no `owner:`), so it carries no stamp. Then apply the same
+content with rc5 **and** an `owner:` key:
+
+```bash
+docker config ls --filter label=com.swarmcli.type=release | wc -l   # before
+/tmp/swarmcli-rc5 charts apply -f rel-with-owner.yaml --dry-run
+```
+
+Expect **`unchanged`**, and no new revision after a real apply.
+
+If this reports `upgrade`, stop and escalate: it means every existing release on
+every user's swarm re-deploys on their first apply after upgrading — every spec
+re-pushed, and with `--resolve-image always`, every digest re-resolved.
+
+**B4 — an apply that claims nothing must not steal.** Take a release stamped
+`apply/a`, and apply an otherwise identical file with **no** `owner:` key.
+Expect `unchanged`, and the `apply/a` stamp must survive.
+
+**B5 — orphan classification is unaffected.** Drop a release from a file that
+owns it: it must still be reported as an **orphan** and still never deleted.
+
+---
+
+## C. `--debug` removed (#451)
+
+PR #520. The flag was parsed into a field nothing read.
+
+```bash
+/tmp/swarmcli-rc5 charts list --debug     # expect: unknown flag "--debug", exit 2
+/tmp/swarmcli-rc5 --debug                 # TUI path — check what this does now
+```
+
+**C1** — the error is `unknown flag "--debug"` and the exit code is 2.
+
+**C2 — regression sweep.** Every other flag must still parse. Walk the list once:
+`-f/--values`, `--set`, `--version`, `--timeout`, `--history-max`, `--revision`,
+`--reuse-values`, `--diff`, `--dry-run`, `--wait`, `--requirements`,
+`--purge-volumes`, `--install`, `--skip-compat-check`, `--for-version`,
+`--resolve-image`.
+
+**C3** — `LOG_LEVEL=debug SWARMCLI_ENV=dev` still produces debug logs. That is
+the mechanism `--debug` was mistaken for, and it is untouched.
+
+---
+
+## D. Release history read without inspecting every config (#510)
+
+PR #514. `ListConfigsWith` no longer inspects each config; `ConfigMeta` now
+carries `Data` from the listing and `allRevisions` decodes from it, falling back
+to an inspect when a Backend leaves it nil.
+
+This sits under `List`, `Status`, `Install`, `Upgrade`, `Rollback` and
+`GetRevision` — the engine's hottest read path — so a wrong answer here is
+wrong nearly everywhere.
+
+**D1 — history is still correct.** With a release at 3+ revisions:
+
+```bash
+/tmp/swarmcli-rc4 charts history hello > /tmp/h-rc4.txt
+/tmp/swarmcli-rc5 charts history hello > /tmp/h-rc5.txt
+diff /tmp/h-rc4.txt /tmp/h-rc5.txt        # expect: identical
+```
+
+Do the same for `charts list`, `charts status hello`, `charts get values hello`
+and `charts get manifest hello`. Byte-identical output is the bar.
+
+**D2 — external configs carrying no swarmcli label are still found.** The commit
+deliberately did **not** filter the listing by `com.swarmcli.type=release`,
+because `ensureExternalSecretsConfigs` uses the same listing to check a
+manifest's `external:` references — and an operator-created config has no
+swarmcli label at all. Verify directly, since a later "optimisation" would break
+exactly this:
+
+```bash
+docker config create plain-operator-config /etc/hostname
+# chart with: configs: { plain-operator-config: { external: true } }
+/tmp/swarmcli-rc5 charts install ext-check . --dry-run    # must pass the pre-flight
+```
+
+**D3 — rollback still restores real content.** `charts rollback hello 1`, then
+`charts get manifest hello` must return revision 1's manifest exactly.
+
+**D4 — the performance claim.** On a swarm with many configs, the reads above
+should be markedly faster. Create ~50 unrelated configs and time it:
+
+```bash
+for i in $(seq 1 50); do echo x | docker config create filler-$i - ; done
+time /tmp/swarmcli-rc4 charts list
+time /tmp/swarmcli-rc5 charts list
+```
+
+Expect a large improvement (the claim is 1+N+R round trips → 1). Not a
+correctness gate, but if it is *not* faster the change did not do what it says.
+
+---
+
+## E. Configs and secrets "used by" in one listing (#516, #517)
+
+PRs #516 and #517. `ServicesUsingConfigs` / `ServicesUsingSecrets` list services
+**once** and return them indexed by both ID and name; the views ask once instead
+of once per row.
+
+TUI-only and the largest behaviour surface in this RC — unit tests cover the
+index, but the wiring into two views is what changed. Test both views
+identically; the second was copied from the first.
+
+Set up: a stack whose services reference at least two configs and two secrets,
+with at least one referenced by **two** services, and one **unreferenced**.
+
+**E1 — the `USED` column.** Open `:configs`. Every config that a service
+references shows as used; the unreferenced one does not. Compare against truth:
+
+```bash
+docker service ls --format '{{.Name}}' | while read s; do
+  docker service inspect "$s" --format '{{.Spec.Name}}: {{range .Spec.TaskTemplate.ContainerSpec.Configs}}{{.ConfigName}} {{end}}'
+done
+```
+
+Repeat in `:secrets`.
+
+**E2 — used-by-stacks drill-in.** Select a used config and open its used-by
+view. It must list every stack/service pair, and each service **once** — even
+if that service mounts the same config at several paths. The old code merged
+name- and ID-keyed results by hand; the dedup now lives in the index, so a
+duplicate row here is the regression to look for.
+
+**E3 — reference by ID and by name.** Both keys must resolve. A stack deployed
+by `docker stack deploy` references by name; other paths reference by ID. If
+you have only name-referencing services, add one referencing by ID.
+
+**E4 — add.** Create a config from the TUI (and a secret in `:secrets`). It must
+appear immediately, marked **not** used. `addConfig`/`addSecret` deliberately
+pass no index, on the reasoning that nothing can reference a config this view
+just created.
+
+**E5 — rotate and the delete guard.** Rotate a secret used by a running service,
+and try to delete a config/secret that is in use. Both still use the
+single-resource lookups and must be unchanged — the guard must still refuse,
+and rotation must still update the referencing services.
+
+**E6 — the poll.** Leave `:configs` open and add a config from another terminal.
+The view must pick it up, with a correct `USED`. The `USED` column is repainted
+after every poll that notices a change, which is what made the old N+1 expensive.
+
+---
+
+## F. `InitSlog` library seam (#512)
+
+PR #512. `utils/log.InitSlog(h slog.Handler)` installs a zapcore that forwards
+every entry to `h`, for consumers importing swarmcli as a library.
+
+**F1 — the TUI is unaffected.** Nothing calls `InitSlog` in this repo, so
+logging must behave exactly as on rc4: `~/.local/state/swarmcli/app.log` (prod,
+JSON) and `app-debug.log` (dev, pretty), `LOG_LEVEL` still honoured.
+
+**F2 — the consumer path.** Build swarmcli-cd against the rc and confirm this
+package's output arrives in cd's own handler, in cd's format, on cd's stream —
+one format on one stream, not two. `docker/snapshot.go`'s two warnings are the
+canonical example: they have never reached an operator via a library consumer.
+
+**F3 — the level belongs to the handler.** Once `InitSlog` is installed,
+`LOG_LEVEL` and `SetLevel` must **not** apply. Two answers to "is this worth
+writing" is how logs go missing.
+
+---
+
+## G. Docs (#465, #452)
+
+PR #521. No runtime behaviour.
+
+**G1** — `swarmcli charts --help` and the command lists in `README.md` and
+`charts/README.md` agree. Every top-level subcommand appears in all three.
+
+**G2** — `charts/README.md` no longer promises a redaction pass "before charts
+ship broadly", and states the limitation instead, pointing at #465.
+
+---
+
+## Cross-repo checks before the GA
+
+**Release asset.** The check #450 specifies — the whole reason the tag is
+blocking:
+
+```bash
+curl -sfL .../v1.13.0-rc5/swarmcli_Linux_x86_64.tar.gz | tar -xz swarmcli
+./swarmcli charts | grep -E "apply|outdated|lint|prune|get"
+```
+
+**swarmcli-charts nightly.** Bump both `SWARMCLI_REF` pins in
+`.github/workflows/nightly.yml` — the repo-apply leg **and** the e2e leg — to
+`v1.13.0-rc5` and take one green nightly. That job is the only thing that
+exercises the published binary rather than `main`, and it is currently
+validating a build five commits stale.
+
+**swarmcli-be.** Build against the rc via `.swarmcli-ref` and run the BE
+integration suite. Section E touches views BE wraps.
+
+**swarmcli-cd.** Bump `go.mod` to the rc and run the integration suite,
+including `integration-tests/mount_guard_test.go` — whose comment documents the
+#513 behaviour that section A just changed, and which is now stale.
+
+---
+
+## Not covered here
+
+- Anything unchanged since rc4. `charts apply`, `outdated`, `lint`, requirements
+  and the compat floor all shipped in rc1–rc4 and are covered by the existing
+  suites.
+- The dependabot bumps (#507, #515), which CI covers.
+- Multi-swarm and `ssh://` contexts (#498), which have their own integration
+  tests and did not change.
+- Redaction of rendered manifests. Still **not implemented** — see #465. The
+  manifest is stored unredacted and readable by anyone with Docker access.
+- The per-subcommand flag allow-list. Still **not implemented** — #451 remains
+  open, so `charts list --purge-volumes` is still parsed and silently ignored.
+
+---
+
+## Sign-off
+
+| § | Area | Result |
+|---|---|---|
+| A | External `name:` (#513) | |
+| B | Owner stamp (#511) — **B3 is the gate** | |
+| C | `--debug` removed (#451) | |
+| D | History read path (#510) | |
+| E | Configs/secrets used-by (#516, #517) | |
+| F | `InitSlog` (#512) | |
+| G | Docs (#465, #452) | |
+| — | Release asset + charts nightly | |
+| — | BE / cd integration suites | |
+
+Tester: &nbsp;&nbsp;&nbsp; Date: &nbsp;&nbsp;&nbsp; Verdict: promote to GA / hold


### PR DESCRIPTION
Adds `docs/testing/v1.13.0-rc5.md` — what changed since rc4 and how to verify it before the GA is tagged.

## Why

`v1.13.0-rc4` is what swarmcli-be, swarmcli-cd and the swarmcli-charts nightly have all been validated against. Everything between it and rc5 is risk nothing downstream has exercised: three bug fixes, three performance changes that rewrote read paths, a new library seam, a flag removal, docs.

## How it is weighted

Towards what would be worst to ship, not towards what was hardest to write. The **performance** changes get the most space, because they replaced a working read path with a faster one and a wrong answer there is silent — #510 sits under `List`, `Status`, `Install`, `Upgrade`, `Rollback` and `GetRevision`, and #516/#517 rewired two TUI views that the unit tests cover at the index level but not at the wiring level.

Each section states the **previous** behaviour, so a tester can tell a fix from a regression rather than guessing what "correct" looks like.

## Three checks are gates, not steps

- **B3** — an unstamped release must still plan as `unchanged`. Getting this wrong re-deploys every release on every user's swarm on their first apply after upgrading.
- **D2** — an external config carrying no swarmcli label is still found by the pre-flight. This is precisely why #510 declined to filter the config listing by `com.swarmcli.type=release`, and a later "optimisation" would break it.
- **A5** — an external network resolves to its declared `name:` *before* being auto-created. Networks are the only kind swarmcli creates, so a wrong name here makes a real object.

There is a 20-minute fast path at the top for when there is not time for the full pass.

## Also records what is missing

Manifest redaction (#465) and the per-subcommand flag allow-list (#451) are both still unimplemented at GA. The guide says so under "Not covered here", so neither reads as an oversight discovered during testing.

First file under `docs/testing/`; the layout is meant to be copied for the next RC.