### PR TITLE
refactor(charts)!: DeployStack takes a request, so it never has to be widened again

### DIFF
--- a/charts/apply_test.go
+++ b/charts/apply_test.go
@@ -336,8 +336,8 @@ type cancellingBackend struct {
 	cancel context.CancelFunc
 }
 
-func (b *cancellingBackend) DeployStack(ctx context.Context, name, manifest, resolve string) error {
-	if err := b.fakeBackend.DeployStack(ctx, name, manifest, resolve); err != nil {
+func (b *cancellingBackend) DeployStack(ctx context.Context, req DeployRequest) error {
+	if err := b.fakeBackend.DeployStack(ctx, req); err != nil {
 		return err
 	}
 	b.cancel()

--- a/charts/backend_docker.go
+++ b/charts/backend_docker.go
@@ -24,6 +24,11 @@ type dockerBackend struct {
 	ctxName string
 }
 
+// Compile-time proof that the production backend still satisfies Backend: an
+// interface implemented outside this repository is one whose in-repo
+// implementation can drift out of it without any call site noticing.
+var _ Backend = (*dockerBackend)(nil)
+
 // NewDockerBackend returns a Backend bound to an explicitly named Docker
 // context, for callers that must address a specific swarm rather than the one
 // the process happens to be pointed at.
@@ -69,12 +74,12 @@ func (b *dockerBackend) snapshot(ctx context.Context) (*docker.SwarmSnapshot, er
 	return docker.SnapshotWith(ctx, cli)
 }
 
-func (b *dockerBackend) DeployStack(ctx context.Context, name, manifest, resolve string) error {
+func (b *dockerBackend) DeployStack(ctx context.Context, req DeployRequest) error {
 	ctxName, err := b.contextName()
 	if err != nil {
 		return err
 	}
-	return docker.DeployStackInContext(ctx, ctxName, name, manifest, docker.ResolveImage(resolve))
+	return docker.DeployStackInContext(ctx, ctxName, req.Name, req.Manifest, docker.ResolveImage(req.Resolve))
 }
 
 func (b *dockerBackend) RemoveStack(ctx context.Context, name string) error {

--- a/charts/release.go
+++ b/charts/release.go
@@ -68,6 +68,31 @@ type ServiceState struct {
 	NewestTaskAge time.Duration
 }
 
+// DeployRequest is one deploy.
+//
+// A struct rather than a parameter list: Backend is implemented outside this
+// repository (swarmcli-cd's backend.Backend), so a field added later costs an
+// implementation nothing, while widening the parameter list is a breaking
+// change to every one of them. This method has been widened twice; it will not
+// be widened again.
+type DeployRequest struct {
+	// Name is the stack, which is also the release name.
+	Name string
+	// Manifest is the rendered compose document.
+	Manifest string
+	// Resolve is the --resolve-image mode, empty for the daemon's default.
+	Resolve string
+	// Files are the chart files the manifest's file: and env_file: keys name,
+	// keyed by their chart-relative path. A backend that serves them must make
+	// each one readable at exactly that relative path from wherever the
+	// manifest is resolved, and must not let a path escape that root.
+	//
+	// Empty for a manifest that names none, which is every manifest a chart
+	// without a files/ directory can produce. Nothing populates this yet — see
+	// #528.
+	Files map[string][]byte
+}
+
 // Backend abstracts the Docker operations the release engine needs, so the
 // lifecycle logic is unit-testable without a live Swarm.
 //
@@ -77,7 +102,7 @@ type ServiceState struct {
 // being shut down, or retiring the application it is syncing, has no other way to
 // stop work already in flight.
 type Backend interface {
-	DeployStack(ctx context.Context, name, manifest string, resolve string) error
+	DeployStack(ctx context.Context, req DeployRequest) error
 	RemoveStack(ctx context.Context, name string) error
 	// RefreshSnapshot invalidates the shared Docker state cache after a mutation
 	// so subsequent reads (status, convergence polling) do not see stale data.
@@ -299,7 +324,7 @@ func (e *Engine) deployAndRecord(ctx context.Context, rel *Release, opts Install
 		}
 		return rel, err
 	}
-	if err := e.Backend.DeployStack(ctx, rel.Name, rel.Manifest, opts.ResolveImage); err != nil {
+	if err := e.Backend.DeployStack(ctx, DeployRequest{Name: rel.Name, Manifest: rel.Manifest, Resolve: opts.ResolveImage}); err != nil {
 		rel.Status = StatusFailed
 		// Roll back networks we auto-created for this install so a failed deploy
 		// leaves no trace; pre-existing networks are untouched.

--- a/charts/release_test.go
+++ b/charts/release_test.go
@@ -15,8 +15,12 @@ import (
 
 // fakeBackend is an in-memory Backend for lifecycle tests.
 type fakeBackend struct {
-	configs       map[string]fakeConfig
-	deployed      map[string]string // stack name -> manifest
+	configs  map[string]fakeConfig
+	deployed map[string]string // stack name -> manifest
+	// lastDeploy is the whole request the last deploy carried. deployed keeps
+	// only two of its fields, and Name, Manifest and Resolve are all strings,
+	// so a pair of them swapped at the call site still fills that map.
+	lastDeploy    DeployRequest
 	volumes       map[string][]string
 	services      map[string][]ServiceState
 	networkScopes map[string]string     // network name -> scope
@@ -58,12 +62,13 @@ func newFakeBackend() *fakeBackend {
 	}
 }
 
-func (f *fakeBackend) DeployStack(_ context.Context, name, manifest, resolve string) error {
+func (f *fakeBackend) DeployStack(_ context.Context, req DeployRequest) error {
 	if f.failNext {
 		f.failNext = false
 		return fmt.Errorf("boom")
 	}
-	f.deployed[name] = manifest
+	f.deployed[req.Name] = req.Manifest
+	f.lastDeploy = req
 	return nil
 }
 func (f *fakeBackend) RemoveStack(_ context.Context, name string) error {
@@ -186,6 +191,26 @@ func TestInstallRecordsRevisionOne(t *testing.T) {
 	require.Equal(t, TypeRelease, cfg.labels[LabelType])
 	require.Equal(t, "my-demo", cfg.labels[LabelRelease])
 	require.Equal(t, "1", cfg.labels[LabelRevision])
+}
+
+// The three strings deployAndRecord unpacks into a DeployRequest come from
+// three different places — the release's name, the release's manifest and the
+// caller's options — and all three fields are strings, so a pair of them
+// swapped at the call site compiles. Resolve is the one nothing else would
+// notice: no other test reads it back, so a deploy resolving images the wrong
+// way stays green. This reads all three apart.
+func TestDeployRequestCarriesEachFieldToItsOwnPlace(t *testing.T) {
+	fb := newFakeBackend()
+	e := testEngine(fb)
+	const manifest = "version: \"3.9\"\nservices:\n  app:\n    image: x\n"
+
+	_, err := e.Install(context.Background(), "my-demo", ReleaseChart{Name: "demo", Version: "0.1.0"},
+		nil, manifest, InstallOptions{ResolveImage: "changed"})
+	require.NoError(t, err)
+
+	require.Equal(t, "my-demo", fb.lastDeploy.Name, "Name must be the release name")
+	require.Equal(t, manifest, fb.lastDeploy.Manifest, "Manifest must be the rendered manifest")
+	require.Equal(t, "changed", fb.lastDeploy.Resolve, "Resolve must be InstallOptions.ResolveImage")
 }
 
 func TestInstallRejectsExisting(t *testing.T) {


### PR DESCRIPTION
PR 2 of 4 for #528. Mechanical, no behaviour change: `DeployRequest.Files` is added and never written.

Independent of #533 (PR 1) — that one touches `chart.go`/`types.go`, this one touches `release.go`/`backend_docker.go`. Both branch from `main`; either can merge first.

## Why now, and why a struct

`charts.Backend` is implemented **outside this repository**: swarmcli-cd asserts `var _ charts.Backend = (*Backend)(nil)` and pins swarmcli by pseudo-version. `DeployStack` was widened **yesterday** by #532, which added `ctx`. #528 needs a fourth field, for the files a chart's manifest references.

swarmcli-cd's own `docs/extensibility.md` states the rule that applies here, in the other direction across the same boundary:

> Every parameter list a companion implements is frozen the day the companion ships, so each one is a struct … Add fields freely; do not widen a parameter list.

A struct costs one mechanical downstream PR now and nothing ever again. The alternative considered was an optional `FileDeployer` capability that swarmcli-cd would not implement — rejected because it falls back *silently* when the type assertion fails, which is exactly the failure mode swarmcli-cd's `capability` package was created to eliminate.

**Only `DeployStack` changes.** The other thirteen methods are untouched; this is not a rewrite of the interface, and none of the others is about to grow a field.

## The one real risk, and the test for it

Three fields of the same type replaced three positional strings, and `Name`/`Manifest`/`Resolve` transposed at the call site **compiles cleanly**. No existing test would have caught it: `fakeBackend.deployed` only ever recorded `Name` and `Manifest`, so `Resolve` is read back nowhere in the suite.

`TestDeployRequestCarriesEachFieldToItsOwnPlace` installs a distinct value in each position and reads all three back by field. Verified load-bearing: setting `Resolve: rel.Name` at the call site fails **exactly** that test and leaves every other test in the package green. A deploy silently resolving images the wrong way would otherwise have shipped green.

## An assertion CE has never had

`var _ Backend = (*dockerBackend)(nil)`, added beside the struct. There was **no** `var _ Backend` anywhere in this repository. An interface implemented outside it is one whose in-repo implementation can drift out of it without any call site noticing — the failure swarmcli-cd's `capability` package exists to spare a companion backend, and CE was carrying the same exposure unguarded.

## Downstream

swarmcli-cd's build breaks the moment it bumps its pin past this — by design; that is what makes the change compile-checked rather than silent. Its `go.mod` pins `v1.13.0-rc5.0.20260731104716-fb0a6634ddef`, so it is not broken until it chooses to bump.

The adapting PR is ~50 sites there: one production implementation, one production call, three test fakes, and 45 calls in `backend/backend_test.go` — **nine of them multi-line**, so a line-oriented rewrite misses them. It is written and will follow promptly. `req.Files` will be deliberately ignored there with a comment, since swarmcli-cd's `checkFileSources` still refuses `file:` outright until #528's PR 4.

Because `Files` is already on the struct, swarmcli-cd adapts **once**, against the final shape.

## Gate

`gofmt`, `go build ./...`, `go vet ./...`, `go vet -tags integration ./...`, `go test ./... -race` (41 packages, clean cache), `golangci-lint run ./... --build-tags=integration` (0 issues), `check-spdx` — all clean.

`integration-tests/` implements no `charts.Backend`; `multiswarm/two_swarms_test.go` consumes one via `NewDockerBackend` + `NewEngineWith` and needed no change.

## Labels

`C1-breaking-change` — an exported interface changes for a known external implementer. Per `CLAUDE.md` that forces a major tag at release, so it wants a deliberate look rather than a rubber stamp.

Refs #528

🤖 Generated with [Claude Code](https://claude.com/claude-code)