### PR TITLE
feat(charts): a chart carries the files it ships, and the loader stops following links

### DIFF
--- a/charts/README.md
+++ b/charts/README.md
@@ -169,14 +169,28 @@ mychart/
 ├── values.yaml         # default values
 ├── values.schema.json  # optional JSON Schema validated before render
 ├── README.md
-└── templates/          # Go-templated Compose fragments
-    ├── stack.yaml
-    ├── configs.yaml
-    ├── secrets.yaml
-    └── volumes.yaml
+├── templates/          # Go-templated Compose fragments
+│   ├── stack.yaml
+│   ├── configs.yaml
+│   ├── secrets.yaml
+│   └── volumes.yaml
+└── files/              # optional; files the chart carries, read recursively
+    ├── nginx.conf
+    └── tls/ca.pem
 ```
 
 `apiVersion` is `v1` (the only format this build reads; absent means `v1`).
+
+`files/` is collected and carried with the chart, keyed by each file's path
+relative to the chart root — `files/nginx.conf`, `files/tls/ca.pem`. It is
+deliberately not Helm's `.Files`: only `files/` is collected, never "everything
+that is not a known member", because a chart's file set is destined for a swarm
+config and a rule that sweeps up whatever is lying beside `values.yaml` ships
+`values.yaml.bak`, a `.env` or an editor swap file to the swarm. Templates stay
+in `templates/`, which unlike `files/` is flat.
+
+Nothing reads these files yet — what a manifest may do with them lands with
+[#528](https://github.com/Eldara-Tech/swarmcli/issues/528).
 
 ### Declaring the swarmcli a chart needs
 

--- a/charts/chart.go
+++ b/charts/chart.go
@@ -6,8 +6,10 @@ package charts
 import (
 	"archive/tar"
 	"compress/gzip"
+	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"path"
 	"path/filepath"
@@ -23,6 +25,7 @@ const (
 	readmeName       = "README.md"
 	requirementsName = "requirements.yaml"
 	templatesDir     = "templates"
+	filesDir         = "files"
 )
 
 // chartAPIVersionV1 is the only Chart.yaml schema this build understands. An
@@ -43,11 +46,82 @@ const (
 	maxChartTotalSize = 64 << 20 // 64 MiB
 )
 
+// dirLoader holds the state one LoadChartDir call shares across every file it
+// reads.
+//
+// The counters are per-CHART, not per-directory, because that is what the
+// limits describe: a chart with 2048 templates and 2048 files under files/ is
+// over a 4096-file limit even though neither walk is, and a per-walk counter
+// would let it through while looking like it enforced something. Every read on
+// every path — the top-level members, templates/ and files/ — therefore goes
+// through readFile.
+type dirLoader struct {
+	root  string
+	count int
+	total int64
+}
+
+// refusal marks a failure that is this loader's decision rather than the
+// filesystem's accident: a symlink, an irregular file, or a limit. It exists
+// because README.md's read is deliberately best-effort, and "this chart is over
+// the limit" must not be swallowed by the branch that swallows "there is no
+// README".
+type refusal struct{ error }
+
+func isRefusal(err error) bool {
+	var r refusal
+	return errors.As(err, &r)
+}
+
+// readFile reads one chart member, named by its slash-separated path relative
+// to the chart root, and is the only place LoadChartDir touches a file.
+//
+// It refuses a symlink instead of following it. os.DirEntry.IsDir and os.Stat
+// both answer about a link's TARGET, so a templates/x.yaml -> /etc/passwd used
+// to read as an ordinary template and its content became a template source;
+// files/ would have made that a second and easier way to put arbitrary
+// operator-side content into a swarm config. LoadChartArchive has the property
+// for free — it skips every entry that is not tar.TypeReg — so this is the
+// directory loader catching up, deliberately including templates/.
+//
+// A missing file returns an error satisfying os.IsNotExist, which is how the
+// optional members keep tolerating their own absence.
+func (l *dirLoader) readFile(rel string) ([]byte, error) {
+	full := filepath.Join(l.root, filepath.FromSlash(rel))
+	fi, err := os.Lstat(full)
+	if err != nil {
+		return nil, err
+	}
+	if fi.Mode()&os.ModeSymlink != 0 {
+		return nil, refusal{fmt.Errorf("chart entry %s is a symlink", rel)}
+	}
+	if !fi.Mode().IsRegular() {
+		return nil, refusal{fmt.Errorf("chart entry %s is not a regular file", rel)}
+	}
+	if l.count++; l.count > maxChartFiles {
+		return nil, refusal{fmt.Errorf("chart has too many files (limit %d)", maxChartFiles)}
+	}
+	// Sized before reading rather than after: the point of the per-file cap is
+	// not to hold 10 MiB+1 in memory to discover it was too big.
+	if fi.Size() > maxChartFileSize {
+		return nil, refusal{fmt.Errorf("chart entry %s exceeds %d bytes", rel, maxChartFileSize)}
+	}
+	body, err := os.ReadFile(full)
+	if err != nil {
+		return nil, err
+	}
+	if l.total += int64(len(body)); l.total > maxChartTotalSize {
+		return nil, refusal{fmt.Errorf("chart contains more than %d bytes", maxChartTotalSize)}
+	}
+	return body, nil
+}
+
 // LoadChartDir loads a chart from a directory on disk.
 func LoadChartDir(dir string) (*Chart, error) {
 	ch := &Chart{Templates: map[string]string{}}
+	l := &dirLoader{root: dir}
 
-	cf, err := os.ReadFile(filepath.Join(dir, chartfileName))
+	cf, err := l.readFile(chartfileName)
 	if err != nil {
 		return nil, fmt.Errorf("read %s: %w", chartfileName, err)
 	}
@@ -55,7 +129,7 @@ func LoadChartDir(dir string) (*Chart, error) {
 		return nil, fmt.Errorf("parse %s: %w", chartfileName, err)
 	}
 
-	if v, err := os.ReadFile(filepath.Join(dir, valuesName)); err == nil {
+	if v, err := l.readFile(valuesName); err == nil {
 		if err := yaml.Unmarshal(v, &ch.Values); err != nil {
 			return nil, fmt.Errorf("parse %s: %w", valuesName, err)
 		}
@@ -67,13 +141,13 @@ func LoadChartDir(dir string) (*Chart, error) {
 		ch.Values = map[string]any{}
 	}
 
-	if s, err := os.ReadFile(filepath.Join(dir, schemaName)); err == nil {
+	if s, err := l.readFile(schemaName); err == nil {
 		ch.Schema = s
 	} else if !os.IsNotExist(err) {
 		return nil, fmt.Errorf("read %s: %w", schemaName, err)
 	}
 
-	if rq, err := os.ReadFile(filepath.Join(dir, requirementsName)); err == nil {
+	if rq, err := l.readFile(requirementsName); err == nil {
 		ch.RequirementsRaw = rq
 		if err := ch.loadRequirements(rq); err != nil {
 			return nil, err
@@ -82,33 +156,112 @@ func LoadChartDir(dir string) (*Chart, error) {
 		return nil, fmt.Errorf("read %s: %w", requirementsName, err)
 	}
 
-	if r, err := os.ReadFile(filepath.Join(dir, readmeName)); err == nil {
+	// A README this loader cannot read has never been fatal, and this does not
+	// change that — but a refusal is not "cannot read", it is "will not", and
+	// swallowing one would leave a symlinked README followed by nothing and a
+	// blown limit reported nowhere.
+	switch r, err := l.readFile(readmeName); {
+	case err == nil:
 		ch.Readme = string(r)
+	case isRefusal(err):
+		return nil, err
 	}
 
-	tdir := filepath.Join(dir, templatesDir)
-	entries, err := os.ReadDir(tdir)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil, fmt.Errorf("chart %q has no %s/ directory", dir, templatesDir)
-		}
-		return nil, fmt.Errorf("read %s/: %w", templatesDir, err)
+	if err := l.loadTemplates(ch); err != nil {
+		return nil, err
 	}
-	for _, e := range entries {
-		if e.IsDir() {
-			continue
-		}
-		body, err := os.ReadFile(filepath.Join(tdir, e.Name()))
-		if err != nil {
-			return nil, fmt.Errorf("read template %s: %w", e.Name(), err)
-		}
-		ch.Templates[templatesDir+"/"+e.Name()] = string(body)
+	if err := l.loadFiles(ch); err != nil {
+		return nil, err
 	}
 
 	if err := validateChart(ch); err != nil {
 		return nil, err
 	}
 	return ch, nil
+}
+
+// loadTemplates reads templates/, which is deliberately flat: a subdirectory is
+// skipped, exactly as LoadChartArchive skips a template path with a second
+// slash in it.
+func (l *dirLoader) loadTemplates(ch *Chart) error {
+	tdir := filepath.Join(l.root, templatesDir)
+	// Lstat first, so a templates -> /etc symlink is refused rather than
+	// turning every file in the target into a template.
+	if fi, err := os.Lstat(tdir); err == nil && fi.Mode()&os.ModeSymlink != 0 {
+		return refusal{fmt.Errorf("chart entry %s is a symlink", templatesDir)}
+	}
+	entries, err := os.ReadDir(tdir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("chart %q has no %s/ directory", l.root, templatesDir)
+		}
+		return fmt.Errorf("read %s/: %w", templatesDir, err)
+	}
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		rel := templatesDir + "/" + e.Name()
+		body, err := l.readFile(rel)
+		if err != nil {
+			if isRefusal(err) {
+				return err // already names the entry
+			}
+			return fmt.Errorf("read template %s: %w", e.Name(), err)
+		}
+		ch.Templates[rel] = string(body)
+	}
+	return nil
+}
+
+// loadFiles reads files/ recursively into ch.Files, keyed by the chart-relative
+// slash path ("files/nginx.conf", "files/tls/ca.pem") so the key is the same on
+// every platform and identical to the one LoadChartArchive produces from a tar
+// header.
+//
+// An absent files/ is not an error and leaves ch.Files nil — every chart
+// written before this existed loads exactly as it did.
+func (l *dirLoader) loadFiles(ch *Chart) error {
+	fdir := filepath.Join(l.root, filesDir)
+	err := filepath.WalkDir(fdir, func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		rel, err := filepath.Rel(l.root, p)
+		if err != nil {
+			return err
+		}
+		// WalkDir reports a symlink — to a file or to a directory — as a
+		// non-directory entry, so readFile is what refuses both.
+		key := filepath.ToSlash(rel)
+		body, err := l.readFile(key)
+		if err != nil {
+			return err
+		}
+		if key == filesDir {
+			// The walk root is a plain file called "files" rather than a
+			// directory. It is not a chart file: every key here starts with
+			// "files/", and LoadChartArchive ignores such an entry for exactly
+			// that reason. Refusing the chart over it would be theatre.
+			return nil
+		}
+		if ch.Files == nil {
+			ch.Files = map[string][]byte{}
+		}
+		ch.Files[key] = body
+		return nil
+	})
+	switch {
+	case err == nil, os.IsNotExist(err):
+		return nil
+	case isRefusal(err):
+		return err // already names the entry
+	default:
+		return fmt.Errorf("read %s/: %w", filesDir, err)
+	}
 }
 
 // loadRequirements records the UNRENDERED view of requirements.yaml, shared by both
@@ -199,6 +352,16 @@ func LoadChartArchive(r io.Reader) (*Chart, error) {
 			ch.Readme = string(body)
 		case strings.HasPrefix(rel, templatesDir+"/") && !strings.ContainsRune(rel[len(templatesDir)+1:], '/'):
 			ch.Templates[rel] = string(body)
+		case strings.HasPrefix(rel, filesDir+"/"):
+			// No second-slash test, unlike templates/ above: files/ is read
+			// recursively on purpose, so files/tls/ca.pem keeps its shape. The
+			// count and size guards above already cover these entries, and the
+			// tar.TypeReg test at the top of the loop has already dropped every
+			// symlink, hardlink and device node.
+			if ch.Files == nil {
+				ch.Files = map[string][]byte{}
+			}
+			ch.Files[rel] = body
 		}
 	}
 	if ch.Values == nil {

--- a/charts/chart_files_test.go
+++ b/charts/chart_files_test.go
@@ -1,0 +1,164 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package charts
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// writeChartFile writes one file under the chart's files/ directory, creating
+// whatever parents the key names.
+func writeChartFile(t *testing.T, dir, rel, body string) {
+	t.Helper()
+	full := filepath.Join(dir, filepath.FromSlash(rel))
+	require.NoError(t, os.MkdirAll(filepath.Dir(full), 0o755))
+	require.NoError(t, os.WriteFile(full, []byte(body), 0o644))
+}
+
+// writeSparse creates a file of exactly n bytes without spending them. The
+// limit tests need sizes in the tens of MiB and none of them care what is in
+// the file, so the bytes are a hole.
+func writeSparse(t *testing.T, dir, rel string, n int64) {
+	t.Helper()
+	full := filepath.Join(dir, filepath.FromSlash(rel))
+	require.NoError(t, os.MkdirAll(filepath.Dir(full), 0o755))
+	f, err := os.Create(full)
+	require.NoError(t, err)
+	require.NoError(t, f.Truncate(n))
+	require.NoError(t, f.Close())
+}
+
+func TestLoadChartDirCollectsFiles(t *testing.T) {
+	dir := t.TempDir()
+	writeMinimalChart(t, dir)
+	writeChartFile(t, dir, "files/nginx.conf", "server {}\n")
+	writeChartFile(t, dir, "files/tls/ca.pem", "-----BEGIN CERTIFICATE-----\n")
+
+	ch, err := LoadChartDir(dir)
+	require.NoError(t, err)
+	require.Equal(t, map[string][]byte{
+		"files/nginx.conf": []byte("server {}\n"),
+		"files/tls/ca.pem": []byte("-----BEGIN CERTIFICATE-----\n"),
+	}, ch.Files)
+}
+
+func TestLoadChartArchiveCollectsFiles(t *testing.T) {
+	tgz := packEntries(t, map[string]string{
+		"demo/Chart.yaml":           "name: demo\nversion: 1.0.0\n",
+		"demo/templates/stack.yaml": "services: {}\n",
+		"demo/files/nginx.conf":     "server {}\n",
+		"demo/files/tls/ca.pem":     "-----BEGIN CERTIFICATE-----\n",
+	})
+	ch, err := LoadChartArchive(strings.NewReader(tgz))
+	require.NoError(t, err)
+	require.Equal(t, map[string][]byte{
+		"files/nginx.conf": []byte("server {}\n"),
+		"files/tls/ca.pem": []byte("-----BEGIN CERTIFICATE-----\n"),
+	}, ch.Files)
+}
+
+// Nil, not empty: every chart written before files/ existed must load exactly
+// as it did, and a caller that ranges over ch.Files must see the same nothing
+// from both loaders.
+func TestLoadChartWithoutFilesIsNil(t *testing.T) {
+	dir := t.TempDir()
+	writeMinimalChart(t, dir)
+	ch, err := LoadChartDir(dir)
+	require.NoError(t, err)
+	require.Nil(t, ch.Files)
+
+	tgz := packEntries(t, map[string]string{
+		"demo/Chart.yaml":           "name: demo\nversion: 1.0.0\n",
+		"demo/templates/stack.yaml": "services: {}\n",
+	})
+	ch, err = LoadChartArchive(strings.NewReader(tgz))
+	require.NoError(t, err)
+	require.Nil(t, ch.Files)
+}
+
+func TestLoadChartDirRefusesSymlinkInFiles(t *testing.T) {
+	dir := t.TempDir()
+	writeMinimalChart(t, dir)
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, filesDir), 0o755))
+	require.NoError(t, os.Symlink("/etc/passwd", filepath.Join(dir, filesDir, "app.conf")))
+
+	_, err := LoadChartDir(dir)
+	require.ErrorContains(t, err, "files/app.conf")
+	require.ErrorContains(t, err, "symlink")
+}
+
+// The behaviour change: a symlinked template used to be followed, so
+// templates/x.yaml -> /etc/passwd made an arbitrary operator-side file a
+// template source. LoadChartArchive never had that hole (it skips every entry
+// that is not tar.TypeReg), and now neither loader does.
+func TestLoadChartDirRefusesSymlinkInTemplates(t *testing.T) {
+	dir := t.TempDir()
+	writeMinimalChart(t, dir)
+	require.NoError(t, os.Symlink("/etc/passwd", filepath.Join(dir, templatesDir, "leak.yaml")))
+
+	_, err := LoadChartDir(dir)
+	require.ErrorContains(t, err, "templates/leak.yaml")
+	require.ErrorContains(t, err, "symlink")
+}
+
+// The directory loader's mirror of TestLoadChartArchiveTooManyFiles: the three
+// limits were declared for both loaders and enforced by one.
+func TestLoadChartDirTooManyFiles(t *testing.T) {
+	dir := t.TempDir()
+	writeMinimalChart(t, dir)
+	fdir := filepath.Join(dir, filesDir)
+	require.NoError(t, os.MkdirAll(fdir, 0o755))
+	for i := 0; i <= maxChartFiles; i++ {
+		if err := os.WriteFile(filepath.Join(fdir, fmt.Sprintf("f%d", i)), []byte("x"), 0o644); err != nil {
+			require.NoError(t, err)
+		}
+	}
+	_, err := LoadChartDir(dir)
+	require.ErrorContains(t, err, "too many files")
+}
+
+func TestLoadChartDirFileTooLarge(t *testing.T) {
+	dir := t.TempDir()
+	writeMinimalChart(t, dir)
+	writeSparse(t, dir, "files/big.bin", maxChartFileSize+1)
+
+	_, err := LoadChartDir(dir)
+	require.ErrorContains(t, err, "files/big.bin")
+	require.ErrorContains(t, err, fmt.Sprintf("exceeds %d bytes", maxChartFileSize))
+}
+
+func TestLoadChartDirTotalTooLarge(t *testing.T) {
+	dir := t.TempDir()
+	writeMinimalChart(t, dir)
+	for i := 0; i <= maxChartTotalSize/maxChartFileSize; i++ {
+		writeSparse(t, dir, fmt.Sprintf("files/big%d.bin", i), maxChartFileSize)
+	}
+
+	_, err := LoadChartDir(dir)
+	require.ErrorContains(t, err, fmt.Sprintf("more than %d bytes", maxChartTotalSize))
+}
+
+// The counters are per-chart, not per-walk. templates/ holds 40 MiB and files/
+// holds 40 MiB: each walk is comfortably inside the 64 MiB limit and the chart
+// is not, so a loader counting each directory on its own accepts this and this
+// test is what says so.
+func TestLoadChartDirLimitsAreSharedAcrossDirectories(t *testing.T) {
+	const each = 4 // 4 x 10 MiB = 40 MiB per directory, 80 MiB in total
+	dir := t.TempDir()
+	writeMinimalChart(t, dir)
+	for i := 0; i < each; i++ {
+		writeSparse(t, dir, fmt.Sprintf("templates/big%d.yaml", i), maxChartFileSize)
+		writeSparse(t, dir, fmt.Sprintf("files/big%d.bin", i), maxChartFileSize)
+	}
+	require.Less(t, int64(each)*maxChartFileSize, int64(maxChartTotalSize), "each directory must be under the limit on its own")
+
+	_, err := LoadChartDir(dir)
+	require.ErrorContains(t, err, fmt.Sprintf("more than %d bytes", maxChartTotalSize))
+}

--- a/charts/loader_equivalence_test.go
+++ b/charts/loader_equivalence_test.go
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package charts
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// The same chart reaches the engine through two loaders — a repository serves
+// the tarball, a local path serves the directory — and they have drifted
+// before: the archive loader bounded itself with maxChartFiles/maxChartFileSize/
+// maxChartTotalSize while the directory loader applied none of them, and the
+// archive loader skipped symlinks while the directory loader followed them. No
+// per-loader test can see that class of bug, because each loader is
+// self-consistent. Only comparing them can.
+func TestLoadersAgreeOnEveryMember(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "templates"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "files", "tls"), 0o755))
+
+	wantFiles := map[string][]byte{
+		"files/nginx.conf": []byte("server { listen 80; }\n"),
+		"files/tls/ca.pem": []byte("-----BEGIN CERTIFICATE-----\nnot-a-real-cert\n-----END CERTIFICATE-----\n"),
+	}
+	for name, body := range map[string]string{
+		"Chart.yaml": "apiVersion: v1\nname: equiv\nversion: 0.1.0\nappVersion: \"1.0\"\n" +
+			"description: Chart exercising every member both loaders read\n" +
+			"maintainers:\n  - name: Eldara Tech\n    email: hello@eldara.io\n",
+		"values.yaml":           "replicas: 2\nimage:\n  repo: traefik\n  tag: v3.0.0\n",
+		"values.schema.json":    "{\n  \"type\": \"object\",\n  \"required\": [\"replicas\", \"image\"]\n}\n",
+		"requirements.yaml":     "networks:\n  - name: traefik-public\n    description: shared ingress\n",
+		"README.md":             "# equiv\n\nChart used by the loader-equivalence test.\n",
+		"templates/stack.yaml":  "services:\n  web:\n    image: {{ .Values.image.repo }}:{{ .Values.image.tag }}\n",
+		"templates/extras.yaml": "# nothing here, but it must reach Templates\n",
+		"files/nginx.conf":      string(wantFiles["files/nginx.conf"]),
+		"files/tls/ca.pem":      string(wantFiles["files/tls/ca.pem"]),
+	} {
+		require.NoError(t, os.WriteFile(filepath.Join(dir, filepath.FromSlash(name)), []byte(body), 0o644))
+	}
+
+	fromDir, err := LoadChartDir(dir)
+	require.NoError(t, err)
+
+	// A packaged chart is a single top-level directory the archive loader
+	// strips; pack it flat and the loader finds no chart at all, so the
+	// comparison below would be against nothing.
+	fromArchive, err := LoadChartArchive(strings.NewReader(packDirToTgz(t, dir, "equiv")))
+	require.NoError(t, err)
+
+	// The whole struct, never a field list: a test that names the fields keeps
+	// passing when a field is added, which is the drift it exists to catch.
+	require.Equal(t, *fromDir, *fromArchive)
+
+	// Equality only proves the loaders agree — two of them leaving a field zero
+	// agree vacuously. Reflection rather than a written-out list so that a field
+	// added later fails here until the fixture above exercises it too. If a
+	// field ever legitimately cannot be exercised, assert on it by name with the
+	// reason, rather than dropping it from the loop.
+	v := reflect.ValueOf(*fromDir)
+	for i := range v.NumField() {
+		require.Falsef(t, v.Field(i).IsZero(),
+			"Chart.%s is zero: extend this chart so the loader comparison covers it", v.Type().Field(i).Name)
+	}
+
+	// And equality says nothing about whether they agree on the right answer.
+	// The intended shape, stated once: keys relative to the chart root,
+	// slash-separated, recursive under files/.
+	require.Equal(t, wantFiles, fromDir.Files)
+}
+
+// Where the loaders deliberately do NOT agree, and why it is safe.
+//
+// A symlink under files/ is refused by LoadChartDir (see the directory loader's
+// own tests). The archive loader never gets the chance: tar.TypeSymlink is not
+// tar.TypeReg, so the entry is skipped before anything reads it, and the chart
+// loads with that file simply absent. Refusing there instead would buy nothing —
+// there is no content to refuse.
+//
+// The consequence is the point of this test, and it is not a loader property at
+// all: symlink safety in the archive path is decided at PACKAGING time. A packer
+// that stores links as links — GNU tar's default, which is what
+// swarmcli-charts/Makefile's `tar -czf` uses — produces the entry this test
+// builds, and the link is dropped. A packer that FOLLOWS links resolves them
+// while packing, so the target's bytes arrive as an ordinary regular file and
+// no loader can tell. packDirToTgz in this package is itself such a packer: it
+// calls os.ReadFile and writes tar.TypeReg. So `tar -czhf`, or a Go packer
+// written the way that helper is, would put /etc/passwd in a chart and every
+// check downstream would see a perfectly ordinary file.
+//
+// That is why the refusal lives in LoadChartDir, where the link is still a link.
+func TestTheArchiveLoaderDropsASymlinkRatherThanRefusingIt(t *testing.T) {
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+
+	write := func(name, body string) {
+		require.NoError(t, tw.WriteHeader(&tar.Header{
+			Name: "x/" + name, Mode: 0o644, Size: int64(len(body)), Typeflag: tar.TypeReg,
+		}))
+		_, err := tw.Write([]byte(body))
+		require.NoError(t, err)
+	}
+	write("Chart.yaml", "name: x\nversion: 1.0.0\n")
+	write("templates/stack.yaml", "services: {}\n")
+	write("files/real.conf", "kept\n")
+	// The link itself: no body, and a Typeflag the loader's regular-file test
+	// rejects before it reads anything.
+	require.NoError(t, tw.WriteHeader(&tar.Header{
+		Name: "x/files/link.conf", Linkname: "/etc/passwd", Mode: 0o777, Typeflag: tar.TypeSymlink,
+	}))
+	require.NoError(t, tw.Close())
+	require.NoError(t, gz.Close())
+
+	ch, err := LoadChartArchive(&buf)
+	require.NoError(t, err, "the archive loader drops a symlink; it does not refuse the chart")
+	require.Equal(t, map[string][]byte{"files/real.conf": []byte("kept\n")}, ch.Files)
+}
+
+// tar carries no entry for an empty directory, so the archive loader cannot see
+// an empty files/ where the directory loader can. That asymmetry is real and
+// invisible to either loader's own tests, and the answer both must give is nil
+// rather than an empty map.
+func TestLoadersAgreeOnEmptyFilesDir(t *testing.T) {
+	dir := t.TempDir()
+	writeMinimalChart(t, dir)
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "files"), 0o755))
+
+	fromDir, err := LoadChartDir(dir)
+	require.NoError(t, err)
+	fromArchive, err := LoadChartArchive(strings.NewReader(packDirToTgz(t, dir, "x")))
+	require.NoError(t, err)
+
+	require.Nil(t, fromDir.Files)
+	require.Nil(t, fromArchive.Files)
+	require.Equal(t, *fromDir, *fromArchive)
+}

--- a/charts/types.go
+++ b/charts/types.go
@@ -78,6 +78,23 @@ type Chart struct {
 	Readme          string            // README.md, empty if absent
 	Requirements    *Requirements     // parsed requirements.yaml (raw, unrendered), nil if absent
 	RequirementsRaw []byte            // raw requirements.yaml bytes, nil if absent; re-rendered with values at pre-flight
+	// Files are the chart's files/ directory, keyed by path relative to the
+	// chart root — "files/nginx.conf", "files/tls/ca.pem". Nil for a chart
+	// without a files/ directory, which is every chart written before it
+	// existed.
+	//
+	// It is a directory rather than Helm's "everything that is not a known
+	// member" because a chart's file set ends up inside a swarm config, and a
+	// rule that sweeps up whatever happens to be lying beside values.yaml is a
+	// rule that ships an editor backup to the swarm: values.yaml.bak, .env, a
+	// vim swap file, a stray .git. An explicit directory is one rule, both
+	// loaders implement it identically, and a chart author can see what they
+	// are shipping by listing one directory.
+	//
+	// Templates are not here; they are in Templates. Unlike templates/, which
+	// is deliberately flat, files/ is read recursively — files/tls/ca.pem is an
+	// obvious shape and there is no reason to forbid it.
+	Files map[string][]byte
 }
 
 // Requirements is the parsed, defaulted requirements.yaml: the external


### PR DESCRIPTION
PR 1 of 4 for #528. This one only teaches the loaders; nothing consumes `Chart.Files` yet, and the README says so rather than describing a resolution that does not exist in this build.

## Why a chart needs this

A compose stack can give a config or secret content in exactly one way: `file:`. A chart had nowhere to put such a file — `Chart` carried metadata, values, schema, templates, readme and requirements, and both loaders discarded everything else — so a chart could reference an operator-created resource with `external:` and nothing more.

`files/` is now read recursively and carried on `Chart.Files`, keyed by the path relative to the chart root: `files/nginx.conf`, `files/tls/ca.pem`.

**Only `files/`, never Helm's "everything that is not a known member".** A chart's file set is destined for a swarm config, and a rule that sweeps up whatever is lying beside `values.yaml` ships `values.yaml.bak`, a `.env` or an editor swap file to the swarm. The cost is that Helm's `.Files` does not port directly, and the docs say that plainly rather than implying compatibility.

## Two things had to be true first, and neither was

**The three limits were the archive loader's alone.** `maxChartFiles`, `maxChartFileSize` and `maxChartTotalSize` bounded a tarball; `LoadChartDir` applied *none* of them. Adding an arbitrary file set to the directory loader would have added an unbounded read to an unbounded walk.

They are now per-**chart** rather than per-directory, shared across the top-level members, `templates/` and `files/` through the one `readFile` every read goes through. A chart with 2048 templates and 2048 files is over a 4096-file limit even though neither walk is, and a per-walk counter would have let it through while looking like it enforced something. There is a test for exactly that.

**`LoadChartDir` followed symlinks.** `os.DirEntry.IsDir` and `os.Stat` both answer about a link's *target*, so `templates/x.yaml -> /etc/passwd` read as an ordinary template and its content became a template source. `files/` would have made that a second and easier way to put arbitrary operator-side content where a manifest can reach it.

`readFile` now `Lstat`s first and refuses a link — **deliberately including `templates/`, because it is the same defect.** `loadTemplates` also `Lstat`s `templates/` itself, so a `templates -> /etc` symlink cannot turn the target into a chart's templates. `LoadChartArchive` has had the property for free all along, skipping every entry that is not `tar.TypeReg`.

A `README.md` this loader cannot read has never been fatal and still is not — but a refusal is not "cannot read", it is "will not", so a symlinked README or a blown limit is no longer swallowed by the branch that swallows a missing one.

## The loaders are now checked against each other

Both of the above are the same class of bug: a divergence between two loaders that are each internally consistent, which no per-loader test can see. `TestLoadersAgreeOnEveryMember` builds one chart, loads it both ways and compares whole structs — plus a reflection pass requiring every field to be non-zero, so a `Chart` member added later fails until the fixture exercises it rather than comparing equal vacuously.

**Where they do not agree, the test says so.** A symlink in a tarball is *dropped* rather than refused, because `tar.TypeSymlink` never reaches a read. The consequence is the interesting part and it is not a loader property at all:

> Symlink safety in the archive path is decided at **packaging** time. A packer that stores links as links — GNU tar's default, which is what `swarmcli-charts/Makefile` uses — produces an entry that is dropped. A packer that *follows* them resolves the link while packing, so the target's bytes arrive as an ordinary regular file and no loader can tell. `tar -czhf`, or a Go packer written with `filepath.Walk` + `os.ReadFile`, would put `/etc/passwd` in a chart as `files/x.conf`.

That is why the refusal lives in `LoadChartDir`, at the one point where the link is still a link. Noted here because `swarmcli-charts` should not gain a `-h` or a Go packer without this being reconsidered. (`packDirToTgz` in this package's own tests is such a packer, which is how it was found.)

## Load-bearing

Each reverted, the named test observed to fail, restored: resetting the counters per-walk → `TestLoadChartDirLimitsAreSharedAcrossDirectories`; disabling the symlink refusal → both symlink tests, and the `files/` one then reads `/etc/passwd`, which is the hole; renaming `README.md` in the equivalence fixture → the reflection pass names `Chart.Readme`; injecting a key into one loader's result → the struct comparison.

## Scope note

`C0` despite the symlink refusal being a behaviour change: a chart that symlinks a template or a values file is not a shape anything documents, and following the link was the defect. Flagging it for the label review rather than burying it.

The chart-layout list turned out **not** to be one of the three duplicated command lists `CLAUDE.md` warns about — that note is about the `charts` *command* list. Neither `chartsUsage` nor the root README describes the directory layout, so `charts/README.md` was the only edit needed.

## Gate

`gofmt`, `go build ./...`, `go vet ./...`, `go test ./charts/... -race`, `golangci-lint run ./charts/...` (0 issues). Repo-wide `go test ./...` green.

## What follows

PR 2 makes `charts.Backend.DeployStack` take a `DeployRequest` struct so the files can reach a deploy — swarmcli-cd implements that interface, and it has been widened twice in two days, so it becomes a struct while that is still free. PR 3 adapts swarmcli-cd. PR 4 resolves `file:` against the chart, materialises what a manifest references, and refuses what escapes.

Refs #528

🤖 Generated with [Claude Code](https://claude.com/claude-code)