### PR TITLE
fix(charts): a repository name is a path component, and plaintext is opt-in

### DIFF
--- a/.github/UPGRADE_NOTES.md
+++ b/.github/UPGRADE_NOTES.md
@@ -1,9 +1,34 @@
-<!--
-Upgrade Notes — curated breaking-change callout for the next release.
+### Chart repositories must now be served over HTTPS
 
-Leave this file as-is (this comment only) when the release has no breaking
-changes. For a breaking release, replace the comment with migration prose in
-Markdown; the release workflow prepends it as a "## ⚠️ Upgrade Notes" section
-at the top of the GitHub release notes (see .github/workflows/release.yml).
-Clear it back to this comment once the GA is cut.
--->
+A chart repository serves the tarball that *becomes* the deployed workload, so
+anything on the path to it decides what runs on your swarm. The digest published
+per version does not close that: it travels in the same `index.yaml`, over the
+same connection, so an on-path attacker rewrites both — and an entry that
+publishes no digest only warns.
+
+Plain `http://` is therefore refused: when adding a repository, when refreshing
+its index, and for a tarball URL an index points at. A repository already in
+`repos.json` from an earlier version is refused too, so this bites on
+`swarmcli charts repo update`, `install`, `upgrade` and `apply`, not only on
+`repo add`.
+
+If your registry is internal and you already trust the network between you and
+it, opt that machine out:
+
+```bash
+export SWARMCLI_CHARTS_ALLOW_PLAINTEXT=1
+```
+
+Otherwise, re-point the repository at its HTTPS URL:
+
+```bash
+swarmcli charts repo remove <name>
+swarmcli charts repo add <name> https://…
+```
+
+### Repository names are restricted to `[A-Za-z0-9._-]`
+
+The name is a component of the file its cached index is written to, so it is now
+validated the same way a release name is — in the store and in
+`swarmcli-release.yaml`. Any name outside that charset (a `/`, a `..` segment)
+is rejected rather than resolved into a path.

--- a/.github/UPGRADE_NOTES.md
+++ b/.github/UPGRADE_NOTES.md
@@ -1,34 +1,9 @@
-### Chart repositories must now be served over HTTPS
+<!--
+Upgrade Notes — curated breaking-change callout for the next release.
 
-A chart repository serves the tarball that *becomes* the deployed workload, so
-anything on the path to it decides what runs on your swarm. The digest published
-per version does not close that: it travels in the same `index.yaml`, over the
-same connection, so an on-path attacker rewrites both — and an entry that
-publishes no digest only warns.
-
-Plain `http://` is therefore refused: when adding a repository, when refreshing
-its index, and for a tarball URL an index points at. A repository already in
-`repos.json` from an earlier version is refused too, so this bites on
-`swarmcli charts repo update`, `install`, `upgrade` and `apply`, not only on
-`repo add`.
-
-If your registry is internal and you already trust the network between you and
-it, opt that machine out:
-
-```bash
-export SWARMCLI_CHARTS_ALLOW_PLAINTEXT=1
-```
-
-Otherwise, re-point the repository at its HTTPS URL:
-
-```bash
-swarmcli charts repo remove <name>
-swarmcli charts repo add <name> https://…
-```
-
-### Repository names are restricted to `[A-Za-z0-9._-]`
-
-The name is a component of the file its cached index is written to, so it is now
-validated the same way a release name is — in the store and in
-`swarmcli-release.yaml`. Any name outside that charset (a `/`, a `..` segment)
-is rejected rather than resolved into a path.
+Leave this file as-is (this comment only) when the release has no breaking
+changes. For a breaking release, replace the comment with migration prose in
+Markdown; the release workflow prepends it as a "## ⚠️ Upgrade Notes" section
+at the top of the GitHub release notes (see .github/workflows/release.yml).
+Clear it back to this comment once the GA is cut.
+-->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,6 +107,7 @@ utils/log/
 | `LOG_LEVEL` | `debug`/`info`/`warn`/`error` | `debug` (dev), `info` (prod) |
 | `DOCKER_CONTEXT` | Override Docker context | `docker context show` |
 | `TEST_LOG` | Enable logging in tests | unset |
+| `SWARMCLI_CHARTS_ALLOW_PLAINTEXT` | Allow chart repositories served over plain `http://`; read only by `cli`, which wires it to `charts.RepoStore.AllowPlaintext` (the `charts` package never reads the environment, so embedders keep the https-only default) | unset (https only) |
 
 ## Pro Feature Boundary
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,7 +107,7 @@ utils/log/
 | `LOG_LEVEL` | `debug`/`info`/`warn`/`error` | `debug` (dev), `info` (prod) |
 | `DOCKER_CONTEXT` | Override Docker context | `docker context show` |
 | `TEST_LOG` | Enable logging in tests | unset |
-| `SWARMCLI_CHARTS_ALLOW_PLAINTEXT` | Allow chart repositories served over plain `http://`; read only by `cli`, which wires it to `charts.RepoStore.AllowPlaintext` (the `charts` package never reads the environment, so embedders keep the https-only default) | unset (https only) |
+| `SWARMCLI_CHARTS_ALLOW_PLAINTEXT` | Opt out of the https-only default for chart repositories; read only by `cli`, which wires it to `charts.RepoStore.AllowPlaintext` (the `charts` package never reads the environment, so embedders keep the default) | unset (https only) |
 
 ## Pro Feature Boundary
 

--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ $ LOG_LEVEL=debug SWARMCLI_ENV=dev go run .
 - `SWARMCLI_ENV`: `dev` enables pretty debug logs (default is `prod`).
 - `LOG_LEVEL`: `debug`, `info`, `warn`, `error`, …
 - `SWARMCLI_DISABLE_VERSION_CHECK=true`: disables the startup request to `https://swarmcli.io/api/v1/version` that checks whether a newer release is available.
-- `SWARMCLI_CHARTS_ALLOW_PLAINTEXT=1`: allows chart repositories served over plain `http://`, which are otherwise refused (see [charts/README.md](charts/README.md#transport)).
+- `SWARMCLI_CHARTS_ALLOW_PLAINTEXT=1`: allows chart repositories served over plain `http://`, which are refused by default (see [charts/README.md](charts/README.md#transport)).
 
 On startup, SwarmCLI checks for a newer release by sending the current version and edition to `https://swarmcli.io/api/v1/version`. Set `SWARMCLI_DISABLE_VERSION_CHECK=true` to opt out.
 

--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ $ LOG_LEVEL=debug SWARMCLI_ENV=dev go run .
 - `SWARMCLI_ENV`: `dev` enables pretty debug logs (default is `prod`).
 - `LOG_LEVEL`: `debug`, `info`, `warn`, `error`, …
 - `SWARMCLI_DISABLE_VERSION_CHECK=true`: disables the startup request to `https://swarmcli.io/api/v1/version` that checks whether a newer release is available.
+- `SWARMCLI_CHARTS_ALLOW_PLAINTEXT=1`: allows chart repositories served over plain `http://`, which are otherwise refused (see [charts/README.md](charts/README.md#transport)).
 
 On startup, SwarmCLI checks for a newer release by sending the current version and edition to `https://swarmcli.io/api/v1/version`. Set `SWARMCLI_DISABLE_VERSION_CHECK=true` to opt out.
 

--- a/charts/README.md
+++ b/charts/README.md
@@ -255,14 +255,17 @@ letters, digits, `-`, `_` and `.`.
 
 ### Transport
 
-Repositories must be served over **HTTPS**. A repository serves the tarball that
-*becomes* the deployed workload, so anything on the path to it decides what runs
-on your swarm — and the digest below does not close that, because it is published
-in the same `index.yaml`, fetched over the same connection.
+Repositories are **HTTPS by default**. A repository serves the tarball that
+*becomes* the deployed workload, so anything on the network path to it decides
+what runs on your swarm — and the digest below does not close that, because it is
+published in the same `index.yaml` and fetched over the same connection.
 
-Plain `http://` is therefore refused: when adding a repository, when refreshing
-its index, and for a tarball URL an index points at. If your registry is internal
-and you already trust the network between you and it, opt that machine out:
+Plain `http://` is therefore refused wherever bytes would cross the network:
+adding a repository, refreshing its index, and downloading a tarball an index
+points at — a repository already configured over `http://` included.
+
+An internal registry on a network you already trust is a legitimate setup, so
+this is a default rather than a rule. Opt that machine out:
 
 ```bash
 export SWARMCLI_CHARTS_ALLOW_PLAINTEXT=1
@@ -270,9 +273,10 @@ export SWARMCLI_CHARTS_ALLOW_PLAINTEXT=1
 
 It is read once, where the CLI builds its repository store, so it covers every
 command that touches a repository — `repo add`, `repo update`, `search`,
-`install`, `upgrade`, `apply`. Programs embedding this package get the
-https-only default and decide for themselves; the `charts` package never reads
-the environment.
+`install`, `upgrade`, `apply`. One line in a shell profile or a CI job's
+environment restores a plaintext setup in full; nothing about it is one-way.
+Programs embedding this package get the https-only default and decide for
+themselves — the `charts` package never reads the environment.
 
 ### Integrity
 

--- a/charts/README.md
+++ b/charts/README.md
@@ -246,10 +246,33 @@ manifest is validated as a Docker stack before use.
 
 ## Repositories
 
-A repository is an HTTP(S)-served `index.yaml` listing chart versions, each with
+A repository is an HTTPS-served `index.yaml` listing chart versions, each with
 a tarball URL (Helm repository format) — hostable on GitHub Pages/Releases, S3,
 or any static host. Configured repos and cached indexes live under
-`$XDG_STATE_HOME/swarmcli/charts` (default `~/.local/state/swarmcli/charts`).
+`$XDG_STATE_HOME/swarmcli/charts` (default `~/.local/state/swarmcli/charts`); a
+repository's name is a component of its cache filename, so it is limited to
+letters, digits, `-`, `_` and `.`.
+
+### Transport
+
+Repositories must be served over **HTTPS**. A repository serves the tarball that
+*becomes* the deployed workload, so anything on the path to it decides what runs
+on your swarm — and the digest below does not close that, because it is published
+in the same `index.yaml`, fetched over the same connection.
+
+Plain `http://` is therefore refused: when adding a repository, when refreshing
+its index, and for a tarball URL an index points at. If your registry is internal
+and you already trust the network between you and it, opt that machine out:
+
+```bash
+export SWARMCLI_CHARTS_ALLOW_PLAINTEXT=1
+```
+
+It is read once, where the CLI builds its repository store, so it covers every
+command that touches a repository — `repo add`, `repo update`, `search`,
+`install`, `upgrade`, `apply`. Programs embedding this package get the
+https-only default and decide for themselves; the `charts` package never reads
+the environment.
 
 ### Integrity
 

--- a/charts/apply_test.go
+++ b/charts/apply_test.go
@@ -373,7 +373,7 @@ func TestPlanApplyAgainstARealRepository(t *testing.T) {
 
 	// A fresh store, so EnsureRepos genuinely has to add the repository — exactly
 	// what `charts apply -f` does on a CI runner that has never seen it.
-	fresh := NewRepoStoreAt(t.TempDir())
+	fresh := newTestStore(t)
 	require.NoError(t, fresh.EnsureRepos(rf.Repositories))
 
 	e := NewEngineWith(newFakeBackend())

--- a/charts/release.go
+++ b/charts/release.go
@@ -1103,11 +1103,22 @@ func validateReleaseName(name string) error {
 	if name == "" {
 		return fmt.Errorf("release name is required")
 	}
+	if !isPlainName(name) {
+		return fmt.Errorf("invalid release name %q: use letters, digits, '-', '_', '.'", name)
+	}
+	return nil
+}
+
+// isPlainName reports whether name is made only of letters, digits, '-', '_' and
+// '.'. A release name and a repository name are constrained for unrelated reasons
+// — Docker stack naming for one, a path component and a chart reference for the
+// other — but to the same charset, and one spelling of it is enough.
+func isPlainName(name string) bool {
 	for _, r := range name {
 		if !(r == '-' || r == '_' || r == '.' ||
 			(r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9')) {
-			return fmt.Errorf("invalid release name %q: use letters, digits, '-', '_', '.'", name)
+			return false
 		}
 	}
-	return nil
+	return true
 }

--- a/charts/releasefile.go
+++ b/charts/releasefile.go
@@ -105,9 +105,14 @@ func (rf *ReleaseFile) validate() error {
 
 	seenRepo := map[string]bool{}
 	for i, r := range rf.Repositories {
+		// A repository name reaches the store as a path component of its cached
+		// index, so it gets the same charset check a release name gets. Checking
+		// here as well as in the store is the point: this file may have been
+		// written by whoever raised the pull request.
+		if err := validateRepoName(r.Name); err != nil {
+			return rf.errf("repositories[%d]: %v", i, err)
+		}
 		switch {
-		case r.Name == "":
-			return rf.errf("repositories[%d]: name is required", i)
 		case r.URL == "":
 			return rf.errf("repositories[%d] (%s): url is required", i, r.Name)
 		case seenRepo[r.Name]:

--- a/charts/releasefile_test.go
+++ b/charts/releasefile_test.go
@@ -94,13 +94,16 @@ func TestParseRejectsVersionOnLocalChart(t *testing.T) {
 
 func TestParseValidationErrors(t *testing.T) {
 	for name, tc := range map[string]struct{ body, want string }{
-		"no releases":    {"releases: []\n", "no releases"},
-		"missing name":   {"releases:\n  - chart: r/c\n    version: \"1\"\n", "name is required"},
-		"missing chart":  {"releases:\n  - name: a\n", "chart is required"},
-		"dup release":    {"releases:\n  - {name: a, chart: r/c, version: \"1\"}\n  - {name: a, chart: r/d, version: \"1\"}\n", "duplicate release"},
-		"dup repo":       {"repositories:\n  - {name: r, url: http://x}\n  - {name: r, url: http://y}\nreleases:\n  - {name: a, chart: r/c, version: \"1\"}\n", "duplicate repository"},
-		"repo no url":    {"repositories:\n  - {name: r}\nreleases:\n  - {name: a, chart: r/c, version: \"1\"}\n", "url is required"},
-		"repo no name":   {"repositories:\n  - {url: http://x}\nreleases:\n  - {name: a, chart: r/c, version: \"1\"}\n", "name is required"},
+		"no releases":   {"releases: []\n", "no releases"},
+		"missing name":  {"releases:\n  - chart: r/c\n    version: \"1\"\n", "name is required"},
+		"missing chart": {"releases:\n  - name: a\n", "chart is required"},
+		"dup release":   {"releases:\n  - {name: a, chart: r/c, version: \"1\"}\n  - {name: a, chart: r/d, version: \"1\"}\n", "duplicate release"},
+		"dup repo":      {"repositories:\n  - {name: r, url: http://x}\n  - {name: r, url: http://y}\nreleases:\n  - {name: a, chart: r/c, version: \"1\"}\n", "duplicate repository"},
+		"repo no url":   {"repositories:\n  - {name: r}\nreleases:\n  - {name: a, chart: r/c, version: \"1\"}\n", "url is required"},
+		"repo no name":  {"repositories:\n  - {url: http://x}\nreleases:\n  - {name: a, chart: r/c, version: \"1\"}\n", "name is required"},
+		// The name becomes a path component of the cached index, so a manifest
+		// out of a git repository must not be able to steer where that is written.
+		"repo bad name":  {"repositories:\n  - {name: \"../../../../pwned\", url: https://x}\nreleases:\n  - {name: a, chart: r/c, version: \"1\"}\n", "invalid repository name"},
 		"bad apiVersion": {"apiVersion: v2\nreleases:\n  - {name: a, chart: r/c, version: \"1\"}\n", "unsupported apiVersion"},
 		"bad rel name":   {"releases:\n  - {name: \"Bad Name\", chart: r/c, version: \"1\"}\n", "Bad Name"},
 	} {

--- a/charts/repo.go
+++ b/charts/repo.go
@@ -33,6 +33,13 @@ const maxIndexSize = 16 << 20 // 16 MiB
 // can be buffered and hashed before any of it reaches the archive parser.
 const maxChartArchiveSize = 20 << 20 // 20 MiB
 
+// AllowPlaintextEnv is the environment variable a host program may honour to set
+// AllowPlaintext. The name lives here so the refusal message and whatever reads
+// it cannot drift, but this package never reads the environment itself: whether
+// an operator is allowed to opt out is the embedder's call, and cli's answer
+// (yes, for an interactive user's own machine) is not automatically a daemon's.
+const AllowPlaintextEnv = "SWARMCLI_CHARTS_ALLOW_PLAINTEXT"
+
 // RepoStore persists configured repositories and caches their indexes under a
 // base directory (default: the XDG state dir, ~/.local/state/swarmcli/charts).
 type RepoStore struct {
@@ -45,6 +52,20 @@ type RepoStore struct {
 	// charts is a library with no output of its own; nil is silent, and cli wires
 	// this to stderr.
 	Warnf func(format string, a ...any)
+
+	// AllowPlaintext permits repositories reached over plain http. It defaults to
+	// false because a chart repository serves the tarball that *becomes* the
+	// deployed workload, so whoever sits on the path to it chooses what runs on
+	// the swarm. The published digest does not close that hole: it travels in the
+	// same index.yaml over the same channel, so an on-path attacker rewrites both
+	// — and an entry that publishes no digest only warns. swarmcli-cd refuses
+	// plaintext git remotes for exactly this reason; the same argument applies one
+	// layer down, to where the chart itself comes from.
+	//
+	// Set it only for an internal registry on a network you already trust. cli
+	// wires it to AllowPlaintextEnv so an existing plaintext setup keeps working
+	// with one deliberate, greppable opt-out rather than none.
+	AllowPlaintext bool
 }
 
 // NewRepoStore returns a store rooted at the standard charts state directory.
@@ -75,8 +96,63 @@ func checkRedirect(req *http.Request, via []*http.Request) error {
 }
 
 func (s *RepoStore) reposFile() string { return filepath.Join(s.dir, "repos.json") }
-func (s *RepoStore) indexFile(name string) string {
-	return filepath.Join(s.dir, "cache", "index-"+name+".yaml")
+
+// indexFile is where a repository's cached index lives. It validates rather than
+// trusting its caller because names arrive here from repos.json as well as from
+// the command line, and this process is not that file's only possible author.
+//
+// The concatenation is the sharp edge: the name is glued on *after* "index-", so
+// "index-.." is an ordinary path segment and filepath.Join's Clean has nothing to
+// collapse. A traversing name is not neutralised, it merely costs one extra "../"
+// — and what then lands outside the cache directory is whatever the repository
+// served for index.yaml.
+func (s *RepoStore) indexFile(name string) (string, error) {
+	if err := validateRepoName(name); err != nil {
+		return "", err
+	}
+	return filepath.Join(s.dir, "cache", "index-"+name+".yaml"), nil
+}
+
+// validateRepoName constrains a repository name to the charset a release name
+// uses. The name is not just a label: it is a path component of the cached index
+// file (see indexFile) and the part before the "/" in a "<repo>/<chart>"
+// reference, so anything exotic in it is a bug at best.
+func validateRepoName(name string) error {
+	switch {
+	case name == "":
+		return fmt.Errorf("repository name is required")
+	case !isPlainName(name):
+		return fmt.Errorf("invalid repository name %q: use letters, digits, '-', '_', '.'", name)
+	case name == "." || name == "..":
+		// Harmless today only because indexFile prefixes the name, which leaves
+		// "index-.." rather than "..". Refusing them keeps that accident from
+		// quietly becoming load-bearing.
+		return fmt.Errorf("invalid repository name %q", name)
+	}
+	return nil
+}
+
+// checkRepoURL rejects a URL this store must not fetch an index from: anything
+// that is not an absolute http(s) URL, and plain http unless AllowPlaintext.
+func (s *RepoStore) checkRepoURL(repoURL string) error {
+	u, err := url.ParseRequestURI(repoURL)
+	if err != nil || (u.Scheme != "http" && u.Scheme != "https") {
+		return fmt.Errorf("repository URL must be an absolute http(s) URL")
+	}
+	return s.checkPlaintext(u)
+}
+
+// checkPlaintext refuses a plain-http URL unless the caller opted in; see
+// AllowPlaintext for why the default is a refusal. It echoes the URL redacted,
+// as checkRedirect does: a repository URL may carry credentials, and this error
+// goes to a terminal or a CI log.
+func (s *RepoStore) checkPlaintext(u *url.URL) error {
+	if u.Scheme != "http" || s.AllowPlaintext {
+		return nil
+	}
+	return fmt.Errorf("refusing the plaintext URL %q: anything on the path to it decides what gets "+
+		"deployed on your swarm, and the index digest travels the same path; set %s=1 if this is an "+
+		"internal registry on a network you already trust", u.Redacted(), AllowPlaintextEnv)
 }
 
 // List returns the configured repositories sorted by name.
@@ -97,13 +173,14 @@ func (s *RepoStore) List() ([]RepoEntry, error) {
 }
 
 // Add registers a repository and downloads its index. It rejects duplicate
-// names and invalid URLs.
+// names, names it will not build a cache path from, and URLs it will not fetch
+// from — all before the download, so a bad request is reported as one.
 func (s *RepoStore) Add(name, repoURL string) error {
-	if name == "" {
-		return fmt.Errorf("repository name is required")
+	if err := validateRepoName(name); err != nil {
+		return err
 	}
-	if u, err := url.ParseRequestURI(repoURL); err != nil || (u.Scheme != "http" && u.Scheme != "https") {
-		return fmt.Errorf("repository URL must be an absolute http(s) URL")
+	if err := s.checkRepoURL(repoURL); err != nil {
+		return err
 	}
 	repos, err := s.List()
 	if err != nil {
@@ -121,10 +198,14 @@ func (s *RepoStore) Add(name, repoURL string) error {
 	if err != nil {
 		return fmt.Errorf("index download failed, repository not added: %w%s", err, githubPagesHint(repoURL))
 	}
-	if err := os.MkdirAll(filepath.Dir(s.indexFile(name)), 0o755); err != nil {
+	path, err := s.indexFile(name)
+	if err != nil {
 		return err
 	}
-	if err := os.WriteFile(s.indexFile(name), idx, 0o644); err != nil {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	if err := os.WriteFile(path, idx, 0o644); err != nil {
 		return err
 	}
 	repos = append(repos, RepoEntry{Name: name, URL: repoURL})
@@ -152,7 +233,12 @@ func (s *RepoStore) Remove(name string) error {
 	if err := s.save(out); err != nil {
 		return err
 	}
-	_ = os.Remove(s.indexFile(name))
+	// Best-effort, and deliberately skipped for a name indexFile will not vouch
+	// for: the entry is gone from repos.json either way, and a path we refused to
+	// build is not one to hand to os.Remove.
+	if path, perr := s.indexFile(name); perr == nil {
+		_ = os.Remove(path)
+	}
 	return nil
 }
 
@@ -167,21 +253,27 @@ func (s *RepoStore) Update(name string) (changed, unchanged []string, err error)
 		if name != "" && r.Name != name {
 			continue
 		}
+		// Before the network round trip: a name repos.json should never have held
+		// is not one to fetch an index for, let alone write one under.
+		path, err := s.indexFile(r.Name)
+		if err != nil {
+			return changed, unchanged, fmt.Errorf("update %q: %w", r.Name, err)
+		}
 		idx, err := s.fetchIndex(r.URL)
 		if err != nil {
 			return changed, unchanged, fmt.Errorf("update %q: %w", r.Name, err)
 		}
 		// The served index is byte-stable between releases, so an identical
 		// payload means nothing new — report it as already up-to-date.
-		existing, _ := os.ReadFile(s.indexFile(r.Name))
+		existing, _ := os.ReadFile(path)
 		if existing != nil && bytes.Equal(existing, idx) {
 			unchanged = append(unchanged, r.Name)
 			continue
 		}
-		if err := os.MkdirAll(filepath.Dir(s.indexFile(r.Name)), 0o755); err != nil {
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 			return changed, unchanged, err
 		}
-		if err := os.WriteFile(s.indexFile(r.Name), idx, 0o644); err != nil {
+		if err := os.WriteFile(path, idx, 0o644); err != nil {
 			return changed, unchanged, err
 		}
 		changed = append(changed, r.Name)
@@ -194,7 +286,11 @@ func (s *RepoStore) Update(name string) (changed, unchanged []string, err error)
 
 // LoadIndex returns the cached, parsed index for a repository.
 func (s *RepoStore) LoadIndex(name string) (*Index, error) {
-	data, err := os.ReadFile(s.indexFile(name))
+	path, err := s.indexFile(name)
+	if err != nil {
+		return nil, err
+	}
+	data, err := os.ReadFile(path)
 	if os.IsNotExist(err) {
 		return nil, fmt.Errorf("no cached index for %q; run `charts repo update`", name)
 	}
@@ -377,6 +473,11 @@ func (s *RepoStore) Pull(entry IndexEntry, baseURL string) (*Chart, error) {
 	if u.Scheme != "http" && u.Scheme != "https" {
 		return nil, fmt.Errorf("chart download URL must be http(s), got %q", tarURL)
 	}
+	// The index may point the tarball anywhere — a CDN, a release asset — so the
+	// scheme has to be checked here too, not only where the repository was added.
+	if err := s.checkPlaintext(u); err != nil {
+		return nil, err
+	}
 	resp, err := s.client.Get(tarURL)
 	if err != nil {
 		return nil, fmt.Errorf("download chart: %w", err)
@@ -470,6 +571,12 @@ func githubPagesHint(repoURL string) string {
 }
 
 func (s *RepoStore) fetchIndex(repoURL string) ([]byte, error) {
+	// Add checks this before anything else, to fail without a round trip; the
+	// re-check is for Update, whose URLs come out of repos.json — including ones
+	// added before this store had an opinion about plain http.
+	if err := s.checkRepoURL(repoURL); err != nil {
+		return nil, err
+	}
 	indexURL := strings.TrimRight(repoURL, "/") + "/index.yaml"
 	resp, err := s.client.Get(indexURL)
 	if err != nil {

--- a/charts/repo_test.go
+++ b/charts/repo_test.go
@@ -10,11 +10,23 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
+
+// newTestStore returns a store in a fresh directory that accepts the plain-http
+// URL an httptest server hands out. Chart repositories are https-only by default
+// (see RepoStore.AllowPlaintext); the tests below are about everything else, and
+// the gate itself is covered by TestRepoStoreRefusesPlaintextURL.
+func newTestStore(t *testing.T) *RepoStore {
+	t.Helper()
+	s := NewRepoStoreAt(t.TempDir())
+	s.AllowPlaintext = true
+	return s
+}
 
 func TestRepoStoreAddListRemove(t *testing.T) {
 	idx := `apiVersion: v1
@@ -38,7 +50,7 @@ entries:
 	}))
 	defer srv.Close()
 
-	s := NewRepoStoreAt(t.TempDir())
+	s := newTestStore(t)
 	require.NoError(t, s.Add("eldara", srv.URL))
 
 	// duplicate rejected
@@ -92,7 +104,7 @@ entries:
 	}))
 	defer srv.Close()
 
-	s := NewRepoStoreAt(t.TempDir())
+	s := newTestStore(t)
 	require.NoError(t, s.Add("eldara", srv.URL))
 
 	for _, want := range []string{"0.1.3", "v0.1.3"} {
@@ -123,7 +135,7 @@ entries:
 	}))
 	defer srv.Close()
 
-	s := NewRepoStoreAt(t.TempDir())
+	s := newTestStore(t)
 	require.NoError(t, s.Add("eldara", srv.URL)) // Add caches the index
 
 	// Nothing changed since Add → already up-to-date.
@@ -145,27 +157,142 @@ entries:
 }
 
 func TestRepoStoreAddRejectsBadURL(t *testing.T) {
-	s := NewRepoStoreAt(t.TempDir())
+	s := newTestStore(t)
 	require.Error(t, s.Add("x", "not-a-url"))
 	require.Error(t, s.Add("x", "ftp://example.com"))
+}
+
+// A repository name is a path component of its cached index, and indexFile glues
+// it on *after* "index-" — so "index-.." is an ordinary segment that Clean has
+// nothing to collapse, and a traversing name escapes for the price of one extra
+// "../". These assertions are about where the bytes landed, not only about the
+// error returned: containment is the property under test.
+func TestRepoStoreContainsTraversingRepositoryName(t *testing.T) {
+	body := "apiVersion: v1\nentries:\n  demo:\n    - {name: demo, version: 0.1.0, urls: [\"d.tgz\"]}\n"
+	up := true
+	srv := newIndexServer(t, &body, &up)
+
+	// The store lives two directories below root, and the index would be written
+	// a third down in "cache" — so four "../" reach root: one is eaten unescaping
+	// the "index-.." segment, the other three walk back up.
+	root := t.TempDir()
+	s := NewRepoStoreAt(filepath.Join(root, "state"))
+	s.AllowPlaintext = true
+	const escape = "../../../../pwned"
+	landing := filepath.Join(root, "pwned.yaml")
+
+	require.ErrorContains(t, s.Add(escape, srv.URL), "invalid repository name")
+	require.NoFileExists(t, landing)
+
+	// Add settles the name before it fetches anything, so an unreachable
+	// repository does not mask what is actually wrong with the request.
+	up = false
+	require.ErrorContains(t, s.Add(escape, srv.URL), "invalid repository name")
+	up = true
+
+	// The same name arriving from repos.json instead of the command line — an
+	// older store, or one somebody hand-edited — must be refused just as hard.
+	// That is why the check lives in indexFile and not only in Add.
+	require.NoError(t, s.save([]RepoEntry{{Name: escape, URL: srv.URL}}))
+	_, _, err := s.Update("")
+	require.ErrorContains(t, err, "invalid repository name")
+	require.NoFileExists(t, landing)
+
+	_, err = s.LoadIndex(escape)
+	require.ErrorContains(t, err, "invalid repository name")
+
+	// And an ordinary name still lands exactly where it always did.
+	good := newTestStore(t)
+	require.NoError(t, good.Add("eldara", srv.URL))
+	require.FileExists(t, filepath.Join(good.dir, "cache", "index-eldara.yaml"))
+}
+
+// Plain http is refused by default. A chart repository serves the tarball that
+// *becomes* the deployed workload, so whoever is on the path chooses what runs —
+// and the digest that would catch a swap is published in the same index, over the
+// same channel. The refusal names its opt-out, because an internal registry on a
+// trusted network is a setup that worked until this change.
+func TestRepoStoreRefusesPlaintextURL(t *testing.T) {
+	body := "apiVersion: v1\nentries: {}\n"
+	up := true
+	srv := newIndexServer(t, &body, &up)
+
+	t.Run("add is refused and records nothing", func(t *testing.T) {
+		s := NewRepoStoreAt(t.TempDir())
+		err := s.Add("eldara", srv.URL)
+		require.ErrorContains(t, err, "plaintext")
+		require.ErrorContains(t, err, AllowPlaintextEnv)
+		require.NotContains(t, err.Error(), "index download failed",
+			"the scheme is settled before the fetch, so nothing may blame the download")
+
+		repos, lerr := s.List()
+		require.NoError(t, lerr)
+		require.Empty(t, repos)
+	})
+
+	// Otherwise the default would only bind repositories nobody has added yet.
+	t.Run("an already-configured http repository is refused too", func(t *testing.T) {
+		s := NewRepoStoreAt(t.TempDir())
+		require.NoError(t, s.save([]RepoEntry{{Name: "old", URL: srv.URL}}))
+		_, _, err := s.Update("")
+		require.ErrorContains(t, err, "plaintext")
+	})
+
+	// The index can point the tarball anywhere, so the repository's own scheme
+	// does not settle the download's.
+	t.Run("a plaintext tarball URL is refused", func(t *testing.T) {
+		s := NewRepoStoreAt(t.TempDir())
+		_, err := s.Pull(IndexEntry{Name: "demo", URLs: []string{"http://example.com/demo.tgz"}}, "https://example.com")
+		require.ErrorContains(t, err, "plaintext")
+	})
+
+	t.Run("a malformed URL is still refused, and not as plaintext", func(t *testing.T) {
+		s := NewRepoStoreAt(t.TempDir())
+		err := s.Add("eldara", "not-a-url")
+		require.ErrorContains(t, err, "absolute http(s)")
+		require.NotContains(t, err.Error(), "plaintext")
+		require.NotContains(t, err.Error(), "index download failed")
+	})
+
+	// https goes through. Only the test CA is added to the store's own client, so
+	// its timeout and redirect policy still apply — this is the real path.
+	t.Run("https is accepted", func(t *testing.T) {
+		tsrv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if strings.HasSuffix(r.URL.Path, "/index.yaml") {
+				_, _ = w.Write([]byte(body))
+				return
+			}
+			http.NotFound(w, r)
+		}))
+		defer tsrv.Close()
+
+		s := NewRepoStoreAt(t.TempDir())
+		s.client.Transport = tsrv.Client().Transport
+		require.NoError(t, s.Add("secure", tsrv.URL))
+	})
+
+	t.Run("the opt-out restores an internal plaintext registry", func(t *testing.T) {
+		s := newTestStore(t)
+		require.NoError(t, s.Add("internal", srv.URL))
+	})
 }
 
 // Pull must refuse a chart URL that is not http(s) (e.g. a malicious index
 // pointing at file://), before any download happens.
 func TestPullRejectsNonHTTPScheme(t *testing.T) {
-	s := NewRepoStoreAt(t.TempDir())
+	s := newTestStore(t)
 	_, err := s.Pull(IndexEntry{Name: "demo", URLs: []string{"file:///etc/passwd"}}, "http://example.com")
 	require.ErrorContains(t, err, "http(s)")
 }
 
 func TestUpdateUnknownRepo(t *testing.T) {
-	s := NewRepoStoreAt(t.TempDir())
+	s := newTestStore(t)
 	_, _, err := s.Update("ghost")
 	require.ErrorContains(t, err, "not found")
 }
 
 func TestLoadIndexMissing(t *testing.T) {
-	s := NewRepoStoreAt(t.TempDir())
+	s := newTestStore(t)
 	_, err := s.LoadIndex("ghost")
 	require.ErrorContains(t, err, "no cached index")
 }
@@ -183,7 +310,7 @@ func TestUpdateReportsFetchFailure(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	s := NewRepoStoreAt(t.TempDir())
+	s := newTestStore(t)
 	require.NoError(t, s.Add("eldara", srv.URL))
 	serve = false
 	_, _, err := s.Update("") // all repos
@@ -204,7 +331,7 @@ func TestRepoStoreAddIndexFailureDoesNotPersist(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	s := NewRepoStoreAt(t.TempDir())
+	s := newTestStore(t)
 
 	// index 404s → add fails and persists nothing
 	require.Error(t, s.Add("eldara", srv.URL))
@@ -252,7 +379,7 @@ entries:
 	}))
 	defer srv.Close()
 
-	s := NewRepoStoreAt(t.TempDir())
+	s := newTestStore(t)
 	require.NoError(t, s.Add("eldara", srv.URL))
 	e, base, err := s.Resolve("eldara/demo", "")
 	require.NoError(t, err)
@@ -289,7 +416,7 @@ entries:
 	}))
 	t.Cleanup(srv.Close)
 
-	s := NewRepoStoreAt(t.TempDir())
+	s := newTestStore(t)
 	require.NoError(t, s.Add("eldara", srv.URL))
 	e, base, err := s.Resolve("eldara/demo", "")
 	require.NoError(t, err)
@@ -392,7 +519,7 @@ func TestEnsureReposAddsAbsentRepository(t *testing.T) {
 	up := true
 	srv := newIndexServer(t, &body, &up)
 
-	s := NewRepoStoreAt(t.TempDir())
+	s := newTestStore(t)
 	require.NoError(t, s.EnsureRepos([]RepoSpec{{Name: "eldara", URL: srv.URL}}))
 
 	repos, err := s.List()
@@ -413,7 +540,7 @@ func TestEnsureReposRefreshesSameRepositoryAndToleratesTrailingSlash(t *testing.
 	up := true
 	srv := newIndexServer(t, &body, &up)
 
-	s := NewRepoStoreAt(t.TempDir())
+	s := newTestStore(t)
 	require.NoError(t, s.Add("eldara", srv.URL))
 
 	body = "apiVersion: v1\nentries:\n  demo:\n    - {name: demo, version: 0.2.0, urls: [\"d.tgz\"]}\n"
@@ -432,7 +559,7 @@ func TestEnsureReposRefusesToRepointADifferentURL(t *testing.T) {
 	srvA := newIndexServer(t, &body, &up)
 	srvB := newIndexServer(t, &body, &up)
 
-	s := NewRepoStoreAt(t.TempDir())
+	s := newTestStore(t)
 	require.NoError(t, s.Add("eldara", srvA.URL))
 
 	err := s.EnsureRepos([]RepoSpec{{Name: "eldara", URL: srvB.URL}})
@@ -452,7 +579,7 @@ func TestEnsureReposWarnsAndUsesCacheWhenRefreshFails(t *testing.T) {
 	up := true
 	srv := newIndexServer(t, &body, &up)
 
-	s := NewRepoStoreAt(t.TempDir())
+	s := newTestStore(t)
 	require.NoError(t, s.Add("eldara", srv.URL))
 
 	var warnings []string
@@ -471,7 +598,7 @@ func TestEnsureReposWarnsAndUsesCacheWhenRefreshFails(t *testing.T) {
 }
 
 func TestEnsureReposNoSpecsIsANoOp(t *testing.T) {
-	s := NewRepoStoreAt(t.TempDir())
+	s := newTestStore(t)
 	require.NoError(t, s.EnsureRepos(nil))
 	repos, err := s.List()
 	require.NoError(t, err)
@@ -485,7 +612,7 @@ func TestIndexesSkipsRepositoriesWithNoCachedIndex(t *testing.T) {
 	up := true
 	srv := newIndexServer(t, &body, &up)
 
-	s := NewRepoStoreAt(t.TempDir())
+	s := newTestStore(t)
 	require.NoError(t, s.Add("good", srv.URL))
 
 	// A repo recorded with no cached index (e.g. the cache file was cleared).
@@ -506,7 +633,7 @@ func TestEnsureReposFailsWhenAnAbsentRepositoryCannotBeAdded(t *testing.T) {
 	up := false
 	srv := newIndexServer(t, &body, &up)
 
-	s := NewRepoStoreAt(t.TempDir())
+	s := newTestStore(t)
 	err := s.EnsureRepos([]RepoSpec{{Name: "eldara", URL: srv.URL}})
 	require.Error(t, err)
 

--- a/charts/source_test.go
+++ b/charts/source_test.go
@@ -39,7 +39,7 @@ func serveRepo(t *testing.T, versions ...string) *RepoStore {
 	}))
 	t.Cleanup(srv.Close)
 
-	s := NewRepoStoreAt(t.TempDir())
+	s := newTestStore(t)
 	require.NoError(t, s.Add("eldara", srv.URL))
 	return s
 }

--- a/cli/charts.go
+++ b/cli/charts.go
@@ -173,7 +173,20 @@ func newStore() (*charts.RepoStore, int) {
 		return nil, fail(err)
 	}
 	s.Warnf = errf
+	s.AllowPlaintext = plaintextAllowed()
 	return s, -1
+}
+
+// plaintextAllowed reports whether the operator opted this machine out of the
+// store's https-only default. It is an environment variable rather than a flag
+// because a plaintext repository is not only reachable through `repo add`: once
+// it is in repos.json, `repo update`, `search`, `install`, `upgrade` and `apply`
+// all fetch from it, and a flag would have to be threaded — honestly — through
+// every one of them. Someone running an internal registry sets this once, in a
+// shell profile or a CI job, and everything keeps working.
+func plaintextAllowed() bool {
+	allowed, err := strconv.ParseBool(strings.TrimSpace(os.Getenv(charts.AllowPlaintextEnv)))
+	return err == nil && allowed
 }
 
 // --- repo ---

--- a/cli/charts_test.go
+++ b/cli/charts_test.go
@@ -291,3 +291,25 @@ func TestReportUnclaimedCoversBothLists(t *testing.T) {
 	o, _ = capture(t, func() { reportUnclaimed(&charts.Plan{}) })
 	require.Empty(t, o, "a clean apply prints no headers at all")
 }
+
+// The store is https-only by default, and this env var is the whole of the
+// compatibility story for anyone already pointing swarmcli at an internal
+// plaintext registry — so assert the wiring, not just the parsing.
+func TestNewStoreWiresThePlaintextOptOut(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+
+	s, code := newStore()
+	require.Equal(t, -1, code)
+	require.False(t, s.AllowPlaintext, "https-only unless the operator says otherwise")
+
+	t.Setenv(charts.AllowPlaintextEnv, "1")
+	s, code = newStore()
+	require.Equal(t, -1, code)
+	require.True(t, s.AllowPlaintext)
+
+	// Anything that is not a truthy boolean leaves the default in place, rather
+	// than any non-empty value opting out by accident.
+	t.Setenv(charts.AllowPlaintextEnv, "maybe")
+	s, _ = newStore()
+	require.False(t, s.AllowPlaintext)
+}

--- a/integration-tests/charts/charts_apply_test.go
+++ b/integration-tests/charts/charts_apply_test.go
@@ -238,6 +238,10 @@ func TestChartsApplyFromARepositoryAndOutdated(t *testing.T) {
 
 	// Keep the repo store out of the developer's real XDG state dir.
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	// This test drives the CLI, which builds its own store, so the field is out
+	// of reach — the env var is the documented way in. The httptest server
+	// above serves plain http.
+	t.Setenv("SWARMCLI_CHARTS_ALLOW_PLAINTEXT", "1")
 
 	dir := t.TempDir()
 	relFile := filepath.Join(dir, "swarmcli-release.yaml")

--- a/integration-tests/charts/charts_lifecycle_test.go
+++ b/integration-tests/charts/charts_lifecycle_test.go
@@ -200,6 +200,7 @@ func TestChartsRepoInstallLifecycle(t *testing.T) {
 	// Add the repo (downloads + validates the index), then find and fetch the
 	// chart through the public store API.
 	store := charts.NewRepoStoreAt(t.TempDir())
+	store.AllowPlaintext = true // the httptest server above serves plain http
 	require.NoError(t, store.Add("itest-repo", srv.URL))
 
 	hits, err := store.Search("itest")


### PR DESCRIPTION
> Ships as `C0-breaks-nothing`. It does change a default — `http://` chart repositories are refused
> unless opted back in — but `SWARMCLI_CHARTS_ALLOW_PLAINTEXT` means no setup is permanently stuck,
> so this does not force a major tag. **See "Downstream" before bumping this dependency in swarmcli-cd.**

## 1 — the repository name was an unguarded path component

`indexFile` built `filepath.Join(dir, "cache", "index-"+name+".yaml")`. Because the name is concatenated **after** `"index-"`, `index-..` is a literal segment, so `Clean` does not neutralise a traversal. Verified by execution with a store at `/var/lib/x/state`:

```
2 ../ -> /var/lib/x/state/cache/pwned.yaml
3 ../ -> /var/lib/x/state/pwned.yaml
4 ../ -> /var/lib/x/pwned.yaml      <- outside the store
```

The written bytes are whatever the repository's server returns for `<url>/index.yaml`. For the CLI that needs a hostile release file; for the swarmcli-cd controller, which takes release files from watched git repositories, it was an arbitrary root file write (fixed downstream in swarmcli-cd#100, but the engine should defend itself rather than relying on every embedder).

`indexFile` now returns `(string, error)` and validates, so **the path cannot be built without passing the check**. `validateReleaseName`'s charset loop was extracted into a shared `isPlainName`; `validateRepoName` adds an explicit refusal of `.` and `..`. Call sites updated in `Add`, `Remove`, `Update`, `LoadIndex`, and `ReleaseFile.validate` gained the same check.

Note `validateReleaseName` **permits** `.`, so reusing it verbatim would have let `..` through — hence a separate function over the shared predicate rather than a call.

## 2 — `http://` is now opt-in

A chart repository serves the tarball that **becomes** the deployed workload, so anyone on the path chooses what runs. The digest does not close it: it is published in the same `index.yaml`, fetched over the same channel. swarmcli-cd already refuses plaintext *git* remotes with exactly this reasoning — *"anything on the path to it decides what this controller deploys"* — and the same sentence applies one layer down.

`checkRepoURL` runs in `Add` **and** in `fetchIndex` (which is what catches an `http://` repo already sitting in `repos.json`), and `Pull` checks the resolved tarball URL. Messages are redacted via `u.Redacted()`, matching `checkRedirect`.

### The default, and the way out

Default is now refuse. The escape hatch is `RepoStore.AllowPlaintext` (exported field, default false) plus `charts.AllowPlaintextEnv = "SWARMCLI_CHARTS_ALLOW_PLAINTEXT"`, which **only `cli` reads**.

Env var rather than a flag because `chartsRepo` does not call `parseArgs` at all, and a plaintext repo is reachable through `repo update`/`search`/`install`/`upgrade`/`apply` once it is in `repos.json` — and `CLAUDE.md` warns that the global `flags` struct makes every subcommand parse every flag and silently ignore what it does not read, so a global `--allow-plaintext` would be a lie on ~15 subcommands. Precedent: `SWARMCLI_DISABLE_VERSION_CHECK`, and `--skip-compat-check` as the "opt-in downgrades a refusal" pattern.

A field rather than `os.Getenv` inside `charts` because swarmcli-cd embeds this package and already refuses plaintext git with no escape hatch; a library reading the environment would silently widen cd's stance. Mirrors the existing `Warnf` seam.

`.github/UPGRADE_NOTES.md` is deliberately **not** filled — that file gates a breaking release, and this is not one.

### Downstream — needs a decision before the next CE bump

This is a consequence of the behaviour, not the label, so it stands regardless of how this is tagged.

swarmcli-cd's `source/source_test.go:120` and `:206` stand up plain-`http` `httptest` servers against `charts.NewRepoStoreAt`, so they will fail. It must either set `AllowPlaintext = true` in those tests or — more consistent with its own git stance — switch them to TLS. Any of its release files naming an `http://` repository will also start failing. Out of scope here; flagging it so the bump is not a surprise.

## Deferred

A missing index digest stays a warning. `errNoDigest`'s comment records a deliberate compatibility decision, flipping it is a separate behaviour change on a different code path with its own compat story, and its severity is better judged *after* the index is guaranteed to arrive over TLS. There is also no interactive/non-interactive distinction in `charts` to hang it on.

## Load-bearing

Each hunk reverted individually and the matching test confirmed failing: the `indexFile` guard (a scratch test showed the index written to `<root>/pwned.yaml` while the store was `<root>/state` — the escape reproduced); `Add`'s name check; `ReleaseFile.validate`; `Add`'s and `fetchIndex`'s URL checks (the latter is what catches an already-configured plaintext repo); `Pull`'s tarball check; and the `cli` wiring.

`gofmt`, `build`, `vet`, `go test ./...`, `check-spdx.sh` and `golangci-lint --build-tags=integration` all clean. Integration tests need a daemon and were not run; `integration-tests/charts/charts_lifecycle_test.go:203` sets `AllowPlaintext = true` because its `httptest` server is plain http.

Closes #527. Surfaced by the swarmcli-cd audit, Eldara-Tech/swarmcli-cd#114.
