### PR TITLE
feat(charts): every Backend operation is cancellable

### DIFF
--- a/charts/apply.go
+++ b/charts/apply.go
@@ -273,9 +273,19 @@ type ApplyResult struct {
 // It stops at the first failure and returns the results completed so far
 // alongside the error, so a partial apply still reports what it did. Re-running
 // is safe: the successful releases become no-ops.
+//
+// A cancelled context stops it the same way, and at the same seam: the next
+// release is never started, and the error is the context's, so a caller can tell
+// a shutdown from a release that failed. Checking here rather than relying on the
+// deploy to fail is what keeps the boundary clean — Upgrade would otherwise be
+// entered, and a stack half-deployed by a killed CLI is worse than one not
+// deployed at all.
 func (e *Engine) Apply(ctx context.Context, plan *Plan, opts InstallOptions) ([]ApplyResult, error) {
 	var results []ApplyResult
 	for _, rp := range plan.Releases {
+		if err := ctx.Err(); err != nil {
+			return results, err
+		}
 		if rp.Action == ActionUnchanged {
 			results = append(results, ApplyResult{Name: rp.Name, Action: ActionUnchanged})
 			continue

--- a/charts/apply_test.go
+++ b/charts/apply_test.go
@@ -302,6 +302,48 @@ func TestApplyFailsFastAndReportsPartialProgress(t *testing.T) {
 	require.NotContains(t, fb.deployed, "second", "apply must stop at the first failure")
 }
 
+// Cancelling an apply stops it at the same seam a failure does: between
+// releases. A controller retiring an application, or shutting down, must not
+// keep converging the rest of the file — and the error it gets back has to be
+// the context's, or it cannot tell its own teardown from a broken release.
+func TestApplyStopsBetweenReleasesOnCancellation(t *testing.T) {
+	body := `releases:
+  - name: first
+    chart: swarmcli-charts/demo
+    version: "0.1.0"
+  - name: second
+    chart: swarmcli-charts/demo
+    version: "0.1.0"
+`
+	e, fb, src, rf := applyEnv(t, body, "0.1.0")
+	ctx, cancel := context.WithCancel(context.Background())
+	e.Backend = &cancellingBackend{fakeBackend: fb, cancel: cancel}
+
+	plan, err := e.PlanApply(ctx, rf, src, PlanOptions{})
+	require.NoError(t, err)
+
+	res, err := e.Apply(ctx, plan, InstallOptions{})
+	require.ErrorIs(t, err, context.Canceled)
+	require.Len(t, res, 1, "the release that did converge is still reported")
+	require.Contains(t, fb.deployed, "first")
+	require.NotContains(t, fb.deployed, "second", "apply must not converge the remainder of a cancelled plan")
+}
+
+// cancellingBackend cancels the apply the moment one release has been deployed,
+// which is what a controller told to stop halfway through a run looks like.
+type cancellingBackend struct {
+	*fakeBackend
+	cancel context.CancelFunc
+}
+
+func (b *cancellingBackend) DeployStack(ctx context.Context, name, manifest, resolve string) error {
+	if err := b.fakeBackend.DeployStack(ctx, name, manifest, resolve); err != nil {
+		return err
+	}
+	b.cancel()
+	return nil
+}
+
 // A release that appears between planning and applying must upgrade cleanly
 // rather than colliding with "already exists".
 func TestApplyToleratesReleaseAppearingAfterPlan(t *testing.T) {

--- a/charts/backend_docker.go
+++ b/charts/backend_docker.go
@@ -58,41 +58,41 @@ func (b *dockerBackend) contextName() (string, error) {
 // unchanged. An explicitly targeted one fetches its own every time: the shared
 // cache holds exactly one swarm, and a convergence poll that read another
 // swarm's tasks out of it would report a rollout finished that never started.
-func (b *dockerBackend) snapshot() (*docker.SwarmSnapshot, error) {
+func (b *dockerBackend) snapshot(ctx context.Context) (*docker.SwarmSnapshot, error) {
 	if b.ctxName == "" {
-		return docker.GetOrRefreshSnapshot()
+		return docker.GetOrRefreshSnapshotCtx(ctx)
 	}
 	cli, err := b.client()
 	if err != nil {
 		return nil, err
 	}
-	return docker.SnapshotWith(context.Background(), cli)
+	return docker.SnapshotWith(ctx, cli)
 }
 
-func (b *dockerBackend) DeployStack(name, manifest, resolve string) error {
+func (b *dockerBackend) DeployStack(ctx context.Context, name, manifest, resolve string) error {
 	ctxName, err := b.contextName()
 	if err != nil {
 		return err
 	}
-	return docker.DeployStackInContext(ctxName, name, manifest, docker.ResolveImage(resolve))
+	return docker.DeployStackInContext(ctx, ctxName, name, manifest, docker.ResolveImage(resolve))
 }
 
-func (b *dockerBackend) RemoveStack(name string) error {
+func (b *dockerBackend) RemoveStack(ctx context.Context, name string) error {
 	ctxName, err := b.contextName()
 	if err != nil {
 		return err
 	}
-	return docker.RemoveStackCLIInContext(ctxName, name)
+	return docker.RemoveStackCLIInContext(ctx, ctxName, name)
 }
 
 // RefreshSnapshot invalidates the shared cache after a mutation. An explicitly
 // targeted backend has no shared cache to invalidate — snapshot() always
 // fetches — so there is nothing to do and nothing to get stale.
-func (b *dockerBackend) RefreshSnapshot() error {
+func (b *dockerBackend) RefreshSnapshot(ctx context.Context) error {
 	if b.ctxName != "" {
 		return nil
 	}
-	_, err := docker.RefreshSnapshot()
+	_, err := docker.RefreshSnapshotCtx(ctx)
 	return err
 }
 
@@ -141,8 +141,8 @@ func (b *dockerBackend) DeleteConfig(ctx context.Context, name string) error {
 	return docker.DeleteConfigWith(ctx, cli, name)
 }
 
-func (b *dockerBackend) StackServices(name string) []ServiceState {
-	snap, err := b.snapshot()
+func (b *dockerBackend) StackServices(ctx context.Context, name string) []ServiceState {
+	snap, err := b.snapshot(ctx)
 	if err != nil {
 		return nil
 	}

--- a/charts/backend_docker_test.go
+++ b/charts/backend_docker_test.go
@@ -4,6 +4,7 @@
 package charts
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -46,7 +47,7 @@ func TestNamedBackendRefreshDoesNotTouchTheSharedCache(t *testing.T) {
 	mine := &docker.SwarmSnapshot{Services: []swarm.Service{{ID: "sentinel"}}}
 	docker.SetSnapshot(mine)
 
-	require.NoError(t, NewDockerBackend("swarm-b").RefreshSnapshot())
+	require.NoError(t, NewDockerBackend("swarm-b").RefreshSnapshot(context.Background()))
 
 	got := docker.GetSnapshot()
 	require.NotNil(t, got)

--- a/charts/release.go
+++ b/charts/release.go
@@ -70,17 +70,23 @@ type ServiceState struct {
 
 // Backend abstracts the Docker operations the release engine needs, so the
 // lifecycle logic is unit-testable without a live Swarm.
+//
+// Every method takes a context and is expected to honour it. Release operations
+// are the long ones — a --wait deploy legitimately runs for minutes — and the
+// daemon is reached over a connection the caller does not hold, so a controller
+// being shut down, or retiring the application it is syncing, has no other way to
+// stop work already in flight.
 type Backend interface {
-	DeployStack(name, manifest string, resolve string) error
-	RemoveStack(name string) error
+	DeployStack(ctx context.Context, name, manifest string, resolve string) error
+	RemoveStack(ctx context.Context, name string) error
 	// RefreshSnapshot invalidates the shared Docker state cache after a mutation
 	// so subsequent reads (status, convergence polling) do not see stale data.
-	RefreshSnapshot() error
+	RefreshSnapshot(ctx context.Context) error
 	CreateConfig(ctx context.Context, name string, data []byte, labels map[string]string) error
 	ListConfigs(ctx context.Context) ([]ConfigMeta, error)
 	InspectConfig(ctx context.Context, name string) ([]byte, error)
 	DeleteConfig(ctx context.Context, name string) error
-	StackServices(name string) []ServiceState
+	StackServices(ctx context.Context, name string) []ServiceState
 	StackVolumes(ctx context.Context, name string) ([]string, error)
 	RemoveVolume(ctx context.Context, name string) error
 	// NetworkScopes returns existing network names mapped to their scope
@@ -293,7 +299,7 @@ func (e *Engine) deployAndRecord(ctx context.Context, rel *Release, opts Install
 		}
 		return rel, err
 	}
-	if err := e.Backend.DeployStack(rel.Name, rel.Manifest, opts.ResolveImage); err != nil {
+	if err := e.Backend.DeployStack(ctx, rel.Name, rel.Manifest, opts.ResolveImage); err != nil {
 		rel.Status = StatusFailed
 		// Roll back networks we auto-created for this install so a failed deploy
 		// leaves no trace; pre-existing networks are untouched.
@@ -306,7 +312,7 @@ func (e *Engine) deployAndRecord(ctx context.Context, rel *Release, opts Install
 	}
 	// The deploy mutated swarm state; invalidate the shared cache so the
 	// convergence poll and any follow-up status read see fresh data.
-	_ = e.Backend.RefreshSnapshot()
+	_ = e.Backend.RefreshSnapshot(ctx)
 	// Persist the networks we auto-created this revision so uninstall can report
 	// what it leaves behind (see Uninstall). Networks already present from an
 	// earlier revision are not re-created here, so uninstall unions across all
@@ -316,7 +322,7 @@ func (e *Engine) deployAndRecord(ctx context.Context, rel *Release, opts Install
 		return rel, fmt.Errorf("stack %q was deployed but recording its release history failed: %w; re-run install/upgrade to reconcile", rel.Name, err)
 	}
 	if opts.Wait {
-		if err := e.waitReady(rel.Name, opts.Timeout); err != nil {
+		if err := e.waitReady(ctx, rel.Name, opts.Timeout); err != nil {
 			return rel, err
 		}
 	}
@@ -562,10 +568,10 @@ func (e *Engine) Uninstall(ctx context.Context, release string, purgeVolumes boo
 	// failed (e.g. a retry where the stack is already gone). Errors are
 	// aggregated and returned together.
 	var errs []error
-	if err := e.Backend.RemoveStack(release); err != nil {
+	if err := e.Backend.RemoveStack(ctx, release); err != nil {
 		errs = append(errs, fmt.Errorf("removing stack: %w", err))
 	} else {
-		_ = e.Backend.RefreshSnapshot()
+		_ = e.Backend.RefreshSnapshot(ctx)
 	}
 
 	if purgeVolumes {
@@ -652,7 +658,7 @@ func (e *Engine) Status(ctx context.Context, release string) (*Release, []Servic
 	if cur == nil {
 		return nil, nil, fmt.Errorf("release %q not found", release)
 	}
-	return cur, e.Backend.StackServices(release), nil
+	return cur, e.Backend.StackServices(ctx, release), nil
 }
 
 // --- helpers ---
@@ -925,13 +931,18 @@ const defaultStabilityWindow = 5 * time.Second
 // continue from any of them on its own — the paused pair needs a human, and a
 // completed rollback is a deploy that already failed and was undone — so
 // waiting out the timeout only delays the same answer.
-func (e *Engine) waitReady(release string, timeout time.Duration) error {
+//
+// A cancelled ctx ends the wait with the context's own error rather than running
+// on to the timeout. This is the longest thing a release operation does, and the
+// timeout it would otherwise serve out defaults to five minutes — far longer than
+// the grace period a caller being shut down has to work with.
+func (e *Engine) waitReady(ctx context.Context, release string, timeout time.Duration) error {
 	if timeout <= 0 {
 		timeout = 5 * time.Minute
 	}
 	deadline := e.now().Add(timeout)
 	for {
-		switch c := Rollup(e.Backend.StackServices(release)); c.Phase {
+		switch c := Rollup(e.Backend.StackServices(ctx, release)); c.Phase {
 		case PhaseWedged:
 			return fmt.Errorf("release %q: %s", release, c.Reason)
 		case PhaseConverged:
@@ -940,7 +951,11 @@ func (e *Engine) waitReady(release string, timeout time.Duration) error {
 		if !e.now().Before(deadline) {
 			return fmt.Errorf("timed out after %s waiting for release %q to converge", timeout, release)
 		}
-		time.Sleep(waitPollInterval)
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(waitPollInterval):
+		}
 	}
 }
 

--- a/charts/release_test.go
+++ b/charts/release_test.go
@@ -58,7 +58,7 @@ func newFakeBackend() *fakeBackend {
 	}
 }
 
-func (f *fakeBackend) DeployStack(name, manifest, resolve string) error {
+func (f *fakeBackend) DeployStack(_ context.Context, name, manifest, resolve string) error {
 	if f.failNext {
 		f.failNext = false
 		return fmt.Errorf("boom")
@@ -66,14 +66,14 @@ func (f *fakeBackend) DeployStack(name, manifest, resolve string) error {
 	f.deployed[name] = manifest
 	return nil
 }
-func (f *fakeBackend) RemoveStack(name string) error {
+func (f *fakeBackend) RemoveStack(_ context.Context, name string) error {
 	if f.rmStackErr != nil {
 		return f.rmStackErr
 	}
 	delete(f.deployed, name)
 	return nil
 }
-func (f *fakeBackend) RefreshSnapshot() error { return f.refreshErr }
+func (f *fakeBackend) RefreshSnapshot(context.Context) error { return f.refreshErr }
 func (f *fakeBackend) CreateConfig(_ context.Context, name string, data []byte, labels map[string]string) error {
 	if f.onCreate != nil {
 		if err := f.onCreate(name); err != nil {
@@ -112,7 +112,9 @@ func (f *fakeBackend) DeleteConfig(_ context.Context, name string) error {
 	delete(f.configs, name)
 	return nil
 }
-func (f *fakeBackend) StackServices(name string) []ServiceState { return f.services[name] }
+func (f *fakeBackend) StackServices(_ context.Context, name string) []ServiceState {
+	return f.services[name]
+}
 func (f *fakeBackend) StackVolumes(_ context.Context, name string) ([]string, error) {
 	return f.volumes[name], nil
 }
@@ -521,7 +523,7 @@ func TestConvergenceRejectsACompletedRollback(t *testing.T) {
 
 	b := &convergenceBackend{states: []ServiceState{rolledBack}}
 	e := &Engine{Backend: b, now: time.Now}
-	require.ErrorContains(t, e.waitReady("rel", time.Hour), "rolled back")
+	require.ErrorContains(t, e.waitReady(context.Background(), "rel", time.Hour), "rolled back")
 	require.Equal(t, 1, b.calls, "should fail on the first observation, not wait out the timeout")
 }
 
@@ -616,7 +618,7 @@ func TestWaitReadyHoldsTheStabilityWindow(t *testing.T) {
 		return clock
 	}}
 
-	err := e.waitReady("rel", 50*time.Millisecond)
+	err := e.waitReady(context.Background(), "rel", 50*time.Millisecond)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "timed out")
 	require.Greater(t, b.calls, 1, "should keep polling rather than returning at first parity")
@@ -633,7 +635,7 @@ func TestWaitReadyReturnsOnceTheWindowElapses(t *testing.T) {
 	b := &scriptedBackend{script: [][]ServiceState{young, young, aged}}
 	e := &Engine{Backend: b, now: time.Now}
 
-	require.NoError(t, e.waitReady("rel", time.Hour))
+	require.NoError(t, e.waitReady(context.Background(), "rel", time.Hour))
 	require.Equal(t, 3, b.calls, "must wait for the task to outlive the window, not return at parity")
 }
 
@@ -652,7 +654,7 @@ func TestWaitReadyWaitsOutAReplacementTasksFreshWindow(t *testing.T) {
 	b := &scriptedBackend{script: [][]ServiceState{young, lost, young, aged}}
 	e := &Engine{Backend: b, now: time.Now}
 
-	require.NoError(t, e.waitReady("rel", time.Hour))
+	require.NoError(t, e.waitReady(context.Background(), "rel", time.Hour))
 	require.Equal(t, 4, b.calls, "the fresh task's remaining window must still be waited out")
 }
 
@@ -665,10 +667,38 @@ func TestWaitReadyFailsFastOnWedgedRollout(t *testing.T) {
 	b := &convergenceBackend{states: []ServiceState{{Name: "api", Running: 0, Desired: 1, UpdateState: "paused"}}}
 	e := &Engine{Backend: b, now: time.Now}
 
-	err := e.waitReady("rel", time.Hour)
+	err := e.waitReady(context.Background(), "rel", time.Hour)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "update paused")
 	require.Equal(t, 1, b.calls, "should fail on the first observation, not wait out the timeout")
+}
+
+// A cancelled wait ends at once, with the context's own error. The timeout it
+// would otherwise serve out defaults to five minutes and is legitimately set
+// higher, so a caller with a shutdown grace period measured in seconds cannot
+// wait for it — and the release may be one that never converges at all.
+func TestWaitReadyReturnsOnACancelledContext(t *testing.T) {
+	// Long enough that nothing but the cancellation can end the sleep, and a
+	// timeout to match, so the wait has exactly one way out.
+	prev := waitPollInterval
+	waitPollInterval = time.Hour
+	defer func() { waitPollInterval = prev }()
+
+	b := &convergenceBackend{states: []ServiceState{{Name: "api", Running: 0, Desired: 1}}}
+	e := &Engine{Backend: b, now: time.Now}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	done := make(chan error, 1)
+	go func() { done <- e.waitReady(ctx, "rel", time.Hour) }()
+
+	select {
+	case err := <-done:
+		require.ErrorIs(t, err, context.Canceled, "the wait must report the cancellation, not a timeout")
+	case <-time.After(5 * time.Second):
+		t.Fatal("waitReady ignored the cancelled context and sat on its poll interval")
+	}
 }
 
 // convergenceBackend is a Backend that only answers StackServices; waitReady
@@ -679,7 +709,7 @@ type convergenceBackend struct {
 	calls  int
 }
 
-func (b *convergenceBackend) StackServices(string) []ServiceState {
+func (b *convergenceBackend) StackServices(context.Context, string) []ServiceState {
 	b.calls++
 	return b.states
 }
@@ -691,7 +721,7 @@ type scriptedBackend struct {
 	calls  int
 }
 
-func (b *scriptedBackend) StackServices(string) []ServiceState {
+func (b *scriptedBackend) StackServices(context.Context, string) []ServiceState {
 	i := b.calls
 	b.calls++
 	if i >= len(b.script) {

--- a/docker/context_lint_test.go
+++ b/docker/context_lint_test.go
@@ -23,6 +23,10 @@ var allowedBareBackground = map[string]string{
 	// makes is bounded: SnapshotWith applies the 30s deadline itself, so the
 	// timeout lives in one place instead of at every call site.
 	"docker/snapshot.go": "RefreshSnapshot",
+	// DeployStack is the TUI's entry point, called from Bubble Tea commands that
+	// hold no context. Everything under it takes one, so the caller that does
+	// have a context to give — the release engine — reaches the child process.
+	"docker/stack_deploy.go": "DeployStack",
 }
 
 func TestNoBareContextBackground(t *testing.T) {

--- a/docker/explicit_context_test.go
+++ b/docker/explicit_context_test.go
@@ -4,6 +4,7 @@
 package docker
 
 import (
+	"context"
 	"testing"
 
 	"github.com/docker/docker/api/types/swarm"
@@ -18,9 +19,9 @@ func TestExplicitContextRejectsEmptyName(t *testing.T) {
 	_, err := ClientFor("")
 	require.ErrorContains(t, err, "docker context name is required")
 
-	require.ErrorContains(t, DeployStackInContext("", "web", "services: {}\n", ResolveImageDefault),
+	require.ErrorContains(t, DeployStackInContext(context.Background(), "", "web", "services: {}\n", ResolveImageDefault),
 		"docker context name is required")
-	require.ErrorContains(t, RemoveStackCLIInContext("", "web"),
+	require.ErrorContains(t, RemoveStackCLIInContext(context.Background(), "", "web"),
 		"docker context name is required")
 }
 

--- a/docker/resolveimage_test.go
+++ b/docker/resolveimage_test.go
@@ -3,7 +3,10 @@
 
 package docker
 
-import "testing"
+import (
+	"context"
+	"testing"
+)
 
 func TestResolveImageValid(t *testing.T) {
 	valid := []ResolveImage{ResolveImageDefault, ResolveImageAlways, ResolveImageChanged, ResolveImageNever}
@@ -21,7 +24,7 @@ func TestResolveImageValid(t *testing.T) {
 
 // An invalid mode must be refused before anything is written or deployed.
 func TestDeployStackResolvedRejectsInvalidMode(t *testing.T) {
-	err := DeployStackResolved("stack", "services:\n  a:\n    image: nginx\n", "bogus")
+	err := DeployStackResolved(context.Background(), "stack", "services:\n  a:\n    image: nginx\n", "bogus")
 	if err == nil {
 		t.Fatal("DeployStackResolved with an invalid mode returned nil, want an error")
 	}

--- a/docker/snapshot.go
+++ b/docker/snapshot.go
@@ -84,11 +84,22 @@ func InvalidateSnapshot() {
 // RefreshSnapshot fetches all swarm data (nodes, services, tasks) at once
 // and updates the global cache.
 func RefreshSnapshot() (*SwarmSnapshot, error) {
+	return RefreshSnapshotCtx(context.Background())
+}
+
+// RefreshSnapshotCtx is RefreshSnapshot under a context the caller can cancel.
+//
+// It exists beside RefreshSnapshot rather than replacing it because the TUI is
+// the overwhelming majority of the callers and has no context to give: a Bubble
+// Tea command refreshing the cache after a scale or a restart would have to
+// invent one. The release engine does have one — a reconcile it must be able to
+// abort — and this is how it reaches the four API calls the refresh makes.
+func RefreshSnapshotCtx(ctx context.Context) (*SwarmSnapshot, error) {
 	c, err := GetClient()
 	if err != nil {
 		return nil, fmt.Errorf("docker client: %w", err)
 	}
-	snap, err := SnapshotWith(context.Background(), c)
+	snap, err := SnapshotWith(ctx, c)
 	if err != nil {
 		return nil, err
 	}
@@ -192,14 +203,32 @@ func TriggerRefreshIfNeeded() {
 // GetOrRefreshSnapshot returns the current snapshot, refreshing it
 // if the cache is empty or too old.
 func GetOrRefreshSnapshot() (*SwarmSnapshot, error) {
-	snapshotMu.RLock()
-	s := snapshot
-	snapshotMu.RUnlock()
-
-	if s == nil || time.Since(s.Fetched) > cacheTTL {
-		return RefreshSnapshot()
+	if s := freshSnapshot(); s != nil {
+		return s, nil
 	}
-	return s, nil
+	return RefreshSnapshot()
+}
+
+// GetOrRefreshSnapshotCtx is GetOrRefreshSnapshot under a context the caller can
+// cancel; see RefreshSnapshotCtx for why both spellings exist. A cache hit never
+// consults the context, because it never talks to the daemon.
+func GetOrRefreshSnapshotCtx(ctx context.Context) (*SwarmSnapshot, error) {
+	if s := freshSnapshot(); s != nil {
+		return s, nil
+	}
+	return RefreshSnapshotCtx(ctx)
+}
+
+// freshSnapshot returns the cached snapshot while it is still inside the TTL,
+// and nil when it is absent or stale — i.e. when a caller has to go and fetch.
+func freshSnapshot() *SwarmSnapshot {
+	snapshotMu.RLock()
+	defer snapshotMu.RUnlock()
+
+	if snapshot == nil || time.Since(snapshot.Fetched) > cacheTTL {
+		return nil
+	}
+	return snapshot
 }
 
 // ToNodeEntries converts the full nodes into display-friendly entries.

--- a/docker/stack_deploy.go
+++ b/docker/stack_deploy.go
@@ -79,18 +79,22 @@ func (r ResolveImage) Valid() bool {
 
 // DeployStack deploys a stack with the provided name and YAML content, leaving
 // image resolution at Docker's default. See DeployStackResolved.
+//
+// It is the TUI's entry point, and a Bubble Tea command has no context to
+// inherit, so the background one is spelled out here instead of being pushed
+// onto every caller. Everything below this takes a context.
 func DeployStack(stackName string, yamlContent string) error {
-	return DeployStackResolved(stackName, yamlContent, ResolveImageDefault)
+	return DeployStackResolved(context.Background(), stackName, yamlContent, ResolveImageDefault)
 }
 
 // DeployStackResolved deploys a stack with an explicit image-resolution mode,
 // on whichever context the process is pointed at.
-func DeployStackResolved(stackName string, yamlContent string, resolve ResolveImage) error {
+func DeployStackResolved(ctx context.Context, stackName string, yamlContent string, resolve ResolveImage) error {
 	ctxName, err := GetDockerContext()
 	if err != nil {
 		return fmt.Errorf("failed to get docker context: %w", err)
 	}
-	return DeployStackInContext(ctxName, stackName, yamlContent, resolve)
+	return DeployStackInContext(ctx, ctxName, stackName, yamlContent, resolve)
 }
 
 // DeployStackInContext deploys a stack to an explicitly named Docker context.
@@ -99,7 +103,11 @@ func DeployStackResolved(stackName string, yamlContent string, resolve ResolveIm
 // context is what keeps the target an argument rather than whatever
 // DOCKER_CONTEXT or `docker context show` happens to say at the moment the
 // command runs.
-func DeployStackInContext(ctxName, stackName, yamlContent string, resolve ResolveImage) error {
+//
+// Cancelling ctx kills the child. Nothing else can reach it: the CLI holds its
+// own connection to the daemon, so a caller being torn down while the daemon is
+// unresponsive would otherwise sit on a `docker stack deploy` that never returns.
+func DeployStackInContext(ctx context.Context, ctxName, stackName, yamlContent string, resolve ResolveImage) error {
 	if ctxName == "" {
 		return fmt.Errorf("docker context name is required")
 	}
@@ -139,12 +147,19 @@ func DeployStackInContext(ctxName, stackName, yamlContent string, resolve Resolv
 		args = append(args, "--resolve-image", string(resolve))
 	}
 	args = append(args, stackName)
-	cmd := exec.Command("docker", args...)
+	cmd := exec.CommandContext(ctx, "docker", args...)
 	cmd.Env = os.Environ()
 
 	// Capture output for error reporting
 	output, err := cmd.CombinedOutput()
 	if err != nil {
+		// A killed child reports "signal: killed", which reads as a deploy that
+		// failed and would send us into the network cleanup below. Report the
+		// cancellation itself so a caller shutting down can tell the two apart
+		// and does not spend its remaining seconds tidying up.
+		if cerr := ctx.Err(); cerr != nil {
+			return fmt.Errorf("deploying stack %q: %w", stackName, cerr)
+		}
 		// If deployment failed, try to clean up any networks that might have been created
 		// This handles the case where a network with the wrong type was created
 		if networkNames := extractNetworkNames(yamlContent); len(networkNames) > 0 {
@@ -162,26 +177,32 @@ func DeployStackInContext(ctxName, stackName, yamlContent string, resolve Resolv
 // counterpart to DeployStack. Unlike RemoveStack (services only), this removes
 // the stack's services, networks, configs and secrets while leaving volumes
 // intact — matching standard Docker stack semantics.
-func RemoveStackCLI(stackName string) error {
+func RemoveStackCLI(ctx context.Context, stackName string) error {
 	ctxName, err := GetDockerContext()
 	if err != nil {
 		return fmt.Errorf("failed to get docker context: %w", err)
 	}
-	return RemoveStackCLIInContext(ctxName, stackName)
+	return RemoveStackCLIInContext(ctx, ctxName, stackName)
 }
 
 // RemoveStackCLIInContext is RemoveStackCLI against an explicitly named context.
-func RemoveStackCLIInContext(ctxName, stackName string) error {
+// As with DeployStackInContext, cancelling ctx kills the child.
+func RemoveStackCLIInContext(ctx context.Context, ctxName, stackName string) error {
 	if ctxName == "" {
 		return fmt.Errorf("docker context name is required")
 	}
 	if stackName == "" {
 		return fmt.Errorf("stack name cannot be empty")
 	}
-	cmd := exec.Command("docker", "--context", ctxName, "stack", "rm", stackName)
+	cmd := exec.CommandContext(ctx, "docker", "--context", ctxName, "stack", "rm", stackName)
 	cmd.Env = os.Environ()
 	output, err := cmd.CombinedOutput()
 	if err != nil {
+		// A killed child produces no output to interpret, so decide on the
+		// cancellation before reading the message below.
+		if cerr := ctx.Err(); cerr != nil {
+			return fmt.Errorf("removing stack %q: %w", stackName, cerr)
+		}
 		// An already-absent stack is success: makes uninstall idempotent so a
 		// retry after a partial teardown can still finish cleanup.
 		if strings.Contains(string(output), "Nothing found in stack") {

--- a/docker/stack_deploy_test.go
+++ b/docker/stack_deploy_test.go
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package docker
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// The stack commands shell out, so a cancelled context is the only thing that
+// can reach the running `docker` process — and what comes back has to say so.
+// Left to itself the dead child reports "signal: killed", which is
+// indistinguishable from a daemon that rejected the deploy; a controller being
+// shut down would record a failed sync for work it cancelled itself.
+func TestStackCommandsReportCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := DeployStackInContext(ctx, "no-such-context", "web", "services:\n  a:\n    image: x\n", ResolveImageDefault)
+	require.ErrorIs(t, err, context.Canceled)
+
+	require.ErrorIs(t, RemoveStackCLIInContext(ctx, "no-such-context", "web"), context.Canceled)
+}


### PR DESCRIPTION
`charts.Backend` declared fourteen methods; ten took a `context.Context` and honoured it, four did not. Cancellation therefore reached the config, network, secret and volume half of a release operation and stopped dead at the service half — which is the half that takes minutes.

The consumer that this costs is `Eldara-Tech/swarmcli-cd`, the GitOps controller. It holds the Docker socket and reconciles applications on a timer, so its implementation of this interface had to substitute `context.Background()` at every one of the four. A controller being shut down — Swarm sends SIGKILL 10s after SIGTERM — could not abort a deploy against an unresponsive daemon, and an application being retired from the set could not stop its own in-flight sync. See Eldara-Tech/swarmcli-cd#106, where this is the fourth finding.

## What changed

`DeployStack`, `RemoveStack`, `RefreshSnapshot` and `StackServices` now take a context as their first parameter, and it is threaded rather than accepted and discarded:

- **`waitReady` honours it.** This is the valuable part. It polls under `opts.Wait` with a default five-minute timeout and used `time.Sleep`, so a cancelled wait ran on to that timeout regardless. It is now a `select` on `ctx.Done()`.
- **`Engine.Apply` checks between releases**, so a cancelled apply stops at a release boundary instead of deploying the remainder.
- **`DeployStackInContext` and `RemoveStackCLIInContext` use `exec.CommandContext`**, so the `docker stack deploy` child is actually killable. Both prefer `ctx.Err()` over the child's error: a killed child reports `signal: killed`, which would otherwise read as a failed deploy and send the deploy path into its network-rollback cleanup.

## What deliberately did not change

`docker.RefreshSnapshot` and `docker.GetOrRefreshSnapshot` keep their existing signatures and gain `…Ctx` variants beside them, which the existing spellings delegate to. Widening them in place would have meant writing `context.Background()` at roughly forty call sites — 26 and 8 respectively, plus the exported `docker.SnapshotOps` interface the TUI reads them through and its mocks — because a Bubble Tea command has no context to inherit. It would also have broken `swarmcli-be`, which calls `docker.RefreshSnapshot()` in `bootstrap` and in its integration suite. Nothing outside `charts/` changed as a result.

`docker.DeployStack(name, yaml)` is likewise untouched; it is the TUI's entry point and `swarmcli-be`'s bootstrap depends on it.

## Breaking

`C1` for `charts.Backend` — any implementor must add the parameter. In this repository that is `dockerBackend` and the test fakes. Outside it, `swarmcli-cd` is the only implementor; `swarmcli-be` does not implement this interface. `docker.DeployStackResolved` and `docker.RemoveStackCLI*` are also widened; `RemoveStackCLI` has no callers anywhere.

## Verification

`go build`, `go vet`, `go vet -tags integration`, `gofmt -l`, `golangci-lint run --build-tags=integration` (0 issues) and `go test ./...` are all clean, `-race` included.

Two new tests, each proven load-bearing by reverting its own hunk:

- `TestWaitReadyReturnsOnACancelledContext` — with the `select` reverted to `time.Sleep`, fails with *"waitReady ignored the cancelled context and sat on its poll interval"* after 5.00s.
- `TestApplyStopsBetweenReleasesOnCancellation` — with the `ctx.Err()` check deleted, fails with *"Expected error with context canceled in chain but got nil"*, and the fake shows both releases deployed.

`TestStackCommandsReportCancellation` covers the exec path. Honest limitation: for an **already-cancelled** context the `ctx.Err()` hunk and `exec.CommandContext` are redundant with each other — `exec.Cmd.Start` returns `ctx.Err()` itself — so only reverting both makes it fail. The hunks are not redundant for **mid-flight** cancellation, where `Wait` returns `signal: killed` with no `context.Canceled` in the chain; testing that needs a hanging child and is not covered here.

**No Docker daemon was available**, so the integration suite compiles (`go vet -tags integration`) but was not run. Everything touching a real `docker stack deploy` is first-run-in-CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
