### PR TITLE
fix(charts)!: file: means the chart, and everything else is refused

### DIFF
--- a/charts/README.md
+++ b/charts/README.md
@@ -78,7 +78,7 @@ swarmcli charts outdated                                   # what has a newer ch
 | Behaviour | |
 |---|---|
 | Missing release | installed |
-| Changed chart version, values, or rendered manifest | upgraded |
+| Changed chart version, values, rendered manifest, or referenced `files/` content | upgraded |
 | Identical | **skipped — no new revision** |
 | On the swarm but not in the file | **reported, never removed** |
 | Installed by this file, no longer in it | **reported as an orphan, still never removed** |
@@ -181,6 +181,8 @@ mychart/
 
 `apiVersion` is `v1` (the only format this build reads; absent means `v1`).
 
+### Files a chart ships
+
 `files/` is collected and carried with the chart, keyed by each file's path
 relative to the chart root — `files/nginx.conf`, `files/tls/ca.pem`. It is
 deliberately not Helm's `.Files`: only `files/` is collected, never "everything
@@ -189,8 +191,82 @@ config and a rule that sweeps up whatever is lying beside `values.yaml` ships
 `values.yaml.bak`, a `.env` or an editor swap file to the swarm. Templates stay
 in `templates/`, which unlike `files/` is flat.
 
-Nothing reads these files yet — what a manifest may do with them lands with
-[#528](https://github.com/Eldara-Tech/swarmcli/issues/528).
+Compose gives a config or a secret its content in exactly one way, which is what
+these are for:
+
+```yaml
+# templates/configs.yaml
+configs:
+  nginx:
+    file: files/nginx.conf
+```
+
+A config's `file:`, a secret's `file:` and a service's `env_file:` all mean **the
+chart**: the path is resolved against the chart root, and the file the manifest
+names is carried to the deploy and written beside the rendered manifest for the
+`docker` CLI to read.
+
+That is new, and it replaces something worse. Those three keys are resolved by
+the docker CLI against the directory of the compose file it is handed, which was
+the temp file swarmcli wrote — so `file: ./nginx.conf` read `$TMPDIR/nginx.conf`,
+a path any local user can plant a file in, and `file: /etc/shadow` was read as
+the invoking operator into a Docker config readable by anyone with Docker access.
+A relative path has therefore never meant what a chart author intended.
+
+So a path that cannot mean a file in the chart is refused, and the rule is the
+same for every chart however it was loaded — from a repository, from a `.tgz`, or
+from a directory on your own disk:
+
+| `file:` / `env_file:` | |
+|---|---|
+| `files/nginx.conf`, `files/tls/ca.pem` | resolved against the chart |
+| `nginx.conf` | refused — outside `files/`, so not something the chart ships |
+| `files/missing.conf` | refused — the chart does not contain it |
+| `../../etc/shadow` | refused — escapes the chart |
+| `/etc/shadow` | refused — absolute, **for every chart** |
+
+A local-directory chart is not an exception, deliberately: vendoring a repository
+chart to disk would otherwise convert it from the refused case to the permitted
+one, granting the most privilege to the workflow that most obscures where a chart
+came from.
+
+**To keep a file the operator manages**, create the resource outside the chart
+and reference it — the same answer as for any other input a chart must not
+carry:
+
+```bash
+docker config create nginx-site /etc/myapp/nginx.conf   # or docker secret create
+```
+
+```yaml
+configs:
+  nginx-site:
+    external: true
+```
+
+**Declare a `swarmcliVersion` floor on any chart that uses `files/`** (see
+[Declaring the swarmcli a chart needs](#declaring-the-swarmcli-a-chart-needs),
+and set it to the release that introduced `files/`). A swarmcli older than that
+parses `Chart.yaml` leniently, ignores `files/` entirely, carries no guard, and
+resolves `file: files/nginx.conf` against a temp directory of its own — so it
+does not fail, it deploys something else. Nothing can be done to an
+already-released binary, which makes the constraint the only thing that turns
+that into a refusal.
+
+Two consequences worth knowing:
+
+- **The referenced files are stored in the release record**, so a rollback
+  deploys the bytes the original deploy sent rather than whatever the chart says
+  today (it may say nothing: rollback replays a stored manifest and never reads a
+  chart). Only the files the manifest names are stored, and they share the
+  record's ~500 KiB gzipped Docker Config budget with the manifest — an install
+  whose record would not fit is refused before anything is deployed, naming the
+  sizes.
+- **That record is as readable as the manifest beside it.** A file referenced by
+  a chart is stored verbatim in the same Docker Config, with the same exposure
+  [issue #465](https://github.com/Eldara-Tech/swarmcli/issues/465) describes for
+  the manifest. Secret *material* still belongs in a Docker secret created
+  outside the chart and referenced with `external: true`.
 
 ### Declaring the swarmcli a chart needs
 

--- a/charts/apply.go
+++ b/charts/apply.go
@@ -4,8 +4,10 @@
 package charts
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"maps"
 	"os"
 
 	"gopkg.in/yaml.v3"
@@ -33,6 +35,16 @@ type ReleasePlan struct {
 	Values       map[string]any `json:"values,omitempty"`
 	Manifest     string         `json:"manifest"`
 	Requirements *Requirements  `json:"requirements,omitempty"`
+	// Files are the chart files Manifest references, resolved while the chart
+	// was still in scope. Apply re-attaches them to InstallOptions per release,
+	// exactly as it does Requirements.
+	//
+	// json:"-" because ReleasePlan is a wire type — a controller serialises a
+	// plan to show what it would do — and base64 file bytes are neither
+	// readable there nor anything a reader of a plan asked for. It is a
+	// consequence, not a limitation: nothing reconstructs an Engine.Apply from
+	// a plan's JSON.
+	Files map[string][]byte `json:"-"`
 	// CurrentManifest is the deployed manifest, for diffing. Empty for an install.
 	CurrentManifest string `json:"currentManifest,omitempty"`
 	// Compat is the chart's engine requirement checked against this build.
@@ -217,6 +229,17 @@ func (e *Engine) planRelease(rf *ReleaseFile, spec ReleaseSpec, src ChartSource,
 	if err != nil {
 		return ReleasePlan{}, fmt.Errorf("%s: release %q: %w%s", rf.Path, spec.Name, err, compatHint(compat))
 	}
+	// One of the two places a *Chart and a rendered manifest coexist, so one of
+	// the two places the manifest's file: keys can be resolved at all — the
+	// chart is out of scope by the time this returns. A refusal fails the whole
+	// plan before anything is deployed, and its text survives intact under the
+	// same file/release prefix every other failure here carries: for a chart
+	// that reads a path outside itself, that message is the entire migration
+	// path there is.
+	chartFiles, err := ResolveManifestFiles(manifest, ch.Files)
+	if err != nil {
+		return ReleasePlan{}, fmt.Errorf("%s: release %q: %w", rf.Path, spec.Name, err)
+	}
 
 	rp := ReleasePlan{
 		Name:         spec.Name,
@@ -226,6 +249,7 @@ func (e *Engine) planRelease(rf *ReleaseFile, spec ReleaseSpec, src ChartSource,
 		Values:       values,
 		Manifest:     manifest,
 		Requirements: req,
+		Files:        chartFiles,
 		Compat:       compat,
 	}
 
@@ -236,7 +260,7 @@ func (e *Engine) planRelease(rf *ReleaseFile, spec ReleaseSpec, src ChartSource,
 	default:
 		rp.FromVersion = cur.Chart.Version
 		rp.CurrentManifest = cur.Manifest
-		same, err := unchanged(&cur, rc, values, manifest, owner)
+		same, err := unchanged(&cur, rc, values, manifest, owner, chartFiles)
 		if err != nil {
 			return ReleasePlan{}, fmt.Errorf("%s: release %q: %w", rf.Path, spec.Name, err)
 		}
@@ -292,6 +316,7 @@ func (e *Engine) Apply(ctx context.Context, plan *Plan, opts InstallOptions) ([]
 		}
 		o := opts
 		o.Requirements = rp.Requirements
+		o.Files = rp.Files
 		// Always Upgrade with Install set, never Install: a release that appeared
 		// between planning and applying then upgrades cleanly instead of failing
 		// with "already exists".
@@ -306,8 +331,24 @@ func (e *Engine) Apply(ctx context.Context, plan *Plan, opts InstallOptions) ([]
 }
 
 // unchanged reports whether the current revision already encodes the desired
-// state: same chart, same rendered manifest, same values — and the ownership
-// this plan is being asked to establish.
+// state: same chart, same rendered manifest, same files, same values — and the
+// ownership this plan is being asked to establish.
+//
+// Files are in the comparison because they are deployed content that nothing
+// else here can stand in for. A chart's files/ can change with neither a
+// version bump nor a manifest change — editing files/nginx.conf and re-running
+// `charts apply ./mychart` is the local-development loop — and while that
+// comparison was missing, such a release planned as ActionUnchanged and the
+// edited bytes never left the machine. Nil and empty compare equal: one means
+// "this release ships no files" and so does the other.
+//
+// Requirements are deliberately not compared, and that asymmetry is meant. They
+// declare what must already exist on the swarm for a deploy to work — external
+// networks, secrets, configs — and are re-rendered and re-checked at pre-flight
+// on every deploy that happens; they are not content the deploy sends. A
+// requirements-only edit therefore changes nothing about the deployed release,
+// and forcing a revision for it would spend a Docker Config to record a
+// no-change. Adding them here would need its own argument, not this one.
 //
 // Ownership is part of the desired state because the stamp is the only evidence
 // prune has. deployAndRecord is the sole writer of rel.Owner, and Apply skips
@@ -325,7 +366,7 @@ func (e *Engine) Apply(ctx context.Context, plan *Plan, opts InstallOptions) ([]
 // unparseable stamp is no evidence of anything, so it is a mismatch and gets
 // healed. An empty plan owner never forces: an apply that claims nothing must
 // not strip a stamp somebody else wrote.
-func unchanged(cur *Release, chart ReleaseChart, values map[string]any, manifest, owner string) (bool, error) {
+func unchanged(cur *Release, chart ReleaseChart, values map[string]any, manifest, owner string, files map[string][]byte) (bool, error) {
 	if cur == nil || cur.Status == StatusUninstalled {
 		return false, nil
 	}
@@ -333,6 +374,9 @@ func unchanged(cur *Release, chart ReleaseChart, values map[string]any, manifest
 		return false, nil
 	}
 	if cur.Manifest != manifest {
+		return false, nil
+	}
+	if !maps.EqualFunc(cur.Files, files, bytes.Equal) {
 		return false, nil
 	}
 	if owner != "" && cur.Owner != "" && !ownedBy(*cur, owner) {

--- a/charts/apply_test.go
+++ b/charts/apply_test.go
@@ -5,6 +5,8 @@ package charts
 
 import (
 	"context"
+	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -495,6 +497,168 @@ func TestPlanApplyMissingValuesFileFailsBeforeDeploying(t *testing.T) {
 	_, err := e.PlanApply(context.Background(), rf, src, PlanOptions{})
 	require.ErrorContains(t, err, "absent.yaml")
 	require.ErrorContains(t, err, "hello")
+	require.Empty(t, fb.deployed)
+}
+
+// fileChart is demoChart plus a files/ directory and a template that references
+// one of its entries, which is the shape planning has to resolve.
+func fileChart(t *testing.T, version, ref string) *Chart {
+	t.Helper()
+	ch := demoChart(t, version)
+	ch.Files = map[string][]byte{"files/nginx.conf": []byte("server { listen 80; }")}
+	ch.Templates["templates/site.yaml"] = "configs:\n  site:\n    file: " + ref + "\n"
+	return ch
+}
+
+// planRelease is one of the two places a *Chart and a rendered manifest coexist,
+// so it is one of the two places file: can be resolved at all — the chart goes
+// out of scope when it returns, and Apply, Upgrade and the record downstream of
+// it never see one.
+func TestPlanApplyResolvesTheFilesTheManifestNames(t *testing.T) {
+	e, fb, src, rf := applyEnv(t, oneRelease)
+	src.charts["swarmcli-charts/demo@0.1.0"] = fileChart(t, "0.1.0", "files/nginx.conf")
+	ctx := context.Background()
+
+	plan, err := e.PlanApply(ctx, rf, src, PlanOptions{})
+	require.NoError(t, err)
+	require.Equal(t, map[string][]byte{"files/nginx.conf": []byte("server { listen 80; }")}, plan.Releases[0].Files)
+
+	// And Apply re-attaches them per release, the way it does Requirements.
+	_, err = e.Apply(ctx, plan, InstallOptions{})
+	require.NoError(t, err)
+	require.Equal(t, plan.Releases[0].Files, fb.lastDeploy.Files)
+}
+
+// A chart's files/ can change with neither a version bump nor a manifest
+// change — edit files/nginx.conf, re-run `charts apply` against the same local
+// chart — and that is the local-development loop, so it is how this feature is
+// most often used. While unchanged() did not compare files, such a release
+// planned as ActionUnchanged and the edited bytes never left the machine.
+func TestPlanApplyDetectsAFilesOnlyChange(t *testing.T) {
+	e, fb, src, rf := applyEnv(t, oneRelease)
+	src.charts["swarmcli-charts/demo@0.1.0"] = fileChart(t, "0.1.0", "files/nginx.conf")
+	ctx := context.Background()
+
+	plan, err := e.PlanApply(ctx, rf, src, PlanOptions{})
+	require.NoError(t, err)
+	_, err = e.Apply(ctx, plan, InstallOptions{})
+	require.NoError(t, err)
+
+	// Same chart version and same templates, so the rendered manifest is
+	// byte-identical: only the file content distinguishes the two.
+	edited := fileChart(t, "0.1.0", "files/nginx.conf")
+	edited.Files["files/nginx.conf"] = []byte("server { listen 8080; }")
+	src.charts["swarmcli-charts/demo@0.1.0"] = edited
+
+	plan2, err := e.PlanApply(ctx, rf, src, PlanOptions{})
+	require.NoError(t, err)
+	require.Equal(t, plan.Releases[0].Manifest, plan2.Releases[0].Manifest,
+		"the manifest must be identical, or this proves nothing about files")
+	require.Equal(t, ActionUpgrade, plan2.Releases[0].Action)
+
+	// And the edited bytes reach the deploy, which is the point of noticing.
+	_, err = e.Apply(ctx, plan2, InstallOptions{})
+	require.NoError(t, err)
+	require.Equal(t, map[string][]byte{"files/nginx.conf": []byte("server { listen 8080; }")}, fb.lastDeploy.Files)
+}
+
+// The other half of the same comparison: noticing a file change must not make
+// every apply an upgrade. The no-churn guarantee TestApplyInstallsThenIsIdempotent
+// pins has to hold for a release that ships files too.
+func TestPlanApplyWithTheSameFilesStaysUnchanged(t *testing.T) {
+	e, fb, src, rf := applyEnv(t, oneRelease)
+	src.charts["swarmcli-charts/demo@0.1.0"] = fileChart(t, "0.1.0", "files/nginx.conf")
+	ctx := context.Background()
+
+	plan, err := e.PlanApply(ctx, rf, src, PlanOptions{})
+	require.NoError(t, err)
+	_, err = e.Apply(ctx, plan, InstallOptions{})
+	require.NoError(t, err)
+	before := len(fb.configs)
+
+	// A freshly built chart, so the second plan compares equal bytes rather than
+	// the same map — and the stored side has been through YAML and gzip.
+	src.charts["swarmcli-charts/demo@0.1.0"] = fileChart(t, "0.1.0", "files/nginx.conf")
+	plan2, err := e.PlanApply(ctx, rf, src, PlanOptions{})
+	require.NoError(t, err)
+	require.Equal(t, ActionUnchanged, plan2.Releases[0].Action)
+
+	_, err = e.Apply(ctx, plan2, InstallOptions{})
+	require.NoError(t, err)
+	require.Len(t, fb.configs, before, "an unchanged apply must not record a revision")
+}
+
+// nil and empty both mean "this release ships no files", and they turn up in
+// either position: a record written before Files existed decodes to nil, and a
+// manifest naming no file resolves to nil, but a map that happens to be empty
+// must not read as a change. TestApplyInstallsThenIsIdempotent covers the
+// fileless case end to end; this pins the comparison itself, both directions.
+func TestUnchangedComparesTheFiles(t *testing.T) {
+	const manifest = "services: {}\n"
+	chart := ReleaseChart{Name: "demo", Version: "0.1.0"}
+	rel := func(files releaseFiles) *Release {
+		return &Release{Name: "hello", Status: StatusDeployed, Chart: chart, Manifest: manifest, Files: files}
+	}
+
+	for _, tc := range []struct {
+		name    string
+		stored  releaseFiles
+		desired map[string][]byte
+		want    bool
+	}{
+		{"nil against nil", nil, nil, true},
+		{"nil against empty", nil, map[string][]byte{}, true},
+		{"empty against nil", releaseFiles{}, nil, true},
+		{"empty against empty", releaseFiles{}, map[string][]byte{}, true},
+		{"the same content", releaseFiles{"files/a.conf": []byte("x")}, map[string][]byte{"files/a.conf": []byte("x")}, true},
+		{"edited content", releaseFiles{"files/a.conf": []byte("x")}, map[string][]byte{"files/a.conf": []byte("y")}, false},
+		{"a file added", nil, map[string][]byte{"files/a.conf": []byte("x")}, false},
+		{"a file removed", releaseFiles{"files/a.conf": []byte("x")}, nil, false},
+		{"a file renamed", releaseFiles{"files/a.conf": []byte("x")}, map[string][]byte{"files/b.conf": []byte("x")}, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := unchanged(rel(tc.stored), chart, nil, manifest, "", tc.desired)
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// A plan is a wire type: a controller serialises one to show what it would do.
+// File bytes are not something a reader of a plan asked for, and base64 in the
+// middle of a diff is not something anyone can read, so Files carries json:"-".
+// charts/json_test.go pins the rest of the key shape and must stay green
+// untouched — which a json:"-" field is, being invisible to it.
+func TestReleasePlanFilesStayOutOfThePlanJSON(t *testing.T) {
+	b, err := json.Marshal(Plan{Releases: []ReleasePlan{{
+		Name:     "hello",
+		Manifest: "services: {}\n",
+		Files:    map[string][]byte{"files/nginx.conf": []byte("server { listen 80; }")},
+	}}})
+	require.NoError(t, err)
+	require.NotContains(t, string(b), "files")
+	require.NotContains(t, string(b), base64.StdEncoding.EncodeToString([]byte("server { listen 80; }")))
+
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(b, &got))
+	rp := got["releases"].([]any)[0].(map[string]any)
+	require.NotContains(t, rp, "Files")
+}
+
+// A path a chart may not read fails the whole plan, before any release in it is
+// deployed, and the refusal reaches the operator intact: it names the offending
+// path and the replacement, and for this one breaking shape that message is the
+// entire migration path there is.
+func TestPlanApplyRefusesAPathOutsideTheChart(t *testing.T) {
+	e, fb, src, rf := applyEnv(t, oneRelease)
+	src.charts["swarmcli-charts/demo@0.1.0"] = fileChart(t, "0.1.0", "/etc/shadow")
+
+	_, err := e.PlanApply(context.Background(), rf, src, PlanOptions{})
+	require.ErrorContains(t, err, `"/etc/shadow"`)
+	require.ErrorContains(t, err, "absolute path")
+	require.ErrorContains(t, err, "external: true")
+	require.ErrorContains(t, err, rf.Path)
+	require.ErrorContains(t, err, `release "hello"`)
 	require.Empty(t, fb.deployed)
 }
 

--- a/charts/backend_docker.go
+++ b/charts/backend_docker.go
@@ -79,7 +79,7 @@ func (b *dockerBackend) DeployStack(ctx context.Context, req DeployRequest) erro
 	if err != nil {
 		return err
 	}
-	return docker.DeployStackInContext(ctx, ctxName, req.Name, req.Manifest, docker.ResolveImage(req.Resolve))
+	return docker.DeployStackInContext(ctx, ctxName, req.Name, req.Manifest, docker.ResolveImage(req.Resolve), req.Files)
 }
 
 func (b *dockerBackend) RemoveStack(ctx context.Context, name string) error {

--- a/charts/files.go
+++ b/charts/files.go
@@ -1,0 +1,188 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package charts
+
+import (
+	"fmt"
+	"iter"
+	"maps"
+	"path"
+	"slices"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// chartFilesRule is the sentence every refusal below carries.
+//
+// Refusing an absolute path breaks a chart shape that works today, and there is
+// no compatibility flag and no deprecation window, so the error text is the
+// whole of the migration path. One that only said "refused" would turn a
+// breaking change into a support question.
+const chartFilesRule = "a chart may only read files it ships in " + filesDir + "/"
+
+// ResolveManifestFiles returns the chart files a rendered manifest names, and
+// refuses every path that cannot mean a file in the chart.
+//
+// Exactly three compose keys read a path — a config's file:, a secret's file:
+// and a service's env_file: — and the docker CLI resolves all three against the
+// directory of the compose file it was handed, then reads them itself,
+// client-side and as the invoking user, before anything reaches the daemon. In
+// docker/cli v28.5.1 that is absPath in cli/compose/loader/loader.go for all
+// three, then fileObjectConfig in cli/compose/convert/compose.go for the two
+// file: keys and parseEnvFile in cli/compose/loader/envfile.go for env_file:.
+//
+// swarmcli writes that compose file to a temp directory. So an unguarded
+// relative path has always meant "a file in the system temp directory" — which
+// any local user can plant, against a temp name predictable enough to know when
+// to try — and an absolute one has always meant itself, read as the operator
+// into a swarm config that anyone with Docker access can read.
+//
+// This therefore refuses on the way past, in order: a path that is absolute,
+// one that escapes the chart, and one the chart does not contain — the last
+// including anything outside files/. None of it depends on where the chart was
+// loaded from. Trusting a local-path chart with an absolute path would grant the
+// most privilege to vendoring a repository chart to disk, which is the workflow
+// that most obscures a chart's origin.
+//
+// What survives comes back keyed exactly as Chart.Files keys it, and is
+// materialised beside the manifest at that same relative path — which is what
+// makes file: mean the chart. Only the referenced subset is returned: it is
+// persisted in the release record so a rollback replays the bytes the original
+// deploy sent, and that record has a hard size ceiling it shares with the
+// manifest.
+//
+// A manifest naming no file at all yields a nil map and no error, which is every
+// manifest a chart without a files/ directory can produce.
+func ResolveManifestFiles(manifest string, files map[string][]byte) (map[string][]byte, error) {
+	refs, err := manifestFileRefs(manifest)
+	if err != nil {
+		return nil, err
+	}
+	var out map[string][]byte
+	for _, ref := range refs {
+		key, err := ref.resolve(files)
+		if err != nil {
+			return nil, err
+		}
+		if out == nil {
+			out = map[string][]byte{}
+		}
+		out[key] = files[key]
+	}
+	return out, nil
+}
+
+// fileRef is one path a rendered manifest asks the docker CLI to read, carrying
+// the compose key that asked for it so a refusal can name both.
+type fileRef struct {
+	key  string // "configs.site.file", "services.web.env_file"
+	path string // the path exactly as the manifest wrote it
+}
+
+// resolve returns the Chart.Files key this reference names, or the error that
+// refuses it. Every message names the offending path and states the rule; the
+// absolute one additionally names its replacement, because it is the only
+// refusal with a working chart behind it.
+func (r fileRef) resolve(files map[string][]byte) (string, error) {
+	if path.IsAbs(r.path) {
+		return "", fmt.Errorf(
+			"%s: %q is an absolute path, and %s — copy it into the chart's %s/ and reference it by that path, "+
+				"or keep it operator-managed by creating it outside the chart "+
+				"(docker config create <name> <path>, or docker secret create) and referencing it with external: true",
+			r.key, r.path, chartFilesRule, filesDir)
+	}
+	// The value came from YAML, which is slash-separated whatever the host is,
+	// so this is path and not filepath. Clean resolves every interior "..", so a
+	// leading one afterwards is the complete test for leaving the chart root.
+	clean := path.Clean(r.path)
+	if clean == ".." || strings.HasPrefix(clean, "../") {
+		return "", fmt.Errorf("%s: %q escapes the chart, and %s", r.key, r.path, chartFilesRule)
+	}
+	if !strings.HasPrefix(clean, filesDir+"/") {
+		return "", fmt.Errorf("%s: %q is outside %s/, and %s — reference it as %q",
+			r.key, r.path, filesDir, chartFilesRule, filesDir+"/"+clean)
+	}
+	if _, ok := files[clean]; !ok {
+		return "", fmt.Errorf("%s: %q is not in the chart, and %s", r.key, r.path, chartFilesRule)
+	}
+	return clean, nil
+}
+
+// manifestFileRefs returns every path the manifest asks the docker CLI to read,
+// in a stable order so a manifest with more than one bad path always refuses on
+// the same one.
+//
+// The manifest is walked as yaml.Nodes rather than decoded into map[string]any
+// because a single non-string key anywhere in a mapping makes yaml.v3 hand back
+// a map[any]any for the WHOLE mapping — so one "services: {1: …}" entry would
+// make every sibling service invisible to a type assertion, and a guard that
+// quietly stops looking is worse than no guard. A node map coerces the key to a
+// string, and decoding each entry on its own means one malformed entry cannot
+// hide the others.
+//
+// Anything that is still not the shape compose describes names no path here and
+// is left to the deploy, which validates the manifest against the real schema.
+func manifestFileRefs(manifest string) ([]fileRef, error) {
+	var top map[string]yaml.Node
+	if err := yaml.Unmarshal([]byte(manifest), &top); err != nil {
+		// A refusal rather than an empty result: this is the guard, and a
+		// manifest it cannot parse is one whose file: keys it cannot see.
+		return nil, fmt.Errorf("parse manifest: %w", err)
+	}
+
+	var refs []fileRef
+	for _, section := range []string{"configs", "secrets"} {
+		for name, node := range entries(top[section]) {
+			var entry struct {
+				File string `yaml:"file"`
+			}
+			// An entry with no file: — external: true, or driver-backed — is
+			// indistinguishable from file: "" here, and neither names anything.
+			if err := node.Decode(&entry); err != nil || entry.File == "" {
+				continue
+			}
+			refs = append(refs, fileRef{key: section + "." + name + ".file", path: entry.File})
+		}
+	}
+
+	for name, node := range entries(top["services"]) {
+		var entry struct {
+			EnvFile yaml.Node `yaml:"env_file"`
+		}
+		if err := node.Decode(&entry); err != nil {
+			continue
+		}
+		// env_file is the one of the three compose gives two shapes: a bare
+		// string, or a list of them. Both are read, and the list is walked item
+		// by item so an item of the wrong type does not lose the rest.
+		items := []*yaml.Node{&entry.EnvFile}
+		if entry.EnvFile.Kind == yaml.SequenceNode {
+			items = entry.EnvFile.Content
+		}
+		for _, item := range items {
+			var p string
+			if err := item.Decode(&p); err != nil || p == "" {
+				continue
+			}
+			refs = append(refs, fileRef{key: "services." + name + ".env_file", path: p})
+		}
+	}
+	return refs, nil
+}
+
+// entries yields the named entries of one top-level compose block, sorted by
+// name. A block that is absent, or present but not a mapping, yields nothing.
+func entries(node yaml.Node) iter.Seq2[string, yaml.Node] {
+	var block map[string]yaml.Node
+	_ = node.Decode(&block)
+	names := slices.Sorted(maps.Keys(block))
+	return func(yield func(string, yaml.Node) bool) {
+		for _, name := range names {
+			if !yield(name, block[name]) {
+				return
+			}
+		}
+	}
+}

--- a/charts/files_test.go
+++ b/charts/files_test.go
@@ -1,0 +1,235 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package charts
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// chartFiles is the chart every test below resolves against: one file at the
+// top of files/ and one nested, so the recursive shape is always available.
+func chartFiles() map[string][]byte {
+	return map[string][]byte{
+		"files/nginx.conf":  []byte("server { listen 80; }"),
+		"files/tls/ca.pem":  []byte("-----BEGIN CERTIFICATE-----"),
+		"files/unused.conf": []byte("nothing references this"),
+	}
+}
+
+func quoted(p string) string { return strconv.Quote(p) }
+
+// The three manifest shapes, one per key that reads a path. Each names exactly
+// one path so a refusal can only have come from the key under test.
+func configManifest(p string) string {
+	return "services:\n  web:\n    image: nginx\nconfigs:\n  site:\n    file: " + quoted(p) + "\n"
+}
+
+func secretManifest(p string) string {
+	return "services:\n  web:\n    image: nginx\nsecrets:\n  site:\n    file: " + quoted(p) + "\n"
+}
+
+func envFileManifest(p string) string {
+	return "services:\n  web:\n    image: nginx\n    env_file: " + quoted(p) + "\n"
+}
+
+// TestResolveManifestFilesRefusesEveryShapeOnEveryKey is the specification: the
+// guard covers three keys, and a test that covers one proves nothing about the
+// other two — swarmcli-cd#99 was one key, and this is the same defect three
+// times. Dropping any single key from manifestFileRefs fails four subtests.
+func TestResolveManifestFilesRefusesEveryShapeOnEveryKey(t *testing.T) {
+	keys := []struct {
+		name     string
+		manifest func(string) string
+		errKey   string
+	}{
+		{"configs.file", configManifest, "configs.site.file"},
+		{"secrets.file", secretManifest, "secrets.site.file"},
+		{"services.env_file", envFileManifest, "services.web.env_file"},
+	}
+	shapes := []struct {
+		name  string
+		path  string
+		wants []string
+	}{
+		{
+			name: "absolute",
+			path: "/etc/shadow",
+			// The absolute case is the one with a working chart behind it, so
+			// its message is the entire migration path (R-4): the rule, and the
+			// operator-managed replacement by name.
+			wants: []string{
+				`"/etc/shadow"`, "absolute path", "files/",
+				"external: true", "docker config create", "docker secret create",
+			},
+		},
+		{
+			name:  "escapes the chart",
+			path:  "../../etc/shadow",
+			wants: []string{`"../../etc/shadow"`, "escapes the chart", "files/"},
+		},
+		{
+			name:  "well-formed but absent",
+			path:  "files/missing.conf",
+			wants: []string{`"files/missing.conf"`, "not in the chart", "files/"},
+		},
+		{
+			// The likeliest author mistake, so the message has to say files/ and
+			// show the corrected path.
+			name:  "outside files/",
+			path:  "nginx.conf",
+			wants: []string{`"nginx.conf"`, "outside files/", `"files/nginx.conf"`},
+		},
+	}
+	for _, k := range keys {
+		for _, s := range shapes {
+			t.Run(k.name+"/"+s.name, func(t *testing.T) {
+				got, err := ResolveManifestFiles(k.manifest(s.path), chartFiles())
+				require.Nil(t, got)
+				require.Error(t, err)
+				require.Contains(t, err.Error(), k.errKey, "the error must name the offending key")
+				for _, want := range s.wants {
+					require.Contains(t, err.Error(), want)
+				}
+			})
+		}
+	}
+}
+
+func TestResolveManifestFilesEscapesFromInsideFiles(t *testing.T) {
+	// files/../../etc/shadow cleans to ../etc/shadow: it leaves the chart root
+	// even though it started under files/, which is what path.Clean is for.
+	_, err := ResolveManifestFiles(configManifest("files/../../etc/shadow"), chartFiles())
+	require.ErrorContains(t, err, `"files/../../etc/shadow" escapes the chart`)
+
+	// files/../nginx.conf stays inside the chart but leaves files/, so it is the
+	// outside-files/ refusal and not the escape one.
+	_, err = ResolveManifestFiles(configManifest("files/../nginx.conf"), chartFiles())
+	require.ErrorContains(t, err, "is outside files/")
+}
+
+func TestResolveManifestFilesResolvesWhatTheManifestNames(t *testing.T) {
+	got, err := ResolveManifestFiles(configManifest("files/nginx.conf"), chartFiles())
+	require.NoError(t, err)
+	require.Equal(t, map[string][]byte{"files/nginx.conf": []byte("server { listen 80; }")}, got)
+}
+
+func TestResolveManifestFilesResolvesANestedFile(t *testing.T) {
+	got, err := ResolveManifestFiles(secretManifest("files/tls/ca.pem"), chartFiles())
+	require.NoError(t, err)
+	require.Equal(t, map[string][]byte{"files/tls/ca.pem": []byte("-----BEGIN CERTIFICATE-----")}, got)
+}
+
+func TestResolveManifestFilesNormalisesTheKey(t *testing.T) {
+	// ./files/nginx.conf resolves to the same file the docker CLI would read, so
+	// it comes back under the key Chart.Files uses — the key the materialiser
+	// writes to.
+	got, err := ResolveManifestFiles(configManifest("./files/nginx.conf"), chartFiles())
+	require.NoError(t, err)
+	require.Equal(t, map[string][]byte{"files/nginx.conf": []byte("server { listen 80; }")}, got)
+}
+
+func TestResolveManifestFilesReturnsOnlyTheReferencedSubset(t *testing.T) {
+	manifest := "services:\n" +
+		"  web:\n    image: nginx\n    env_file: files/tls/ca.pem\n" +
+		"configs:\n  site:\n    file: files/nginx.conf\n"
+	got, err := ResolveManifestFiles(manifest, chartFiles())
+	require.NoError(t, err)
+	require.Equal(t, map[string][]byte{
+		"files/nginx.conf": []byte("server { listen 80; }"),
+		"files/tls/ca.pem": []byte("-----BEGIN CERTIFICATE-----"),
+	}, got)
+	require.NotContains(t, got, "files/unused.conf")
+}
+
+func TestResolveManifestFilesReturnsNilWhenNothingIsNamed(t *testing.T) {
+	cases := []struct {
+		name     string
+		manifest string
+	}{
+		{"no configs, secrets or env_file", "services:\n  web:\n    image: nginx\n"},
+		{"external config carries no file", "configs:\n  site:\n    external: true\n"},
+		{"driver-backed secret carries no file", "secrets:\n  s:\n    driver: vault\n"},
+		{"empty manifest", ""},
+		{"services entry is not a map", "services:\n  web: nginx\n"},
+		{"services block is a list", "services:\n  - web\n"},
+		{"configs entry is not a map", "configs:\n  site: true\n"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ResolveManifestFiles(tc.manifest, chartFiles())
+			require.NoError(t, err)
+			require.Nil(t, got, "a manifest naming no file must yield nil, not an empty map")
+		})
+	}
+}
+
+func TestResolveManifestFilesReadsBothEnvFileShapes(t *testing.T) {
+	t.Run("bare string", func(t *testing.T) {
+		got, err := ResolveManifestFiles(envFileManifest("files/nginx.conf"), chartFiles())
+		require.NoError(t, err)
+		require.Equal(t, map[string][]byte{"files/nginx.conf": []byte("server { listen 80; }")}, got)
+	})
+	t.Run("list", func(t *testing.T) {
+		manifest := "services:\n  web:\n    image: nginx\n    env_file:\n" +
+			"      - files/nginx.conf\n      - files/tls/ca.pem\n"
+		got, err := ResolveManifestFiles(manifest, chartFiles())
+		require.NoError(t, err)
+		require.Len(t, got, 2)
+		require.Contains(t, got, "files/nginx.conf")
+		require.Contains(t, got, "files/tls/ca.pem")
+	})
+	t.Run("a bad path anywhere in the list is refused", func(t *testing.T) {
+		manifest := "services:\n  web:\n    image: nginx\n    env_file:\n" +
+			"      - files/nginx.conf\n      - /etc/shadow\n"
+		_, err := ResolveManifestFiles(manifest, chartFiles())
+		require.ErrorContains(t, err, `"/etc/shadow"`)
+	})
+}
+
+// TestResolveManifestFilesSeesEntriesBesideAMalformedOne is the load-bearing
+// test for walking yaml.Nodes rather than map[string]any: a single non-string
+// key makes yaml.v3 hand back a map[any]any for the WHOLE mapping, so a type
+// assertion would see no services at all and let /etc/shadow through.
+func TestResolveManifestFilesSeesEntriesBesideAMalformedOne(t *testing.T) {
+	cases := []string{
+		"services:\n  1:\n    image: nginx\n  web:\n    env_file: /etc/shadow\n",
+		"services:\n  broken: nginx\n  web:\n    env_file: /etc/shadow\n",
+		"configs:\n  1:\n    external: true\n  site:\n    file: /etc/shadow\n",
+	}
+	for _, manifest := range cases {
+		_, err := ResolveManifestFiles(manifest, chartFiles())
+		require.ErrorContains(t, err, `"/etc/shadow"`, manifest)
+	}
+}
+
+func TestResolveManifestFilesRefusesAManifestItCannotParse(t *testing.T) {
+	_, err := ResolveManifestFiles("services:\n  web:\n   - :\n  bad\n", chartFiles())
+	require.ErrorContains(t, err, "parse manifest")
+}
+
+// TestResolveManifestFilesRefusesDeterministically pins the sort in
+// manifestFileRefs: without it, which of several bad paths is reported depends
+// on Go's map iteration order and the error text flakes.
+func TestResolveManifestFilesRefusesDeterministically(t *testing.T) {
+	manifest := "configs:\n" +
+		"  a:\n    file: /etc/shadow\n" +
+		"  b:\n    file: ../../etc/passwd\n" +
+		"  c:\n    file: nginx.conf\n"
+	first, err := ResolveManifestFiles(manifest, chartFiles())
+	require.Nil(t, first)
+	require.Error(t, err)
+	for range 20 {
+		_, again := ResolveManifestFiles(manifest, chartFiles())
+		require.EqualError(t, again, err.Error())
+	}
+	require.Contains(t, err.Error(), "configs.a.file")
+}
+
+func TestResolveManifestFilesRefusesAgainstAChartWithNoFiles(t *testing.T) {
+	_, err := ResolveManifestFiles(configManifest("files/nginx.conf"), nil)
+	require.ErrorContains(t, err, `"files/nginx.conf" is not in the chart`)
+}

--- a/charts/owner_test.go
+++ b/charts/owner_test.go
@@ -195,7 +195,7 @@ func TestUnchangedComparesTheOwner(t *testing.T) {
 		{"an unparseable stamp is healed", "not-a-stamp", "apply/a", false},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := unchanged(rel(tc.stamp), chart, nil, manifest, tc.owner)
+			got, err := unchanged(rel(tc.stamp), chart, nil, manifest, tc.owner, nil)
 			require.NoError(t, err)
 			require.Equal(t, tc.want, got)
 		})

--- a/charts/release.go
+++ b/charts/release.go
@@ -7,9 +7,12 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"io"
+	"maps"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -88,8 +91,7 @@ type DeployRequest struct {
 	// manifest is resolved, and must not let a path escape that root.
 	//
 	// Empty for a manifest that names none, which is every manifest a chart
-	// without a files/ directory can produce. Nothing populates this yet — see
-	// #528.
+	// without a files/ directory can produce.
 	Files map[string][]byte
 }
 
@@ -163,6 +165,15 @@ type InstallOptions struct {
 	// every external resource the manifest references must be declared in it. Nil
 	// falls back to manifest-driven pre-flight (auto-create attachable overlays).
 	Requirements *Requirements
+	// Files are the chart files the manifest references, already resolved
+	// against the chart by the caller that still had one (ResolveManifestFiles).
+	// They are recorded on the revision and handed to the deploy.
+	//
+	// Carried the same way Requirements is, and for the same reason: it is
+	// chart-derived data the engine needs, and the engine has no chart. Nil for
+	// a manifest that names no file — and nil on a rollback, which is not a
+	// gap: a rollback replays the files off the revision it is rolling back to.
+	Files map[string][]byte
 	// Owner claims the release for a manifest or controller, e.g.
 	// "apply/prod-swarm" or "cd/edge". It is recorded on every revision this
 	// call writes, as the id half of an OwnerRef naming the release.
@@ -190,7 +201,7 @@ func (e *Engine) Install(ctx context.Context, release string, chart ReleaseChart
 		return nil, fmt.Errorf("release %q already exists (revision %d); use upgrade", release, cur.Revision)
 	}
 
-	rel := e.newRevision(release, nextRevision(revs), chart, values, manifest)
+	rel := e.newRevision(release, nextRevision(revs), chart, values, manifest, opts.Files)
 	return e.deployAndRecord(ctx, rel, opts)
 }
 
@@ -211,7 +222,7 @@ func (e *Engine) Upgrade(ctx context.Context, release string, chart ReleaseChart
 			return nil, fmt.Errorf("release %q does not exist; use install or upgrade --install", release)
 		}
 	}
-	rel := e.newRevision(release, nextRevision(revs), chart, values, manifest)
+	rel := e.newRevision(release, nextRevision(revs), chart, values, manifest, opts.Files)
 	return e.deployAndRecord(ctx, rel, opts)
 }
 
@@ -238,7 +249,12 @@ func (e *Engine) Rollback(ctx context.Context, release string, targetRev int, op
 	if target.Status == StatusFailed {
 		return nil, fmt.Errorf("cannot roll back to failed revision %d", targetRev)
 	}
-	rel := e.newRevision(release, nextRevision(revs), target.Chart, target.Values, target.Manifest)
+	// target.Files, never opts.Files: a rollback is a replay, not a re-resolution.
+	// Nothing on this path has a chart — no ChartSource, no re-render, not even a
+	// filesystem — so the stored record is the only thing that knows what the
+	// manifest being replayed refers to, and deploying it without those bytes
+	// deploys a manifest naming files that are gone.
+	rel := e.newRevision(release, nextRevision(revs), target.Chart, target.Values, target.Manifest, target.Files)
 	return e.deployAndRecord(ctx, rel, opts)
 }
 
@@ -277,7 +293,11 @@ func (e *Engine) GetRevision(ctx context.Context, release string, rev int) (*Rel
 }
 
 // newRevision builds an unsaved, deployed-status revision.
-func (e *Engine) newRevision(release string, rev int, chart ReleaseChart, values map[string]any, manifest string) *Release {
+//
+// files travels with the manifest rather than beside it because the two are one
+// document: the manifest's file: keys are meaningless without the bytes they
+// name, and a revision recorded without them is one no rollback can replay.
+func (e *Engine) newRevision(release string, rev int, chart ReleaseChart, values map[string]any, manifest string, files map[string][]byte) *Release {
 	return &Release{
 		Name:      release,
 		Revision:  rev,
@@ -285,6 +305,7 @@ func (e *Engine) newRevision(release string, rev int, chart ReleaseChart, values
 		Chart:     chart,
 		Values:    values,
 		Manifest:  manifest,
+		Files:     files,
 		Namespace: release,
 		Created:   e.now().UTC().Format(time.RFC3339),
 	}
@@ -309,6 +330,17 @@ func (e *Engine) deployAndRecord(ctx context.Context, rel *Release, opts Install
 	if opts.DryRun {
 		return rel, nil
 	}
+	// Measure the record before anything is mutated. record() runs after the
+	// deploy, so an over-limit payload used to fail once the stack was already
+	// up — and a release with no record is invisible to list, history, status
+	// and rollback, which is worse than not deploying at all. The bytes are
+	// thrown away: storeRevision re-encodes per attempt because record() bumps
+	// the revision number on a collision, so this is an early refusal and
+	// storeRevision's own check remains the one that gates the write.
+	if _, err := encodeRevision(rel); err != nil {
+		rel.Status = StatusFailed
+		return rel, err
+	}
 	// Validate prerequisites that cannot be auto-created (external secrets and
 	// configs) before mutating any swarm state, so a missing one fails fast
 	// without leaving auto-created networks behind.
@@ -324,7 +356,12 @@ func (e *Engine) deployAndRecord(ctx context.Context, rel *Release, opts Install
 		}
 		return rel, err
 	}
-	if err := e.Backend.DeployStack(ctx, DeployRequest{Name: rel.Name, Manifest: rel.Manifest, Resolve: opts.ResolveImage}); err != nil {
+	// rel.Files rather than opts.Files: the revision is the one thing every entry
+	// point has already agreed on, and on a rollback it is the only one that
+	// carries files at all.
+	if err := e.Backend.DeployStack(ctx, DeployRequest{
+		Name: rel.Name, Manifest: rel.Manifest, Resolve: opts.ResolveImage, Files: rel.Files,
+	}); err != nil {
 		rel.Status = StatusFailed
 		// Roll back networks we auto-created for this install so a failed deploy
 		// leaves no trace; pre-existing networks are untouched.
@@ -791,18 +828,124 @@ func isAlreadyExists(err error) bool {
 	return err != nil && strings.Contains(err.Error(), "already exists")
 }
 
-// storeRevision writes a single release revision as a gzipped, labeled Config.
-func (e *Engine) storeRevision(ctx context.Context, rel *Release) error {
+// releaseFiles is Release.Files as it is stored: base64 in YAML, one string per
+// file, rather than what yaml.v3 does with a []byte left to itself.
+//
+// yaml.v3 has no special case for []byte. It sees a slice of integers and
+// writes a sequence node per byte — "files/a.conf:\n    - 104\n    - 101" —
+// which is roughly 13 characters of YAML for every byte of content, and gzip
+// only partly undoes it because what it then compresses is decimal digits
+// rather than the content's own redundancy. Measured through this exact path
+// (yaml.Marshal then gzipBytes) with 100 KiB of nginx-style config: 1,378,425
+// bytes of YAML and 18,365 gzipped, against 136,823 and 5,784 for base64 —
+// where gzipping the content on its own is 4,356. For incompressible content, a
+// certificate or a keyring, the integer sequence costs ~1.7x the raw size
+// gzipped (172,006 for 100 KiB) where base64 costs ~1.006x (103,090).
+//
+// That matters because the budget is not notional: the record is one Docker
+// Config, maxConfigPayload is measured after gzip, and a chart's files spend
+// that budget alongside the rendered manifest they belong to. Every byte the
+// encoding wastes is a byte of chart content that cannot ship.
+//
+// It is fixed here rather than later because this is a stored format. A record
+// written under one encoding has to be readable by whatever reads it next —
+// history, status, rollback — so changing it after releases exist in the field
+// means either a migration or a reader that understands both. There is no
+// version marker in the payload to hang that off.
+//
+// Nil and empty both marshal to nil, so `omitempty` still elides the key and a
+// release with no files stores exactly the bytes it stored before this type
+// existed; both decode back to nil, so a rollback of such a release deploys no
+// files rather than an empty map. encoding/json needs none of this — it already
+// encodes []byte as base64 — so Release's JSON shape is untouched.
+type releaseFiles map[string][]byte
+
+func (f releaseFiles) MarshalYAML() (any, error) {
+	if len(f) == 0 {
+		return nil, nil
+	}
+	out := make(map[string]string, len(f))
+	for name, body := range f {
+		out[name] = base64.StdEncoding.EncodeToString(body)
+	}
+	return out, nil
+}
+
+// UnmarshalYAML decodes the stored form, and refuses a value that is not
+// base64 instead of yielding empty content for it. Silence there would be the
+// worst possible failure: a corrupt record would read as "this release shipped
+// an empty file", and a rollback would deploy that emptiness over a config that
+// was fine.
+func (f *releaseFiles) UnmarshalYAML(value *yaml.Node) error {
+	var encoded map[string]string
+	if err := value.Decode(&encoded); err != nil {
+		return err
+	}
+	if len(encoded) == 0 {
+		*f = nil
+		return nil
+	}
+	out := make(releaseFiles, len(encoded))
+	for name, body := range encoded {
+		raw, err := base64.StdEncoding.DecodeString(body)
+		if err != nil {
+			return fmt.Errorf("release file %q: %w", name, err)
+		}
+		out[name] = raw
+	}
+	*f = out
+	return nil
+}
+
+// encodeRevision is the record exactly as it would be stored: marshalled,
+// gzipped, and refused if it does not fit a Docker Config.
+//
+// It is called twice per deploy on purpose — once by deployAndRecord before it
+// mutates anything, once by storeRevision for the write — because the two
+// answers can legitimately differ: record() bumps rel.Revision when a
+// concurrent actor claims the number, which changes the payload. Encoding once
+// and reusing the bytes would store a payload naming a revision the Config is
+// not.
+func encodeRevision(rel *Release) ([]byte, error) {
 	payload, err := yaml.Marshal(rel)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	gz, err := gzipBytes(payload)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	if len(gz) > maxConfigPayload {
-		return fmt.Errorf("release payload is %d bytes gzipped, exceeding the %d-byte Docker Config limit", len(gz), maxConfigPayload)
+		return nil, oversizeRecord(rel, len(gz))
+	}
+	return gz, nil
+}
+
+// oversizeRecord explains a release that will not fit its Config.
+//
+// It itemises the manifest and every file the manifest names, because gzipped
+// total is the one number an operator cannot act on: the budget is spent by
+// uncompressed content they choose, and until this refusal moved ahead of the
+// deploy nobody had to be told what to shrink — the stack was already up.
+func oversizeRecord(rel *Release, gz int) error {
+	var b strings.Builder
+	fmt.Fprintf(&b, "release %q revision %d cannot be recorded: its payload is %d bytes gzipped, exceeding the %d-byte Docker Config limit\n",
+		rel.Name, rel.Revision, gz, maxConfigPayload)
+	fmt.Fprintf(&b, "  manifest: %d bytes\n", len(rel.Manifest))
+	for _, name := range slices.Sorted(maps.Keys(rel.Files)) {
+		fmt.Fprintf(&b, "  %s: %d bytes\n", name, len(rel.Files[name]))
+	}
+	b.WriteString("shrink the manifest or the chart files it references (sizes shown uncompressed), " +
+		"or keep large content out of the chart: create it with docker config create / docker secret create " +
+		"and reference it with external: true")
+	return errors.New(b.String())
+}
+
+// storeRevision writes a single release revision as a gzipped, labeled Config.
+func (e *Engine) storeRevision(ctx context.Context, rel *Release) error {
+	gz, err := encodeRevision(rel)
+	if err != nil {
+		return err
 	}
 	labels := map[string]string{
 		LabelType:         TypeRelease,

--- a/charts/release_test.go
+++ b/charts/release_test.go
@@ -4,8 +4,15 @@
 package charts
 
 import (
+	"bytes"
+	"compress/gzip"
 	"context"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
 	"fmt"
+	"io"
+	"strconv"
 	"testing"
 	"time"
 
@@ -252,6 +259,216 @@ func TestInstallFailureDoesNotRecord(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 1, rel.Revision)
 	require.Equal(t, StatusDeployed, rel.Status)
+}
+
+// incompressible returns n bytes gzip cannot shrink, so a test can exceed a
+// limit measured after compression without depending on how well anything
+// compresses.
+func incompressible(t *testing.T, n int) []byte {
+	t.Helper()
+	b := make([]byte, n)
+	_, err := rand.Read(b)
+	require.NoError(t, err)
+	return b
+}
+
+// The record's size ceiling is checked before the deploy, not after it.
+//
+// It used to be reached only from record(), which runs once the stack is
+// already up — so an over-limit release deployed and then vanished: no Config
+// means no list, no history, no status and no rollback, and the engine that
+// made it cannot even uninstall it. Nothing had hit it while the budget was a
+// ~500 KiB gzipped manifest; a chart's files share that budget and a couple of
+// certificates reach it, which is what turns a latent defect into a live one.
+func TestAnOversizedRecordRefusesBeforeAnythingIsDeployed(t *testing.T) {
+	fb := newFakeBackend()
+	e := testEngine(fb)
+	// fb.deployed is the recorder: DeployStack is the only thing that writes it.
+	//
+	// More raw bytes than the limit, and incompressible, so the record is over
+	// budget however it happens to encode them — the assertion is about the
+	// check running early, not about a particular serialisation surviving.
+	files := map[string][]byte{"files/tls/ca.pem": incompressible(t, 520<<10)}
+
+	rel, err := e.Install(context.Background(), "demo", ReleaseChart{Name: "demo", Version: "1"},
+		nil, "services:\n  a:\n    image: x\n", InstallOptions{Files: files})
+	require.Error(t, err)
+	require.Empty(t, fb.deployed, "the stack must not be deployed when its record cannot be written")
+	require.Empty(t, fb.configs)
+	require.Equal(t, StatusFailed, rel.Status)
+
+	// The sizes, and the file that spends them: gzipped total alone names
+	// nothing the operator can shrink.
+	require.Contains(t, err.Error(), "Docker Config limit")
+	require.Contains(t, err.Error(), strconv.Itoa(maxConfigPayload))
+	require.Contains(t, err.Error(), "files/tls/ca.pem: 532480 bytes")
+	require.Contains(t, err.Error(), "external: true")
+}
+
+// The same release without the files fits, so the refusal above is about size
+// and not about carrying files at all.
+func TestARecordedRevisionCarriesItsFiles(t *testing.T) {
+	fb := newFakeBackend()
+	e := testEngine(fb)
+	files := map[string][]byte{"files/nginx.conf": []byte("server { listen 80; }")}
+
+	_, err := e.Install(context.Background(), "demo", ReleaseChart{Name: "demo", Version: "1"},
+		nil, "services:\n  a:\n    image: x\n", InstallOptions{Files: files})
+	require.NoError(t, err)
+	require.Equal(t, files, fb.lastDeploy.Files)
+
+	stored, err := decodeRelease(fb.configs[releaseConfigName("demo", 1)].data)
+	require.NoError(t, err)
+	// The conversion is require.Equal's, not the code's: Release.Files is the
+	// named releaseFiles so YAML stores base64, and reflect.DeepEqual compares
+	// types before contents.
+	require.Equal(t, files, map[string][]byte(stored.Files))
+}
+
+// storedYAML is the record as storeRevision wrote it, ungzipped: the exact
+// bytes the Docker Config holds, which is the only place the stored format is
+// visible.
+func storedYAML(t *testing.T, fb *fakeBackend, release string, rev int) string {
+	t.Helper()
+	r, err := gzip.NewReader(bytes.NewReader(fb.configs[releaseConfigName(release, rev)].data))
+	require.NoError(t, err)
+	raw, err := io.ReadAll(r)
+	require.NoError(t, err)
+	require.NoError(t, r.Close())
+	return string(raw)
+}
+
+// The stored form of Release.Files is base64, not yaml.v3's default for a
+// []byte — a sequence node holding one decimal integer per byte.
+//
+// The default is not merely ugly. It costs ~13 characters of YAML per byte of
+// content and, measured through this path, 18,365 gzipped bytes for 100 KiB of
+// config text where base64 costs 5,784; the record shares one ~500 KiB Docker
+// Config budget with the manifest, so the difference is chart content that
+// could not ship. See releaseFiles for the numbers and for why a stored format
+// is not free to change once releases exist in the field.
+func TestARecordedRevisionStoresItsFilesAsBase64(t *testing.T) {
+	fb := newFakeBackend()
+	e := testEngine(fb)
+	text := []byte("server { listen 80; }")
+	// Bytes no text encoding carries, so nothing can quietly degrade to a plain
+	// YAML string and still round-trip.
+	binary := []byte{0x00, 0xff, 0xfe, 0x01, 0x80, 0x0a, 0x7f}
+
+	rel := &Release{
+		Name: "demo", Revision: 1, Status: StatusDeployed,
+		Chart:    ReleaseChart{Name: "demo", Version: "1"},
+		Manifest: "services:\n  a:\n    image: x\n",
+		Files:    releaseFiles{"files/nginx.conf": text, "files/tls/ca.der": binary},
+	}
+	require.NoError(t, e.storeRevision(context.Background(), rel))
+
+	stored := storedYAML(t, fb, "demo", 1)
+	require.Contains(t, stored, base64.StdEncoding.EncodeToString(text))
+	require.Contains(t, stored, base64.StdEncoding.EncodeToString(binary))
+	// 115 is 's', the first element of the sequence yaml.v3 writes for the text
+	// above when the []byte is left to itself.
+	require.NotContains(t, stored, "- 115")
+	require.NotRegexp(t, `(?m)^\s+- \d+$`, stored, "no file may be stored as a sequence of decimal bytes")
+
+	back, err := decodeRelease(fb.configs[releaseConfigName("demo", 1)].data)
+	require.NoError(t, err)
+	require.Equal(t, map[string][]byte{"files/nginx.conf": text, "files/tls/ca.der": binary},
+		map[string][]byte(back.Files))
+}
+
+// A release with no files must store exactly what it stored before this
+// encoding existed: no files: key at all. The literal below was captured from
+// the code as it was before the change, so this is a byte-identical comparison
+// and not a restatement of what the encoder now happens to do.
+//
+// omitempty gets there for nil and for an empty map alike — yaml.v3 tests the
+// map's length before it ever calls MarshalYAML — and both must decode back to
+// nil, or a rollback of a fileless release would deploy an empty map where the
+// original deploy sent nothing.
+func TestAFilelessRecordIsUnchangedByTheFileEncoding(t *testing.T) {
+	const golden = `release: demo
+revision: 1
+status: deployed
+chart:
+    name: demo
+    version: 0.1.0
+values:
+    replicas: 2
+manifest: |
+    services:
+      web:
+        image: nginx
+created: "2023-11-14T22:13:20Z"
+namespace: demo
+owner: apply/prod:release/demo
+`
+	for _, tc := range []struct {
+		name  string
+		files releaseFiles
+	}{
+		{"nil", nil},
+		{"empty", releaseFiles{}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			fb := newFakeBackend()
+			e := testEngine(fb)
+			rel := &Release{
+				Name: "demo", Revision: 1, Status: StatusDeployed,
+				Chart:     ReleaseChart{Name: "demo", Version: "0.1.0"},
+				Values:    map[string]any{"replicas": 2},
+				Manifest:  "services:\n  web:\n    image: nginx\n",
+				Created:   "2023-11-14T22:13:20Z",
+				Namespace: "demo",
+				Owner:     "apply/prod:release/demo",
+				Files:     tc.files,
+			}
+			require.NoError(t, e.storeRevision(context.Background(), rel))
+			require.Equal(t, golden, storedYAML(t, fb, "demo", 1))
+
+			back, err := decodeRelease(fb.configs[releaseConfigName("demo", 1)].data)
+			require.NoError(t, err)
+			require.Nil(t, back.Files)
+		})
+	}
+}
+
+// A stored value that is not base64 must fail loudly, naming the file.
+//
+// Decoding it as empty content would be the worst outcome available: "this
+// release shipped an empty file" is something a record may legitimately say, so
+// nothing downstream could tell corruption from truth — and a rollback would
+// then deploy that emptiness over a config that was fine.
+func TestACorruptStoredFileNamesTheKeyRatherThanReadingAsEmpty(t *testing.T) {
+	gz, err := gzipBytes([]byte("release: demo\nrevision: 1\nfiles:\n    files/nginx.conf: \"not base64!\"\n"))
+	require.NoError(t, err)
+
+	_, err = decodeRelease(gz)
+	require.ErrorContains(t, err, "files/nginx.conf")
+	require.ErrorContains(t, err, "base64")
+}
+
+// encoding/json needs no equivalent of releaseFiles: it already encodes a
+// []byte as a base64 string, and a named map type is a plain map to it. So
+// Release's JSON shape is exactly what charts/json_test.go pins, which is why
+// that file stays green untouched.
+func TestReleaseFilesAreAlreadyBase64InJSON(t *testing.T) {
+	body := []byte("server { listen 80; }")
+	b, err := json.Marshal(Release{Name: "demo", Files: releaseFiles{"files/nginx.conf": body}})
+	require.NoError(t, err)
+
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(b, &got))
+	require.Equal(t, map[string]any{"files/nginx.conf": base64.StdEncoding.EncodeToString(body)}, got["files"])
+
+	var back Release
+	require.NoError(t, json.Unmarshal(b, &back))
+	require.Equal(t, map[string][]byte{"files/nginx.conf": body}, map[string][]byte(back.Files))
+
+	// Absent rather than null when there are none, like every other optional key.
+	b, err = json.Marshal(Release{Name: "demo"})
+	require.NoError(t, err)
+	require.NotContains(t, string(b), "files")
 }
 
 const extNetManifest = "version: \"3.9\"\n" +

--- a/charts/types.go
+++ b/charts/types.go
@@ -171,6 +171,23 @@ type Release struct {
 	// release nothing claimed — an imperative install, or an apply from a file
 	// declaring no owner — and an unowned release is never a prune candidate.
 	Owner string `yaml:"owner,omitempty" json:"owner,omitempty"`
+	// Files are the chart files this revision's manifest references, keyed by
+	// their chart-relative path, so that a rollback deploys what the original
+	// deploy did. Rollback has no chart in scope — it replays a stored manifest,
+	// with no ChartSource, no re-render and no filesystem — so anything not here
+	// is gone, and the manifest it replays names files that do not exist.
+	//
+	// The referenced subset, not the chart's whole files/ tree: this record is a
+	// Docker Config with a hard size ceiling it shares with the manifest, so an
+	// asset the manifest never names must not spend it. Absent for a manifest
+	// naming none, which is every manifest a chart without a files/ directory
+	// can produce, and for records written before this field existed.
+	//
+	// releaseFiles, not a bare map[string][]byte, only so that YAML stores the
+	// bytes as base64 rather than as a sequence of decimal integers — see its
+	// doc comment. The two types are assignable both ways, so nothing that
+	// produces or consumes a file set has to know about it.
+	Files releaseFiles `yaml:"files,omitempty" json:"files,omitempty"`
 }
 
 // ReleaseChart is the chart reference recorded in a Release.

--- a/charts/upgrade_test.go
+++ b/charts/upgrade_test.go
@@ -64,6 +64,74 @@ func TestRollbackCopiesTargetRevision(t *testing.T) {
 	require.Equal(t, 3, cur.Revision)
 }
 
+// TestRollbackReplaysTheFilesTheOriginalDeploySent is the end-to-end test for
+// the file chain, and the only one that crosses all six of its links:
+// InstallOptions.Files -> Release.Files -> storeRevision's gzip -> decodeRelease
+// -> newRevision on the rollback path -> DeployRequest.Files.
+//
+// It has to be end to end because every link fails the same silent way. A drop
+// anywhere yields an empty map, and an empty map is exactly what a chart with no
+// files/ directory legitimately produces — so nothing downstream can tell the
+// two apart, and a test of any single link passes while the chain is severed.
+//
+// Rollback is where it matters: it holds no chart, no ChartSource and no
+// filesystem, so unless the bytes came back out of the stored record there is
+// nowhere else they could have come from.
+func TestRollbackReplaysTheFilesTheOriginalDeploySent(t *testing.T) {
+	fb := newFakeBackend()
+	e := testEngine(fb)
+	ctx := context.Background()
+	const manifest = "services:\n  web:\n    image: nginx\nconfigs:\n  site:\n    file: files/nginx.conf\n"
+
+	v1 := map[string][]byte{"files/nginx.conf": []byte("server { listen 80; }")}
+	v2 := map[string][]byte{"files/nginx.conf": []byte("server { listen 8080; }")}
+
+	_, err := e.Install(ctx, "demo", ReleaseChart{Name: "c", Version: "1"}, nil, manifest, InstallOptions{Files: v1})
+	require.NoError(t, err)
+	require.Equal(t, v1, fb.lastDeploy.Files)
+
+	// The manifest is unchanged between the revisions, so only the files can
+	// distinguish what rev 3 deploys from what rev 2 did.
+	_, err = e.Upgrade(ctx, "demo", ReleaseChart{Name: "c", Version: "2"}, nil, manifest, InstallOptions{Files: v2})
+	require.NoError(t, err)
+	require.Equal(t, v2, fb.lastDeploy.Files)
+
+	// No Files in the options: whatever rev 3 deploys, it read off rev 1.
+	rb, err := e.Rollback(ctx, "demo", 1, InstallOptions{})
+	require.NoError(t, err)
+	require.Equal(t, 3, rb.Revision)
+	require.Equal(t, v1, fb.lastDeploy.Files, "a rollback must deploy the bytes the revision it replays deployed")
+	require.Equal(t, v1, map[string][]byte(rb.Files), "and record them, so rolling back to the rollback replays them too")
+
+	// Through the whole store/decode round trip once more, from the record
+	// rather than from the value Rollback returned.
+	stored, err := e.GetRevision(ctx, "demo", 3)
+	require.NoError(t, err)
+	require.Equal(t, v1, map[string][]byte(stored.Files))
+}
+
+// A chart with no files/ directory must keep behaving exactly as it did before
+// any of this existed: nothing recorded, nothing deployed, and nil rather than
+// an empty map at every step — the round trip through YAML and gzip is where a
+// nil would otherwise come back as something else.
+func TestRollbackOfAReleaseWithoutFilesCarriesNone(t *testing.T) {
+	fb := newFakeBackend()
+	e := testEngine(fb)
+	ctx := context.Background()
+	mustInstall(t, e, "demo", "services:\n  s:\n    image: v1\n")
+	_, err := e.Upgrade(ctx, "demo", ReleaseChart{Name: "c", Version: "2"}, nil, "services:\n  s:\n    image: v2\n", InstallOptions{})
+	require.NoError(t, err)
+
+	rb, err := e.Rollback(ctx, "demo", 1, InstallOptions{})
+	require.NoError(t, err)
+	require.Nil(t, rb.Files)
+	require.Nil(t, fb.lastDeploy.Files)
+
+	stored, err := e.GetRevision(ctx, "demo", 1)
+	require.NoError(t, err)
+	require.Nil(t, stored.Files)
+}
+
 func TestRollbackUnknownRevision(t *testing.T) {
 	e := testEngine(newFakeBackend())
 	ctx := context.Background()

--- a/cli/charts.go
+++ b/cli/charts.go
@@ -409,7 +409,7 @@ func chartsTemplate(args []string) int {
 		return usageErr("charts template <release> <repo/chart>")
 	}
 	release, ref := pos[0], pos[1]
-	manifest, _, _, req, code := prepare(release, ref, f, nil, compatWarn)
+	manifest, _, _, req, _, code := prepare(release, ref, f, nil, compatWarn)
 	if code >= 0 {
 		return code
 	}
@@ -440,7 +440,7 @@ func chartsInstall(args []string) int {
 		return usageErr("charts install <release> <repo/chart>")
 	}
 	release, ref := pos[0], pos[1]
-	manifest, values, rc, req, code := prepare(release, ref, f, nil, compatEnforce)
+	manifest, values, rc, req, chartFiles, code := prepare(release, ref, f, nil, compatEnforce)
 	if code >= 0 {
 		return code
 	}
@@ -450,6 +450,7 @@ func chartsInstall(args []string) int {
 		Timeout:      f.timeout,
 		HistoryMax:   f.historyMax,
 		Requirements: req,
+		Files:        chartFiles,
 		ResolveImage: f.resolveImage,
 	})
 	if err != nil {
@@ -481,7 +482,7 @@ func chartsUpgrade(args []string) int {
 			// re-validates the release, so a genuine backend error still surfaces.
 		}
 	}
-	manifest, values, rc, req, code := prepare(release, ref, f, base, compatEnforce)
+	manifest, values, rc, req, chartFiles, code := prepare(release, ref, f, base, compatEnforce)
 	if code >= 0 {
 		return code
 	}
@@ -492,6 +493,7 @@ func chartsUpgrade(args []string) int {
 		Timeout:      f.timeout,
 		HistoryMax:   f.historyMax,
 		Requirements: req,
+		Files:        chartFiles,
 		ResolveImage: f.resolveImage,
 	})
 	if err != nil {
@@ -657,7 +659,7 @@ func chartsDiff(args []string) int {
 	if f.reuseValues {
 		base = cur.Values
 	}
-	next, _, _, _, code := prepare(release, ref, f, base, compatWarn)
+	next, _, _, _, _, code := prepare(release, ref, f, base, compatWarn)
 	if code >= 0 {
 		return code
 	}
@@ -672,30 +674,37 @@ func chartsDiff(args []string) int {
 // prepare loads the chart, merges + validates values, and renders the manifest.
 // base, when non-nil, replaces the chart defaults as the merge base (used by
 // `upgrade --reuse-values` to layer overrides over the previous release).
-func prepare(release, ref string, f flags, base map[string]any, pol compatPolicy) (manifest string, values map[string]any, rc charts.ReleaseChart, req *charts.Requirements, code int) {
+//
+// chartFiles are the chart files the rendered manifest's file:/env_file: keys
+// name. They are resolved here because this is one of only two places a *Chart
+// and a rendered manifest coexist — the chart is gone by the time any of this
+// returns — and every command routed through prepare wants the same answer:
+// template and diff show a manifest that could actually be deployed, install
+// and upgrade deploy it.
+func prepare(release, ref string, f flags, base map[string]any, pol compatPolicy) (manifest string, values map[string]any, rc charts.ReleaseChart, req *charts.Requirements, chartFiles map[string][]byte, code int) {
 	ch, _, c := loadChart(ref, f.version)
 	if c >= 0 {
-		return "", nil, rc, nil, c
+		return "", nil, rc, nil, nil, c
 	}
 	// Before rendering, not after: a chart that needs a newer engine would
 	// otherwise fail somewhere inside Render, and "function X not defined" is a
 	// far worse answer than naming the version it wants.
 	if c := applyCompat(charts.CheckCompat(ch.Metadata), pol, f.skipCompatCheck); c >= 0 {
-		return "", nil, rc, nil, c
+		return "", nil, rc, nil, nil, c
 	}
 	if base == nil {
 		base = ch.Values
 	}
 	files, err := readValuesFiles(f.values)
 	if err != nil {
-		return "", nil, rc, nil, fail(err)
+		return "", nil, rc, nil, nil, fail(err)
 	}
 	values, err = charts.MergeValues(base, files, f.sets)
 	if err != nil {
-		return "", nil, rc, nil, fail(err)
+		return "", nil, rc, nil, nil, fail(err)
 	}
 	if err := charts.ValidateValues(ch.Schema, values); err != nil {
-		return "", nil, rc, nil, fail(err)
+		return "", nil, rc, nil, nil, fail(err)
 	}
 	ctx := charts.RenderContext{
 		Values:  values,
@@ -704,17 +713,24 @@ func prepare(release, ref string, f flags, base map[string]any, pol compatPolicy
 	}
 	manifest, err = charts.Render(ch, ctx)
 	if err != nil {
-		return "", nil, rc, nil, fail(err)
+		return "", nil, rc, nil, nil, fail(err)
 	}
 	// requirements.yaml is rendered with the same values as the manifest, so an
 	// operator-chosen network/secret name (e.g. database.network) is validated
 	// against the name the manifest actually references.
 	req, err = charts.RenderRequirements(ch, ctx)
 	if err != nil {
-		return "", nil, rc, nil, fail(err)
+		return "", nil, rc, nil, nil, fail(err)
+	}
+	// fail() prints the error and nothing else: a path a chart may not read is a
+	// breaking change with no compatibility flag behind it, so this message is
+	// the whole of the migration path and must reach the operator verbatim.
+	chartFiles, err = charts.ResolveManifestFiles(manifest, ch.Files)
+	if err != nil {
+		return "", nil, rc, nil, nil, fail(err)
 	}
 	rc = charts.ReleaseChart{Name: ch.Metadata.Name, Version: ch.Metadata.Version, AppVersion: ch.Metadata.AppVersion}
-	return manifest, values, rc, req, -1
+	return manifest, values, rc, req, chartFiles, -1
 }
 
 // --- uninstall / list / status ---

--- a/cli/charts_test.go
+++ b/cli/charts_test.go
@@ -112,6 +112,64 @@ func TestChartsShowValuesPreservesComments(t *testing.T) {
 	require.Equal(t, raw, o)
 }
 
+// fileChartDir writes a chart whose single template gives a config its content
+// with file: ref, plus one file under files/ for a well-formed ref to name.
+func fileChartDir(t *testing.T, ref string) string {
+	t.Helper()
+	dir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "templates"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "files"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "Chart.yaml"),
+		[]byte("name: demo\nversion: 1.0.0\nswarmcliVersion: \">= 1.13.0\"\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "templates", "stack.yaml"),
+		[]byte("services:\n  web:\n    image: nginx\nconfigs:\n  site:\n    file: "+ref+"\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "files", "nginx.conf"),
+		[]byte("server { listen 80; }"), 0o644))
+	return dir
+}
+
+// prepare is the second of the two places a *Chart and a rendered manifest
+// coexist, and it backs template, diff, install and upgrade alike — so a path
+// the chart may not read is refused on all four, at the earliest point an author
+// or an operator can see it. There is no compatibility flag behind this refusal,
+// so the message it prints IS the migration path and has to survive to stderr
+// whole: the path, the rule, and the operator-managed replacement.
+func TestChartsTemplateRefusesAPathOutsideTheChart(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		ref   string
+		wants []string
+	}{
+		{"absolute", "/etc/shadow", []string{`"/etc/shadow"`, "absolute path", "external: true", "docker config create"}},
+		{"escapes the chart", "../../etc/shadow", []string{`"../../etc/shadow"`, "escapes the chart"}},
+		{"outside files/", "nginx.conf", []string{`"nginx.conf"`, "outside files/", `"files/nginx.conf"`}},
+		{"not in the chart", "files/missing.conf", []string{`"files/missing.conf"`, "not in the chart"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := fileChartDir(t, tc.ref)
+			var code int
+			o, errOut := capture(t, func() {
+				code = Dispatch([]string{"charts", "template", "site", dir}, "dev")
+			})
+			require.Equal(t, 1, code)
+			require.Empty(t, o, "a manifest that cannot be deployed must not be printed as if it could")
+			for _, want := range tc.wants {
+				require.Contains(t, errOut, want)
+			}
+		})
+	}
+}
+
+// And the shape the refusals exist to permit still renders.
+func TestChartsTemplateAcceptsAFileTheChartShips(t *testing.T) {
+	var code int
+	o, errOut := capture(t, func() {
+		code = Dispatch([]string{"charts", "template", "site", fileChartDir(t, "files/nginx.conf")}, "dev")
+	})
+	require.Equal(t, 0, code, errOut)
+	require.Contains(t, o, "file: files/nginx.conf")
+}
+
 func TestParseArgs(t *testing.T) {
 	pos, f, err := parseArgs([]string{"rel", "repo/chart", "-f", "a.yaml", "--values", "b.yaml", "--set", "x=1", "--dry-run", "--timeout", "10m"})
 	require.NoError(t, err)

--- a/docker/explicit_context_test.go
+++ b/docker/explicit_context_test.go
@@ -19,7 +19,7 @@ func TestExplicitContextRejectsEmptyName(t *testing.T) {
 	_, err := ClientFor("")
 	require.ErrorContains(t, err, "docker context name is required")
 
-	require.ErrorContains(t, DeployStackInContext(context.Background(), "", "web", "services: {}\n", ResolveImageDefault),
+	require.ErrorContains(t, DeployStackInContext(context.Background(), "", "web", "services: {}\n", ResolveImageDefault, nil),
 		"docker context name is required")
 	require.ErrorContains(t, RemoveStackCLIInContext(context.Background(), "", "web"),
 		"docker context name is required")

--- a/docker/stack_deploy.go
+++ b/docker/stack_deploy.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -94,7 +95,9 @@ func DeployStackResolved(ctx context.Context, stackName string, yamlContent stri
 	if err != nil {
 		return fmt.Errorf("failed to get docker context: %w", err)
 	}
-	return DeployStackInContext(ctx, ctxName, stackName, yamlContent, resolve)
+	// nil files: the TUI's raw-editor path deploys a document the operator typed,
+	// with no chart behind it to resolve a file: against.
+	return DeployStackInContext(ctx, ctxName, stackName, yamlContent, resolve, nil)
 }
 
 // DeployStackInContext deploys a stack to an explicitly named Docker context.
@@ -107,7 +110,11 @@ func DeployStackResolved(ctx context.Context, stackName string, yamlContent stri
 // Cancelling ctx kills the child. Nothing else can reach it: the CLI holds its
 // own connection to the daemon, so a caller being torn down while the daemon is
 // unresponsive would otherwise sit on a `docker stack deploy` that never returns.
-func DeployStackInContext(ctx context.Context, ctxName, stackName, yamlContent string, resolve ResolveImage) error {
+//
+// files are the chart files the manifest's file: and env_file: keys name, keyed
+// by their slash-separated chart-relative path; they are written beside the
+// manifest so those keys resolve to them. nil for a manifest that names none.
+func DeployStackInContext(ctx context.Context, ctxName, stackName, yamlContent string, resolve ResolveImage, files map[string][]byte) error {
 	if ctxName == "" {
 		return fmt.Errorf("docker context name is required")
 	}
@@ -123,26 +130,17 @@ func DeployStackInContext(ctx context.Context, ctxName, stackName, yamlContent s
 		return fmt.Errorf("stack name cannot be empty")
 	}
 
-	// Create temporary file with the YAML content
-	tmpFile, err := os.CreateTemp("", "swarmcli-stack-*.yml")
+	// Write the manifest and the chart's files into one temporary directory
+	dir, manifestPath, err := writeStackTree(files, yamlContent)
 	if err != nil {
-		return fmt.Errorf("failed to create temporary file: %w", err)
+		return err
 	}
 	defer func() {
-		_ = os.Remove(tmpFile.Name())
+		_ = os.RemoveAll(dir)
 	}()
 
-	// Write YAML content to temp file
-	if _, err := tmpFile.WriteString(yamlContent); err != nil {
-		_ = tmpFile.Close()
-		return fmt.Errorf("failed to write YAML to temporary file: %w", err)
-	}
-	if err := tmpFile.Close(); err != nil {
-		return fmt.Errorf("failed to close temporary file: %w", err)
-	}
-
 	// Execute docker stack deploy command
-	args := []string{"--context", ctxName, "stack", "deploy", "-c", tmpFile.Name()}
+	args := []string{"--context", ctxName, "stack", "deploy", "-c", manifestPath}
 	if resolve != ResolveImageDefault {
 		args = append(args, "--resolve-image", string(resolve))
 	}
@@ -171,6 +169,65 @@ func DeployStackInContext(ctx context.Context, ctxName, stackName, yamlContent s
 
 	l().Infof("Stack %q deployed successfully", stackName)
 	return nil
+}
+
+// writeStackTree materialises one deploy into a fresh temporary directory: the
+// compose document at <dir>/stack.yml, and every entry of files at its
+// chart-relative path beneath it. It returns the directory and the manifest's
+// path; the caller removes the directory. Nothing is left behind on error.
+//
+// A directory rather than the single temp file this used to be, because
+// `docker stack deploy -c <path>` makes filepath.Dir(<path>) the compose working
+// directory and resolves every file: and env_file: against it, reading them
+// client-side before anything reaches the daemon. With a bare temp file that
+// made `file: ./nginx.conf` mean $TMPDIR/nginx.conf; putting the chart's files
+// in the same directory, at the paths the manifest uses, is what makes those
+// keys mean the chart.
+func writeStackTree(files map[string][]byte, manifest string) (dir string, manifestPath string, err error) {
+	// MkdirTemp creates it 0o700, which is what this wants: the content passing
+	// through here is on its way into a swarm config and is written as the
+	// operator, so no other local user should be able to read it — or, worse,
+	// swap it out between the write and the `docker` process reading it.
+	dir, err = os.MkdirTemp("", "swarmcli-stack-*")
+	if err != nil {
+		return "", "", fmt.Errorf("failed to create temporary directory: %w", err)
+	}
+	// A failure below leaves a partial tree, and the caller never learns its path
+	// because it only gets a directory back on success, so clean it up here.
+	defer func() {
+		if err != nil {
+			_ = os.RemoveAll(dir)
+			dir, manifestPath = "", ""
+		}
+	}()
+
+	for name, data := range files {
+		// Re-check containment even though the caller resolved these keys
+		// against the chart. They are chart-authored, and what a bad one buys is
+		// a write outside the temporary directory as the operator.
+		rel := filepath.FromSlash(name)
+		path := filepath.Join(dir, rel)
+		if filepath.IsAbs(rel) || !strings.HasPrefix(path, dir+string(os.PathSeparator)) {
+			err = fmt.Errorf("refusing chart file %q: it resolves outside the stack directory", name)
+			return
+		}
+		if err = os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+			err = fmt.Errorf("failed to create directory for chart file %q: %w", name, err)
+			return
+		}
+		if err = os.WriteFile(path, data, 0o600); err != nil {
+			err = fmt.Errorf("failed to write chart file %q: %w", name, err)
+			return
+		}
+	}
+
+	// Last, so no chart file can displace the manifest.
+	manifestPath = filepath.Join(dir, "stack.yml")
+	if err = os.WriteFile(manifestPath, []byte(manifest), 0o600); err != nil {
+		err = fmt.Errorf("failed to write stack manifest: %w", err)
+		return
+	}
+	return dir, manifestPath, nil
 }
 
 // RemoveStackCLI tears down a stack via `docker stack rm`, the symmetric

--- a/docker/stack_deploy_test.go
+++ b/docker/stack_deploy_test.go
@@ -5,6 +5,8 @@ package docker
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -19,8 +21,103 @@ func TestStackCommandsReportCancellation(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	err := DeployStackInContext(ctx, "no-such-context", "web", "services:\n  a:\n    image: x\n", ResolveImageDefault)
+	err := DeployStackInContext(ctx, "no-such-context", "web", "services:\n  a:\n    image: x\n", ResolveImageDefault, nil)
 	require.ErrorIs(t, err, context.Canceled)
 
 	require.ErrorIs(t, RemoveStackCLIInContext(ctx, "no-such-context", "web"), context.Canceled)
+}
+
+const testManifest = "services:\n  a:\n    image: x\n"
+
+// The layout is the feature: the docker CLI resolves a manifest's file: keys
+// against the directory it was handed, so a chart file has to land at exactly
+// the relative path the manifest names, parents and all.
+func TestWriteStackTreeLaysTheChartOutBesideTheManifest(t *testing.T) {
+	dir, manifestPath, err := writeStackTree(map[string][]byte{
+		"files/nginx.conf": []byte("server {}"),
+		"files/tls/ca.pem": []byte("-----BEGIN-----"),
+	}, testManifest)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+
+	require.Equal(t, filepath.Join(dir, "stack.yml"), manifestPath)
+	requireFile(t, manifestPath, testManifest)
+	requireFile(t, filepath.Join(dir, "files", "nginx.conf"), "server {}")
+	requireFile(t, filepath.Join(dir, "files", "tls", "ca.pem"), "-----BEGIN-----")
+
+	requireMode(t, dir, 0o700)
+	requireMode(t, filepath.Join(dir, "files"), 0o700)
+	requireMode(t, filepath.Join(dir, "files", "tls"), 0o700)
+
+	// And the tree is the unit of cleanup: one call has to take all of it.
+	require.NoError(t, os.RemoveAll(dir))
+	require.NoDirExists(t, dir)
+}
+
+// A manifest naming no files still needs somewhere to be, and nothing else may
+// appear beside it — every chart without a files/ directory takes this path.
+func TestWriteStackTreeWithNoFilesWritesOnlyTheManifest(t *testing.T) {
+	for _, files := range []map[string][]byte{nil, {}} {
+		dir, manifestPath, err := writeStackTree(files, testManifest)
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = os.RemoveAll(dir) })
+
+		requireFile(t, manifestPath, testManifest)
+		entries, err := os.ReadDir(dir)
+		require.NoError(t, err)
+		require.Len(t, entries, 1)
+		require.Equal(t, "stack.yml", entries[0].Name())
+	}
+}
+
+// The caller resolved these keys against the chart already. This is the second
+// check, on the only code that acts on them: a key that escapes here is a write
+// outside a temporary directory as the operator, so it is refused by name and
+// the half-built tree goes with it.
+func TestWriteStackTreeRefusesAKeyThatEscapes(t *testing.T) {
+	for name, key := range map[string]string{
+		"absolute":     "/etc/cron.d/pwn",
+		"parent":       "../../etc/cron.d/pwn",
+		"parent below": "files/../../../etc/cron.d/pwn",
+	} {
+		t.Run(name, func(t *testing.T) {
+			dir, manifestPath, err := writeStackTree(map[string][]byte{key: []byte("x")}, testManifest)
+			require.ErrorContains(t, err, key)
+			require.Empty(t, dir)
+			require.Empty(t, manifestPath)
+		})
+	}
+}
+
+// A failed deploy must take the whole tree with it, not just the manifest the
+// old temp-file version knew about — otherwise every failure leaks a chart's
+// files, readable to nobody but still there.
+func TestDeployStackRemovesTheWholeTree(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("TMPDIR", tmp)
+
+	// No networks: key, so the failure path does not go looking for orphaned
+	// networks to clean up through a daemon this test has no business reaching.
+	err := DeployStackInContext(context.Background(), "no-such-context", "web", testManifest,
+		ResolveImageDefault, map[string][]byte{"files/nginx.conf": []byte("server {}")})
+	require.Error(t, err)
+
+	entries, err := os.ReadDir(tmp)
+	require.NoError(t, err)
+	require.Empty(t, entries)
+}
+
+func requireFile(t *testing.T, path, want string) {
+	t.Helper()
+	got, err := os.ReadFile(path)
+	require.NoError(t, err)
+	require.Equal(t, want, string(got))
+	requireMode(t, path, 0o600)
+}
+
+func requireMode(t *testing.T, path string, want os.FileMode) {
+	t.Helper()
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	require.Equal(t, want, info.Mode().Perm(), "%s", path)
 }


### PR DESCRIPTION
PR 4 of 4, closing #528. Both halves of the same change: the capability a chart was missing, and the hole that made the old behaviour unsafe.

## The defect this closes

**CE never inspected a compose `file:` at all.** A grep for `"file"` and `env_file` across `charts/`, `docker/` and `cli/` returned nothing outside tests.

The manifest is written to `os.CreateTemp("", "swarmcli-stack-*.yml")` and handed to `docker stack deploy -c`. The docker CLI then sets `WorkingDir` to **that temp file's directory** (`cli/command/stack/loader/loader.go:109`), resolves every path key against it (`cli/compose/loader/loader.go:674` and `:469`; an absolute path passes through unchanged) and reads it **client-side, as the invoking user** (`cli/compose/convert/compose.go:180`) before anything reaches the daemon.

So today:
- `file: ./nginx.conf` reads `$TMPDIR/nginx.conf` — a directory any local user can plant a file in, against a name predictable enough (`swarmcli-stack-*.yml`) to know when to try. The content becomes a swarm config.
- `file: /etc/shadow`, or any path the operator can read, is read and stored in a Docker config that anyone with Docker access can read. `charts/README.md` already records that the manifest beside it is unredacted (#465).

It is swarmcli-cd#99 one privilege level down. The mitigating difference is real — there an unattended controller holding the Docker socket read `/run/secrets/swarmcli-cd-token` on its own, here an operator runs the install — but a chart may come from a repository nobody vetted, which is why `charts/render.go` already deletes `env`, `expandenv` and `getHostByName` from sprig.

## The guard

`ResolveManifestFiles` walks the parsed manifest and refuses, in order: **absolute**, **escapes the chart**, **not in the chart** (including anything outside `files/`). Three keys read a path — `configs.*.file`, `secrets.*.file`, `services.*.env_file` — and each has all four refusals tested. Covering one would prove nothing about the other two; #99 *was* one key.

**It reads the manifest as `map[string]yaml.Node`, not `map[string]any`, and that is load-bearing rather than taste.** One non-string key anywhere in a mapping makes yaml.v3 return the *whole* mapping as `map[interface{}]interface{}`, so `doc["configs"].(map[string]any)` yields `ok=false, len=0` — every sibling entry, including `file: /etc/shadow`, becomes invisible and the guard reports nothing wrong. Docker does not save you: `convertToStringKeysRecursive` normalises the key and deploys the entry. There is a test pinning it.

`env_file` is compose's one string-or-list key; both shapes are walked, item by item, so one item of the wrong type does not lose the rest.

## Absolute is refused for every chart — and that is the breaking change

The trust distinction between a local-path chart and a repository chart was considered and rejected: vendoring a repository chart to disk would silently convert it from the refused case to the permitted one, granting the most privilege to the workflow that most obscures a chart's origin.

That breaks **one** working shape: an operator's own chart naming a path on their own machine. Nothing else, because a relative path has never resolved to anything an author intended. So the error message is the entire migration path, and it names the path, says a chart may only read its own `files/`, and names `docker config create` plus `external: true` as the replacement — the same answer #99 gives.

## Making it work

The deploy writes a temp **directory** rather than a temp file: the manifest at `<dir>/stack.yml`, each referenced file at its chart-relative path, `0o700`/`0o600`, whole tree removed on exit. `-c <dir>/stack.yml` makes the CLI's `WorkingDir` that directory, so `file: files/nginx.conf` resolves to the chart's own bytes.

Containment is re-checked when writing. `filepath.Join(dir, "/etc/x")` **cleans to `dir/etc/x`** and passes a prefix test, so refusing `filepath.IsAbs` separately is what actually closes it. The tree-builder is split out so it is unit-testable, leaving only the exec uncovered as before.

## Rollback, and why the files are stored

`Rollback` replays a stored manifest with **no chart in scope** — no `ChartSource`, no re-render, no filesystem. So the referenced files live on the `Release` and are carried through `newRevision` from the revision being replayed.

Six links, every one of which fails **silently**, because an empty map is exactly what a chart without files legitimately has. The test that matters upgrades between two **byte-identical manifests**, so only the file bytes can distinguish the revisions; reverting `target.Files` to `nil` fails it.

**Stored as base64, and that mattered more than expected.** yaml.v3 has no `[]byte` case — it writes one decimal integer per byte. Measured through the real record path, 100 KiB of config text was **1.38 MB of YAML and 18,365 bytes gzipped**; it is now 5,784. The record is one Docker config with a hard ~500 KiB ceiling *shared with the manifest*, so that was chart content that could not ship — and it is a stored format with no version marker, so this was the last cheap moment to choose the encoding.

## Two defects fixed on the way, both found in review

**The record's size check ran after the deploy.** `storeRevision` marshals, gzips and only then checks `maxConfigPayload` — from `record`, *after* `DeployStack`. An over-limit release was deployed and then invisible to `list`/`history`/`status`/`rollback`. Adding files made it reachable rather than theoretical, so it now refuses before deploying anything, naming the manifest and every file with its size. The encode happens twice on purpose: `record` retries with a bumped revision number, so reusing the bytes would write a payload naming the wrong revision.

**Change detection ignored the files.** `unchanged()` compared chart version, manifest, owner and values — so editing `files/nginx.conf` without bumping the version planned as `ActionUnchanged` and the new bytes never deployed. That is exactly the local-development loop, where the feature would have looked broken on first contact. `Requirements` deliberately stays out, and says so where it would be added. A README row documenting the old behaviour was wrong and is corrected.

## Load-bearing

Each reverted, the named test observed to fail, restored: `target.Files` → the rollback test; the early size check → the deploy-nothing test; the `ResolveManifestFiles` call in `planRelease` → the refusal tests; the `maps.EqualFunc` guard → `TestPlanApplyDetectsAFilesOnlyChange` plus four `unchanged` subtests; the base64 codec → the stored-shape test, which then sees `- 115` sequences.

Honest note from that last one: with the codec removed, the round-trip tests **still passed** — the encoding is only guarded by the new tests, because both formats decode correctly.

## Out of scope, and worth its own issue

`services.<n>.volumes[].source` for a bind mount **is** resolved against `WorkingDir` (`loader.go:504`, `~` expanded at `:496`) and **is** used by `docker stack deploy`. It is not read client-side — the rewritten absolute path is shipped to the daemon as `mount.Mount.Source` — so it is outside what this guard is about, but it means `volumes: ["./data:/data"]` is rewritten to a host path under the system temp directory and pushed to every swarm node. This PR **relocates** that rather than fixing it. Ruled out by inspection: `build.*` (unsupported for swarm), `credential_spec.file` (daemon-side), `driver_opts.device`, `extends` (forbidden). `absPath` has exactly three call sites in docker/cli and `os.ReadFile` one, so the surface is closed.

## Gate

`gofmt`, `go build ./...`, `go vet ./...`, `go vet -tags integration ./...`, `go test ./... -race`, `golangci-lint run ./... --build-tags=integration` (0 issues). `charts/json_test.go` passes **untouched**.

Closes #528

🤖 Generated with [Claude Code](https://claude.com/claude-code)