### PR TITLE
fix(dialogs): a path containing "f" can be typed again

### DIFF
--- a/ui/dialog/keys.go
+++ b/ui/dialog/keys.go
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package dialog
+
+// Shared dialog keys used across views, so a handler and the help text that
+// advertises it cannot drift apart.
+const (
+	// BrowseKey opens a file browser from a dialog with a path input. It is a
+	// chord, not a printable character: a printable one cannot be reserved
+	// while a text input has focus, which is what made a path containing an
+	// "f" impossible to type (#525).
+	BrowseKey = "ctrl+o"
+
+	// BrowseHint marks a path input with the browse key. Caret notation keeps
+	// it 11 cells — the width the dialogs are already laid out around.
+	BrowseHint = "[^o Browse]"
+
+	// BrowseHelpKey is how the browse key appears in a dialog's help line.
+	BrowseHelpKey = "<ctrl+o>"
+)

--- a/views/configs/model_test.go
+++ b/views/configs/model_test.go
@@ -70,6 +70,8 @@ func key(s string) tea.KeyMsg {
 		return tea.KeyMsg{Type: tea.KeyEnter}
 	case "esc":
 		return tea.KeyMsg{Type: tea.KeyEsc}
+	case "ctrl+o":
+		return tea.KeyMsg{Type: tea.KeyCtrlO}
 	case "tab":
 		return tea.KeyMsg{Type: tea.KeyTab}
 	case "shift+tab":

--- a/views/configs/update.go
+++ b/views/configs/update.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Eldara-Tech/swarmcli/docker"
 	"github.com/Eldara-Tech/swarmcli/ui"
 	filterlist "github.com/Eldara-Tech/swarmcli/ui/components/filterable/list"
+	"github.com/Eldara-Tech/swarmcli/ui/dialog"
 	"github.com/Eldara-Tech/swarmcli/views/confirmdialog"
 	helpview "github.com/Eldara-Tech/swarmcli/views/help"
 	view "github.com/Eldara-Tech/swarmcli/views/view"
@@ -776,28 +777,15 @@ func (m *Model) handleCreateDialogKey(msg tea.KeyMsg) tea.Cmd {
 				m.createNameInput.Focus()
 			}
 			return nil
-		case "f", "F":
-			// Only open file browser when focused on file input
-			if m.createInputFocus == 1 {
-				m.createDialogActive = false
-				m.fileBrowserActive = true
-				homeDir, _ := os.UserHomeDir()
-				if homeDir == "" {
-					homeDir = "/"
-				}
-				return loadFilesCmd(homeDir)
+		case dialog.BrowseKey:
+			// The dialog has one path input, so browsing needs no focus check.
+			m.createDialogActive = false
+			m.fileBrowserActive = true
+			homeDir, _ := os.UserHomeDir()
+			if homeDir == "" {
+				homeDir = "/"
 			}
-			// Otherwise let textinput handle it (typing 'f')
-			var cmd tea.Cmd
-			if m.createInputFocus == 0 {
-				m.createNameInput, cmd = m.createNameInput.Update(msg)
-			} else {
-				m.createFileInput, cmd = m.createFileInput.Update(msg)
-			}
-			if m.createDialogError != "" {
-				m.createDialogError = ""
-			}
-			return cmd
+			return loadFilesCmd(homeDir)
 		case "enter":
 			// If there's an error, clear it and stay in editing mode
 			if m.createDialogError != "" {
@@ -878,31 +866,6 @@ func (m *Model) handleCreateDialogKey(msg tea.KeyMsg) tea.Cmd {
 				m.createLabelsInput.Blur()
 			}
 			return nil
-		case "e", "E":
-			switch m.createInputFocus {
-			case 1:
-				// Open editor for content - don't require name to be set yet
-				m.createDialogActive = false
-				m.createNameInput.Blur()
-				m.createLabelsInput.Blur()
-				return openEditorForContentCmd(m.createConfigData)
-			case 0:
-				var cmd tea.Cmd
-				m.createNameInput, cmd = m.createNameInput.Update(msg)
-				if m.createDialogError != "" {
-					m.createDialogError = ""
-				}
-				return cmd
-			case 2:
-				var cmd tea.Cmd
-				m.createLabelsInput, cmd = m.createLabelsInput.Update(msg)
-				if m.createDialogError != "" {
-					m.createDialogError = ""
-				}
-				return cmd
-			default:
-				return nil
-			}
 		case "enter":
 			// If there's an error, clear it and stay in editing mode
 			if m.createDialogError != "" {
@@ -935,6 +898,16 @@ func (m *Model) handleCreateDialogKey(msg tea.KeyMsg) tea.Cmd {
 			m.createNameInput.Blur()
 			m.createLabelsInput.Blur()
 			return m.createConfigFromContentCmd(m.createNameInput.Value(), []byte(m.createConfigData), labels)
+		case "e", "E":
+			// Open editor for content - don't require name to be set yet
+			if m.createInputFocus == 1 {
+				m.createDialogActive = false
+				m.createNameInput.Blur()
+				m.createLabelsInput.Blur()
+				return openEditorForContentCmd(m.createConfigData)
+			}
+			// Otherwise it is just a letter — route it like any other key.
+			fallthrough
 		default:
 			// Pass keys to the focused textinput
 			var cmd tea.Cmd

--- a/views/configs/update_test.go
+++ b/views/configs/update_test.go
@@ -470,6 +470,123 @@ func TestFileBrowser_UpDown(t *testing.T) {
 	require.Equal(t, 0, m.fileBrowserCursor)
 }
 
+// --- #525: a printable character must never be a hotkey over a focused input ---
+
+func configFileDialog(t *testing.T) *Model {
+	t.Helper()
+	m := testModel()
+	m.createDialogActive = true
+	m.createDialogStep = "details-file"
+	m.createInputFocus = 0
+	m.createNameInput.Focus()
+	m.Update(key("tab"))
+	require.Equal(t, 1, m.createInputFocus)
+	return m
+}
+
+func TestCreateDialog_DetailsFile_F_TypesIntoPath(t *testing.T) {
+	m := configFileDialog(t)
+	m.createFileInput.SetValue("~/config/")
+	m.Update(key("f"))
+	m.Update(key("F"))
+	require.Equal(t, "~/config/fF", m.createFileInput.Value())
+	require.False(t, m.fileBrowserActive, "f must not open the browser")
+}
+
+func TestCreateDialog_DetailsFile_BrowseKey_OpensFileBrowser(t *testing.T) {
+	m := configFileDialog(t)
+	cmd := m.Update(key("ctrl+o"))
+	require.False(t, m.createDialogActive)
+	require.True(t, m.fileBrowserActive)
+	require.NotNil(t, cmd)
+}
+
+func TestCreateDialog_DetailsFile_BrowseKey_FromNameFocus(t *testing.T) {
+	m := testModel()
+	m.createDialogActive = true
+	m.createDialogStep = "details-file"
+	m.createInputFocus = 0
+	m.createNameInput.Focus()
+	require.NotNil(t, m.Update(key("ctrl+o")))
+	require.True(t, m.fileBrowserActive)
+}
+
+// The labels field is reachable in details-file — picking a file with an
+// invalid labels value lands there — and "f" used to be inserted into the path
+// the browser had just filled in, silently corrupting it.
+func TestCreateDialog_DetailsFile_LabelsFocus_KeepsPathIntact(t *testing.T) {
+	m := testModel()
+	m.createDialogActive = true
+	m.createDialogStep = "details-file"
+	m.createNameInput.SetValue("myconfig")
+	m.createLabelsInput.SetValue("bad-format")
+
+	// Pick a file in the browser: labels fail to parse, so focus lands on them.
+	// Opening the browser hides the dialog, which is what routes keys to it.
+	m.createDialogActive = false
+	m.fileBrowserActive = true
+	m.fileBrowserFiles = []string{"/tmp/app.conf"}
+	m.fileBrowserCursor = 0
+	m.Update(key("enter"))
+	require.Equal(t, 2, m.createInputFocus, "a labels parse failure must focus the labels field")
+	require.Equal(t, "/tmp/app.conf", m.createFileInput.Value())
+
+	m.Update(key("f"))
+	require.Equal(t, "bad-formatf", m.createLabelsInput.Value(), "f must reach the labels field")
+	require.Equal(t, "/tmp/app.conf", m.createFileInput.Value(), "the chosen path must not be touched")
+}
+
+func TestCreateDialog_DetailsFile_RoutesEveryKeyToFocusedInput(t *testing.T) {
+	for _, k := range []string{"f", "F", "e", "x", " "} {
+		t.Run(k, func(t *testing.T) {
+			for _, tc := range []struct {
+				focus int
+				value func(*Model) string
+			}{
+				{0, func(m *Model) string { return m.createNameInput.Value() }},
+				{1, func(m *Model) string { return m.createFileInput.Value() }},
+				{2, func(m *Model) string { return m.createLabelsInput.Value() }},
+			} {
+				m := testModel()
+				m.createDialogActive = true
+				m.createDialogStep = "details-file"
+				m.createInputFocus = tc.focus
+				switch tc.focus {
+				case 0:
+					m.createNameInput.Focus()
+				case 1:
+					m.createFileInput.Focus()
+				case 2:
+					m.createLabelsInput.Focus()
+				}
+				m.Update(key(k))
+				require.Equal(t, k, tc.value(m), "focus %d must receive %q", tc.focus, k)
+			}
+		})
+	}
+}
+
+func TestCreateDialog_DetailsInline_E_TypesIntoFocusedInput(t *testing.T) {
+	m := testModel()
+	m.createDialogActive = true
+	m.createDialogStep = "details-inline"
+	m.createInputFocus = 2
+	m.createLabelsInput.Focus()
+	m.Update(key("e"))
+	require.Equal(t, "e", m.createLabelsInput.Value())
+	require.True(t, m.createDialogActive, "e at the labels field must not open the editor")
+}
+
+func TestCreateDialog_DetailsInline_E_OpensEditorAtContent(t *testing.T) {
+	m := testModel()
+	m.createDialogActive = true
+	m.createDialogStep = "details-inline"
+	m.createInputFocus = 1
+	cmd := m.Update(key("e"))
+	require.False(t, m.createDialogActive)
+	require.NotNil(t, cmd)
+}
+
 // --- parseLabels tests ---
 
 func TestParseLabels_Empty(t *testing.T) {

--- a/views/configs/view.go
+++ b/views/configs/view.go
@@ -195,11 +195,9 @@ func (m *Model) renderCreateDialog() string {
 		lines = append(lines, dialog.ItemStyle.Render(m.createNameInput.View()))
 		lines = append(lines, dialog.ItemStyle.Render(""))
 
-		// Show file path input with browse indicator when focused
-		fileLine := m.createFileInput.View()
-		if m.createInputFocus == 1 {
-			fileLine += "  " + dialog.KeyStyle.Render("[f: Browse]")
-		}
+		// Show file path input with browse indicator. The key is a chord, so it
+		// works from any focus and the hint is always shown.
+		fileLine := m.createFileInput.View() + "  " + dialog.KeyStyle.Render(dialog.BrowseHint)
 		lines = append(lines, dialog.ItemStyle.Render(fileLine))
 		lines = append(lines, dialog.ItemStyle.Render(""))
 

--- a/views/configs/view_test.go
+++ b/views/configs/view_test.go
@@ -8,6 +8,9 @@ import (
 	"testing"
 
 	filterlist "github.com/Eldara-Tech/swarmcli/ui/components/filterable/list"
+	"github.com/Eldara-Tech/swarmcli/ui/dialog"
+
+	"github.com/charmbracelet/x/ansi"
 
 	"github.com/stretchr/testify/require"
 )
@@ -113,4 +116,18 @@ func TestLabelsScroll_Truncation(t *testing.T) {
 	truncated := filterlist.ScrollWindow(full, 0, 5)
 	require.Contains(t, truncated, "…")
 	require.Equal(t, 5, len([]rune(truncated)))
+}
+
+// --- #525: the browse hint advertises the chord, from any focus ---
+
+func TestRenderCreateDialog_ShowsBrowseHintAtEveryFocus(t *testing.T) {
+	for _, focus := range []int{0, 1, 2} {
+		m := testModel()
+		m.createDialogActive = true
+		m.createDialogStep = "details-file"
+		m.createInputFocus = focus
+		out := ansi.Strip(m.renderCreateDialog())
+		require.Contains(t, out, dialog.BrowseHint, "focus %d must show the browse hint", focus)
+		require.NotContains(t, out, "[f: Browse]")
+	}
 }

--- a/views/contexts/model_test.go
+++ b/views/contexts/model_test.go
@@ -87,6 +87,8 @@ func key(s string) tea.KeyMsg {
 		return tea.KeyMsg{Type: tea.KeyEnter}
 	case "esc":
 		return tea.KeyMsg{Type: tea.KeyEsc}
+	case "ctrl+o":
+		return tea.KeyMsg{Type: tea.KeyCtrlO}
 	case "tab":
 		return tea.KeyMsg{Type: tea.KeyTab}
 	case "shift+tab":

--- a/views/contexts/update.go
+++ b/views/contexts/update.go
@@ -6,6 +6,7 @@ package contexts
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/Eldara-Tech/swarmcli/ui/dialog"
 	"github.com/Eldara-Tech/swarmcli/views/confirmdialog"
 	helpview "github.com/Eldara-Tech/swarmcli/views/help"
 	"github.com/Eldara-Tech/swarmcli/views/view"
@@ -417,8 +418,10 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 				m.SetError("")
 				m.SetSuccess("")
 				return nil
-			case "f":
-				// Open file browser for cert file selection (only if focused on cert inputs)
+			case dialog.BrowseKey:
+				// Open file browser for cert file selection. Unlike the other
+				// dialogs this one has three path inputs, so the focused one is
+				// the target and the key does nothing elsewhere.
 				if m.createInputFocus >= 4 && m.createInputFocus <= 6 && m.createTLSEnabled {
 					// Determine which cert file is being browsed
 					switch m.createInputFocus {
@@ -463,17 +466,7 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 					m.fileBrowserPath = currentPath
 					return LoadCertFilesCmd(currentPath)
 				}
-				// If not on cert fields, pass 'f' to the textinput
-				var cmd tea.Cmd
-				switch m.createInputFocus {
-				case 0:
-					m.createNameInput, cmd = m.createNameInput.Update(msg)
-				case 1:
-					m.createDescInput, cmd = m.createDescInput.Update(msg)
-				case 2:
-					m.createHostInput, cmd = m.createHostInput.Update(msg)
-				}
-				return cmd
+				return nil
 			case "tab", "shift+tab", "down":
 				// Move focus forward
 				m.createInputFocus++

--- a/views/contexts/update_test.go
+++ b/views/contexts/update_test.go
@@ -597,6 +597,103 @@ func TestCreateDialog_Enter_ClearsError(t *testing.T) {
 	require.Equal(t, "", m.GetError())
 }
 
+// --- #525: a printable character must never be a hotkey over a focused input ---
+
+// certDialog opens the create dialog with TLS on and one cert field focused.
+func certDialog(t *testing.T, focus int) *Model {
+	t.Helper()
+	m := testModel()
+	m.createDialogActive = true
+	m.createTLSEnabled = true
+	m.createInputFocus = focus
+	m.updateCreateFocus()
+	return m
+}
+
+// Every certificate path a Docker context needs is under a directory with an
+// "f" in it more often than not — /etc/docker/certs.d, fullchain.pem.
+func TestCreateDialog_CertFields_F_TypesIntoFocusedInput(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		focus int
+		value func(*Model) string
+	}{
+		{"ca", 4, func(m *Model) string { return m.createCAInput.Value() }},
+		{"cert", 5, func(m *Model) string { return m.createCertInput.Value() }},
+		{"key", 6, func(m *Model) string { return m.createKeyInput.Value() }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			m := certDialog(t, tc.focus)
+			for _, k := range []string{"f", "u", "l", "l", "F"} {
+				m.Update(key(k))
+			}
+			require.Equal(t, "fullF", tc.value(m))
+			require.False(t, m.certFileBrowserActive, "f must not open the cert browser")
+			// The other two cert fields must be untouched.
+			require.Empty(t, m.createNameInput.Value())
+			require.Empty(t, m.createDescInput.Value())
+			require.Empty(t, m.createHostInput.Value())
+		})
+	}
+}
+
+func TestCreateDialog_CertFields_BrowseKey_OpensCertBrowser(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		focus  int
+		target string
+	}{
+		{"ca", 4, "ca"},
+		{"cert", 5, "cert"},
+		{"key", 6, "key"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			m := certDialog(t, tc.focus)
+			cmd := m.Update(key("ctrl+o"))
+			require.True(t, m.certFileBrowserActive)
+			require.Equal(t, tc.target, m.certFileTarget)
+			require.NotNil(t, cmd)
+		})
+	}
+}
+
+// Unlike the other dialogs this one has three path inputs, so the chord has no
+// unambiguous target away from them and must do nothing.
+func TestCreateDialog_BrowseKey_NoOpAwayFromCertFields(t *testing.T) {
+	for focus := range 4 {
+		m := certDialog(t, focus)
+		m.Update(key("ctrl+o"))
+		require.False(t, m.certFileBrowserActive, "focus %d must not open the cert browser", focus)
+	}
+
+	// Nor with TLS off, where the cert fields are skipped by tab entirely.
+	m := testModel()
+	m.createDialogActive = true
+	m.createInputFocus = 4
+	m.Update(key("ctrl+o"))
+	require.False(t, m.certFileBrowserActive)
+}
+
+func TestCreateDialog_RoutesEveryKeyToFocusedInput(t *testing.T) {
+	value := map[int]func(*Model) string{
+		0: func(m *Model) string { return m.createNameInput.Value() },
+		1: func(m *Model) string { return m.createDescInput.Value() },
+		2: func(m *Model) string { return m.createHostInput.Value() },
+		4: func(m *Model) string { return m.createCAInput.Value() },
+		5: func(m *Model) string { return m.createCertInput.Value() },
+		6: func(m *Model) string { return m.createKeyInput.Value() },
+	}
+	for _, k := range []string{"f", "F", "e", "x"} {
+		t.Run(k, func(t *testing.T) {
+			for _, focus := range []int{0, 1, 2, 4, 5, 6} {
+				m := certDialog(t, focus)
+				m.Update(key(k))
+				require.Equal(t, k, value[focus](m), "focus %d must receive %q", focus, k)
+			}
+		})
+	}
+}
+
 // --- Edit dialog ---
 
 func TestEditDialog_Esc_Closes(t *testing.T) {

--- a/views/contexts/view.go
+++ b/views/contexts/view.go
@@ -260,21 +260,21 @@ func (m *Model) renderCreateDialog() string {
 		// CA file with browse button indicator
 		caLine := m.createCAInput.View()
 		if m.createInputFocus == 4 {
-			caLine += "  " + dialog.KeyStyle.Render("[f: Browse]")
+			caLine += "  " + dialog.KeyStyle.Render(dialog.BrowseHint)
 		}
 		lines = append(lines, dialog.ItemStyle.Render(caLine))
 
 		// Cert file with browse button indicator
 		certLine := m.createCertInput.View()
 		if m.createInputFocus == 5 {
-			certLine += "  " + dialog.KeyStyle.Render("[f: Browse]")
+			certLine += "  " + dialog.KeyStyle.Render(dialog.BrowseHint)
 		}
 		lines = append(lines, dialog.ItemStyle.Render(certLine))
 
 		// Key file with browse button indicator
 		keyLine := m.createKeyInput.View()
 		if m.createInputFocus == 6 {
-			keyLine += "  " + dialog.KeyStyle.Render("[f: Browse]")
+			keyLine += "  " + dialog.KeyStyle.Render(dialog.BrowseHint)
 		}
 		lines = append(lines, dialog.ItemStyle.Render(keyLine))
 	}
@@ -298,11 +298,12 @@ func (m *Model) renderCreateDialog() string {
 			dialog.KeyStyle.Render("<Enter>"),
 			dialog.KeyStyle.Render("<Esc>"))
 	} else {
-		helpText = fmt.Sprintf(" %s Create • %s Navigate • %s Toggle TLS • %s Browse • %s Cancel",
+		// No Browse entry here: this line already sets the dialog's width, and
+		// the per-field hint advertises the key exactly when it is usable.
+		helpText = fmt.Sprintf(" %s Create • %s Navigate • %s Toggle TLS • %s Cancel",
 			dialog.KeyStyle.Render("<Enter>"),
 			dialog.KeyStyle.Render("<Tab/↑/↓>"),
 			dialog.KeyStyle.Render("<Space>"),
-			dialog.KeyStyle.Render("<f>"),
 			dialog.KeyStyle.Render("<Esc>"))
 	}
 	lines = append(lines, dialog.HelpStyle.Render(helpText))

--- a/views/contexts/view_test.go
+++ b/views/contexts/view_test.go
@@ -4,7 +4,13 @@
 package contexts
 
 import (
+	"strings"
 	"testing"
+
+	"github.com/Eldara-Tech/swarmcli/ui/dialog"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
 
 	"github.com/stretchr/testify/require"
 )
@@ -148,4 +154,41 @@ func TestView_CreateDialog_TLSEnabled(t *testing.T) {
 	loadContexts(m, fakeContexts("ctx1"))
 	out := m.View()
 	require.Contains(t, out, "TLS")
+}
+
+// --- #525: the browse hint, and the width it is laid out around ---
+
+func TestRenderCreateDialog_ShowsBrowseHintOnFocusedCertField(t *testing.T) {
+	for _, focus := range []int{4, 5, 6} {
+		m := testModel()
+		m.createDialogActive = true
+		m.createTLSEnabled = true
+		m.createInputFocus = focus
+		m.updateCreateFocus()
+		out := ansi.Strip(m.renderCreateDialog())
+		require.Equal(t, 1, strings.Count(out, dialog.BrowseHint),
+			"focus %d must hint exactly its own cert field", focus)
+		require.NotContains(t, out, "[f: Browse]")
+	}
+}
+
+// The help line sets this dialog's width, and with the browse entry on it the
+// dialog rendered 89 cells wide — nine past an 80-column terminal. The
+// per-field hint carries the key instead, so the line must stay off it.
+func TestRenderCreateDialog_FitsIn80Columns(t *testing.T) {
+	m := testModel()
+	m.createDialogActive = true
+	m.createTLSEnabled = true
+	m.createInputFocus = 4
+	m.updateCreateFocus()
+
+	out := ansi.Strip(m.renderCreateDialog())
+	widest := 0
+	for _, line := range strings.Split(out, "\n") {
+		if w := lipgloss.Width(line); w > widest {
+			widest = w
+		}
+	}
+	require.LessOrEqual(t, widest, 80, "the create dialog must fit an 80-column terminal:\n%s", out)
+	require.NotContains(t, out, "Browse •", "the help line must not carry the browse key")
 }

--- a/views/secrets/model_test.go
+++ b/views/secrets/model_test.go
@@ -70,6 +70,8 @@ func key(s string) tea.KeyMsg {
 		return tea.KeyMsg{Type: tea.KeyEnter}
 	case "esc":
 		return tea.KeyMsg{Type: tea.KeyEsc}
+	case "ctrl+o":
+		return tea.KeyMsg{Type: tea.KeyCtrlO}
 	case "tab":
 		return tea.KeyMsg{Type: tea.KeyTab}
 	case "shift+tab":

--- a/views/secrets/update.go
+++ b/views/secrets/update.go
@@ -8,6 +8,7 @@ import (
 	"github.com/Eldara-Tech/swarmcli/core/primitives/hash"
 	"github.com/Eldara-Tech/swarmcli/ui"
 	filterlist "github.com/Eldara-Tech/swarmcli/ui/components/filterable/list"
+	"github.com/Eldara-Tech/swarmcli/ui/dialog"
 	"github.com/Eldara-Tech/swarmcli/views/confirmdialog"
 	helpview "github.com/Eldara-Tech/swarmcli/views/help"
 	loading "github.com/Eldara-Tech/swarmcli/views/loading"
@@ -619,49 +620,15 @@ func (m *Model) handleCreateDialogKey(msg tea.KeyMsg) tea.Cmd {
 				m.createLabelsInput.Blur()
 			}
 			return nil
-		case " ":
-			// Handle space key depending on focused input
-			switch m.createInputFocus {
-			case 3:
-				// Toggle encode when focused on encode toggle
-				m.createEncodeSecret = !m.createEncodeSecret
-				return nil
-			case 0:
-				var cmd tea.Cmd
-				m.createNameInput, cmd = m.createNameInput.Update(msg)
-				return cmd
-			case 1:
-				var cmd tea.Cmd
-				m.createFileInput, cmd = m.createFileInput.Update(msg)
-				return cmd
-			case 2:
-				var cmd tea.Cmd
-				m.createLabelsInput, cmd = m.createLabelsInput.Update(msg)
-				return cmd
-			default:
-				return nil
+		case dialog.BrowseKey:
+			// The dialog has one path input, so browsing needs no focus check.
+			m.createDialogActive = false
+			m.fileBrowserActive = true
+			homeDir, _ := os.UserHomeDir()
+			if homeDir == "" {
+				homeDir = "/"
 			}
-		case "f", "F":
-			switch m.createInputFocus {
-			case 1:
-				m.createDialogActive = false
-				m.fileBrowserActive = true
-				homeDir, _ := os.UserHomeDir()
-				if homeDir == "" {
-					homeDir = "/"
-				}
-				return loadFilesCmd(homeDir)
-			case 0:
-				var cmd tea.Cmd
-				m.createNameInput, cmd = m.createNameInput.Update(msg)
-				return cmd
-			case 2:
-				var cmd tea.Cmd
-				m.createLabelsInput, cmd = m.createLabelsInput.Update(msg)
-				return cmd
-			default:
-				return nil
-			}
+			return loadFilesCmd(homeDir)
 		case "enter":
 			if m.createDialogError != "" {
 				m.createDialogError = ""
@@ -692,6 +659,14 @@ func (m *Model) handleCreateDialogKey(msg tea.KeyMsg) tea.Cmd {
 			m.createFileInput.Blur()
 			m.createLabelsInput.Blur()
 			return m.createSecretFromFileCmd(m.createNameInput.Value(), filePath, labels, m.createEncodeSecret)
+		case " ":
+			// Toggle encode when focused on encode toggle
+			if m.createInputFocus == 3 {
+				m.createEncodeSecret = !m.createEncodeSecret
+				return nil
+			}
+			// Otherwise it is just a character — route it like any other key.
+			fallthrough
 		default:
 			var cmd tea.Cmd
 			switch m.createInputFocus {
@@ -742,49 +717,15 @@ func (m *Model) handleCreateDialogKey(msg tea.KeyMsg) tea.Cmd {
 				m.createEncodeSecret = !m.createEncodeSecret
 				return nil
 			}
-			// Otherwise pass to focused input
-			switch m.createInputFocus {
-			case 0:
-				var cmd tea.Cmd
-				m.createNameInput, cmd = m.createNameInput.Update(msg)
-				if m.createDialogError != "" {
-					m.createDialogError = ""
-				}
-				return cmd
-			case 2:
-				var cmd tea.Cmd
-				m.createLabelsInput, cmd = m.createLabelsInput.Update(msg)
-				if m.createDialogError != "" {
-					m.createDialogError = ""
-				}
-				return cmd
-			default:
-				return nil
-			}
+			return m.routeInlineKey(msg)
 		case "e", "E":
-			switch m.createInputFocus {
-			case 1:
-				// Open editor for content - don't require name to be set yet
+			// Open editor for content - don't require name to be set yet
+			if m.createInputFocus == 1 {
 				m.createDialogActive = false
 				m.createNameInput.Blur()
 				return openEditorForContentCmd(m.createSecretData)
-			case 0:
-				var cmd tea.Cmd
-				m.createNameInput, cmd = m.createNameInput.Update(msg)
-				if m.createDialogError != "" {
-					m.createDialogError = ""
-				}
-				return cmd
-			case 2:
-				var cmd tea.Cmd
-				m.createLabelsInput, cmd = m.createLabelsInput.Update(msg)
-				if m.createDialogError != "" {
-					m.createDialogError = ""
-				}
-				return cmd
-			default:
-				return nil
 			}
+			return m.routeInlineKey(msg)
 		case "enter":
 			if m.createDialogError != "" {
 				m.createDialogError = ""
@@ -814,28 +755,31 @@ func (m *Model) handleCreateDialogKey(msg tea.KeyMsg) tea.Cmd {
 			m.createLabelsInput.Blur()
 			return m.createSecretFromContentCmd(m.createNameInput.Value(), []byte(m.createSecretData), labels, m.createEncodeSecret)
 		default:
-			switch m.createInputFocus {
-			case 0:
-				var cmd tea.Cmd
-				m.createNameInput, cmd = m.createNameInput.Update(msg)
-				if m.createDialogError != "" {
-					m.createDialogError = ""
-				}
-				return cmd
-			case 2:
-				var cmd tea.Cmd
-				m.createLabelsInput, cmd = m.createLabelsInput.Update(msg)
-				if m.createDialogError != "" {
-					m.createDialogError = ""
-				}
-				return cmd
-			default:
-				return nil
-			}
+			return m.routeInlineKey(msg)
 		}
 	}
 
 	return nil
+}
+
+// routeInlineKey passes a key to whichever input has focus in the inline create
+// dialog. Space and "e" both need it as well as the default branch, and
+// fallthrough only reaches the next clause, so the routing lives here — one
+// copy that cannot disagree with itself when a field is added.
+func (m *Model) routeInlineKey(msg tea.KeyMsg) tea.Cmd {
+	var cmd tea.Cmd
+	switch m.createInputFocus {
+	case 0:
+		m.createNameInput, cmd = m.createNameInput.Update(msg)
+	case 2:
+		m.createLabelsInput, cmd = m.createLabelsInput.Update(msg)
+	default:
+		return nil
+	}
+	if m.createDialogError != "" {
+		m.createDialogError = ""
+	}
+	return cmd
 }
 
 func (m *Model) handleFileBrowserKey(msg tea.KeyMsg) tea.Cmd {

--- a/views/secrets/update_test.go
+++ b/views/secrets/update_test.go
@@ -441,6 +441,109 @@ func TestCreateDialog_DetailsFile_Space_TogglesEncode(t *testing.T) {
 	require.NotEqual(t, initial, m.createEncodeSecret)
 }
 
+// --- #525: a printable character must never be a hotkey over a focused input ---
+
+func secretFileDialog(t *testing.T) *Model {
+	t.Helper()
+	m := testModel()
+	m.createDialogActive = true
+	m.createDialogStep = "details-file"
+	m.createInputFocus = 0
+	m.createNameInput.Focus()
+	m.Update(key("tab"))
+	require.Equal(t, 1, m.createInputFocus)
+	return m
+}
+
+func TestCreateDialog_DetailsFile_F_TypesIntoPath(t *testing.T) {
+	m := secretFileDialog(t)
+	m.createFileInput.SetValue("/etc/ssl/")
+	m.Update(key("f"))
+	m.Update(key("F"))
+	require.Equal(t, "/etc/ssl/fF", m.createFileInput.Value())
+	require.False(t, m.fileBrowserActive, "f must not open the browser")
+}
+
+func TestCreateDialog_DetailsFile_BrowseKey_OpensFileBrowser(t *testing.T) {
+	m := secretFileDialog(t)
+	cmd := m.Update(key("ctrl+o"))
+	require.False(t, m.createDialogActive)
+	require.True(t, m.fileBrowserActive)
+	require.NotNil(t, cmd)
+}
+
+func TestCreateDialog_DetailsFile_BrowseKey_FromNameFocus(t *testing.T) {
+	m := testModel()
+	m.createDialogActive = true
+	m.createDialogStep = "details-file"
+	m.createInputFocus = 0
+	m.createNameInput.Focus()
+	require.NotNil(t, m.Update(key("ctrl+o")))
+	require.True(t, m.fileBrowserActive)
+}
+
+// Both dialog steps hold an encode toggle at focus 3 and route every other key
+// to the focused input. The toggle must keep working and must not swallow a
+// space typed into a field.
+func TestCreateDialog_RoutesEveryKeyToFocusedInput(t *testing.T) {
+	steps := map[string][]int{
+		"details-file":   {0, 1, 2},
+		"details-inline": {0, 2},
+	}
+	value := map[int]func(*Model) string{
+		0: func(m *Model) string { return m.createNameInput.Value() },
+		1: func(m *Model) string { return m.createFileInput.Value() },
+		2: func(m *Model) string { return m.createLabelsInput.Value() },
+	}
+	focusInput := map[int]func(*Model){
+		0: func(m *Model) { m.createNameInput.Focus() },
+		1: func(m *Model) { m.createFileInput.Focus() },
+		2: func(m *Model) { m.createLabelsInput.Focus() },
+	}
+
+	for step, focuses := range steps {
+		for _, k := range []string{"f", "F", "e", "x", " "} {
+			t.Run(step+"/"+k, func(t *testing.T) {
+				for _, focus := range focuses {
+					m := testModel()
+					m.createDialogActive = true
+					m.createDialogStep = step
+					m.createInputFocus = focus
+					focusInput[focus](m)
+					m.Update(key(k))
+					require.Equal(t, k, value[focus](m), "focus %d must receive %q", focus, k)
+				}
+
+				// Focus 3 is the encode toggle, not an input.
+				m := testModel()
+				m.createDialogActive = true
+				m.createDialogStep = step
+				m.createInputFocus = 3
+				before := m.createEncodeSecret
+				m.Update(key(k))
+				if k == " " {
+					require.NotEqual(t, before, m.createEncodeSecret, "space must toggle encode")
+				} else {
+					require.Equal(t, before, m.createEncodeSecret)
+				}
+				require.Empty(t, m.createNameInput.Value())
+				require.Empty(t, m.createFileInput.Value())
+				require.Empty(t, m.createLabelsInput.Value())
+			})
+		}
+	}
+}
+
+func TestCreateDialog_DetailsInline_E_OpensEditorAtContent(t *testing.T) {
+	m := testModel()
+	m.createDialogActive = true
+	m.createDialogStep = "details-inline"
+	m.createInputFocus = 1
+	cmd := m.Update(key("e"))
+	require.False(t, m.createDialogActive)
+	require.NotNil(t, cmd)
+}
+
 // --- UsedBy view key tests ---
 
 func TestUsedByView_Esc_ClosesView(t *testing.T) {

--- a/views/secrets/view.go
+++ b/views/secrets/view.go
@@ -181,11 +181,9 @@ func (m *Model) renderCreateDialog() string {
 		lines = append(lines, dialog.ItemStyle.Render(m.createNameInput.View()))
 		lines = append(lines, dialog.ItemStyle.Render(""))
 
-		// Show file path input with browse indicator when focused
-		fileLine := m.createFileInput.View()
-		if m.createInputFocus == 1 {
-			fileLine += "  " + dialog.KeyStyle.Render("[f: Browse]")
-		}
+		// Show file path input with browse indicator. The key is a chord, so it
+		// works from any focus and the hint is always shown.
+		fileLine := m.createFileInput.View() + "  " + dialog.KeyStyle.Render(dialog.BrowseHint)
 		lines = append(lines, dialog.ItemStyle.Render(fileLine))
 		lines = append(lines, dialog.ItemStyle.Render(""))
 

--- a/views/secrets/view_test.go
+++ b/views/secrets/view_test.go
@@ -7,6 +7,9 @@ import (
 	"testing"
 
 	filterlist "github.com/Eldara-Tech/swarmcli/ui/components/filterable/list"
+	"github.com/Eldara-Tech/swarmcli/ui/dialog"
+
+	"github.com/charmbracelet/x/ansi"
 
 	"github.com/stretchr/testify/require"
 )
@@ -128,3 +131,17 @@ var errTest = errorMsg(testErr{})
 type testErr struct{}
 
 func (testErr) Error() string { return "test error" }
+
+// --- #525: the browse hint advertises the chord, from any focus ---
+
+func TestRenderCreateDialog_ShowsBrowseHintAtEveryFocus(t *testing.T) {
+	for _, focus := range []int{0, 1, 2, 3} {
+		m := testModel()
+		m.createDialogActive = true
+		m.createDialogStep = "details-file"
+		m.createInputFocus = focus
+		out := ansi.Strip(m.renderCreateDialog())
+		require.Contains(t, out, dialog.BrowseHint, "focus %d must show the browse hint", focus)
+		require.NotContains(t, out, "[f: Browse]")
+	}
+}

--- a/views/stacks/model_test.go
+++ b/views/stacks/model_test.go
@@ -101,6 +101,8 @@ func key(s string) tea.KeyMsg {
 		return tea.KeyMsg{Type: tea.KeyEnter}
 	case "esc":
 		return tea.KeyMsg{Type: tea.KeyEsc}
+	case "ctrl+o":
+		return tea.KeyMsg{Type: tea.KeyCtrlO}
 	case "tab":
 		return tea.KeyMsg{Type: tea.KeyTab}
 	case "shift+tab":

--- a/views/stacks/update.go
+++ b/views/stacks/update.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Eldara-Tech/swarmcli/core/primitives/hash"
 	"github.com/Eldara-Tech/swarmcli/docker"
 	"github.com/Eldara-Tech/swarmcli/ui"
+	"github.com/Eldara-Tech/swarmcli/ui/dialog"
 	"github.com/Eldara-Tech/swarmcli/views/confirmdialog"
 	helpview "github.com/Eldara-Tech/swarmcli/views/help"
 	servicesview "github.com/Eldara-Tech/swarmcli/views/services"
@@ -734,29 +735,16 @@ func (m *Model) handleCreateDialogKey(msg tea.KeyMsg) tea.Cmd {
 				m.createNameInput.Focus()
 			}
 			return nil
-		case "f", "F":
-			// Only open file browser when focused on file input
-			if m.createInputFocus == 1 {
-				m.createDialogActive = false
-				m.fileBrowserActive = true
-				m.fileBrowserContext = "create"
-				homeDir, _ := os.UserHomeDir()
-				if homeDir == "" {
-					homeDir = "/"
-				}
-				return loadFilesCmd(homeDir)
+		case dialog.BrowseKey:
+			// The dialog has one path input, so browsing needs no focus check.
+			m.createDialogActive = false
+			m.fileBrowserActive = true
+			m.fileBrowserContext = "create"
+			homeDir, _ := os.UserHomeDir()
+			if homeDir == "" {
+				homeDir = "/"
 			}
-			// Otherwise let textinput handle it (typing 'f')
-			var cmd tea.Cmd
-			if m.createInputFocus == 0 {
-				m.createNameInput, cmd = m.createNameInput.Update(msg)
-			} else {
-				m.createFileInput, cmd = m.createFileInput.Update(msg)
-			}
-			if m.createDialogError != "" {
-				m.createDialogError = ""
-			}
-			return cmd
+			return loadFilesCmd(homeDir)
 		case "enter":
 			// If there's an error, clear it and stay in editing mode
 			if m.createDialogError != "" {
@@ -818,9 +806,10 @@ func (m *Model) handleCreateDialogKey(msg tea.KeyMsg) tea.Cmd {
 		default:
 			// Pass keys to the focused textinput
 			var cmd tea.Cmd
-			if m.createInputFocus == 0 {
+			switch m.createInputFocus {
+			case 0:
 				m.createNameInput, cmd = m.createNameInput.Update(msg)
-			} else {
+			case 1:
 				m.createFileInput, cmd = m.createFileInput.Update(msg)
 			}
 			// Clear error when user types
@@ -849,25 +838,6 @@ func (m *Model) handleCreateDialogKey(msg tea.KeyMsg) tea.Cmd {
 				m.createNameInput.Focus()
 			}
 			return nil
-		case "e", "E":
-			// Open editor for content when focused on content
-			if m.createInputFocus == 1 {
-				preview := m.createDialogContent
-				if len(preview) > 100 {
-					preview = preview[:100] + "..."
-				}
-				l().Infof("Opening editor with content (%d bytes), preview: %q", len(m.createDialogContent), preview)
-				m.createDialogActive = false
-				m.createNameInput.Blur()
-				return openEditorForStackCmd(m.createDialogContent)
-			}
-			// Otherwise let textinput handle it (typing 'e')
-			var cmd tea.Cmd
-			m.createNameInput, cmd = m.createNameInput.Update(msg)
-			if m.createDialogError != "" {
-				m.createDialogError = ""
-			}
-			return cmd
 		case "enter":
 			// If there's an error, clear it and stay in editing mode
 			if m.createDialogError != "" {
@@ -929,6 +899,20 @@ func (m *Model) handleCreateDialogKey(msg tea.KeyMsg) tea.Cmd {
 				}
 				return Msg{NodeID: m.nodeID}
 			}
+		case "e", "E":
+			// Open editor for content when focused on content
+			if m.createInputFocus == 1 {
+				preview := m.createDialogContent
+				if len(preview) > 100 {
+					preview = preview[:100] + "..."
+				}
+				l().Infof("Opening editor with content (%d bytes), preview: %q", len(m.createDialogContent), preview)
+				m.createDialogActive = false
+				m.createNameInput.Blur()
+				return openEditorForStackCmd(m.createDialogContent)
+			}
+			// Otherwise it is just a letter — route it like any other key.
+			fallthrough
 		default:
 			// Pass keys to the focused textinput (name only in inline mode)
 			var cmd tea.Cmd
@@ -954,7 +938,7 @@ func (m *Model) handleSaveDialogKey(msg tea.KeyMsg) tea.Cmd {
 		m.saveDialogError = ""
 		m.saveFileInput.Blur()
 		return nil
-	case "f", "F":
+	case dialog.BrowseKey:
 		// Open file browser for directory selection
 		m.saveDialogActive = false
 		m.fileBrowserActive = true

--- a/views/stacks/update_test.go
+++ b/views/stacks/update_test.go
@@ -470,6 +470,102 @@ func TestCreateDialog_DetailsFile_EnterEmptyPath(t *testing.T) {
 	require.Contains(t, m.createDialogError, "file path")
 }
 
+// --- #525: a printable character must never be a hotkey over a focused input ---
+
+// createFileDialog opens the create dialog on details-file with the file input
+// focused, the way tabbing there leaves it.
+func createFileDialog(t *testing.T) *Model {
+	t.Helper()
+	m := testModel()
+	m.createDialogActive = true
+	m.createDialogStep = "details-file"
+	m.createInputFocus = 0
+	m.createNameInput.Focus()
+	m.Update(key("tab"))
+	require.Equal(t, 1, m.createInputFocus)
+	return m
+}
+
+func TestCreateDialog_DetailsFile_F_TypesIntoPath(t *testing.T) {
+	m := createFileDialog(t)
+	m.createFileInput.SetValue("/etc/docker/certs.d/")
+	m.Update(key("f"))
+	require.Equal(t, "/etc/docker/certs.d/f", m.createFileInput.Value())
+	require.False(t, m.fileBrowserActive, "f must not open the browser")
+	require.True(t, m.createDialogActive)
+}
+
+func TestCreateDialog_DetailsFile_ShiftF_TypesIntoPath(t *testing.T) {
+	m := createFileDialog(t)
+	m.Update(key("F"))
+	require.Equal(t, "F", m.createFileInput.Value())
+	require.False(t, m.fileBrowserActive)
+}
+
+func TestCreateDialog_DetailsFile_BrowseKey_OpensFileBrowser(t *testing.T) {
+	m := createFileDialog(t)
+	cmd := m.Update(key("ctrl+o"))
+	require.False(t, m.createDialogActive)
+	require.True(t, m.fileBrowserActive)
+	require.Equal(t, "create", m.fileBrowserContext)
+	require.NotNil(t, cmd)
+}
+
+// The chord is unambiguous — there is one path input — so it browses from the
+// name field too, where the old "f" hotkey did nothing.
+func TestCreateDialog_DetailsFile_BrowseKey_FromNameFocus(t *testing.T) {
+	m := testModel()
+	m.createDialogActive = true
+	m.createDialogStep = "details-file"
+	m.createInputFocus = 0
+	m.createNameInput.Focus()
+	cmd := m.Update(key("ctrl+o"))
+	require.True(t, m.fileBrowserActive)
+	require.NotNil(t, cmd)
+}
+
+func TestCreateDialog_DetailsFile_RoutesEveryKeyToFocusedInput(t *testing.T) {
+	for _, k := range []string{"f", "F", "e", "x", " "} {
+		t.Run(k, func(t *testing.T) {
+			m := testModel()
+			m.createDialogActive = true
+			m.createDialogStep = "details-file"
+			m.createInputFocus = 0
+			m.createNameInput.Focus()
+
+			m.Update(key(k))
+			require.Equal(t, k, m.createNameInput.Value(), "focus 0 must type into the name")
+			require.Empty(t, m.createFileInput.Value(), "focus 0 must not touch the path")
+
+			m.Update(key("tab"))
+			m.Update(key(k))
+			require.Equal(t, k, m.createFileInput.Value(), "focus 1 must type into the path")
+			require.Equal(t, k, m.createNameInput.Value(), "focus 1 must not touch the name")
+		})
+	}
+}
+
+func TestCreateDialog_DetailsInline_E_TypesIntoName(t *testing.T) {
+	m := testModel()
+	m.createDialogActive = true
+	m.createDialogStep = "details-inline"
+	m.createInputFocus = 0
+	m.createNameInput.Focus()
+	m.Update(key("e"))
+	require.Equal(t, "e", m.createNameInput.Value())
+	require.True(t, m.createDialogActive, "e at the name field must not open the editor")
+}
+
+func TestCreateDialog_DetailsInline_E_OpensEditorAtContent(t *testing.T) {
+	m := testModel()
+	m.createDialogActive = true
+	m.createDialogStep = "details-inline"
+	m.createInputFocus = 1
+	cmd := m.Update(key("e"))
+	require.False(t, m.createDialogActive)
+	require.NotNil(t, cmd)
+}
+
 func TestCreateDialog_DetailsInline_Esc(t *testing.T) {
 	m := testModel()
 	m.createDialogActive = true
@@ -715,16 +811,31 @@ func TestSaveDialog_EnterWithError_ClearsError(t *testing.T) {
 	require.True(t, m.saveDialogActive)
 }
 
-func TestSaveDialog_F_OpensFileBrowser(t *testing.T) {
+func TestSaveDialog_BrowseKey_OpensFileBrowser(t *testing.T) {
 	m := testModel()
 	m.saveDialogActive = true
 	m.saveStackName = "mystack"
 	m.saveFileInput.SetValue("mystack.yml")
-	cmd := m.Update(key("f"))
+	cmd := m.Update(key("ctrl+o"))
 	require.False(t, m.saveDialogActive)
 	require.True(t, m.fileBrowserActive)
 	require.Equal(t, "save", m.fileBrowserContext)
 	require.NotNil(t, cmd)
+}
+
+// The save dialog never had a focus guard at all, so "f" was unreachable in its
+// only field — and its placeholder ("./my-stack.yml") invites relative paths.
+func TestSaveDialog_F_TypesIntoPath(t *testing.T) {
+	m := testModel()
+	m.saveDialogActive = true
+	m.saveStackName = "mystack"
+	m.saveFileInput.Focus()
+	m.saveFileInput.SetValue("./con")
+	m.Update(key("f"))
+	m.Update(key("F"))
+	require.Equal(t, "./confF", m.saveFileInput.Value())
+	require.True(t, m.saveDialogActive)
+	require.False(t, m.fileBrowserActive)
 }
 
 func TestStackSavedMsg_ShowsSuccess(t *testing.T) {

--- a/views/stacks/view.go
+++ b/views/stacks/view.go
@@ -108,15 +108,9 @@ func (m *Model) renderCreateDialog() string {
 		lines = append(lines, dialog.ItemStyle.Render(m.createNameInput.View()))
 		lines = append(lines, dialog.ItemStyle.Render(""))
 
-		// Show file path input with browse indicator when focused
-		// Always reserve space for the hint to prevent dialog resizing
-		fileLine := m.createFileInput.View()
-		if m.createInputFocus == 1 {
-			fileLine += "  " + dialog.KeyStyle.Render("[f: Browse]")
-		} else {
-			// Add invisible spacing to maintain consistent width
-			fileLine += "             " // 13 characters to match "  [f: Browse]"
-		}
+		// Show file path input with browse indicator. The key is a chord, so it
+		// works from any focus and the hint is always shown.
+		fileLine := m.createFileInput.View() + "  " + dialog.KeyStyle.Render(dialog.BrowseHint)
 		lines = append(lines, dialog.ItemStyle.Render(fileLine))
 		lines = append(lines, dialog.ItemStyle.Render(""))
 
@@ -131,7 +125,7 @@ func (m *Model) renderCreateDialog() string {
 			helpText = fmt.Sprintf(" %s Deploy • %s Navigate • %s Browse • %s Cancel",
 				dialog.KeyStyle.Render("<Enter>"),
 				dialog.KeyStyle.Render("<Tab>"),
-				dialog.KeyStyle.Render("<f>"),
+				dialog.KeyStyle.Render(dialog.BrowseHelpKey),
 				dialog.KeyStyle.Render("<Esc>"))
 		}
 		lines = append(lines, dialog.HelpStyle.Render(helpText))
@@ -222,7 +216,7 @@ func (m *Model) renderSaveDialog() string {
 	}
 
 	fileLine := m.saveFileInput.View()
-	fileLine += "  " + dialog.KeyStyle.Render("[f: Browse]")
+	fileLine += "  " + dialog.KeyStyle.Render(dialog.BrowseHint)
 	lines = append(lines, dialog.ItemStyle.Render(fileLine))
 	lines = append(lines, dialog.ItemStyle.Render(""))
 
@@ -234,7 +228,7 @@ func (m *Model) renderSaveDialog() string {
 	} else {
 		helpText = fmt.Sprintf(" %s Save • %s Browse • %s Cancel",
 			dialog.KeyStyle.Render("<Enter>"),
-			dialog.KeyStyle.Render("<f>"),
+			dialog.KeyStyle.Render(dialog.BrowseHelpKey),
 			dialog.KeyStyle.Render("<Esc>"))
 	}
 	lines = append(lines, dialog.HelpStyle.Render(helpText))

--- a/views/stacks/view_test.go
+++ b/views/stacks/view_test.go
@@ -4,9 +4,13 @@
 package stacksview
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/Eldara-Tech/swarmcli/docker"
+	"github.com/Eldara-Tech/swarmcli/ui/dialog"
+
+	"github.com/charmbracelet/lipgloss"
 
 	"github.com/charmbracelet/x/ansi"
 	"github.com/stretchr/testify/require"
@@ -137,4 +141,54 @@ func TestView_ErrorColumnHeader(t *testing.T) {
 	m.List.Viewport.Height = 20
 	out := m.View()
 	require.Contains(t, out, "ERROR: 1")
+}
+
+// --- #525: the browse hint advertises the chord, from any focus ---
+
+func TestRenderCreateDialog_ShowsBrowseHintAtEveryFocus(t *testing.T) {
+	for _, focus := range []int{0, 1} {
+		m := testModel()
+		m.createDialogActive = true
+		m.createDialogStep = "details-file"
+		m.createInputFocus = focus
+		out := ansi.Strip(m.renderCreateDialog())
+		require.Contains(t, out, dialog.BrowseHint, "focus %d must show the browse hint", focus)
+		require.Contains(t, out, dialog.BrowseHelpKey)
+		require.NotContains(t, out, "[f: Browse]")
+		require.NotContains(t, out, "<f>")
+	}
+}
+
+func TestRenderSaveDialog_ShowsBrowseHint(t *testing.T) {
+	m := testModel()
+	m.saveDialogActive = true
+	m.saveStackName = "mystack"
+	out := ansi.Strip(m.renderSaveDialog())
+	require.Contains(t, out, dialog.BrowseHint)
+	require.Contains(t, out, dialog.BrowseHelpKey)
+	require.NotContains(t, out, "[f: Browse]")
+}
+
+// The hint used to be padded to a fixed width so the dialog would not resize
+// between focuses. It is unconditional now, so the width must hold on its own.
+func TestRenderCreateDialog_WidthIsStableAcrossFocus(t *testing.T) {
+	width := func(focus int) int {
+		m := testModel()
+		m.createDialogActive = true
+		m.createDialogStep = "details-file"
+		m.createInputFocus = focus
+		return widestLine(m.renderCreateDialog())
+	}
+	require.Equal(t, width(0), width(1))
+}
+
+// widestLine returns the widest rendered line, in cells.
+func widestLine(s string) int {
+	max := 0
+	for _, line := range strings.Split(ansi.Strip(s), "\n") {
+		if w := lipgloss.Width(line); w > max {
+			max = w
+		}
+	}
+	return max
 }


### PR DESCRIPTION
Closes #525.

## What was wrong

Five dialogs reserved a printable character as a hotkey while a text input held focus, so that character could not be typed into the field. All five reserved `f` over a **file-path** input, which rules out `/etc/docker/certs.d/…`, `fullchain.pem`, `./config/frontend.yml` — anything with an `f` anywhere in it. The only ways in were the file browser or a paste.

| Site | Key | Field with focus |
|---|---|---|
| `views/stacks/update.go:737` | `f`, `F` | create dialog path input |
| `views/stacks/update.go:957` | `f`, `F` | save dialog path input — no guard at all |
| `views/configs/update.go:779` | `f`, `F` | create dialog path input |
| `views/secrets/update.go:644` | `f`, `F` | create dialog path input |
| `views/contexts/update.go:420` | `f` only | CA / Cert / Key path inputs |

Three carried a comment that reads as a guard and is the opposite of one — focus 1 *is* the path input, so `f` reached the input only while the input was **not** focused.

## Why `ctrl+o` and not `ctrl+b`

The issue suggested `ctrl+b` as free across the repo. It is not free where it counts: `bubbles@v1.0.0/textinput/textinput.go:71` binds it to *CharacterBackward* in exactly these inputs, and it is **tmux's default prefix** — a swarmcli user inside tmux would have to press it twice.

`ctrl+o` is absent from the textinput keymap, free of the tmux and screen prefixes, and already the in-dialog "open" chord in the license dialog, where a test asserts it must not leak into the focused field. `^O`'s terminal `discard` meaning comes from `IEXTEN`, which raw mode clears.

## The second defect disappears rather than getting patched

`views/configs/update.go:791` routed its `f` fallthrough two ways where the dialog has three fields, so typing `f` into the labels field — reachable when label parsing fails after a file is picked, `:1029` — inserted it into the path the user had just chosen, with no feedback. The chord is focus-independent in the four dialogs that have exactly one path input, so the misrouting branch no longer exists. Contexts keeps a focus check: three cert paths, so the focused one is the target and the key is a no-op elsewhere.

## Adjacent, in the code already open

- **One router per dialog step.** Every other hand-rolled "route this key to the focused input" copy folds onto the single `default:` router via the `fallthrough` idiom `views/contexts/update.go:505` already used for space. `secrets` `details-inline` held **three** copies of one router in one switch, and `fallthrough` reaches only the next clause, so that one gets a `routeInlineKey` method instead. The copies were the hazard, not just the two that had already drifted.
- **A pre-existing 80-column overflow.** The contexts create dialog measured **89 cells** with TLS on — nine past an 80-column terminal — driven entirely by the help line being edited here. It drops the now-redundant browse entry (the per-field hint already advertises the key exactly when it is usable) and renders at **76**, pinned by a test.
- `views/stacks/update.go:818` had the same two-way `else` as the configs misroute, harmless only because stacks cannot reach focus 2. Normalised.

## Behaviour changes to know about

- **Muscle memory.** `f` worked for anyone who tabbed to the path field and pressed it. That breaks. Mitigated by the hint now rendering unconditionally rather than only on focus, so the new key is on screen before it is needed. Worth a release-note line.
- Space in the secrets file dialog now clears the error banner like every other typed character; the copy it replaced did not.
- The hint is `[^o Browse]` — the same 11 cells as `[f: Browse]`, so no dialog is re-laid-out, and the fixed-width padding that existed to stop the stacks dialog resizing is retired.

## Testing

`go build`, `go vet ./...`, `go test ./...` and `golangci-lint run ./... --build-tags=integration` (0 issues) all green.

New coverage, asserting on **input values** rather than on which branch ran: a regression test per site (typing `f` lands in the focused path), a trigger test per site, focus-independence for the four single-path dialogs plus the contexts no-op mirror, the configs misroute driven through the real browser-selection path so it proves focus 2 is reachable, table-driven walks of every reachable focus × `{f, F, e, x, space}` per collapsed switch, and rendering tests including the 80-column guard.

Note the `key()` helpers needed a real `tea.KeyCtrlO` case: they end in `KeyRunes{[]rune(s)}`, so `key("ctrl+o")` would otherwise have been a six-rune message that `String()`s to `"ctrl+o"` — passing against an event no terminal emits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)