### PR TITLE
fix(services): show how far a rollout got, and stop hiding scheduled tasks

### DIFF
--- a/charts/backend_docker.go
+++ b/charts/backend_docker.go
@@ -167,10 +167,11 @@ func (b *dockerBackend) StackServices(ctx context.Context, name string) []Servic
 // swarms is not forced through the ambient one.
 func ServiceStatesFrom(snap *docker.SwarmSnapshot, name string) []ServiceState {
 	entries := snap.StackServices(name)
-	// Convergence facts come from a separate loader because ServiceEntry counts
-	// replicas by desired state, which is right for the services view but wrong
-	// for deciding a rollout finished (issues #473, #480). Both now read the
-	// same snapshot, so the display and the decision cannot disagree.
+	// Convergence facts come from a separate loader because ServiceEntry mirrors
+	// `docker service ls` — counting every generation, on any node — which is
+	// right for the services view but wrong for deciding a rollout finished
+	// (issues #473, #480). Both now read the same snapshot, so the display and
+	// the decision cannot disagree.
 	conv := make(map[string]docker.ServiceConvergence, len(entries))
 	for _, c := range snap.StackConvergence(name) {
 		conv[c.Name] = c

--- a/charts/release.go
+++ b/charts/release.go
@@ -47,9 +47,10 @@ type ServiceState struct {
 	Status   string
 
 	// Running counts tasks that are actually running on an active node.
-	// Deliberately not derived from Replicas: that string counts tasks by
-	// DESIRED state, so it reaches its target the moment Swarm schedules the
-	// tasks rather than when they are up (see issue #480).
+	// Deliberately not derived from Replicas: that string mirrors `docker
+	// service ls` and so counts every generation, superseded tasks included, and
+	// counts them wherever they sit — a down node's stale task included (see
+	// issue #480).
 	Running int
 	// Desired is the target task count over active nodes.
 	Desired int
@@ -1178,10 +1179,10 @@ func (s ServiceState) Convergence() Convergence {
 		return Convergence{PhaseProgressing, "rolling back"}
 	}
 	// Parity is measured from the actual running count, not the Replicas display
-	// string. That string counts tasks by DESIRED state, so it reaches parity
-	// the instant swarm schedules the tasks — before any container is up — which
-	// made --wait return immediately on a fresh install, where UpdateState is
-	// empty and the in-flight arm above cannot fire either (issue #473).
+	// string. That string counts every generation on any node, so it can reach
+	// parity on tasks this package would not accept — which made --wait return
+	// early on a fresh install, where UpdateState is empty and the in-flight arm
+	// above cannot fire either (issue #473).
 	//
 	// A job's task ends Complete and is never replaced, so requiring a running
 	// task would report a step that succeeded as one that never came up. A

--- a/docker/convergence.go
+++ b/docker/convergence.go
@@ -11,9 +11,10 @@ import (
 
 // ServiceConvergence is what a caller needs to decide whether one service has
 // finished rolling out. It is deliberately separate from ServiceEntry: that
-// struct backs the services view, and its ReplicasOnNode counts tasks by
-// DESIRED state, which answers "what does the orchestrator intend" rather than
-// "what is actually up" (see issue #480).
+// struct backs the services view, where ReplicasOnNode mirrors `docker service
+// ls` and so keeps counting a superseded task while its container runs. Running
+// here drops the outgoing generation, which is the question --wait asks and the
+// services view answers with UpToDate instead (see issue #480).
 type ServiceConvergence struct {
 	Name string
 	Mode string
@@ -175,6 +176,14 @@ func isJobService(svc swarm.Service) bool {
 	default:
 		return false
 	}
+}
+
+// DesiredReplicas is the service's target task count against this snapshot: the
+// declared replicas, or for a global service one per node that can currently run
+// one. Exported for callers outside this package that would otherwise duplicate
+// the mode switch and get the global case wrong (issue #480).
+func (snap *SwarmSnapshot) DesiredReplicas(svc swarm.Service) int {
+	return desiredOverActiveNodes(svc, len(activeNodeIDs(snap)))
 }
 
 // desiredOverActiveNodes is the target task count. For a global service that is

--- a/docker/service.go
+++ b/docker/service.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"os/exec"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -352,10 +353,21 @@ type ServiceEntry struct {
 	ServiceID      string
 	ReplicasOnNode int
 	ReplicasTotal  int
-	Status         string
-	Mode           string
-	Image          string
-	Ports          string
+	// UpToDate counts the replicas running the service's *current* generation.
+	// ReplicasOnNode counts every running task, superseded ones included, so it
+	// matches `docker service ls` — which means a start-first rollout reads as
+	// fully converged while the outgoing generation is what is actually up. The
+	// two together say what one ratio cannot: how many replicas are serving, and
+	// how many of those are the version being rolled out (issue #480).
+	UpToDate int
+	// RollingOut reports a rollout in flight — updating, paused, or either
+	// rollback state. It gates the display of UpToDate: outside a rollout a
+	// replica short of the current generation is a restart, not a stale version.
+	RollingOut bool
+	Status     string
+	Mode       string
+	Image      string
+	Ports      string
 	// Health is an aggregate health summary for the service's running replicas
 	// (e.g. "2/2 healthy"); "" when unknown. The swarm API does not expose
 	// container health, so the default loaders leave it empty; it is an
@@ -388,8 +400,12 @@ func LoadNodeServices(nodeID string) []ServiceEntry {
 		// Count tasks running on this node
 		onNode := countTasksForNode(svc.ID, nodeID, snap)
 
-		// Skip if no tasks on this node
-		if onNode == 0 {
+		// Skip if the node neither runs a task for this service nor is meant to.
+		// Presence cannot be read off onNode alone: that counts running tasks, so
+		// a service whose task here is still preparing — or wedged pending on an
+		// unsatisfiable constraint — would vanish from the view of the very node
+		// an operator opened to find out why.
+		if onNode == 0 && !hasIntendedTaskOnNode(svc.ID, nodeID, snap) {
 			continue
 		}
 
@@ -399,6 +415,8 @@ func LoadNodeServices(nodeID string) []ServiceEntry {
 			ServiceID:      svc.ID,
 			ReplicasOnNode: onNode,
 			ReplicasTotal:  desired,
+			UpToDate:       countUpToDateTasks(svc.ID, snap),
+			RollingOut:     isRollingOut(svc),
 			Status:         getServiceStatus(svc),
 			Mode:           getServiceMode(svc),
 			Image:          getServiceImage(svc),
@@ -443,6 +461,8 @@ func (snap *SwarmSnapshot) StackServices(stackName string) []ServiceEntry {
 			ServiceID:      svc.ID,
 			ReplicasOnNode: onNode,
 			ReplicasTotal:  desired,
+			UpToDate:       countUpToDateTasks(svc.ID, snap),
+			RollingOut:     isRollingOut(svc),
 			Status:         getServiceStatus(svc),
 			Mode:           getServiceMode(svc),
 			Image:          getServiceImage(svc),
@@ -480,6 +500,8 @@ func LoadAllServices() []ServiceEntry {
 			ServiceID:      svc.ID,
 			ReplicasOnNode: onNode,
 			ReplicasTotal:  desired,
+			UpToDate:       countUpToDateTasks(svc.ID, snap),
+			RollingOut:     isRollingOut(svc),
 			Status:         getServiceStatus(svc),
 			Mode:           getServiceMode(svc),
 			Image:          getServiceImage(svc),
@@ -506,7 +528,7 @@ func getServiceStackAndDesired(svc swarm.Service, snap *SwarmSnapshot) (stack st
 	// target is one task per node that can actually run one, so a drained or
 	// down node lowers the target instead of making the service read
 	// permanently short (issue #480).
-	desired = desiredOverActiveNodes(svc, len(activeNodeIDs(snap)))
+	desired = snap.DesiredReplicas(svc)
 	return
 }
 
@@ -521,8 +543,8 @@ func getServiceStackAndDesired(svc swarm.Service, snap *SwarmSnapshot) (stack st
 // operator most needs the truth (issue #480).
 //
 // Superseded tasks from a rolling update are still counted while they run,
-// matching `docker service ls`. Up-to-dateness is a different question from
-// readiness, and LoadStackConvergence is where --wait asks it.
+// matching `docker service ls`. Up-to-dateness is the separate question
+// countUpToDateTasks answers, and LoadStackConvergence is where --wait asks it.
 func countTasksForNode(serviceID, nodeID string, snap *SwarmSnapshot) int {
 	count := 0
 	for _, t := range snap.Tasks {
@@ -537,6 +559,87 @@ func countTasksForNode(serviceID, nodeID string, snap *SwarmSnapshot) int {
 		}
 	}
 	return count
+}
+
+// hasIntendedTaskOnNode reports whether swarm means to run a task of this
+// service on the node, whatever state that task has reached. It is the
+// visibility test the node-scoped services view needs: a task still preparing,
+// or pending on a constraint it cannot satisfy, is exactly what the operator
+// opened that node to see, and counting only running tasks hid it.
+func hasIntendedTaskOnNode(serviceID, nodeID string, snap *SwarmSnapshot) bool {
+	for _, t := range snap.Tasks {
+		if t.ServiceID == serviceID && t.NodeID == nodeID && t.DesiredState == swarm.TaskStateRunning {
+			return true
+		}
+	}
+	return false
+}
+
+// countUpToDateTasks counts the running tasks belonging to the service's current
+// generation — one per slot at most, so a start-first rollout cannot count the
+// outgoing task it is replacing.
+//
+// The current generation is the newest task per slot, by CreatedAt: swarm
+// creates a slot's replacement after the task it supersedes, so creation order
+// *is* generation order. DesiredState cannot draw the line, because under
+// start-first the outgoing task keeps DesiredState=running until its replacement
+// is up — which is precisely the window where the count matters.
+//
+// This is deliberately not taskutil.LatestTasksByServiceKey: that helper prefers
+// a task that wants to be running over a newer terminal one, because it picks a
+// task worth surfacing an error from. Here that preference would pick the
+// outgoing task and report the old generation as current.
+func countUpToDateTasks(serviceID string, snap *SwarmSnapshot) int {
+	newest := make(map[string]swarm.Task)
+	for _, t := range snap.Tasks {
+		if t.ServiceID != serviceID {
+			continue
+		}
+		// An unassigned task has neither slot nor node, so it has no identity to
+		// be the newest of; it is also, by definition, not running yet.
+		key := taskSlotKey(t)
+		if key == "" {
+			continue
+		}
+		if cur, seen := newest[key]; !seen || t.CreatedAt.After(cur.CreatedAt) {
+			newest[key] = t
+		}
+	}
+
+	count := 0
+	for _, t := range newest {
+		if t.Status.State == swarm.TaskStateRunning {
+			count++
+		}
+	}
+	return count
+}
+
+// taskSlotKey identifies the replica a task belongs to: the slot for a
+// replicated service, the node for a global one (whose tasks carry no slot).
+// Empty when the task has neither, i.e. it has not been assigned yet.
+func taskSlotKey(t swarm.Task) string {
+	if t.Slot > 0 {
+		return strconv.Itoa(t.Slot)
+	}
+	return t.NodeID
+}
+
+// isRollingOut reports a rollout in flight. The paused states count: a rollout
+// halted by a failing task is the case where an operator most needs to see how
+// far it got. The completed states do not — the generation on show is the
+// current one.
+func isRollingOut(svc swarm.Service) bool {
+	if svc.UpdateStatus == nil {
+		return false
+	}
+	switch svc.UpdateStatus.State {
+	case swarm.UpdateStateUpdating, swarm.UpdateStatePaused,
+		swarm.UpdateStateRollbackStarted, swarm.UpdateStateRollbackPaused:
+		return true
+	default:
+		return false
+	}
 }
 
 // sortEntries sorts entries by stack name then service name

--- a/docker/service_test.go
+++ b/docker/service_test.go
@@ -178,6 +178,125 @@ func TestCountTasksForNode_CountsSupersededTasksStillRunning(t *testing.T) {
 	require.Equal(t, 2, countTasksForNode("svc1", "", snap))
 }
 
+// A node runs a service's task, or is meant to. Counting only running tasks made
+// the node-scoped view drop a service whose task there had not started — the one
+// an operator opens that node to find (issue #480).
+func TestHasIntendedTaskOnNode(t *testing.T) {
+	preparing := runningTask("svc1", "n1")
+	preparing.Status.State = swarm.TaskStatePreparing
+
+	terminal := runningTask("svc1", "n2")
+	terminal.DesiredState = swarm.TaskStateShutdown
+	terminal.Status.State = swarm.TaskStateShutdown
+
+	snap := &SwarmSnapshot{Tasks: []swarm.Task{preparing, terminal, runningTask("svc2", "n3")}}
+
+	require.True(t, hasIntendedTaskOnNode("svc1", "n1", snap), "task preparing on the node")
+	require.False(t, hasIntendedTaskOnNode("svc1", "n2", snap), "only a terminal task on the node")
+	require.False(t, hasIntendedTaskOnNode("svc1", "n3", snap), "another service's node")
+}
+
+// slotTask builds a task carrying the three facts generation counting turns on:
+// which replica it is, whether it is up, and when it was created.
+func slotTask(svcID, nodeID string, slot int, state swarm.TaskState, ageSeconds int) swarm.Task {
+	return swarm.Task{
+		ServiceID:    svcID,
+		NodeID:       nodeID,
+		Slot:         slot,
+		DesiredState: swarm.TaskStateRunning,
+		Status:       swarm.TaskStatus{State: state},
+		Meta:         swarm.Meta{CreatedAt: time.Now().Add(-time.Duration(ageSeconds) * time.Second)},
+	}
+}
+
+func TestCountUpToDateTasks_SteadyState(t *testing.T) {
+	snap := &SwarmSnapshot{Tasks: []swarm.Task{
+		slotTask("svc1", "n1", 1, swarm.TaskStateRunning, 3600),
+		slotTask("svc1", "n2", 2, swarm.TaskStateRunning, 3600),
+	}}
+	require.Equal(t, 2, countUpToDateTasks("svc1", snap))
+}
+
+// The reported case: a start-first rollout where every running replica is still
+// the outgoing generation. REPLICAS reads 2/2 — matching `docker service ls` —
+// so the count that shows the rollout has not landed has to come from elsewhere.
+func TestCountUpToDateTasks_StartFirstRolloutExcludesOutgoing(t *testing.T) {
+	outgoing := slotTask("svc1", "n3", 1, swarm.TaskStateRunning, 1209600) // up 2 weeks
+	incoming := slotTask("svc1", "n29", 1, swarm.TaskStatePreparing, 26)   // replacing it
+
+	replaced := slotTask("svc1", "n2", 2, swarm.TaskStateShutdown, 1209600)
+	replaced.DesiredState = swarm.TaskStateShutdown
+	landed := slotTask("svc1", "n2", 2, swarm.TaskStateRunning, 36)
+
+	snap := &SwarmSnapshot{Tasks: []swarm.Task{outgoing, incoming, replaced, landed}}
+
+	require.Equal(t, 2, countTasksForNode("svc1", "", snap), "two containers are up")
+	require.Equal(t, 1, countUpToDateTasks("svc1", snap), "only one replica is on the new generation")
+}
+
+// The window start-first opens: the incoming task is up before the outgoing one
+// is torn down, so a 2-replica service has three containers running. REPLICAS
+// reads 3/2 — as `docker service ls` does — while the generation count stays
+// bounded by the slots.
+func TestCountUpToDateTasks_BoundedBySlotsDuringOverlap(t *testing.T) {
+	snap := &SwarmSnapshot{Tasks: []swarm.Task{
+		slotTask("svc1", "n3", 1, swarm.TaskStateRunning, 1209600),
+		slotTask("svc1", "n29", 1, swarm.TaskStateRunning, 26),
+		slotTask("svc1", "n2", 2, swarm.TaskStateRunning, 36),
+	}}
+
+	require.Equal(t, 3, countTasksForNode("svc1", "", snap))
+	require.Equal(t, 2, countUpToDateTasks("svc1", snap))
+}
+
+// A global service's tasks carry no slot, so the node is what identifies the
+// replica.
+func TestCountUpToDateTasks_GlobalKeysByNode(t *testing.T) {
+	snap := &SwarmSnapshot{Tasks: []swarm.Task{
+		slotTask("svc1", "n1", 0, swarm.TaskStateRunning, 3600),
+		slotTask("svc1", "n2", 0, swarm.TaskStateShutdown, 3600),
+		slotTask("svc1", "n2", 0, swarm.TaskStatePreparing, 10),
+	}}
+	require.Equal(t, 1, countUpToDateTasks("svc1", snap))
+}
+
+// A task with neither slot nor node has not been assigned yet. It identifies no
+// replica, so it must not collide with the others under a shared empty key.
+func TestCountUpToDateTasks_SkipsUnassignedTasks(t *testing.T) {
+	snap := &SwarmSnapshot{Tasks: []swarm.Task{
+		slotTask("svc1", "", 0, swarm.TaskStatePending, 5),
+		slotTask("svc1", "n1", 0, swarm.TaskStateRunning, 3600),
+	}}
+	require.Equal(t, 1, countUpToDateTasks("svc1", snap))
+}
+
+func TestCountUpToDateTasks_IgnoresOtherServices(t *testing.T) {
+	snap := &SwarmSnapshot{Tasks: []swarm.Task{
+		slotTask("svc1", "n1", 1, swarm.TaskStateRunning, 3600),
+		slotTask("svc2", "n1", 1, swarm.TaskStateRunning, 3600),
+	}}
+	require.Equal(t, 1, countUpToDateTasks("svc1", snap))
+}
+
+func TestIsRollingOut(t *testing.T) {
+	require.False(t, isRollingOut(swarm.Service{}), "never updated")
+
+	cases := map[swarm.UpdateState]bool{
+		swarm.UpdateStateUpdating:          true,
+		swarm.UpdateStatePaused:            true,
+		swarm.UpdateStateRollbackStarted:   true,
+		swarm.UpdateStateRollbackPaused:    true,
+		swarm.UpdateStateCompleted:         false,
+		swarm.UpdateStateRollbackCompleted: false,
+	}
+	for state, want := range cases {
+		t.Run(string(state), func(t *testing.T) {
+			svc := swarm.Service{UpdateStatus: &swarm.UpdateStatus{State: state}}
+			require.Equal(t, want, isRollingOut(svc))
+		})
+	}
+}
+
 func TestSortEntries(t *testing.T) {
 	entries := []ServiceEntry{
 		{StackName: "beta", ServiceName: "web"},

--- a/docker/task.go
+++ b/docker/task.go
@@ -14,8 +14,12 @@ import (
 
 // TaskEntry represents a task in a human-readable format
 type TaskEntry struct {
-	ID           string
-	Name         string
+	ID   string
+	Name string
+	// Slot is the replica this task belongs to, so two tasks of the same slot
+	// read as one replica being replaced rather than as two replicas. Zero for a
+	// global service, whose tasks carry no slot and are identified by node.
+	Slot         int
 	ServiceName  string
 	Image        string
 	NodeName     string
@@ -143,6 +147,7 @@ func GetTasksForStack(stackName string) ([]TaskEntry, error) {
 			tasks = append(tasks, TaskEntry{
 				ID:           id,
 				Name:         fmt.Sprintf("%s.%d", svc.Spec.Name, task.Slot),
+				Slot:         task.Slot,
 				ServiceName:  svc.Spec.Name,
 				Image:        image,
 				NodeName:     nodeName,
@@ -255,6 +260,7 @@ func GetTasksForService(serviceID string) ([]TaskEntry, error) {
 			tasks = append(tasks, TaskEntry{
 				ID:           id,
 				Name:         fmt.Sprintf("%s.%d", serviceName, task.Slot),
+				Slot:         task.Slot,
 				ServiceName:  serviceName,
 				Image:        image,
 				NodeName:     nodeName,

--- a/views/services/columns.go
+++ b/views/services/columns.go
@@ -56,6 +56,14 @@ func (m *Model) serviceColumns() []serviceColumn {
 				if e.PullProgress != "" {
 					return e.PullProgress
 				}
+				// REPLICAS counts every running replica, superseded ones included,
+				// so a rollout that has not moved a single replica onto the new
+				// generation still reads as fully converged. Say how far it got
+				// while it is in flight — that is the question "updating" raises
+				// and the ratio beside it cannot answer.
+				if e.RollingOut && e.ReplicasTotal > 0 && e.UpToDate < e.ReplicasTotal {
+					return fmt.Sprintf("%s · %d/%d new", e.Status, e.UpToDate, e.ReplicasTotal)
+				}
 				return e.Status
 			}}},
 		{isHealth: true, col: filterlist.Column[docker.ServiceEntry]{

--- a/views/services/columns_test.go
+++ b/views/services/columns_test.go
@@ -100,6 +100,43 @@ func TestColumns_HealthColumnAndFootnote(t *testing.T) {
 		"HEALTH should sit immediately after STATUS")
 }
 
+// statusCell returns the rendered STATUS cell for e.
+func statusCell(m *Model, e docker.ServiceEntry) string {
+	for _, c := range m.serviceColumns() {
+		if c.col.Label == "STATUS" {
+			return c.col.Cell(e)
+		}
+	}
+	return ""
+}
+
+// REPLICAS counts every running replica, superseded ones included, so a
+// start-first rollout that has not moved a single replica onto the new
+// generation still reads 2/2. STATUS is where that gets said (issue #480).
+func TestColumns_StatusShowsRolloutProgress(t *testing.T) {
+	m := testModel()
+	loadWithFilter(m, AllFilter, fakeEntries("web"))
+
+	rollingOut := docker.ServiceEntry{
+		Status: "updating", RollingOut: true, ReplicasOnNode: 2, ReplicasTotal: 2, UpToDate: 1,
+	}
+	require.Equal(t, "updating · 1/2 new", statusCell(m, rollingOut))
+
+	landed := rollingOut
+	landed.UpToDate = 2
+	require.Equal(t, "updating", statusCell(m, landed), "no counter once every replica is current")
+
+	settled := docker.ServiceEntry{Status: "active", ReplicasOnNode: 1, ReplicasTotal: 2, UpToDate: 1}
+	require.Equal(t, "active", statusCell(m, settled), "a restart outside a rollout is not a stale version")
+
+	pulling := rollingOut
+	pulling.PullProgress = "pulling · 3/12 layers"
+	require.Equal(t, "pulling · 3/12 layers", statusCell(m, pulling), "a pull in flight still owns the cell")
+
+	unknown := docker.ServiceEntry{Status: "updating", RollingOut: true, ReplicasTotal: 0}
+	require.Equal(t, "updating", statusCell(m, unknown), "no target to count against")
+}
+
 func TestExpandedRow_ContainerStateFallback(t *testing.T) {
 	m := testModel()
 	loadWithFilter(m, AllFilter, fakeEntries("web"))

--- a/views/services/columns_test.go
+++ b/views/services/columns_test.go
@@ -179,18 +179,79 @@ func TestFirstNonEmpty(t *testing.T) {
 }
 
 func TestFormatTaskRow_ConditionalColumns(t *testing.T) {
-	// Neither flag set → layout matches the pre-existing NAME…ERROR row.
-	plain := formatTaskRow("web.1", "node-1", "Running", "running 8m", "healthy", "8000/tcp", "boom", false, false)
+	cells := taskRow{
+		replica: "1", image: "web:v2", node: "node-1", desired: "Running",
+		current: "running 8m", health: "healthy", ports: "8000/tcp", errText: "boom",
+	}
+
+	// No flags set → the mandatory REPLICA…ERROR row only.
+	plain := formatTaskRow(cells, taskRowColumns{})
+	require.NotContains(t, plain, "web:v2")
 	require.NotContains(t, plain, "healthy")
 	require.NotContains(t, plain, "8000/tcp")
 	require.Contains(t, plain, "boom")
 
-	// Both flags set → HEALTH and PORTS appear before ERROR.
-	full := formatTaskRow("web.1", "node-1", "Running", "running 8m", "healthy", "8000/tcp", "boom", true, true)
-	require.Contains(t, full, "healthy")
-	require.Contains(t, full, "8000/tcp")
+	// All set → IMAGE sits before NODE, HEALTH and PORTS before ERROR.
+	full := formatTaskRow(cells, taskRowColumns{image: true, health: true, ports: true})
+	require.Less(t, indexOf(full, "web:v2"), indexOf(full, "node-1"))
 	require.Less(t, indexOf(full, "healthy"), indexOf(full, "boom"))
 	require.Less(t, indexOf(full, "8000/tcp"), indexOf(full, "boom"))
+}
+
+// The reported confusion: three task rows against a target of 2 read as a
+// contradiction, because the slot — the one field that says two of them are one
+// replica being replaced — was truncated out of the NAME column (issue #480).
+func TestExpandedRow_ReplicaAndImageIdentifyGenerations(t *testing.T) {
+	m := testModel()
+	loadWithFilter(m, AllFilter, fakeEntries("web"))
+	m.expandedServices["id-web"] = true
+	m.serviceTasks["id-web"] = []docker.TaskEntry{
+		{Slot: 1, Image: "registry.example.com/acme/web:v2", NodeName: "node-29",
+			DesiredState: "Running", CurrentState: "preparing 26s"},
+		{Slot: 2, Image: "registry.example.com/acme/web:v2", NodeName: "node-02",
+			DesiredState: "Running", CurrentState: "running 36s"},
+		{Slot: 1, Image: "registry.example.com/acme/web:v1", NodeName: "node-03",
+			DesiredState: "Running", CurrentState: "running 2 weeks"},
+	}
+	m.setRenderItem()
+
+	out := m.List.RenderItem(m.List.Filtered[0], false, 0)
+	require.Contains(t, out, "REPLICA", "the slot must be a column of its own")
+	require.NotContains(t, out, "web.1", "the service name is on the row above, not repeated per task")
+	require.Contains(t, out, "IMAGE", "generations differ, so IMAGE earns its width")
+	require.Contains(t, out, "web:v1", "the outgoing generation is identifiable")
+	require.Contains(t, out, "web:v2")
+	require.NotContains(t, out, "registry.example.com", "the registry path is dropped, the tag is not")
+}
+
+// A settled service renders no wider than before: every replica agrees on the
+// image, so the column would only repeat the service row above it.
+func TestExpandedRow_ImageColumnHiddenWhenGenerationsAgree(t *testing.T) {
+	m := testModel()
+	loadWithFilter(m, AllFilter, fakeEntries("web"))
+	m.expandedServices["id-web"] = true
+	m.serviceTasks["id-web"] = []docker.TaskEntry{
+		{Slot: 1, Image: "acme/web:v2", NodeName: "node-1", DesiredState: "Running", CurrentState: "running 8m"},
+		{Slot: 2, Image: "acme/web:v2", NodeName: "node-2", DesiredState: "Running", CurrentState: "running 8m"},
+	}
+	m.setRenderItem()
+
+	out := m.List.RenderItem(m.List.Filtered[0], false, 0)
+	require.NotContains(t, out, "IMAGE")
+	require.NotContains(t, out, "web:v2")
+}
+
+// A global service's tasks carry no slot; NODE is what tells them apart.
+func TestExpandedRow_GlobalServiceHasNoSlot(t *testing.T) {
+	require.Equal(t, "—", replicaCell(docker.TaskEntry{Slot: 0}))
+	require.Equal(t, "3", replicaCell(docker.TaskEntry{Slot: 3}))
+}
+
+func TestShortImage(t *testing.T) {
+	require.Equal(t, "frontend:v1.3.23", shortImage("dockerhub.esix.hu/eldara-tech/swarmcli-website/frontend:v1.3.23"))
+	require.Equal(t, "repo:tag", shortImage("host:5000/repo:tag"), "a registry port is not a path separator")
+	require.Equal(t, "nginx:latest", shortImage("nginx:latest"))
+	require.Equal(t, "", shortImage(""))
 }
 
 func indexOf(s, sub string) int {

--- a/views/services/update.go
+++ b/views/services/update.go
@@ -648,13 +648,10 @@ func (m *Model) refreshServiceErrorsFromSnapshot() {
 	svcDesired := make(map[string]int)
 	svcRunning := make(map[string]int)
 	for _, svc := range snap.Services {
-		desired := 1
-		if svc.Spec.Mode.Replicated != nil && svc.Spec.Mode.Replicated.Replicas != nil {
-			desired = int(*svc.Spec.Mode.Replicated.Replicas)
-		} else if svc.Spec.Mode.Global != nil {
-			desired = len(snap.Nodes)
-		}
-		svcDesired[svc.ID] = desired
+		// Shared with the loaders rather than duplicated: counting every node as
+		// a global service's target flagged a fully healthy service as erroring
+		// for as long as one node stayed drained or down (issue #480).
+		svcDesired[svc.ID] = snap.DesiredReplicas(svc)
 		// Initialize svcRunning with 0 for all services
 		svcRunning[svc.ID] = 0
 	}

--- a/views/services/update.go
+++ b/views/services/update.go
@@ -18,6 +18,7 @@ import (
 	"github.com/Eldara-Tech/swarmcli/views/taskutil"
 	"github.com/Eldara-Tech/swarmcli/views/view"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -793,34 +794,45 @@ func (m *Model) setRenderItem() {
 				// HEALTH cell shows the healthcheck token when present, else the
 				// container's live state (running / restarting / exited), so the
 				// column appears whenever the decorator is active.
-				showHealth, showPorts := false, false
+				// IMAGE earns its width only while the replicas disagree about it:
+				// that is a rollout, and it is the column that says which row is
+				// the outgoing generation. In a settled service every row would
+				// repeat the image already on the service row above.
+				show := taskRowColumns{}
 				for _, t := range tasks {
 					if t.Health != "" || t.ContainerState != "" {
-						showHealth = true
+						show.health = true
 					}
 					if t.Ports != "" {
-						showPorts = true
+						show.ports = true
+					}
+					if t.Image != tasks[0].Image {
+						show.image = true
 					}
 				}
 
 				// Add task header (include ERROR column)
 				taskHeaderStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("8")).Italic(true)
 				// Align header columns with task row formatting
-				taskHeader := formatTaskRow("NAME", "NODE", "DESIRED STATE", "CURRENT STATE",
-					"HEALTH", "PORTS", "ERROR", showHealth, showPorts)
+				taskHeader := formatTaskRow(taskRow{
+					replica: "REPLICA", image: "IMAGE", node: "NODE",
+					desired: "DESIRED STATE", current: "CURRENT STATE",
+					health: "HEALTH", ports: "PORTS", errText: "ERROR",
+				}, show)
 				lineStr += "\n" + taskHeaderStyle.Render(taskHeader)
 
 				// Add each task as a row
 				for taskIdx, task := range tasks {
-					taskName := filterlist.TruncateRunes(task.Name, 22)
-					taskNode := filterlist.TruncateRunes(task.NodeName, 12)
-					taskDesired := filterlist.TruncateRunes(task.DesiredState, 13)
-					taskCurrent := filterlist.TruncateRunes(task.StatusText(), 40)
-					taskHealth := dashIfEmpty(filterlist.TruncateRunes(firstNonEmpty(task.Health, task.ContainerState), 9))
-					taskPorts := dashIfEmpty(filterlist.TruncateRunes(task.Ports, 20))
-					taskErr := filterlist.TruncateRunes(task.Error, 30)
-					rowText := formatTaskRow(taskName, taskNode, taskDesired, taskCurrent,
-						taskHealth, taskPorts, taskErr, showHealth, showPorts)
+					rowText := formatTaskRow(taskRow{
+						replica: replicaCell(task),
+						image:   filterlist.TruncateRunes(shortImage(task.Image), 20),
+						node:    filterlist.TruncateRunes(task.NodeName, 12),
+						desired: filterlist.TruncateRunes(task.DesiredState, 13),
+						current: filterlist.TruncateRunes(task.StatusText(), 40),
+						health:  dashIfEmpty(filterlist.TruncateRunes(firstNonEmpty(task.Health, task.ContainerState), 9)),
+						ports:   dashIfEmpty(filterlist.TruncateRunes(task.Ports, 20)),
+						errText: filterlist.TruncateRunes(task.Error, 30),
+					}, show)
 
 					// Check if this task is selected
 					taskSelected := selected && m.selectedTaskIndex == taskIdx
@@ -856,19 +868,51 @@ func (m *Model) setRenderItem() {
 	}
 }
 
+// taskRow is one expanded task sub-row's cells, or the header's labels.
+type taskRow struct {
+	replica, image, node, desired, current, health, ports, errText string
+}
+
+// taskRowColumns says which optional columns the caller found data for.
+type taskRowColumns struct {
+	image, health, ports bool
+}
+
 // formatTaskRow lays out one expanded task sub-row (or the header when passed
-// labels). The HEALTH and PORTS columns are only emitted when the caller found
-// data for them, so services without per-container health/port info render
-// exactly as before.
-func formatTaskRow(name, node, desired, current, health, ports, errText string, showHealth, showPorts bool) string {
-	s := fmt.Sprintf("   %-22s  %-12s  %-13s  %-40s", name, node, desired, current)
-	if showHealth {
-		s += fmt.Sprintf("  %-9s", health)
+// labels). The IMAGE, HEALTH and PORTS columns are only emitted when the caller
+// found data worth showing, so a settled service renders no wider than before.
+func formatTaskRow(r taskRow, show taskRowColumns) string {
+	s := fmt.Sprintf("   %-7s", r.replica)
+	if show.image {
+		s += fmt.Sprintf("  %-20s", r.image)
 	}
-	if showPorts {
-		s += fmt.Sprintf("  %-20s", ports)
+	s += fmt.Sprintf("  %-12s  %-13s  %-40s", r.node, r.desired, r.current)
+	if show.health {
+		s += fmt.Sprintf("  %-9s", r.health)
 	}
-	return s + "  " + errText
+	if show.ports {
+		s += fmt.Sprintf("  %-20s", r.ports)
+	}
+	return s + "  " + r.errText
+}
+
+// replicaCell identifies which replica a task belongs to. A global service's
+// tasks carry no slot; the NODE column is what distinguishes them there.
+func replicaCell(t docker.TaskEntry) string {
+	if t.Slot <= 0 {
+		return "—"
+	}
+	return strconv.Itoa(t.Slot)
+}
+
+// shortImage drops the registry and repository path, keeping the last segment
+// and its tag — the part that differs between two generations of one service.
+// The service row above already carries the full reference.
+func shortImage(image string) string {
+	if i := strings.LastIndex(image, "/"); i >= 0 {
+		return image[i+1:]
+	}
+	return image
 }
 
 // taskRowStyle tints an expanded task sub-row by container status: failed


### PR DESCRIPTION
Reported from a live cluster: a service row read `2/2` while the task table expanded under it showed **three** tasks with `DESIRED STATE = running`.

```
swarmcli-frontend_frontend   2/2   updating  2/2 healthy  replicated  …/frontend:v1.3.23
   NAME                    NODE     DESIRED STATE  CURRENT STATE
   swarmcli-frontend_fro…  node-29  running        preparing 26 seconds ago
   swarmcli-frontend_fro…  node-02  running        running 36 seconds ago
   swarmcli-frontend_fro…  node-03  running        running 2 weeks ago
```

Every number there is right, and that is the problem. Two separate defects, both from b60d2d2 (#489), plus a table that hides what would have made the row legible.

## What is actually happening

`REPLICAS` is `running / declared replicas`. The denominator is literally `*Spec.Mode.Replicated.Replicas`, so the service targets **2** replicas; the three rows are two slots' worth, one of them mid-replacement. Two containers are up, so the numerator is 2.

That matches `docker service ls` exactly — checked against the source rather than the docs: swarmkit's `ListServiceStatuses` counts `RunningTasks` as any task with `Status.State == Running`, with no desired-state and no active-node filter, and `DesiredTasks` as `replicas` ([`controlapi/service.go`](https://github.com/moby/swarmkit/blob/v2.1.2/manager/controlapi/service.go#L1083-L1124)). `docker service ls` prints `2/2` here too.

So under a **start-first** rollout both containers counted are the *outgoing* generation. The row reads fully converged while nothing has landed — and node-29 has a task that shut down 32s ago and another preparing 26s ago, i.e. a retry loop. A rollout wedged on an image pull looks converged for as long as it stays wedged. This is the case #480 flagged and deferred:

> Worth deciding deliberately: whether `REPLICAS` should also require tasks to be *up-to-date* with the current service spec. `docker service ls` does not, which is why a mid-rollout service can read `3/3` there too.

## 1. STATUS says how far the rollout got

`REPLICAS` is unchanged — the parity #489 established is the right answer to "how many replicas are serving". The other question, how many of those are the generation being rolled out, gets its own count, and `STATUS` carries it, since `updating` is what raises the question and the ratio beside it cannot answer it:

```
before   swarmcli-frontend_frontend  2/2  updating              2/2 healthy
after    swarmcli-frontend_frontend  2/2  updating · 1/2 new    2/2 healthy
```

It appears only while a rollout is in flight — `updating`, `paused`, or either rollback state — and only while it is short of target. A settled service renders exactly as before, and a pull in flight still owns the cell.

**How the current generation is identified.** The newest task per slot, by `CreatedAt`: swarm creates a slot's replacement after the task it supersedes, so creation order *is* generation order. `DesiredState` cannot draw this line — under start-first the outgoing task keeps `DesiredState=running` until its replacement is up, which is precisely the window that matters. Comparing task images against the service's `TaskTemplate` was rejected: digest resolution makes it fragile, and a force-update or env-only change leaves the images identical, so the counter would report converged immediately.

This is deliberately **not** `taskutil.LatestTasksByServiceKey`. That helper prefers a task that wants to be running over a newer terminal one, because it picks a task worth surfacing an *error* from; on a slot whose replacement was rejected that picks the outgoing task and would report the old generation as current. Two different rules, kept separate rather than one growing a mode flag.

The `--wait` path already reached the same conclusion independently — `charts/release.go:981` returns `PhaseProgressing` for `updating` with the comment "the count may still be the outgoing generation" — so this agrees with the codebase's settled position rather than inventing one.

## 2. The expanded table names the replica and the generation

The counter above says the rollout has not landed. It cannot say why the table shows three rows against a target of two, and that is not derivable from it: `2/2` plus `1/2 new` is equally consistent with two task records (swarm has not created the replacement yet) and three.

The slot answers it, and the table was throwing it away. Every task in this expansion belongs to the service on the row directly above, so `NAME` spent 22 columns re-printing that name once per row and truncated off the `.1`/`.2` suffix — the only part that differs. `swarmcli-frontend_frontend.1` and `…frontend.2` both rendered as `swarmcli-frontend_fro…`.

```
before   swarmcli-frontend_fro…  node-29  running  preparing 26 seconds ago
         swarmcli-frontend_fro…  node-02  running  running 36 seconds ago
         swarmcli-frontend_fro…  node-03  running  running 2 weeks ago

after    REPLICA  IMAGE             NODE     DESIRED STATE  CURRENT STATE
         1        frontend:v1.3.23  node-29  running        preparing 26 seconds ago
         2        frontend:v1.3.23  node-02  running        running 36 seconds ago
         1        frontend:v1.3.22  node-03  running        running 2 weeks ago
```

Two rows are replica 1, so three tasks against a target of two stops reading as a contradiction. `IMAGE` names which one is outgoing and follows the `HEALTH`/`PORTS` precedent of appearing only when it carries information — the replicas disagreeing about the image *is* the rollout, and in a settled service the column would only repeat the service row above. A settled service therefore renders **narrower** than before.

The registry and repository path are dropped (`frontend:v1.3.23`, not the full reference), since the service row already carries it and the tag is what differs. A force-update or env-only change leaves both generations on the same tag, so `IMAGE` stays hidden there while `REPLICA` still separates them. A global service's tasks carry no slot and render `—`; `NODE` is the discriminator there.

Scoped to the services-view expansion. The stacks-view expansion spans multiple services, where `NAME` is doing real work, and is untouched. `formatTaskRow` took nine positional parameters and would have taken twelve, so its cells and its column flags are structs now.

## 3. The node view stops hiding scheduled tasks

`LoadNodeServices` decided row *visibility* from the running-only count:

```go
if onNode == 0 { continue }
```

Since #489 `onNode` counts only tasks that have actually started, so a node's services view silently drops any service whose task there is preparing, pending on an unsatisfiable constraint, or rejected — the service an operator opened that node to diagnose. On the reported cluster, node-29's view does not list `swarmcli-frontend_frontend` at all right now.

Visibility now asks whether swarm *intends* a task on the node. Such a row renders `0/N`, which is the informative answer.

## Missed call sites, swept here rather than deferred

All belong to the #480 defect:

- `refreshServiceErrorsFromSnapshot` kept its own inline desired count using `len(snap.Nodes)` for global services — the exact lie #489 removed from `getServiceStackAndDesired` but missed here, so a fully healthy global service was flagged as erroring for as long as one node stayed drained or down. Both now go through an exported `(*SwarmSnapshot).DesiredReplicas`, deleting the duplicated mode switch.
- Four comments still described the pre-#489 `DesiredState` semantics of the `REPLICAS` string: `docker/convergence.go:14`, `charts/release.go:46`, `charts/release.go:986`, `charts/backend_docker.go:165`. Their conclusion survives — the convergence path must not derive parity from that string — but for the opposite reason: it now counts every generation on any node, rather than counting intent.

## Not in scope

**`REPLICAS` semantics** stay as #489 left them.

**BE needs no change.** Its `2/2 healthy` is computed over a different task set (it additionally requires `DesiredState == running`) and will legitimately keep disagreeing with `REPLICAS` mid-rollout. BE builds and tests green against this tree.

**Relocating `views/taskutil` into `docker`** is the tidier structure — it is snapshot logic, not view logic, and both slot-latest rules could then share one key function. Held off deliberately: `swarmcli-be/bootstrap/health.go:8` imports it, so the move removes an exported package from this module's API. That is a `C1-breaking-change`, which forces a major tag at release, and rc5 is mid-flight. Worth a deliberate window with the BE import updated alongside, not a rider on a bugfix.

## Tests

`docker/service_test.go` — the reported scenario as a fixture (`2/2` with `UpToDate == 1`); the overlap moment right after, when the incoming task starts and `REPLICAS` reads `3/2` while the generation count stays bounded by the slots; steady state; a global service keyed by node; an unassigned task not colliding on an empty key; `isRollingOut` across all six update states plus nil; `hasIntendedTaskOnNode` for preparing / terminal-only / other-service nodes.

`views/services/columns_test.go` — the STATUS counter renders while rolling out and short, disappears at parity, stays absent outside a rollout, loses to `PullProgress`, and is skipped when there is no target; the expansion shows `REPLICA` and drops the repeated service name, shows `IMAGE` only when generations disagree, renders `—` for a global service's slot, and `shortImage` keeps the tag while dropping a registry path (including one with a port).

`gofmt`, `go vet ./...`, `go test -race -count=1 ./...`, `golangci-lint run ./... --build-tags=integration` → 0 issues.

## Verification on a real cluster

Not verified against live Swarm — no cluster access from here. Worth checking manually:

1. The reported service's row shows `updating · 0/2 new` or `· 1/2 new` while node-29 keeps retrying, and drops back to a bare `updating` → `updated` as replicas land.
2. Expanding it shows `REPLICA 1` twice — the outgoing `v1.3.22` and the incoming `v1.3.23` — so three rows against a target of two reads correctly.
3. A settled service's expansion shows no `IMAGE` column and is no wider than before.
4. Node-29's services view lists `swarmcli-frontend_frontend` again, at `0/2`.
5. `docker service inspect swarmcli-frontend_frontend --format '{{.Spec.Mode.Replicated.Replicas}}'` prints `2` — the premise of the diagnosis above. If it prints `3`, the denominator is a separate bug and this PR does not address it.

Refs #480.
