### PR TITLE
feat(charts): an operator can supply a config, and changing it rotates it

### DIFF
--- a/charts/README.md
+++ b/charts/README.md
@@ -220,6 +220,7 @@ from a directory on your own disk:
 | `file:` / `env_file:` | |
 |---|---|
 | `files/nginx.conf`, `files/tls/ca.pem` | resolved against the chart |
+| `values/config` | resolved against the values — see below; a config's `file:` only |
 | `nginx.conf` | refused — outside `files/`, so not something the chart ships |
 | `files/missing.conf` | refused — the chart does not contain it |
 | `../../etc/shadow` | refused — escapes the chart |
@@ -244,16 +245,75 @@ configs:
     external: true
 ```
 
-**Declare a `swarmcliVersion` floor on any chart that uses `files/`** (see
+### A config the operator supplies
+
+The section above is about files a chart *ships*. A config the **operator**
+writes — a `config.js` they keep in their own git repository — is the other
+half, and `values/` is how a chart accepts one:
+
+```yaml
+# templates/configs.yaml
+configs:
+  config:
+    file: values/config
+    # Swarm config data is immutable, so the name has to change when the
+    # content does. Hashing the content makes that automatic and idempotent.
+    name: "{{ .Release.Name }}_config_{{ .Values.config | sha256sum | trunc 12 }}"
+```
+
+```yaml
+# values.yaml — "" so the name above renders; the operator supplies the content
+config: ""
+```
+
+```bash
+swarmcli charts upgrade renovate swarmcli-charts/renovate \
+  -f values.yaml --set-file config=./config.js
+```
+
+`--set-file <key>=<path>` reads the file into `.Values.<key>` verbatim — no comma
+splitting, no `{a,b}` list literal and no type inference, all of which `--set`
+does and all of which would corrupt a file. `values/<key>` then materialises that
+value beside the manifest for the `docker` CLI to read, exactly as `files/` does
+for a file the chart ships. The key is the full values path, so a nested one is
+`values/renovate.config`.
+
+Two rules keep this as safe as the refusals above:
+
+- **The operator names the path, never the chart.** That is the whole asymmetry.
+  A path on the operator's own command line carries exactly the authority they
+  already have; a path a chart chose does not, which is why `file: /etc/shadow`
+  stays refused.
+- **Only a config's `file:` may name `values/`.** A secret's is refused, and so
+  is `env_file:`. Values are stored in the release record — see below — so secret
+  *material* would land in the one place a secret exists to keep it out of.
+  Secrets stay `docker secret create` + `external: true`.
+
+An absent or empty value is refused rather than deployed, so an operator who
+forgets `--set-file` gets a message and not an empty config over a working one.
+
+**Why rotation, rather than editing the config?** Swarm config data is immutable.
+`docker stack deploy` reacts to changed content under an existing name by calling
+`ConfigUpdate`, and swarmkit refuses that with `only updates to Labels are
+allowed` — so a stable name does not update the config, it fails the deploy. A
+content-derived name is the only mechanism Swarm offers, and it is idempotent for
+free: unchanged content resolves to the same name and the same bytes, which is
+the one `ConfigUpdate` swarmkit does allow. Superseded configs are left in place
+— Swarm refuses to delete one still in use, and a custom `name:` still carries
+the stack's namespace label, so `docker stack rm` collects them.
+
+**Declare a `swarmcliVersion` floor on any chart that uses `files/` or
+`values/`** (see
 [Declaring the swarmcli a chart needs](#declaring-the-swarmcli-a-chart-needs),
-and set it to the release that introduced `files/`). A swarmcli older than that
-parses `Chart.yaml` leniently, ignores `files/` entirely, carries no guard, and
+and set it to the release that introduced them). A swarmcli older than that
+parses `Chart.yaml` leniently, ignores both entirely, carries no guard, and
 resolves `file: files/nginx.conf` against a temp directory of its own — so it
 does not fail, it deploys something else. Nothing can be done to an
 already-released binary, which makes the constraint the only thing that turns
 that into a refusal.
 
-Two consequences worth knowing:
+Two consequences worth knowing, and they apply to `values/` exactly as they do
+to `files/`:
 
 - **The referenced files are stored in the release record**, so a rollback
   deploys the bytes the original deploy sent rather than whatever the chart says
@@ -265,8 +325,10 @@ Two consequences worth knowing:
 - **That record is as readable as the manifest beside it.** A file referenced by
   a chart is stored verbatim in the same Docker Config, with the same exposure
   [issue #465](https://github.com/Eldara-Tech/swarmcli/issues/465) describes for
-  the manifest. Secret *material* still belongs in a Docker secret created
-  outside the chart and referenced with `external: true`.
+  the manifest — and so is every value, for **every retained revision**, not just
+  the current one. That is the reason a `values/` path may only give a *config*
+  its content: secret *material* still belongs in a Docker secret created outside
+  the chart and referenced with `external: true`.
 
 ### Declaring the swarmcli a chart needs
 

--- a/charts/apply.go
+++ b/charts/apply.go
@@ -236,7 +236,7 @@ func (e *Engine) planRelease(rf *ReleaseFile, spec ReleaseSpec, src ChartSource,
 	// same file/release prefix every other failure here carries: for a chart
 	// that reads a path outside itself, that message is the entire migration
 	// path there is.
-	chartFiles, err := ResolveManifestFiles(manifest, ch.Files)
+	chartFiles, err := ResolveManifestFiles(manifest, ch.Files, values)
 	if err != nil {
 		return ReleasePlan{}, fmt.Errorf("%s: release %q: %w", rf.Path, spec.Name, err)
 	}

--- a/charts/files.go
+++ b/charts/files.go
@@ -22,8 +22,27 @@ import (
 // breaking change into a support question.
 const chartFilesRule = "a chart may only read files it ships in " + filesDir + "/"
 
-// ResolveManifestFiles returns the chart files a rendered manifest names, and
-// refuses every path that cannot mean a file in the chart.
+// valuesDir is the one other directory a manifest may name: not a directory on
+// anyone's disk, but the effective values, materialised as files.
+//
+// It exists because a config the OPERATOR supplies had no mechanism at all.
+// Compose gives a config its content only through file:, there is no content:
+// field to inline with (docker/cli v28.5.1 config_schema_v3.9.json is
+// name/file/external/labels/template_driver, additionalProperties: false), and a
+// chart naming a path outside itself is exactly what chartFilesRule refuses —
+// rightly, since the docker CLI reads it as the invoking operator.
+//
+// The asymmetry that makes this safe is that the OPERATOR names the path, on
+// their own command line (--set-file), and the chart names only a values key. A
+// path the operator typed carries the authority they already have; a path a
+// chart chose does not. See issue #537.
+const valuesDir = "values"
+
+// valuesFilesRule is the sentence every refusal of a values/ path carries.
+const valuesFilesRule = valuesDir + "/ names a value, which the operator supplies (--set-file <key>=<path>, or a values file)"
+
+// ResolveManifestFiles returns the files a rendered manifest names, and refuses
+// every path that cannot mean either a file in the chart or one of values.
 //
 // Exactly three compose keys read a path — a config's file:, a secret's file:
 // and a service's env_file: — and the docker CLI resolves all three against the
@@ -40,36 +59,37 @@ const chartFilesRule = "a chart may only read files it ships in " + filesDir + "
 // into a swarm config that anyone with Docker access can read.
 //
 // This therefore refuses on the way past, in order: a path that is absolute,
-// one that escapes the chart, and one the chart does not contain — the last
-// including anything outside files/. None of it depends on where the chart was
-// loaded from. Trusting a local-path chart with an absolute path would grant the
-// most privilege to vendoring a repository chart to disk, which is the workflow
-// that most obscures a chart's origin.
+// one that escapes the chart, and one that is neither in the chart's files/ nor
+// in values/. None of it depends on where the chart was loaded from. Trusting a
+// local-path chart with an absolute path would grant the most privilege to
+// vendoring a repository chart to disk, which is the workflow that most obscures
+// a chart's origin.
 //
-// What survives comes back keyed exactly as Chart.Files keys it, and is
-// materialised beside the manifest at that same relative path — which is what
-// makes file: mean the chart. Only the referenced subset is returned: it is
-// persisted in the release record so a rollback replays the bytes the original
-// deploy sent, and that record has a hard size ceiling it shares with the
-// manifest.
+// A files/ path comes back keyed exactly as Chart.Files keys it; a values/ path
+// comes back keyed by the path the manifest wrote, carrying the value's bytes.
+// Both are materialised beside the manifest at that relative path — which is
+// what makes file: mean the chart, or the operator's own file, and nothing else.
+// Only the referenced subset is returned: it is persisted in the release record
+// so a rollback replays the bytes the original deploy sent, and that record has
+// a hard size ceiling it shares with the manifest.
 //
 // A manifest naming no file at all yields a nil map and no error, which is every
 // manifest a chart without a files/ directory can produce.
-func ResolveManifestFiles(manifest string, files map[string][]byte) (map[string][]byte, error) {
+func ResolveManifestFiles(manifest string, files map[string][]byte, values map[string]any) (map[string][]byte, error) {
 	refs, err := manifestFileRefs(manifest)
 	if err != nil {
 		return nil, err
 	}
 	var out map[string][]byte
 	for _, ref := range refs {
-		key, err := ref.resolve(files)
+		key, data, err := ref.resolve(files, values)
 		if err != nil {
 			return nil, err
 		}
 		if out == nil {
 			out = map[string][]byte{}
 		}
-		out[key] = files[key]
+		out[key] = data
 	}
 	return out, nil
 }
@@ -81,33 +101,92 @@ type fileRef struct {
 	path string // the path exactly as the manifest wrote it
 }
 
-// resolve returns the Chart.Files key this reference names, or the error that
-// refuses it. Every message names the offending path and states the rule; the
-// absolute one additionally names its replacement, because it is the only
-// refusal with a working chart behind it.
-func (r fileRef) resolve(files map[string][]byte) (string, error) {
+// resolve returns the key this reference contributes to the resolved file set
+// and the bytes behind it, or the error that refuses it. Every message names the
+// offending path and states the rule; the absolute one additionally names its
+// replacements, because it is the only refusal with a working chart behind it.
+func (r fileRef) resolve(files map[string][]byte, values map[string]any) (string, []byte, error) {
 	if path.IsAbs(r.path) {
-		return "", fmt.Errorf(
+		return "", nil, fmt.Errorf(
 			"%s: %q is an absolute path, and %s — copy it into the chart's %s/ and reference it by that path, "+
+				"or let the operator supply it (--set-file <key>=%s, referenced as %s/<key>), "+
 				"or keep it operator-managed by creating it outside the chart "+
 				"(docker config create <name> <path>, or docker secret create) and referencing it with external: true",
-			r.key, r.path, chartFilesRule, filesDir)
+			r.key, r.path, chartFilesRule, filesDir, r.path, valuesDir)
 	}
 	// The value came from YAML, which is slash-separated whatever the host is,
 	// so this is path and not filepath. Clean resolves every interior "..", so a
 	// leading one afterwards is the complete test for leaving the chart root.
 	clean := path.Clean(r.path)
 	if clean == ".." || strings.HasPrefix(clean, "../") {
-		return "", fmt.Errorf("%s: %q escapes the chart, and %s", r.key, r.path, chartFilesRule)
+		return "", nil, fmt.Errorf("%s: %q escapes the chart, and %s", r.key, r.path, chartFilesRule)
+	}
+	if key, ok := strings.CutPrefix(clean, valuesDir+"/"); ok {
+		data, err := r.resolveValue(key, values)
+		return clean, data, err
 	}
 	if !strings.HasPrefix(clean, filesDir+"/") {
-		return "", fmt.Errorf("%s: %q is outside %s/, and %s — reference it as %q",
-			r.key, r.path, filesDir, chartFilesRule, filesDir+"/"+clean)
+		return "", nil, fmt.Errorf("%s: %q is outside %s/ and %s/, and %s — reference it as %q",
+			r.key, r.path, filesDir, valuesDir, chartFilesRule, filesDir+"/"+clean)
 	}
 	if _, ok := files[clean]; !ok {
-		return "", fmt.Errorf("%s: %q is not in the chart, and %s", r.key, r.path, chartFilesRule)
+		return "", nil, fmt.Errorf("%s: %q is not in the chart, and %s", r.key, r.path, chartFilesRule)
 	}
-	return clean, nil
+	return clean, files[clean], nil
+}
+
+// resolveValue returns the bytes of the value a values/ path names.
+//
+// Only a config's file: may name one, and the two refusals are not symmetry for
+// its own sake. A values/ path is content the operator supplied through values,
+// and values are persisted in the release record — a Docker Config readable by
+// anyone with Docker access, for every retained revision, not just the current
+// one. Routing a SECRET's material through that would put it in the one place a
+// secret exists to keep it out of, so a secret stays what it has always been:
+// created outside the chart, referenced with external: true. env_file: is
+// refused for a different reason — it is expanded into the service's
+// environment, where docker inspect shows it, and it creates no config object,
+// so none of the rotation this mechanism exists for applies to it.
+func (r fileRef) resolveValue(key string, values map[string]any) ([]byte, error) {
+	if !strings.HasPrefix(r.key, "configs.") {
+		// Each refusal names its own replacement: a secret's is an external
+		// secret, and env_file:'s is the environment: block it expands into
+		// anyway, or a file the chart ships.
+		remedy := "put them in the service's environment: block, or ship the file in " + filesDir + "/"
+		if strings.HasPrefix(r.key, "secrets.") {
+			remedy = "create it outside the chart (docker secret create <name> <path>) " +
+				"and reference it with external: true"
+		}
+		return nil, fmt.Errorf("%s: %q — only a config's file: may name %s/, because a value is stored in the "+
+			"release record and is as readable as any config — %s",
+			r.key, r.path, valuesDir, remedy)
+	}
+	steps, err := parseSetPath(key)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %q is not a values path: %w", r.key, r.path, err)
+	}
+	v, ok := lookupPath(values, steps)
+	if !ok {
+		return nil, fmt.Errorf("%s: %q names no value, and %s", r.key, r.path, valuesFilesRule)
+	}
+	// Deliberately not a stringified number or a marshalled map: a config's
+	// content is a file the operator wrote, and anything else here is a chart
+	// naming the wrong key — which should say so rather than deploy a plausible
+	// rendering of the wrong thing.
+	s, ok := v.(string)
+	if !ok {
+		return nil, fmt.Errorf("%s: %q is a %T, and only a string can be a file — %s", r.key, r.path, v, valuesFilesRule)
+	}
+	// An empty value is unsupplied, not empty content. A chart referencing
+	// values/<key> has to default that key in values.yaml — to "", since a
+	// template computing the config's rotating name from it must render before
+	// anything here runs — so the operator who forgets --set-file arrives with
+	// exactly this, and the alternative to refusing is deploying an empty config
+	// over a working one. A config that must genuinely be empty can be a newline.
+	if s == "" {
+		return nil, fmt.Errorf("%s: %q is empty, and %s", r.key, r.path, valuesFilesRule)
+	}
+	return []byte(s), nil
 }
 
 // manifestFileRefs returns every path the manifest asks the docker CLI to read,

--- a/charts/files_test.go
+++ b/charts/files_test.go
@@ -4,6 +4,7 @@
 package charts
 
 import (
+	"path"
 	"strconv"
 	"testing"
 
@@ -87,7 +88,7 @@ func TestResolveManifestFilesRefusesEveryShapeOnEveryKey(t *testing.T) {
 	for _, k := range keys {
 		for _, s := range shapes {
 			t.Run(k.name+"/"+s.name, func(t *testing.T) {
-				got, err := ResolveManifestFiles(k.manifest(s.path), chartFiles())
+				got, err := ResolveManifestFiles(k.manifest(s.path), chartFiles(), nil)
 				require.Nil(t, got)
 				require.Error(t, err)
 				require.Contains(t, err.Error(), k.errKey, "the error must name the offending key")
@@ -102,23 +103,23 @@ func TestResolveManifestFilesRefusesEveryShapeOnEveryKey(t *testing.T) {
 func TestResolveManifestFilesEscapesFromInsideFiles(t *testing.T) {
 	// files/../../etc/shadow cleans to ../etc/shadow: it leaves the chart root
 	// even though it started under files/, which is what path.Clean is for.
-	_, err := ResolveManifestFiles(configManifest("files/../../etc/shadow"), chartFiles())
+	_, err := ResolveManifestFiles(configManifest("files/../../etc/shadow"), chartFiles(), nil)
 	require.ErrorContains(t, err, `"files/../../etc/shadow" escapes the chart`)
 
 	// files/../nginx.conf stays inside the chart but leaves files/, so it is the
 	// outside-files/ refusal and not the escape one.
-	_, err = ResolveManifestFiles(configManifest("files/../nginx.conf"), chartFiles())
+	_, err = ResolveManifestFiles(configManifest("files/../nginx.conf"), chartFiles(), nil)
 	require.ErrorContains(t, err, "is outside files/")
 }
 
 func TestResolveManifestFilesResolvesWhatTheManifestNames(t *testing.T) {
-	got, err := ResolveManifestFiles(configManifest("files/nginx.conf"), chartFiles())
+	got, err := ResolveManifestFiles(configManifest("files/nginx.conf"), chartFiles(), nil)
 	require.NoError(t, err)
 	require.Equal(t, map[string][]byte{"files/nginx.conf": []byte("server { listen 80; }")}, got)
 }
 
 func TestResolveManifestFilesResolvesANestedFile(t *testing.T) {
-	got, err := ResolveManifestFiles(secretManifest("files/tls/ca.pem"), chartFiles())
+	got, err := ResolveManifestFiles(secretManifest("files/tls/ca.pem"), chartFiles(), nil)
 	require.NoError(t, err)
 	require.Equal(t, map[string][]byte{"files/tls/ca.pem": []byte("-----BEGIN CERTIFICATE-----")}, got)
 }
@@ -127,7 +128,7 @@ func TestResolveManifestFilesNormalisesTheKey(t *testing.T) {
 	// ./files/nginx.conf resolves to the same file the docker CLI would read, so
 	// it comes back under the key Chart.Files uses — the key the materialiser
 	// writes to.
-	got, err := ResolveManifestFiles(configManifest("./files/nginx.conf"), chartFiles())
+	got, err := ResolveManifestFiles(configManifest("./files/nginx.conf"), chartFiles(), nil)
 	require.NoError(t, err)
 	require.Equal(t, map[string][]byte{"files/nginx.conf": []byte("server { listen 80; }")}, got)
 }
@@ -136,7 +137,7 @@ func TestResolveManifestFilesReturnsOnlyTheReferencedSubset(t *testing.T) {
 	manifest := "services:\n" +
 		"  web:\n    image: nginx\n    env_file: files/tls/ca.pem\n" +
 		"configs:\n  site:\n    file: files/nginx.conf\n"
-	got, err := ResolveManifestFiles(manifest, chartFiles())
+	got, err := ResolveManifestFiles(manifest, chartFiles(), nil)
 	require.NoError(t, err)
 	require.Equal(t, map[string][]byte{
 		"files/nginx.conf": []byte("server { listen 80; }"),
@@ -160,7 +161,7 @@ func TestResolveManifestFilesReturnsNilWhenNothingIsNamed(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := ResolveManifestFiles(tc.manifest, chartFiles())
+			got, err := ResolveManifestFiles(tc.manifest, chartFiles(), nil)
 			require.NoError(t, err)
 			require.Nil(t, got, "a manifest naming no file must yield nil, not an empty map")
 		})
@@ -169,14 +170,14 @@ func TestResolveManifestFilesReturnsNilWhenNothingIsNamed(t *testing.T) {
 
 func TestResolveManifestFilesReadsBothEnvFileShapes(t *testing.T) {
 	t.Run("bare string", func(t *testing.T) {
-		got, err := ResolveManifestFiles(envFileManifest("files/nginx.conf"), chartFiles())
+		got, err := ResolveManifestFiles(envFileManifest("files/nginx.conf"), chartFiles(), nil)
 		require.NoError(t, err)
 		require.Equal(t, map[string][]byte{"files/nginx.conf": []byte("server { listen 80; }")}, got)
 	})
 	t.Run("list", func(t *testing.T) {
 		manifest := "services:\n  web:\n    image: nginx\n    env_file:\n" +
 			"      - files/nginx.conf\n      - files/tls/ca.pem\n"
-		got, err := ResolveManifestFiles(manifest, chartFiles())
+		got, err := ResolveManifestFiles(manifest, chartFiles(), nil)
 		require.NoError(t, err)
 		require.Len(t, got, 2)
 		require.Contains(t, got, "files/nginx.conf")
@@ -185,7 +186,7 @@ func TestResolveManifestFilesReadsBothEnvFileShapes(t *testing.T) {
 	t.Run("a bad path anywhere in the list is refused", func(t *testing.T) {
 		manifest := "services:\n  web:\n    image: nginx\n    env_file:\n" +
 			"      - files/nginx.conf\n      - /etc/shadow\n"
-		_, err := ResolveManifestFiles(manifest, chartFiles())
+		_, err := ResolveManifestFiles(manifest, chartFiles(), nil)
 		require.ErrorContains(t, err, `"/etc/shadow"`)
 	})
 }
@@ -201,13 +202,13 @@ func TestResolveManifestFilesSeesEntriesBesideAMalformedOne(t *testing.T) {
 		"configs:\n  1:\n    external: true\n  site:\n    file: /etc/shadow\n",
 	}
 	for _, manifest := range cases {
-		_, err := ResolveManifestFiles(manifest, chartFiles())
+		_, err := ResolveManifestFiles(manifest, chartFiles(), nil)
 		require.ErrorContains(t, err, `"/etc/shadow"`, manifest)
 	}
 }
 
 func TestResolveManifestFilesRefusesAManifestItCannotParse(t *testing.T) {
-	_, err := ResolveManifestFiles("services:\n  web:\n   - :\n  bad\n", chartFiles())
+	_, err := ResolveManifestFiles("services:\n  web:\n   - :\n  bad\n", chartFiles(), nil)
 	require.ErrorContains(t, err, "parse manifest")
 }
 
@@ -219,17 +220,152 @@ func TestResolveManifestFilesRefusesDeterministically(t *testing.T) {
 		"  a:\n    file: /etc/shadow\n" +
 		"  b:\n    file: ../../etc/passwd\n" +
 		"  c:\n    file: nginx.conf\n"
-	first, err := ResolveManifestFiles(manifest, chartFiles())
+	first, err := ResolveManifestFiles(manifest, chartFiles(), nil)
 	require.Nil(t, first)
 	require.Error(t, err)
 	for range 20 {
-		_, again := ResolveManifestFiles(manifest, chartFiles())
+		_, again := ResolveManifestFiles(manifest, chartFiles(), nil)
 		require.EqualError(t, again, err.Error())
 	}
 	require.Contains(t, err.Error(), "configs.a.file")
 }
 
 func TestResolveManifestFilesRefusesAgainstAChartWithNoFiles(t *testing.T) {
-	_, err := ResolveManifestFiles(configManifest("files/nginx.conf"), nil)
+	_, err := ResolveManifestFiles(configManifest("files/nginx.conf"), nil, nil)
 	require.ErrorContains(t, err, `"files/nginx.conf" is not in the chart`)
+}
+
+// --- values/: the config the operator supplies (#537) ---
+
+const operatorConfig = "module.exports = { platform: 'github' };\n"
+
+func TestResolveManifestFilesResolvesAValue(t *testing.T) {
+	cases := []struct {
+		name   string
+		path   string
+		values map[string]any
+	}{
+		{"top-level key", "values/config", map[string]any{"config": operatorConfig}},
+		{
+			"nested key", "values/renovate.config",
+			map[string]any{"renovate": map[string]any{"config": operatorConfig}},
+		},
+		{
+			// The docker CLI reads ./values/config and values/config as the same
+			// file, so both must key the materialised tree identically.
+			"normalised", "./values/config", map[string]any{"config": operatorConfig},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ResolveManifestFiles(configManifest(tc.path), chartFiles(), tc.values)
+			require.NoError(t, err)
+			require.Equal(t, map[string][]byte{path.Clean(tc.path): []byte(operatorConfig)}, got)
+		})
+	}
+}
+
+// TestResolveManifestFilesRefusesAValueForASecret is the containment: values are
+// persisted in the release record, which is a Docker Config readable by anyone
+// with Docker access for every retained revision, so secret material must not
+// reach it. env_file: is refused too — it expands into the service environment
+// and creates no config object.
+func TestResolveManifestFilesRefusesAValueForASecret(t *testing.T) {
+	values := map[string]any{"config": operatorConfig}
+	cases := []struct {
+		name     string
+		manifest func(string) string
+		errKey   string
+		// Each refusal names the replacement for ITS key, not a generic one:
+		// docker secret create is no help to an env_file:.
+		remedy []string
+	}{
+		{"secrets.file", secretManifest, "secrets.site.file", []string{"docker secret create", "external: true"}},
+		{"services.env_file", envFileManifest, "services.web.env_file", []string{"environment:", "files/"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ResolveManifestFiles(tc.manifest("values/config"), chartFiles(), values)
+			require.Nil(t, got)
+			require.ErrorContains(t, err, tc.errKey)
+			require.ErrorContains(t, err, "only a config's file: may name values/")
+			for _, want := range tc.remedy {
+				require.ErrorContains(t, err, want)
+			}
+		})
+	}
+}
+
+func TestResolveManifestFilesRefusesAValueItCannotUse(t *testing.T) {
+	cases := []struct {
+		name   string
+		path   string
+		values map[string]any
+		want   string
+	}{
+		{"absent", "values/config", nil, `"values/config" names no value`},
+		{
+			// The chart has to default the key so its rotating name renders, so
+			// this is what a forgotten --set-file looks like — and deploying an
+			// empty config over a working one is the worst available outcome.
+			"empty", "values/config",
+			map[string]any{"config": ""},
+			`"values/config" is empty`,
+		},
+		{
+			"absent under a key that exists", "values/renovate.config",
+			map[string]any{"renovate": map[string]any{"other": "x"}},
+			`"values/renovate.config" names no value`,
+		},
+		{
+			// Walking into a scalar as if it were a map is absence, not a panic.
+			"parent is not a map", "values/renovate.config",
+			map[string]any{"renovate": "not a map"},
+			`"values/renovate.config" names no value`,
+		},
+		{
+			"a map is not a file", "values/config",
+			map[string]any{"config": map[string]any{"a": 1}},
+			"is a map[string]interface {}, and only a string can be a file",
+		},
+		{
+			// A number would stringify plausibly, which is exactly why it is
+			// refused: it means the chart named the wrong key.
+			"a number is not a file", "values/config",
+			map[string]any{"config": 42},
+			"is a int, and only a string can be a file",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ResolveManifestFiles(configManifest(tc.path), chartFiles(), tc.values)
+			require.Nil(t, got)
+			require.ErrorContains(t, err, tc.want)
+			// Every one of these names the flag that supplies the value.
+			require.ErrorContains(t, err, "--set-file")
+		})
+	}
+}
+
+// TestResolveManifestFilesRefusesAnEscapeFromValues pins that values/ is a
+// prefix rule and not a prefix strip: a path leaving it is refused exactly as
+// one leaving files/ is, so it can never reach a value by walking out and back.
+func TestResolveManifestFilesRefusesAnEscapeFromValues(t *testing.T) {
+	values := map[string]any{"config": operatorConfig}
+	_, err := ResolveManifestFiles(configManifest("values/../../etc/shadow"), chartFiles(), values)
+	require.ErrorContains(t, err, "escapes the chart")
+
+	_, err = ResolveManifestFiles(configManifest("values/../nginx.conf"), chartFiles(), values)
+	require.ErrorContains(t, err, "is outside files/ and values/")
+}
+
+func TestResolveManifestFilesMixesChartFilesAndValues(t *testing.T) {
+	manifest := "services:\n  web:\n    image: nginx\n" +
+		"configs:\n  site:\n    file: files/nginx.conf\n  app:\n    file: values/config\n"
+	got, err := ResolveManifestFiles(manifest, chartFiles(), map[string]any{"config": operatorConfig})
+	require.NoError(t, err)
+	require.Equal(t, map[string][]byte{
+		"files/nginx.conf": []byte("server { listen 80; }"),
+		"values/config":    []byte(operatorConfig),
+	}, got)
 }

--- a/charts/values.go
+++ b/charts/values.go
@@ -64,6 +64,37 @@ func applySet(dst map[string]any, expr string) error {
 	return nil
 }
 
+// SetFile is one --set-file: the values key to populate, and the bytes read
+// from the path the operator named. The caller does the reading, so nothing in
+// this package opens a file it was not handed.
+type SetFile struct {
+	Key  string
+	Data []byte
+}
+
+// ApplySetFiles sets each key to its file's contents, verbatim.
+//
+// It is --set without the parsing: no comma splitting, no "{a,b}" list literal
+// and no type inference, because the content is a file the operator wrote and
+// every one of those would corrupt it — a config.js full of commas would be cut
+// into fragments, and one reading "true" would become a boolean.
+//
+// Applied after MergeValues, so a --set-file wins over both a values file and a
+// --set naming the same key, matching the order the flags are documented in.
+func ApplySetFiles(dst map[string]any, sets []SetFile) error {
+	for _, sf := range sets {
+		if sf.Key == "" {
+			return fmt.Errorf("--set-file: empty key")
+		}
+		steps, err := parseSetPath(sf.Key)
+		if err != nil {
+			return fmt.Errorf("--set-file %q: %w", sf.Key, err)
+		}
+		setPath(dst, steps, string(sf.Data))
+	}
+	return nil
+}
+
 // setStep is one hop of a --set path: a map key, or a list index.
 type setStep struct {
 	key     string
@@ -161,6 +192,37 @@ func inferValue(s string) any {
 		return out
 	}
 	return inferScalar(unescapeCommas(s))
+}
+
+// lookupPath reads the value at the given hops, reporting whether every hop
+// existed. The inverse of setPath, and the reason a manifest's values/<key> is
+// resolved against the effective values rather than against the --set-file
+// flags: an upgrade with --reuse-values, a values file carrying the content
+// inline, and a rollback replaying a stored record all reach the value the same
+// way, and none of them has a flag to consult.
+//
+// A hop into something that is not the container the step wants — a key of a
+// list, an index of a map — is absent rather than an error, which is what
+// "names no value" means to the caller.
+func lookupPath(cur any, steps []setStep) (any, bool) {
+	for _, s := range steps {
+		if s.isIndex {
+			lst, ok := cur.([]any)
+			if !ok || s.index >= len(lst) {
+				return nil, false
+			}
+			cur = lst[s.index]
+			continue
+		}
+		m, ok := cur.(map[string]any)
+		if !ok {
+			return nil, false
+		}
+		if cur, ok = m[s.key]; !ok {
+			return nil, false
+		}
+	}
+	return cur, true
 }
 
 // setPath assigns val at the given hops, creating maps and lists along the way and

--- a/charts/values_test.go
+++ b/charts/values_test.go
@@ -97,3 +97,73 @@ func TestMergeValuesSetListErrors(t *testing.T) {
 		require.Contains(t, err.Error(), "--set")
 	}
 }
+
+// --- --set-file (#537) ---
+
+// The whole point of a separate flag: --set applies inference and comma
+// splitting, and both destroy a file. A config.js is full of commas and a
+// one-line file may read "true".
+func TestApplySetFilesTakesTheContentVerbatim(t *testing.T) {
+	const js = "module.exports = { a: 1, b: [2, 3] };\n"
+	dst := map[string]any{}
+	require.NoError(t, ApplySetFiles(dst, []SetFile{
+		{Key: "config", Data: []byte(js)},
+		{Key: "flag", Data: []byte("true")},
+	}))
+	require.Equal(t, js, dst["config"])
+	require.Equal(t, "true", dst["flag"], "a file reading \"true\" is a string, not a bool")
+}
+
+func TestApplySetFilesWritesANestedKey(t *testing.T) {
+	dst := map[string]any{"renovate": map[string]any{"image": "renovate/renovate"}}
+	require.NoError(t, ApplySetFiles(dst, []SetFile{{Key: "renovate.config", Data: []byte("x")}}))
+	require.Equal(t, map[string]any{"image": "renovate/renovate", "config": "x"}, dst["renovate"])
+}
+
+// --set-file is applied after MergeValues, so it wins over a values file and a
+// --set naming the same key.
+func TestApplySetFilesOverrideOrder(t *testing.T) {
+	dst, err := MergeValues(map[string]any{"config": "from defaults"}, nil, []string{"config=from --set"})
+	require.NoError(t, err)
+	require.NoError(t, ApplySetFiles(dst, []SetFile{{Key: "config", Data: []byte("from --set-file")}}))
+	require.Equal(t, "from --set-file", dst["config"])
+}
+
+func TestApplySetFilesRejectsAMalformedKey(t *testing.T) {
+	for _, key := range []string{"", "a..b", "a[x]", "[0]"} {
+		require.Error(t, ApplySetFiles(map[string]any{}, []SetFile{{Key: key, Data: []byte("x")}}),
+			"--set-file %q must be rejected", key)
+	}
+}
+
+// lookupPath is the inverse of setPath, and every path setPath writes it must
+// read back — that pairing is what lets a manifest's values/<key> resolve
+// against the effective values, whatever put them there.
+func TestLookupPathRoundTripsSetPath(t *testing.T) {
+	for _, path := range []string{"a", "a.b.c", "a[0]", "a.b[1].c"} {
+		steps, err := parseSetPath(path)
+		require.NoError(t, err)
+		dst := map[string]any{}
+		setPath(dst, steps, "x")
+		got, ok := lookupPath(dst, steps)
+		require.True(t, ok, "lookupPath must find what setPath wrote at %q", path)
+		require.Equal(t, "x", got)
+	}
+}
+
+func TestLookupPathReportsAbsence(t *testing.T) {
+	values := map[string]any{"a": map[string]any{"b": "x"}, "list": []any{"one"}}
+	for _, path := range []string{
+		"missing",   // no such key
+		"a.missing", // no such key under an existing map
+		"a.b.c",     // hop into a scalar
+		"list[1]",   // index past the end
+		"a[0]",      // index into a map
+		"list.key",  // key of a list
+	} {
+		steps, err := parseSetPath(path)
+		require.NoError(t, err)
+		_, ok := lookupPath(values, steps)
+		require.False(t, ok, "%q names no value", path)
+	}
+}

--- a/cli/apply.go
+++ b/cli/apply.go
@@ -123,6 +123,9 @@ func rejectUnsupported(f flags) error {
 	if len(f.sets) > 0 {
 		bad = append(bad, "--set")
 	}
+	if len(f.setFiles) > 0 {
+		bad = append(bad, "--set-file")
+	}
 	if f.version != "" {
 		bad = append(bad, "--version")
 	}

--- a/cli/args.go
+++ b/cli/args.go
@@ -17,6 +17,7 @@ import (
 type flags struct {
 	values       []string // -f/--values, repeatable
 	sets         []string // --set, repeatable
+	setFiles     []string // --set-file key=path, repeatable
 	version      string   // --version, chart version selector
 	dryRun       bool
 	wait         bool
@@ -82,6 +83,12 @@ func parseArgs(args []string) ([]string, flags, error) {
 				return nil, f, err
 			}
 			f.sets = append(f.sets, v)
+		case "--set-file":
+			v, err := next()
+			if err != nil {
+				return nil, f, err
+			}
+			f.setFiles = append(f.setFiles, v)
 		case "--resolve-image":
 			v, err := next()
 			if err != nil {

--- a/cli/charts.go
+++ b/cli/charts.go
@@ -83,6 +83,10 @@ interactively; apply never does. template, diff and show only warn. Pass
 Common options:
   -f, --values <file>   Values file (repeatable). For apply: the release file.
       --set k=v         Override a value (repeatable)
+      --set-file k=path Set a value to a file's contents (repeatable). A chart
+                        references it as values/<k> from a config's file:, which
+                        is how an operator supplies a config the chart does not
+                        ship. See charts/README.md.
       --version <ver>   Chart version, for a <repo>/<chart> reference (default: latest).
                         Not valid with a local chart path — its Chart.yaml sets the version.
       --dry-run         Render and validate without deploying
@@ -110,8 +114,8 @@ other version — it cannot tell you the chart RUNS on that version, because thi
 binary carries only its own engine's behaviour. Rendering with a real binary of
 that version is the only thing that settles that.
 
-apply honours --wait, --timeout, --history-max and --resolve-image. It REJECTS --set, --version,
---reuse-values, --install, --purge-volumes, --requirements and --revision rather
+apply honours --wait, --timeout, --history-max and --resolve-image. It REJECTS --set,
+--set-file, --version, --reuse-values, --install, --purge-volumes, --requirements and --revision rather
 than ignoring them: the release file is the only source of truth, so a value passed
 on the command line would be a lie. outdated refreshes the repository indexes first
 and falls back to the cached ones if the network is unavailable.
@@ -703,6 +707,15 @@ func prepare(release, ref string, f flags, base map[string]any, pol compatPolicy
 	if err != nil {
 		return "", nil, rc, nil, nil, fail(err)
 	}
+	setFiles, err := readSetFiles(f.setFiles)
+	if err != nil {
+		return "", nil, rc, nil, nil, fail(err)
+	}
+	// After the merge and before validation: a --set-file is an override like
+	// --set, and the schema should see the content the render will.
+	if err := charts.ApplySetFiles(values, setFiles); err != nil {
+		return "", nil, rc, nil, nil, fail(err)
+	}
 	if err := charts.ValidateValues(ch.Schema, values); err != nil {
 		return "", nil, rc, nil, nil, fail(err)
 	}
@@ -725,7 +738,7 @@ func prepare(release, ref string, f flags, base map[string]any, pol compatPolicy
 	// fail() prints the error and nothing else: a path a chart may not read is a
 	// breaking change with no compatibility flag behind it, so this message is
 	// the whole of the migration path and must reach the operator verbatim.
-	chartFiles, err = charts.ResolveManifestFiles(manifest, ch.Files)
+	chartFiles, err = charts.ResolveManifestFiles(manifest, ch.Files, values)
 	if err != nil {
 		return "", nil, rc, nil, nil, fail(err)
 	}
@@ -834,6 +847,31 @@ func readValuesFiles(paths []string) ([][]byte, error) {
 			return nil, fmt.Errorf("read values file %q: %w", p, err)
 		}
 		out = append(out, b)
+	}
+	return out, nil
+}
+
+// readSetFiles parses each --set-file "key=path" and reads the file the
+// operator named.
+//
+// Split on the FIRST "=", so a path containing one still works; a key cannot
+// contain one, since a values path is dots and bracketed indices.
+func readSetFiles(specs []string) ([]charts.SetFile, error) {
+	var out []charts.SetFile
+	for _, s := range specs {
+		key, path, ok := strings.Cut(s, "=")
+		if !ok {
+			return nil, fmt.Errorf("--set-file %q: expected key=path", s)
+		}
+		key, path = strings.TrimSpace(key), strings.TrimSpace(path)
+		if key == "" || path == "" {
+			return nil, fmt.Errorf("--set-file %q: expected key=path", s)
+		}
+		b, err := os.ReadFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("--set-file %s: read %q: %w", key, path, err)
+		}
+		out = append(out, charts.SetFile{Key: key, Data: b})
 	}
 	return out, nil
 }

--- a/cli/charts_test.go
+++ b/cli/charts_test.go
@@ -170,6 +170,85 @@ func TestChartsTemplateAcceptsAFileTheChartShips(t *testing.T) {
 	require.Contains(t, o, "file: files/nginx.conf")
 }
 
+// valueChartDir writes the chart shape #537 exists for: a config the chart does
+// not ship, supplied by the operator, whose swarm object is named after the
+// content it carries so that changing the content rotates it. Swarm config data
+// is immutable — `docker stack deploy` reacts to changed content under an
+// existing name with ConfigUpdate, which swarmkit refuses with "only updates to
+// Labels are allowed" — so a stable name would not update, it would fail.
+func valueChartDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "templates"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "Chart.yaml"),
+		[]byte("name: renovate\nversion: 1.0.0\nswarmcliVersion: \">= 1.13.0\"\n"), 0o644))
+	// config: "" so the name below renders before anything supplies it; an
+	// operator who forgets --set-file is then refused rather than deploying it.
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "values.yaml"), []byte("config: \"\"\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "templates", "stack.yaml"), []byte(
+		"services:\n  renovate:\n    image: renovate/renovate\n    configs:\n"+
+			"      - source: config\n        target: /usr/src/app/config.js\n"+
+			"configs:\n  config:\n    file: values/config\n"+
+			"    name: \"{{ .Release.Name }}_config_{{ .Values.config | sha256sum | trunc 12 }}\"\n"), 0o644))
+	return dir
+}
+
+func TestChartsTemplateSetFileSuppliesAConfig(t *testing.T) {
+	dir := valueChartDir(t)
+	js := filepath.Join(t.TempDir(), "config.js")
+	require.NoError(t, os.WriteFile(js, []byte("module.exports = { platform: 'github' };\n"), 0o644))
+
+	render := func() string {
+		var code int
+		o, errOut := capture(t, func() {
+			code = Dispatch([]string{"charts", "template", "renovate", dir, "--set-file", "config=" + js}, "dev")
+		})
+		require.Equal(t, 0, code, errOut)
+		return o
+	}
+
+	first := render()
+	require.Contains(t, first, "file: values/config")
+	require.Regexp(t, `name: renovate_config_[0-9a-f]{12}`, first)
+
+	// Rotation: new content, new name — which is the whole mechanism, and the
+	// only thing Swarm offers for changing a config's contents.
+	require.NoError(t, os.WriteFile(js, []byte("module.exports = { platform: 'gitea' };\n"), 0o644))
+	require.NotEqual(t, first, render(), "changed content must render a different config name")
+}
+
+func TestChartsTemplateSetFileRefusals(t *testing.T) {
+	dir := valueChartDir(t)
+	js := filepath.Join(t.TempDir(), "config.js")
+	require.NoError(t, os.WriteFile(js, []byte("module.exports = {};\n"), 0o644))
+
+	for _, tc := range []struct {
+		name string
+		args []string
+		want string
+	}{
+		{
+			// The chart renders — the refusal is the resolution, and without it
+			// the operator would get an empty config deployed over a working one.
+			"forgotten flag", nil, `"values/config" is empty`,
+		},
+		{"unreadable file", []string{"--set-file", "config=" + filepath.Join(dir, "nope.js")}, "read"},
+		{"no key", []string{"--set-file", js}, "expected key=path"},
+		{"empty path", []string{"--set-file", "config="}, "expected key=path"},
+		{"malformed key", []string{"--set-file", "config..x=" + js}, "--set-file"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var code int
+			o, errOut := capture(t, func() {
+				code = Dispatch(append([]string{"charts", "template", "renovate", dir}, tc.args...), "dev")
+			})
+			require.Equal(t, 1, code)
+			require.Empty(t, o, "a manifest that cannot be deployed must not be printed as if it could")
+			require.Contains(t, errOut, tc.want)
+		})
+	}
+}
+
 func TestParseArgs(t *testing.T) {
 	pos, f, err := parseArgs([]string{"rel", "repo/chart", "-f", "a.yaml", "--values", "b.yaml", "--set", "x=1", "--dry-run", "--timeout", "10m"})
 	require.NoError(t, err)
@@ -181,10 +260,20 @@ func TestParseArgs(t *testing.T) {
 }
 
 func TestParseArgsInlineValue(t *testing.T) {
-	_, f, err := parseArgs([]string{"--set=a=1", "--version=2.0.0"})
+	_, f, err := parseArgs([]string{"--set=a=1", "--set-file=b=./b.js", "--version=2.0.0"})
 	require.NoError(t, err)
 	require.Equal(t, []string{"a=1"}, f.sets)
+	require.Equal(t, []string{"b=./b.js"}, f.setFiles)
 	require.Equal(t, "2.0.0", f.version)
+}
+
+func TestParseArgsSetFile(t *testing.T) {
+	_, f, err := parseArgs([]string{"--set-file", "a=./a.js", "--set-file", "b.c=./b.js"})
+	require.NoError(t, err)
+	require.Equal(t, []string{"a=./a.js", "b.c=./b.js"}, f.setFiles)
+
+	_, _, err = parseArgs([]string{"--set-file"})
+	require.ErrorContains(t, err, "requires a value")
 }
 
 func TestParseArgsRequirements(t *testing.T) {
@@ -253,6 +342,7 @@ func TestChartsApplyRejectsUnsupportedFlags(t *testing.T) {
 
 	for _, flag := range [][]string{
 		{"--set", "a=1"},
+		{"--set-file", "a=/dev/null"},
 		{"--version", "1.0.0"},
 		{"--reuse-values"},
 		{"--install"},


### PR DESCRIPTION
Closes #537.

## What was missing

A config the **operator** writes had no mechanism, and no way to change it afterwards. The three premises #537 rests on, verified against the dependency source:

- **No `content:` to inline with.** `docker/cli` v28.5.1 `cli/compose/schema/data/config_schema_v3.9.json` defines a config as `name`/`file`/`external`/`labels`/`template_driver` with `additionalProperties: false`.
- **Re-deploying cannot update one.** `createConfigs` (`cli/command/stack/swarm/deploy_composefile.go:134`) calls `ConfigUpdate` for an existing name, and swarmkit v2.1.2 `manager/controlapi/config.go:66` refuses it with `only updates to Labels are allowed` whenever `!bytes.Equal(request.Spec.Data, config.Spec.Data)`. Editing the file does not update anything — it fails the deploy.
- **Rotation is collectable.** `fileObjectConfig` (`cli/compose/convert/compose.go:179`) applies `AddStackLabel` even to a custom `name:`, so superseded objects still carry the stack namespace label and `docker stack rm` collects them.

## The shape

```yaml
# templates/configs.yaml
configs:
  config:
    file: values/config
    name: "{{ .Release.Name }}_config_{{ .Values.config | sha256sum | trunc 12 }}"
```
```yaml
# values.yaml — "" so the name above renders; the operator supplies the content
config: ""
```
```bash
swarmcli charts upgrade renovate swarmcli-charts/renovate \
  -f values.yaml --set-file config=./config.js
```

The engine creates **nothing** out of band. `writeStackTree` already materialises an arbitrary file set beside the manifest, and `docker stack deploy` resolves `file:` against that directory — so it still does the creating, the stack-labelling and the rollout. Content-hash naming is idempotent for free: unchanged content resolves to the same name and the same bytes, which is the one `ConfigUpdate` swarmkit *does* allow.

`--set-file` is `--set` without the parsing — no comma splitting, no `{a,b}` literal, no type inference, all three of which corrupt a file (a `config.js` is full of commas; a one-line file may read `true`).

## Why values, not the flag

`values/<key>` resolves against the **effective values**, so `--set-file` is only sugar for "set this key to these bytes". `--reuse-values` on upgrade, a values file carrying the content inline, and a rollback replaying a stored record all reach the value the same way — and none of them has a flag to consult. Resolving against the flag would have made `--reuse-values` refuse a manifest it had itself produced.

## Containment

`newRevision` persists `Values` **and** `Files`, in a Docker Config readable by anyone with Docker access, for **every retained revision**. #537 asked for that to be settled before building rather than retrofitted; this is the answer:

- **Only a config's `file:` may name `values/`.** A secret's is refused — secret material must not land in the one place a secret exists to keep it out of — and `env_file:` is refused too, since it expands into the service environment and creates no config object, so none of the rotation applies. Each refusal names its own replacement.
- **An absent or empty value is refused rather than deployed.** A chart must default the key to `""` for its rotating name to render, so an operator who forgets `--set-file` arrives with exactly that; the alternative to refusing is deploying an empty config over a working one.
- **`apply` REJECTS `--set-file`**, like `--set`: the release file is its only source of truth.

No new read authority: a chart could already render any value into an env var or a command, which lands in the service spec *and* the record. `values/` reaches values, and nothing else — `file: /etc/shadow` stays refused, for every chart, however it was loaded.

## Tests

`charts`: values/ resolution (top-level, nested, normalised), the secret/`env_file` refusals with their distinct remedies, absent/empty/wrong-type values, escapes out of `values/`, chart files and values in one manifest; `ApplySetFiles` verbatim-content and override order; `lookupPath` round-tripping `setPath` and reporting absence. `cli`: the full path end to end — `--set-file` through render to resolution, a second render proving the name rotates with the content, and every refusal including the forgotten flag.

## Not verified here

No Docker daemon was available, so the live `docker stack deploy` leg (create → rotate → `stack rm` collects the superseded object) rests on the dependency source cited above, not on an observed deploy.

## Follow-ups, deliberately not in this PR

- The declarative path: a release file's values can already carry the content inline, but there is no `setFiles:` field resolved relative to the file, which is what `swarmcli-charts#109`'s reporter actually keeps in git and what swarmcli-cd would use.
- `swarmcli-charts`: `charts/renovate` can drop its `configVersion` workaround (swarmcli-charts#113) for this, once a release carrying it exists to raise the chart's `swarmcliVersion` floor to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
