### PR TITLE
fix(stacks): show that a deploy is running instead of a silent, stale list

### DIFF
--- a/test-setup/testenv.sh
+++ b/test-setup/testenv.sh
@@ -177,12 +177,18 @@ cmd_test() {
   # Always include integration build tag
   local go_test_cmd=("-tags=integration" "-v")
 
+  # views/stacks carries an integration-tagged test alongside its unit tests:
+  # the view's internals are unexported, so covering the deploy seam against a
+  # real swarm has to happen in-package. Naming the package also re-runs its
+  # (fast) unit tests, which is cheaper than widening this to ./... .
+  local packages=("./integration-tests/..." "./views/stacks/...")
+
   if [[ -n "$test_name" ]]; then
     info "🎯 Running single test: $test_name"
-    go_test_cmd+=("-run" "$test_name" "./integration-tests/...")
+    go_test_cmd+=("-run" "$test_name" "${packages[@]}")
   else
     info "🧩 Running all integration tests"
-    go_test_cmd+=("./integration-tests/...")
+    go_test_cmd+=("${packages[@]}")
   fi
 
   # Combine into gotestsum command

--- a/views/stacks/deploy_integration_test.go
+++ b/views/stacks/deploy_integration_test.go
@@ -49,6 +49,9 @@ func TestDeployProgressAgainstRealSwarm(t *testing.T) {
 
 	m := New(80, 24)
 	m.deps = docker.DefaultDeps()
+	// New() leaves the view hidden and View() short-circuits to "" — the factory
+	// is what flips this in production.
+	m.Visible = true
 	m.List.Viewport.Width = 80
 	m.List.Viewport.Height = 20
 	m.setRenderItem()

--- a/views/stacks/deploy_integration_test.go
+++ b/views/stacks/deploy_integration_test.go
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+//go:build integration
+
+package stacksview
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/Eldara-Tech/swarmcli/docker"
+	swarmlog "github.com/Eldara-Tech/swarmcli/utils/log"
+
+	"github.com/charmbracelet/x/ansi"
+	"github.com/stretchr/testify/require"
+)
+
+const itestCompose = `version: "3.9"
+
+services:
+  whoami:
+    image: traefik/whoami:v1.10
+    deploy:
+      replicas: 1
+`
+
+// TestDeployProgressAgainstRealSwarm covers the one seam the unit tests have to
+// mock: that a real `docker stack deploy` produces the terminal message the view
+// expects, and that the list the view rebuilds from a real post-deploy snapshot
+// actually contains the new stack.
+//
+// The view's own state machine is unit-tested against mocks — every transition
+// is message-driven, so a real daemon adds nothing there — and the shell-out in
+// docker.DeployStackInContext is already exercised by the charts integration
+// tests. This fills the gap between the two.
+func TestDeployProgressAgainstRealSwarm(t *testing.T) {
+	swarmlog.InitTestIfTestLogEnv()
+	fastSpinner(t)
+
+	stackName := fmt.Sprintf("itest-deploy-%d", time.Now().UnixNano())
+	t.Cleanup(func() {
+		if err := docker.RemoveStackCLI(context.Background(), stackName); err != nil {
+			t.Logf("cleanup: removing stack %s: %v", stackName, err)
+		}
+	})
+
+	m := New(80, 24)
+	m.deps = docker.DefaultDeps()
+	m.List.Viewport.Width = 80
+	m.List.Viewport.Height = 20
+	m.setRenderItem()
+
+	m.createDialogActive = true
+	m.createDialogStep = "details-inline"
+	m.createNameInput.SetValue(stackName)
+	m.createDialogContent = itestCompose
+
+	cmd := m.Update(key("enter"))
+	require.NotNil(t, cmd)
+
+	// The indicator is set synchronously, before the deploy goroutine runs —
+	// that is the whole point, since the deploy itself blocks for seconds.
+	require.True(t, m.deploying)
+	require.Equal(t, stackName, m.deployingStack)
+	require.Contains(t, ansi.Strip(m.View()), "Deploying stack")
+
+	deployed, ok := firstOfType[stackDeployedMsg](runBatch(cmd))
+	require.True(t, ok, "a real deploy must report success with stackDeployedMsg")
+	require.Equal(t, stackName, deployed.StackName)
+
+	reload := m.Update(deployed)
+	require.False(t, m.deploying, "the indicator must clear once the deploy returns")
+	require.Contains(t, m.toastMessage, stackName)
+
+	// The blank-list guard, against a real snapshot rather than a canned one:
+	// both create paths used to return a Msg with no Stacks, which emptied the
+	// list until the next poll.
+	loaded, ok := firstOfType[Msg](runBatch(reload))
+	require.True(t, ok, "deploy success must reload the stack list")
+	require.NotEmpty(t, loaded.Stacks, "the list must not be blanked after a deploy")
+
+	names := make([]string, 0, len(loaded.Stacks))
+	for _, s := range loaded.Stacks {
+		names = append(names, s.Name)
+	}
+	require.Contains(t, names, stackName)
+}

--- a/views/stacks/messages.go
+++ b/views/stacks/messages.go
@@ -26,6 +26,13 @@ type PollRetryMsg struct{}
 
 const PollInterval = 5 * time.Second
 
+// SpinnerTickMsg drives the deploy spinner and the toast expiry.
+type SpinnerTickMsg time.Time
+
+// spinnerTickInterval is a var, not a const, so tests can shrink it: a tea.Tick
+// cmd invoked synchronously blocks for the full interval.
+var spinnerTickInterval = 80 * time.Millisecond
+
 // StackTasksLoadedMsg is sent when tasks for a stack are loaded
 type StackTasksLoadedMsg struct {
 	StackName string
@@ -51,6 +58,14 @@ type StackDeleteIntentMsg struct {
 type editorContentMsg struct {
 	Content         string
 	OriginalContent string // populated in edit mode to detect no-change
+}
+
+// stackDeployedMsg is sent when a deploy — create or redeploy — returns
+// successfully. It is the only signal that clears the deploying state: a plain
+// Msg also arrives from the Docker events the deploy itself raises, so clearing
+// on that would drop the indicator at the first service creation.
+type stackDeployedMsg struct {
+	StackName string
 }
 
 // stackCreateErrorMsg is sent when stack creation has an error

--- a/views/stacks/model.go
+++ b/views/stacks/model.go
@@ -93,6 +93,14 @@ type Model struct {
 	// Edit stack tracking
 	editStackName string // non-empty when editing a stack (vs creating new)
 
+	// Deploy progress
+	deploying       bool
+	deployingStack  string
+	deployStartedAt time.Time
+	spinner         int
+	toastMessage    string
+	toastUntil      time.Time
+
 	// Save stack dialog
 	saveDialogActive   bool
 	saveDialogError    string          // error message to display in save dialog
@@ -195,6 +203,47 @@ func tickCmd() tea.Cmd {
 	})
 }
 
+// spinnerTickCmd schedules the next animation frame. Unlike the poll tick it is
+// self-terminating: Update only re-arms it while something is animating, so the
+// view redraws at rest only on the 5s poll.
+func (m *Model) spinnerTickCmd() tea.Cmd {
+	return tea.Tick(spinnerTickInterval, func(t time.Time) tea.Msg {
+		return SpinnerTickMsg(t)
+	})
+}
+
+// beginDeploy marks a deploy in flight and returns the animation tick that
+// drives the footer indicator.
+func (m *Model) beginDeploy(stackName string) tea.Cmd {
+	m.deploying = true
+	m.deployingStack = stackName
+	m.deployStartedAt = time.Now()
+	return m.spinnerTickCmd()
+}
+
+func (m *Model) endDeploy() {
+	m.deploying = false
+	m.deployingStack = ""
+}
+
+func (m *Model) showToast(msg string) {
+	if msg == "" {
+		return
+	}
+	m.toastMessage = msg
+	// Give multi-line toasts a bit more time so users can read them.
+	d := 2 * time.Second
+	if strings.Contains(msg, "\n") {
+		d = 5 * time.Second
+	}
+	m.toastUntil = time.Now().Add(d)
+}
+
+// animating reports whether the footer still has something to redraw.
+func (m *Model) animating() bool {
+	return m.deploying || (m.toastMessage != "" && time.Now().Before(m.toastUntil))
+}
+
 func (m *Model) Name() string { return ViewName }
 
 func (m *Model) ShortHelpItems() []helpbar.HelpEntry {
@@ -280,8 +329,15 @@ func (m *Model) checkStacksCmd(lastHash uint64, nodeID string) tea.Cmd {
 	}
 }
 
-func (m *Model) OnEnter() tea.Cmd { return m.LoadStacksCmd(m.nodeID) }
-func (m *Model) OnExit() tea.Cmd  { return nil }
+// OnEnter re-arms the animation tick when a deploy is still running, so
+// navigating away and back does not leave a frozen spinner in the footer.
+func (m *Model) OnEnter() tea.Cmd {
+	if m.deploying {
+		return tea.Batch(m.LoadStacksCmd(m.nodeID), m.spinnerTickCmd())
+	}
+	return m.LoadStacksCmd(m.nodeID)
+}
+func (m *Model) OnExit() tea.Cmd { return nil }
 
 func (m *Model) HasActiveFilter() bool {
 	return m.List.Query != ""

--- a/views/stacks/model_test.go
+++ b/views/stacks/model_test.go
@@ -7,11 +7,13 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/Eldara-Tech/swarmcli/docker"
 	"github.com/Eldara-Tech/swarmcli/ui"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/docker/docker/api/types/swarm"
 	"github.com/stretchr/testify/require"
 )
 
@@ -133,6 +135,47 @@ func runCmd(cmd tea.Cmd) tea.Msg {
 	return cmd()
 }
 
+// fastSpinner shrinks the animation interval for the duration of a test: a
+// tea.Tick cmd invoked synchronously blocks for its whole interval, so a batch
+// containing one cannot otherwise be drained.
+func fastSpinner(t *testing.T) {
+	t.Helper()
+	prev := spinnerTickInterval
+	spinnerTickInterval = time.Millisecond
+	t.Cleanup(func() { spinnerTickInterval = prev })
+}
+
+// runBatch runs every child of a batched cmd and returns their messages. Call
+// fastSpinner first when the batch carries an animation tick.
+func runBatch(cmd tea.Cmd) []tea.Msg {
+	if cmd == nil {
+		return nil
+	}
+	batch, ok := cmd().(tea.BatchMsg)
+	if !ok {
+		return nil
+	}
+	var msgs []tea.Msg
+	for _, c := range batch {
+		if c == nil {
+			continue
+		}
+		msgs = append(msgs, c())
+	}
+	return msgs
+}
+
+// firstOfType returns the first message of type T produced by a batch.
+func firstOfType[T tea.Msg](msgs []tea.Msg) (T, bool) {
+	for _, msg := range msgs {
+		if typed, ok := msg.(T); ok {
+			return typed, true
+		}
+	}
+	var zero T
+	return zero, false
+}
+
 func noopStackOps() *mockStackOps {
 	return &mockStackOps{
 		removeStackFn:             func(_ context.Context, _ string) error { return nil },
@@ -198,6 +241,21 @@ func fakeStacks(names ...string) []docker.StackEntry {
 
 func loadStacks(m *Model, stacks []docker.StackEntry) {
 	m.Update(Msg{NodeID: "node1", Stacks: stacks})
+}
+
+// snapshotWithStacks builds a snapshot whose ToStackEntries yields one entry per
+// name, so a reload path can be told apart from an empty terminal message.
+func snapshotWithStacks(names ...string) *docker.SwarmSnapshot {
+	snap := &docker.SwarmSnapshot{}
+	for i, name := range names {
+		snap.Services = append(snap.Services, swarm.Service{
+			ID: fmt.Sprintf("svc%d", i),
+			Spec: swarm.ServiceSpec{Annotations: swarm.Annotations{
+				Labels: map[string]string{"com.docker.stack.namespace": name},
+			}},
+		})
+	}
+	return snap
 }
 
 // --- Tests ---

--- a/views/stacks/update.go
+++ b/views/stacks/update.go
@@ -88,6 +88,20 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 	case PollRetryMsg:
 		return tickCmd()
 
+	case SpinnerTickMsg:
+		m.spinner++
+		if m.animating() {
+			return m.spinnerTickCmd()
+		}
+		return nil
+
+	case stackDeployedMsg:
+		m.endDeploy()
+		m.showToast(fmt.Sprintf("✓ Stack %q deployed — services updating", msg.StackName))
+		// Keep ticking through the toast window so it clears on time rather than
+		// lingering until the next 5s poll.
+		return tea.Batch(m.LoadStacksCmd(m.nodeID), m.spinnerTickCmd())
+
 	case RefreshErrorMsg:
 		m.Visible = true
 		m.List.Viewport.SetContent(fmt.Sprintf("Error refreshing stacks: %v", msg.Err))
@@ -239,8 +253,7 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 
 			stackOps := m.deps.Stacks
 			snapOps := m.deps.Snapshot
-			checkCmd := m.checkStacksCmd(m.lastSnapshot, m.nodeID)
-			return func() tea.Msg {
+			return tea.Batch(m.beginDeploy(stackName), func() tea.Msg {
 				l().Infof("Redeploying edited stack: %s", stackName)
 				err := stackOps.DeployStack(stackName, msg.Content)
 				if err != nil {
@@ -252,8 +265,8 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 				if _, err := snapOps.RefreshSnapshot(); err != nil {
 					l().Warnf("Failed to refresh snapshot: %v", err)
 				}
-				return checkCmd()
-			}
+				return stackDeployedMsg{StackName: stackName}
+			})
 		}
 
 		// Create mode: show create dialog with content
@@ -269,6 +282,7 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 
 	case stackUpdateErrorMsg:
 		l().Errorf("Error updating stack %s: %v", msg.StackName, msg.Err)
+		m.endDeploy()
 		m.confirmDialog.Visible = true
 		m.confirmDialog.ErrorMode = true
 		m.confirmDialog.Message = fmt.Sprintf("Failed to update stack %q:\n%v", msg.StackName, msg.Err)
@@ -276,6 +290,7 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 
 	case stackCreateErrorMsg:
 		l().Errorf("Error deploying stack: %v", msg.Err)
+		m.endDeploy()
 		// Return to create dialog with error message
 		// Determine which step to return to based on available data
 		if m.createFileInput.Value() != "" {
@@ -789,7 +804,7 @@ func (m *Model) handleCreateDialogKey(msg tea.KeyMsg) tea.Cmd {
 			m.createFileInput.Blur()
 			stackOps := m.deps.Stacks
 			snapOps := m.deps.Snapshot
-			return func() tea.Msg {
+			return tea.Batch(m.beginDeploy(stackName), func() tea.Msg {
 				l().Infof("Deploying stack %s from file %s", stackName, filePath)
 				err := stackOps.DeployStack(stackName, string(fileContent))
 				if err != nil {
@@ -801,8 +816,8 @@ func (m *Model) handleCreateDialogKey(msg tea.KeyMsg) tea.Cmd {
 				if _, err := snapOps.RefreshSnapshot(); err != nil {
 					l().Warnf("Failed to refresh snapshot: %v", err)
 				}
-				return Msg{NodeID: m.nodeID}
-			}
+				return stackDeployedMsg{StackName: stackName}
+			})
 		default:
 			// Pass keys to the focused textinput
 			var cmd tea.Cmd
@@ -885,7 +900,7 @@ func (m *Model) handleCreateDialogKey(msg tea.KeyMsg) tea.Cmd {
 			m.createNameInput.Blur()
 			stackOps := m.deps.Stacks
 			snapOps := m.deps.Snapshot
-			return func() tea.Msg {
+			return tea.Batch(m.beginDeploy(stackName), func() tea.Msg {
 				l().Infof("Deploying stack %s from inline editor (%d bytes)", stackName, len(contentToDeploy))
 				err := stackOps.DeployStack(stackName, contentToDeploy)
 				if err != nil {
@@ -897,8 +912,8 @@ func (m *Model) handleCreateDialogKey(msg tea.KeyMsg) tea.Cmd {
 				if _, err := snapOps.RefreshSnapshot(); err != nil {
 					l().Warnf("Failed to refresh snapshot: %v", err)
 				}
-				return Msg{NodeID: m.nodeID}
-			}
+				return stackDeployedMsg{StackName: stackName}
+			})
 		case "e", "E":
 			// Open editor for content when focused on content
 			if m.createInputFocus == 1 {

--- a/views/stacks/update_test.go
+++ b/views/stacks/update_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -163,10 +164,11 @@ func TestUpdate_EditorContentMsg_EditMode(t *testing.T) {
 	}
 	m := testModel(func(m *Model) { m.deps.Stacks = stackMock })
 	m.editStackName = "mystack"
+	fastSpinner(t)
 	cmd := m.Update(editorContentMsg{Content: "version: '3'", OriginalContent: "version: '2'"})
 	require.Equal(t, "", m.editStackName) // cleared
 	require.NotNil(t, cmd)
-	runCmd(cmd)
+	runBatch(cmd)
 	require.Equal(t, "mystack", deployed)
 }
 
@@ -629,9 +631,10 @@ func TestCreateDialog_DetailsInline_EnterDeploys(t *testing.T) {
 	m.createDialogStep = "details-inline"
 	m.createNameInput.SetValue("mystack")
 	m.createDialogContent = "version: '3'\nservices:\n  web:\n    image: nginx"
+	fastSpinner(t)
 	cmd := m.Update(key("enter"))
 	require.False(t, m.createDialogActive)
-	runCmd(cmd)
+	runBatch(cmd)
 	require.Equal(t, "mystack", deployed)
 }
 
@@ -1010,4 +1013,135 @@ func TestFileBrowser_Enter_File_SaveContext(t *testing.T) {
 	require.False(t, m.fileBrowserActive)
 	require.True(t, m.saveDialogActive)
 	require.Equal(t, "/tmp/mystack.yml", m.saveFileInput.Value())
+}
+
+// --- Deploy progress tests (#444) ---
+
+func TestDeploy_EditMode_SetsDeployingState(t *testing.T) {
+	fastSpinner(t)
+	m := testModel()
+	m.editStackName = "mystack"
+	cmd := m.Update(editorContentMsg{Content: "version: '3'", OriginalContent: "version: '2'"})
+	require.NotNil(t, cmd)
+	require.True(t, m.deploying)
+	require.Equal(t, "mystack", m.deployingStack)
+	require.False(t, m.deployStartedAt.IsZero())
+}
+
+func TestDeploy_CreateInline_SetsDeployingState(t *testing.T) {
+	fastSpinner(t)
+	m := testModel()
+	m.createDialogActive = true
+	m.createDialogStep = "details-inline"
+	m.createNameInput.SetValue("mystack")
+	m.createDialogContent = "version: '3'\nservices:\n  web:\n    image: nginx"
+	m.Update(key("enter"))
+	require.True(t, m.deploying)
+	require.Equal(t, "mystack", m.deployingStack)
+}
+
+func TestDeploy_CreateFromFile_SetsDeployingState(t *testing.T) {
+	fastSpinner(t)
+	composePath := filepath.Join(t.TempDir(), "compose.yml")
+	require.NoError(t, os.WriteFile(composePath, []byte("services:\n  web:\n    image: nginx\n"), 0o600))
+
+	m := testModel()
+	m.createDialogActive = true
+	m.createDialogStep = "details-file"
+	m.createNameInput.SetValue("mystack")
+	m.createFileInput.SetValue(composePath)
+	m.Update(key("enter"))
+	require.True(t, m.deploying)
+	require.Equal(t, "mystack", m.deployingStack)
+}
+
+func TestDeploy_Success_EmitsStackDeployedMsg(t *testing.T) {
+	fastSpinner(t)
+	m := testModel()
+	m.createDialogActive = true
+	m.createDialogStep = "details-inline"
+	m.createNameInput.SetValue("mystack")
+	m.createDialogContent = "version: '3'\nservices:\n  web:\n    image: nginx"
+	cmd := m.Update(key("enter"))
+
+	deployed, ok := firstOfType[stackDeployedMsg](runBatch(cmd))
+	require.True(t, ok, "deploy cmd must report success with stackDeployedMsg")
+	require.Equal(t, "mystack", deployed.StackName)
+}
+
+func TestUpdate_StackDeployedMsg_ClearsDeployingAndToasts(t *testing.T) {
+	fastSpinner(t)
+	m := testModel()
+	m.beginDeploy("mystack")
+	m.Update(stackDeployedMsg{StackName: "mystack"})
+	require.False(t, m.deploying)
+	require.Equal(t, "", m.deployingStack)
+	require.Contains(t, m.toastMessage, "mystack")
+	require.True(t, time.Now().Before(m.toastUntil))
+}
+
+// Guards the blank-list regression: the create paths used to return a Msg with
+// no Stacks, which emptied the list until the next poll.
+func TestUpdate_StackDeployedMsg_ReloadsStacks(t *testing.T) {
+	fastSpinner(t)
+	snapMock := noopSnapshotOps()
+	snap := snapshotWithStacks("alpha", "beta")
+	snapMock.getSnapshotFn = func() *docker.SwarmSnapshot { return snap }
+	m := testModel(func(m *Model) { m.deps.Snapshot = snapMock })
+	m.beginDeploy("alpha")
+
+	cmd := m.Update(stackDeployedMsg{StackName: "alpha"})
+	loaded, ok := firstOfType[Msg](runBatch(cmd))
+	require.True(t, ok, "deploy success must reload the stack list")
+	require.Len(t, loaded.Stacks, 2)
+}
+
+func TestUpdate_StackCreateErrorMsg_ClearsDeploying(t *testing.T) {
+	m := testModel()
+	m.beginDeploy("mystack")
+	m.Update(stackCreateErrorMsg{Err: fmt.Errorf("deployment failed")})
+	require.False(t, m.deploying)
+	require.True(t, m.createDialogActive)
+}
+
+func TestUpdate_StackUpdateErrorMsg_ClearsDeploying(t *testing.T) {
+	m := testModel()
+	m.beginDeploy("mystack")
+	m.Update(stackUpdateErrorMsg{StackName: "mystack", Err: fmt.Errorf("invalid yaml")})
+	require.False(t, m.deploying)
+	require.True(t, m.confirmDialog.Visible)
+}
+
+func TestUpdate_SpinnerTickMsg_ReArmsWhileDeploying(t *testing.T) {
+	fastSpinner(t)
+	m := testModel()
+	m.beginDeploy("mystack")
+	cmd := m.Update(SpinnerTickMsg(time.Now()))
+	require.Equal(t, 1, m.spinner)
+	require.NotNil(t, cmd)
+}
+
+func TestUpdate_SpinnerTickMsg_StopsWhenIdle(t *testing.T) {
+	m := testModel()
+	cmd := m.Update(SpinnerTickMsg(time.Now()))
+	require.Equal(t, 1, m.spinner)
+	require.Nil(t, cmd, "the animation must not re-arm at rest")
+}
+
+func TestUpdate_SpinnerTickMsg_ReArmsWhileToastVisible(t *testing.T) {
+	fastSpinner(t)
+	m := testModel()
+	m.showToast("deployed")
+	cmd := m.Update(SpinnerTickMsg(time.Now()))
+	require.NotNil(t, cmd, "the toast needs redraws to disappear on time")
+}
+
+// A deploy raises Docker events, which the app turns into a plain Msg. That must
+// not be mistaken for the deploy finishing.
+func TestUpdate_Msg_DoesNotClearDeploying(t *testing.T) {
+	m := testModel()
+	m.beginDeploy("mystack")
+	m.Update(Msg{NodeID: "node1", Stacks: fakeStacks("mystack")})
+	require.True(t, m.deploying)
+	require.Equal(t, "mystack", m.deployingStack)
 }

--- a/views/stacks/view.go
+++ b/views/stacks/view.go
@@ -5,6 +5,8 @@ package stacksview
 
 import (
 	"fmt"
+	"time"
+
 	"github.com/Eldara-Tech/swarmcli/ui"
 	"github.com/Eldara-Tech/swarmcli/ui/dialog"
 
@@ -16,7 +18,31 @@ func (m *Model) FrameTitle() string {
 }
 
 func (m *Model) FrameHeader() string { return m.List.RenderHeader() }
-func (m *Model) FrameFooter() string { return m.List.RenderFooter() }
+
+// FrameFooter shows an in-flight deploy in place of the row counter: `docker
+// stack deploy` blocks with no output of its own, so without this a slow deploy
+// and a hung one look identical.
+func (m *Model) FrameFooter() string {
+	if m.deploying {
+		return ui.StatusBarStyle.Render(fmt.Sprintf("%s Deploying stack %q… %s",
+			ui.SpinnerCharAt(m.spinner), m.deployingStack, formatElapsed(time.Since(m.deployStartedAt))))
+	}
+	if m.toastMessage != "" {
+		if time.Now().Before(m.toastUntil) {
+			return ui.StatusBarStyle.Render(m.toastMessage)
+		}
+		m.toastMessage = ""
+	}
+	return m.List.RenderFooter()
+}
+
+// formatElapsed renders a deploy's age compactly: "12s", "1m30s".
+func formatElapsed(d time.Duration) string {
+	if d < time.Minute {
+		return fmt.Sprintf("%ds", int(d.Seconds()))
+	}
+	return fmt.Sprintf("%dm%02ds", int(d.Minutes()), int(d.Seconds())%60)
+}
 
 func (m *Model) FrameContent() string {
 	m.setRenderItem()

--- a/views/stacks/view_test.go
+++ b/views/stacks/view_test.go
@@ -6,6 +6,7 @@ package stacksview
 import (
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/Eldara-Tech/swarmcli/docker"
 	"github.com/Eldara-Tech/swarmcli/ui/dialog"
@@ -191,4 +192,47 @@ func widestLine(s string) int {
 		}
 	}
 	return max
+}
+
+func TestView_Deploying_ShowsFooterStatus(t *testing.T) {
+	m := testModel()
+	loadStacks(m, fakeStacks("alpha", "beta"))
+	m.setRenderItem()
+	m.List.Viewport.Width = 80
+	m.List.Viewport.Height = 20
+	m.beginDeploy("alpha")
+
+	out := ansi.Strip(m.View())
+	require.Contains(t, out, `Deploying stack "alpha"`)
+	require.Contains(t, out, "0s")
+	require.NotContains(t, out, "Stack 1 of", "the deploy status replaces the row counter")
+}
+
+func TestView_Deploying_ShowsElapsed(t *testing.T) {
+	m := testModel()
+	loadStacks(m, fakeStacks("alpha"))
+	m.setRenderItem()
+	m.List.Viewport.Width = 80
+	m.List.Viewport.Height = 20
+	m.beginDeploy("alpha")
+	m.deployStartedAt = time.Now().Add(-90 * time.Second)
+
+	require.Contains(t, ansi.Strip(m.View()), "1m30s")
+}
+
+func TestView_Toast_ShownThenExpires(t *testing.T) {
+	m := testModel()
+	loadStacks(m, fakeStacks("alpha"))
+	m.setRenderItem()
+	m.List.Viewport.Width = 80
+	m.List.Viewport.Height = 20
+
+	m.showToast("✓ Stack \"alpha\" deployed")
+	require.Contains(t, ansi.Strip(m.View()), "deployed")
+
+	m.toastUntil = time.Now().Add(-time.Second)
+	out := ansi.Strip(m.View())
+	require.NotContains(t, out, "deployed")
+	require.Contains(t, out, "Stack 1 of")
+	require.Equal(t, "", m.toastMessage, "an expired toast is cleared")
 }


### PR DESCRIPTION
Closes #444.

## What it looked like

From `<Enter>` on the create/edit-stack dialog until `docker stack deploy` returned, the stacks view showed nothing: no spinner, no toast, no line anywhere. The dialog vanished and the stale list kept rendering. A slow deploy and a hung TUI were indistinguishable.

The TUI was never actually blocked — `tea.Cmd` closures run on their own goroutine — so nothing here is a concurrency fix. What was missing was state saying a deploy is in flight, and somewhere to render it.

## What it looks like now

```
┌──────────────────────── Stacks(all)[3] ────────────────────────┐
│  STACK ▲       SERVICESTASKS ERROR: 0                          │
│  alpha         1     1                                         │
│  beta          2     2                                         │
│  whoami        3     3                                         │
│                                                                │
│  ⠸ Deploying stack "whoami"… 12s                               │
└────────────────────────────────────────────────────────────────┘
```

…then, for two seconds, `✓ Stack "whoami" deployed — services updating`, then the usual `Stack 1 of 3`. The wording is deliberate: `docker stack deploy` returns once the service specs are accepted, long before any image is pulled, so claiming more than that would be a lie.

The elapsed counter is the part that actually separates *slow* from *hung*, which was the complaint. An 80ms `tea.Tick` drives the animation and re-arms **only** while the deploy or the toast still needs redrawing — unlike `views/networks`, which ticks forever at 12.5Hz. `TestUpdate_SpinnerTickMsg_StopsWhenIdle` guards that.

## Why one terminal message

The three call sites (edit/redeploy, create-from-file, create-inline) now converge on a single `stackDeployedMsg`. That is correctness, not tidiness: `app/update.go` turns Docker `service`/`config`/`network` events into a plain stacks `Msg`, and a deploy raises exactly those — so clearing the indicator on `Msg` would have killed the spinner at the first service creation, the least useful possible moment. `TestUpdate_Msg_DoesNotClearDeploying` guards it.

## Drive-by fix, called out because it is not in the issue

Both create paths returned `Msg{NodeID: m.nodeID}` with a **nil** `Stacks` slice. `setStacks(nil)` emptied the list until the next 5s poll — a blank stack list as the reward for a successful deploy. Routing success through `LoadStacksCmd` repopulates it immediately. `TestUpdate_StackDeployedMsg_ReloadsStacks` is the regression guard.

Incidentally, the deploy closures no longer read any model field, which removes a cross-goroutine read of `m.nodeID`.

## Deliberately not done

- **Streaming the CLI's stdout.** The issue argues it buys little and I agree: `docker stack deploy` returns before any pull or container start, so the interesting waiting happens afterwards on the task rows — Eldara-Tech/swarmcli-be#250's territory.
- **A deploy timeout.** `exec.Command` here is not context-bound, and the existing 15s `userActionTimeout` would be far too short for a large deploy re-resolving images against a registry. The elapsed counter gives the user what they need to judge it; imposing a deadline is a separate, riskier change.

## Testing

15 new unit tests plus one integration test in `views/stacks`, covering all three call sites, both error paths clearing the flag, the tick's start/stop conditions, the toast lifecycle and the two regression guards above. Two existing tests needed repair: once `Update` returns a `tea.Batch`, `cmd()` yields a `BatchMsg` without running children, so they now drain the batch via a `runBatch` helper with a shrunk (injectable) spinner interval.

`go build`, `go test ./...` and `golangci-lint run ./... --build-tags=integration` are all clean.

### Integration coverage

`views/stacks/deploy_integration_test.go` (`//go:build integration`) covers the one seam the unit tests must mock: a real `docker stack deploy` against the DinD swarm, asserting the indicator is set synchronously, that the real deploy yields `stackDeployedMsg`, and that the list rebuilt from a real post-deploy snapshot contains the new stack — the blank-list guard against something other than a canned snapshot.

The other two layers are deliberately not retested: the view state machine is message-driven and unit-covered, and `docker.DeployStackInContext` is already exercised by the charts integration tests via `charts/backend_docker.go:77`.

It is in-package because `deps`, the create-dialog fields and `stackDeployedMsg` are unexported; from `integration-tests/` the only way in is simulated keystrokes, which re-exercise the well-covered layer through a flakier path and would have to route around #525. `testenv.sh` names `./views/stacks/...` alongside `./integration-tests/...`; the CI workflow needs no change, its paths filter already matches `**.go`.

One gap remains open by choice: the app-level Docker-event race that `stackDeployedMsg` exists to avoid lives in `app/update.go`, so covering it for real means driving `app.Model`, which nothing in the repo does. `TestUpdate_Msg_DoesNotClearDeploying` guards it at the unit level instead.

**Not verified:** no Docker daemon was available where this was written, so the DinD manual pass — deploy `test-setup/test-stack.yml`, watch the counter climb, confirm the list never blanks, then deploy a bad image reference and confirm the spinner clears into the error dialog — has not been run. Rendering was checked against the real `View()` output (the box above is actual output, not a mockup).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
