### PR TITLE
fix: a rollback that finished is a failed deploy, not a converged one

### DIFF
--- a/charts/release.go
+++ b/charts/release.go
@@ -921,8 +921,10 @@ const defaultStabilityWindow = 5 * time.Second
 // count and has held it for the stability window, or the timeout elapses.
 //
 // It returns early with an error when swarm reports the rollout wedged
-// ("paused" / "rollback_paused"): swarmkit never rolls back a rollback, so
-// those states need a human and waiting out the timeout only delays the report.
+// ("paused" / "rollback_paused" / "rollback_completed"): swarm will not
+// continue from any of them on its own — the paused pair needs a human, and a
+// completed rollback is a deploy that already failed and was undone — so
+// waiting out the timeout only delays the same answer.
 func (e *Engine) waitReady(release string, timeout time.Duration) error {
 	if timeout <= 0 {
 		timeout = 5 * time.Minute
@@ -977,6 +979,14 @@ func (s ServiceState) Convergence() Convergence {
 		return Convergence{PhaseWedged, "update paused after a task failure; swarm will not continue without intervention"}
 	case "rollback_paused":
 		return Convergence{PhaseWedged, "rollback paused; swarm never rolls back a rollback, so this needs manual recovery"}
+	// A finished rollback is terminal too, and it is a FAILED deploy: swarmkit
+	// restores the previous spec before it marks the rollback complete, so the
+	// tasks that reach parity here are running exactly what the deploy set out
+	// to replace. Falling through to the parity check reported that as success,
+	// which is how a rolled-back release passed --wait and let a pipeline gating
+	// on it go green (issue #526).
+	case "rollback_completed":
+		return Convergence{PhaseWedged, "update failed and was rolled back; the previous spec is running"}
 	// A rolling update in flight is not converged even if the task count
 	// already reads N/N: the count may still be the outgoing generation.
 	case "updating":

--- a/charts/release_test.go
+++ b/charts/release_test.go
@@ -502,6 +502,29 @@ func TestConvergenceWedged(t *testing.T) {
 	require.Contains(t, c.Reason, "manual recovery")
 }
 
+// The bug in #526: swarmkit restores the previous spec BEFORE it marks the
+// rollback complete, so at "rollback_completed" the tasks that reach parity are
+// running exactly what the deploy set out to replace. Falling through to the
+// parity check let a failed rollout serve out the stability window and report
+// converged — --wait returned nil and a pipeline gating on it went green.
+func TestConvergenceRejectsACompletedRollback(t *testing.T) {
+	rolledBack := ServiceState{Name: "api", Running: 1, Desired: 1, UpdateState: "rollback_completed", NewestTaskAge: stableAge}
+
+	c := rolledBack.Convergence()
+	require.Equal(t, PhaseWedged, c.Phase, "a deploy that was rolled back is a failed deploy, not a converged one")
+	require.Contains(t, c.Reason, "rolled back")
+
+	// And --wait says so instead of returning nil.
+	prev := waitPollInterval
+	waitPollInterval = time.Millisecond
+	defer func() { waitPollInterval = prev }()
+
+	b := &convergenceBackend{states: []ServiceState{rolledBack}}
+	e := &Engine{Backend: b, now: time.Now}
+	require.ErrorContains(t, e.waitReady("rel", time.Hour), "rolled back")
+	require.Equal(t, 1, b.calls, "should fail on the first observation, not wait out the timeout")
+}
+
 // The rollup is what a caller reads, so the phase that should worry it most has
 // to win regardless of where in the list it appears — one wedged service must
 // not be masked by another that is merely slow.


### PR DESCRIPTION
`ServiceState.Convergence()` switched over four update states and omitted `rollback_completed`, so it fell through to the parity + stability-window check.

That is wrong because swarmkit restores the previous spec **before** it marks the rollback complete. Verified in `moby/swarmkit@v2.1.2 manager/orchestrator/update/updater.go`: `rollbackUpdate` (:607) sets `ROLLBACK_STARTED` and, in the *same* store transaction, does `service.Spec = *service.PreviousSpec; service.PreviousSpec = nil`; `completeUpdate` (:639-641) later flips it to `ROLLBACK_COMPLETED`. So the tasks reaching parity at that point are running exactly what the deploy set out to replace — and once the 5s stability window elapses, `Rollup` called it Converged.

**Impact:** `waitReady` is `Rollup(Backend.StackServices(release))`, called from `deployAndRecord` under `if opts.Wait`, which is the `--wait` flag (`cli/apply.go:92`, `cli/charts.go:436,477,513`). A release Swarm could not converge, tried, and rolled back reported **success** — `--wait` returned nil, the command exited 0, and a pipeline gating on it went green on a failed rollout.

The codebase already knew the state existed: `docker/service.go:566` renders it as `"rolled back"`. Only the convergence switch omitted it.

## The change

```go
	case "rollback_completed":
		return Convergence{PhaseWedged, "update failed and was rolled back; the previous spec is running"}
```

Wedged rather than Progressing because it is terminal — Swarm will not continue on its own, so waiting out the deadline only delays the same answer, which is the reasoning `rollback_paused` already carries. `waitReady`'s doc comment enumerated the wedged states and has been updated with it.

## Every `UpdateState`, and why each is handled as it is

The wire enum is `UpdateStatus_UpdateState` (swarmkit `api/types.pb.go:429-436`), seven values; the daemon maps six to `swarm.UpdateState*` strings and drops `UNKNOWN` into the empty string (`daemon/cluster/convert/service.go:59-74`). After this change:

| state | verdict | why |
| --- | --- | --- |
| `paused` | Wedged | needs a human |
| `rollback_paused` | Wedged | swarm never rolls back a rollback |
| `rollback_completed` | **Wedged (new)** | previous spec is running; the deploy failed |
| `updating` | Progressing | rollout in flight |
| `rollback_started` | Progressing | rollback in flight |
| `completed` | falls through | the **new** spec reached parity, so parity + stability is exactly the right question |
| empty / `UNKNOWN` | falls through | no rollout has ever run — the fresh-install case from #473 |

The switch is now exhaustive over every state that is not a parity question. I checked the whole enum rather than only the reported value, since this switch has now been found incomplete twice.

## Tests

`TestConvergenceRejectsACompletedRollback` asserts both levels: `Convergence()` is Wedged, and `waitReady` returns an error containing "rolled back" on its **first** poll rather than returning nil. Removing only the `case` makes it fail with `expected: "wedged" / actual: "converged"`.

Existing coverage already pinned the rest — `TestConvergenceRejectsInProgress` covers `updating`/`rollback_started`, the empty-state-at-parity-past-window case (#473) and parity-not-reached; `TestConvergenceWedged` covers `paused`/`rollback_paused` — so nothing was duplicated. The repo uses discrete `require`-based tests with an issue-narrative comment per case rather than table tests; this matches that.

## Downstream

`Rollup` and `Convergence` are exported and consumed by swarmcli-be and swarmcli-cd. This makes a previously-Converged input report Wedged — a behaviour change for them, in the correct direction: swarmcli-cd's `awaitConverged` shares this hole and stops reporting a rolled-back release as a successful sync (Eldara-Tech/swarmcli-cd#104, item 4). No CE call site needs editing; `waitReady` has exactly one, and it already propagates.

Integration tests need a live daemon and were not run here; none of them touch `Convergence`/`Rollup`.

Closes #526. Surfaced by the swarmcli-cd audit, Eldara-Tech/swarmcli-cd#114.