### PR TITLE
ci: label names are payload data, not script text

### DIFF
--- a/.github/workflows/check_labels.yml
+++ b/.github/workflows/check_labels.yml
@@ -30,10 +30,24 @@ jobs:
           - test: C Label (breaking changes)
             enforced_labels: "C0-breaks-nothing,C1-breaking-change"
     steps:
+      # The label names are pull_request payload data, so they must not reach
+      # the runner as script text. A `${{ }}` inside a `run:` block is expanded
+      # by the Actions engine *before* bash is started — the expansion becomes
+      # part of the script source, so no amount of quoting inside the script can
+      # contain it, and toJSON does not help because `'` is not a JSON
+      # metacharacter: it passes through, closes the jq program's single-quoted
+      # string, and the rest of the label name is parsed as shell. Passing the
+      # payload through `env:` instead hands bash a value it never parses, and
+      # jq reads it as data via --argjson (the labels are a JSON array) and
+      # --arg (the enforced set is one comma-separated string). Same program,
+      # same exit semantics — only the delivery changes.
       - name: Label check (At least one of each type)
+        env:
+          USER_LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}
+          ENFORCED_LABELS: ${{ matrix.enforced_labels }}
         run: |
-          MATCH=$(jq -cn '${{ toJSON(github.event.pull_request.labels.*.name) }} as $USER_LABELS |
-          ${{ toJSON(matrix.enforced_labels)  }} | split(",") as $LABELS |
+          MATCH=$(jq -cn --argjson USER_LABELS "$USER_LABELS" --arg ENFORCED_LABELS "$ENFORCED_LABELS" \
+          '($ENFORCED_LABELS | split(",")) as $LABELS |
           $USER_LABELS - ($USER_LABELS - $LABELS)')
           if [[  "$MATCH" == '[]' ]]; then
               exit 1


### PR DESCRIPTION
`check_labels.yml` interpolated `pull_request` payload data into the *text* of a shell script. A `${{ }}` inside a `run:` block is expanded by the Actions engine **before bash is started**, so the expansion becomes part of the script source and no quoting inside the script can contain it. `toJSON` does not help: `'` is not a JSON metacharacter, so it passes through, closes the jq program's single-quoted string, and the rest of the label name is parsed as shell.

Label names are settable by anyone with triage or write access. Passing them through `env:` hands bash a value it never parses, and `jq` reads them as data via `--argjson` (a JSON array) and `--arg` (one comma-separated string).

## The injection passes the check

Worth stating plainly, because it is worse than "code runs on a runner": the injected command is the **last** in the command substitution, so `MATCH` picks up its exit status, never equals `[]`, and **the step exits 0**. The label gate reports *pass* while the payload runs. There is no failing check to notice.

Demonstrated by simulating the engine's text substitution and running `bash -e` on the result, with a harmless `touch` in a temp dir standing in for the payload, across all three matrix rows:

```
  A Label (change type)        OLD exit 0 payload_executed=True   NEW exit 0 payload_executed=False
  B Label (urgency)            OLD exit 0 payload_executed=True   NEW exit 0 payload_executed=False
  C Label (breaking changes)   OLD exit 0 payload_executed=True   NEW exit 0 payload_executed=False
```

## Behaviour is unchanged

Old form vs new, executed rather than reasoned about, for all three rows:

```
labels ['A1-feature','B0-low-priority','C0-breaks-nothing']   old 0/0/0   new 0/0/0
labels ['A1-feature','B0-low-priority']                       old 0/0/1   new 0/0/1
labels []                                                     old 1/1/1   new 1/1/1
```

Then re-run against the **committed YAML** — parsing the file, expanding `env:` as the runner does, executing the real `run:` body: 0 failures, including a single-quote label alongside a complete set.

The matrix, the three enforced label sets, the step name, the `github.base_ref == 'main'` gate and the odd double space in `if [[  "$MATCH"` are all untouched. Only the delivery of two values changes.

## Note on this repo specifically

CE had the same second interpolation (`${{ toJSON(matrix.enforced_labels) }}`), but its jq shape differed from the sibling repos': it was piped inline (`… | split(",") as $LABELS`) rather than parenthesised. Ported to the equivalent `($ENFORCED_LABELS | split(","))` form rather than copied, so the program is unchanged. It is workflow-owned rather than payload data so it was not exploitable, but leaving it would have kept the anti-pattern in the file.

All seven workflows were parsed and every string under a `run:` key scanned: these two lines were the repository's **only** `${{ }}` inside a shell body. Everything else (`concurrency.group`, `if:`, `outputs:`, `with:`) is evaluated by the engine and never reaches a shell.

Since this workflow fires on `opened`, the usual gotcha applies to this PR too: the first run sees no labels and fails, and a later `labeled` event or push is what makes it green.

Refs Eldara-Tech/swarmcli-cd#113 — that issue tracks the same fix across all five repos and stays open until the rest are done. Found by the audit tracked in Eldara-Tech/swarmcli-cd#114.