### PR TITLE
fix(stacks): a bind source names a node, so a relative one is refused

### DIFF
--- a/charts/README.md
+++ b/charts/README.md
@@ -330,6 +330,35 @@ to `files/`:
   its content: secret *material* still belongs in a Docker secret created outside
   the chart and referenced with `external: true`.
 
+### Bind mounts name the node, so their source must be absolute
+
+A `file:` reads the chart. A bind mount does not read anything — it names a path
+on **whichever node runs the task**, which is a machine the chart author has
+never seen. So a source that is not absolute has nothing to resolve against, and
+is refused before the deploy:
+
+```yaml
+services:
+  web:
+    volumes:
+      - ./data:/data          # refused — relative
+      - ~/data:/data          # refused — that is your home, not the node's
+      - /srv/app/data:/data   # deployed — a path on the node
+      - data:/data            # deployed — a named volume
+```
+
+This is the same defect as the one above, one key over: the docker CLI resolved
+those sources against the temp directory swarmcli deploys from, so `./data` meant
+a directory swarmcli itself deletes when the deploy returns. Nothing was read or
+disclosed — a bind source is a string the daemon acts on — but the mount was
+never the one the chart meant.
+
+An absolute source is deployed as written, and is deliberately privileged: a bind
+of `/var/run/docker.sock` on a manager is the swarm's control plane. That is a
+property of compose, and CE leaves the decision with the operator who installs
+the chart. swarmcli-cd, which reconciles charts nobody is watching, additionally
+requires the application's own allowlist to name the path.
+
 ### Declaring the swarmcli a chart needs
 
 A chart may state the chart engine it requires, as a SemVer constraint:

--- a/docker/stack_binds.go
+++ b/docker/stack_binds.go
@@ -1,0 +1,199 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package docker
+
+import (
+	"fmt"
+	"maps"
+	"path"
+	"slices"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// checkBindSources refuses a bind mount whose source is not an absolute path.
+//
+// A swarm bind mount names a path on whichever node runs the task, so a source
+// that is not absolute has no referent at all — and nothing downstream says so.
+// The docker CLI resolves every bind source against the directory of the compose
+// file it was handed (resolveVolumePaths in cli/compose/loader, docker/cli
+// v28.5.1), and the compose file swarmcli hands it is the manifest writeStackTree
+// just put in a temporary directory. So `./data:/data` has always meant a path
+// under swarmcli's own temp directory — on a node that has never heard of it, and
+// which swarmcli deletes the moment the deploy returns. `~/data` differs only in
+// being legible: expandUser resolves it against the HOME of whoever ran swarmcli,
+// which is not the machine the container runs on either.
+//
+// This runs before the manifest is written, because once the loader has run the
+// source has already been rewritten and the evidence is gone — the same reason
+// charts.ResolveManifestFiles reads the document rather than the loaded config.
+//
+// Every deploy passes through here: charts install, upgrade and rollback, and
+// the stacks view's three raw paths. They share the temp directory, so they
+// share the defect, so they share the refusal.
+//
+// An absolute source is left alone. A bind naming a real path on a real node is
+// a documented and deliberately privileged thing for a swarm service to do, and
+// it is a property of compose rather than a swarmcli defect.
+//
+// swarmcli-cd refuses the same thing in the same words (compose.checkBindSources)
+// so that an operator meeting this in both editions meets one rule.
+func checkBindSources(manifest string) error {
+	var top map[string]yaml.Node
+	if err := yaml.Unmarshal([]byte(manifest), &top); err != nil {
+		// A refusal rather than an empty result: this is the guard, and a
+		// manifest it cannot parse is one whose volumes it cannot see.
+		return fmt.Errorf("parse manifest: %w", err)
+	}
+	// Walked as yaml.Nodes rather than decoded into map[string]any because one
+	// non-string key anywhere in the services mapping makes yaml.v3 hand back a
+	// map[any]any for the WHOLE mapping, so a type assertion would hide every
+	// sibling service — a guard that quietly stops looking is worse than none.
+	section := top["services"]
+	var services map[string]yaml.Node
+	_ = section.Decode(&services)
+
+	// Sorted, so a manifest with more than one offender always refuses on the
+	// same one.
+	for _, name := range slices.Sorted(maps.Keys(services)) {
+		node := services[name]
+		var svc struct {
+			Volumes yaml.Node `yaml:"volumes"`
+		}
+		if err := node.Decode(&svc); err != nil || svc.Volumes.Kind != yaml.SequenceNode {
+			continue
+		}
+		for _, item := range svc.Volumes.Content {
+			source, ok := bindSource(item)
+			if !ok || source == "" || isAbsBindSource(source) {
+				continue
+			}
+			return fmt.Errorf("service %q: bind source %q is relative; a swarm bind mount names a path "+
+				"on the node that runs the task, so it must be absolute (or use a named volume)", name, source)
+		}
+	}
+	return nil
+}
+
+// bindSource returns the host path one volume entry names, and whether it names
+// one at all.
+//
+// The long form is read by its type:, and two of the six name a host path: bind,
+// and npipe. npipe is here because it is what this would otherwise be one word
+// away from missing — it converts without complaint. The other four name none:
+// volume and cluster take a volume name, image an image reference, and tmpfs no
+// source at all.
+func bindSource(item *yaml.Node) (string, bool) {
+	switch item.Kind {
+	case yaml.ScalarNode:
+		var spec string
+		if err := item.Decode(&spec); err != nil {
+			return "", false
+		}
+		return shortSyntaxBindSource(spec)
+	case yaml.MappingNode:
+		var entry struct {
+			Type   string `yaml:"type"`
+			Source string `yaml:"source"`
+		}
+		if err := item.Decode(&entry); err != nil {
+			return "", false
+		}
+		if entry.Type != "bind" && entry.Type != "npipe" {
+			return "", false
+		}
+		return entry.Source, true
+	}
+	return "", false
+}
+
+// shortSyntaxBindSource returns the host side of a `source:target[:opts]` entry,
+// and whether that entry is a bind at all.
+//
+// Compose decides that from the source's prefix alone and nowhere else
+// (isFilePath in docker/cli's internal/volumespec, reached from populateType):
+// `data:/d` is a named volume and `./data:/d` is a bind, and `my.data:/d` is a
+// named volume too — a dot elsewhere in the name is not a path, and a guess that
+// "it looks like one" would refuse a chart that was never wrong.
+//
+// The rules are mirrored rather than imported because volumespec is internal to
+// docker/cli and reaching it means cli/compose/loader, whose own dependencies
+// this module deliberately does not carry (see the pin in go.mod). They are two:
+// the prefix test below, and the fact that a drive letter's colon is not a
+// separator — `C:\data:/d` has three colons and only the last two divide fields.
+//
+// An entry the parser would reject names nothing here. loader.Load refuses it
+// during the deploy a moment later, with a better message than this could give.
+func shortSyntaxBindSource(spec string) (string, bool) {
+	// Two characters or fewer is a container path and nothing else, exactly as
+	// volumespec.Parse special-cases it.
+	if len(spec) <= 2 {
+		return "", false
+	}
+	from := 0
+	if isWindowsDrive(spec) {
+		from = 2
+	}
+	i := strings.IndexByte(spec[from:], ':')
+	if i < 0 {
+		// No separator: an anonymous volume, which has no host side.
+		return "", false
+	}
+	source := spec[:from+i]
+	if source == "" || !isFilePath(source) {
+		return "", false
+	}
+	return source, true
+}
+
+// isFilePath mirrors volumespec.isFilePath: the prefixes compose reads as "this
+// source is a path on a host" rather than as a volume name.
+func isFilePath(source string) bool {
+	switch source[0] {
+	case '.', '/', '~':
+		return true
+	}
+	// A Windows named pipe or UNC path, then a drive letter.
+	return strings.HasPrefix(source, `\\`) || isWindowsDrive(source)
+}
+
+// isWindowsDrive reports whether s opens with a drive letter and its colon.
+func isWindowsDrive(s string) bool {
+	if len(s) < 2 || s[1] != ':' {
+		return false
+	}
+	c := s[0] | 0x20
+	return c >= 'a' && c <= 'z'
+}
+
+// isAbsBindSource reports whether a bind source is absolute, by the same test the
+// loader applies before rewriting one — path.IsAbs, then a Windows-absolute check
+// (isAbs in cli/compose/loader/windows_path.go). Sharing the test is what makes
+// this refuse exactly the sources the loader would have resolved against
+// swarmcli's temp directory, and nothing else.
+//
+// A Windows path is absolute here whatever the operator's own OS, because the
+// path names the node that runs the task rather than the machine swarmcli runs
+// on: a Linux workstation deploying to a Windows node writes C:\data, where
+// filepath.IsAbs would say no.
+//
+// `~/data` is deliberately not absolute. expandUser rewrites it first, against
+// the HOME of whoever ran swarmcli, so a test applied after that point would pass
+// it while it named a directory on the wrong machine entirely.
+func isAbsBindSource(source string) bool {
+	if path.IsAbs(source) {
+		return true
+	}
+	// A UNC path or a Windows named pipe (\\.\pipe\docker_engine). Not parsed
+	// further: a malformed one is refused by the daemon, and guessing at where
+	// the host and share end is how this would start disagreeing with the CLI.
+	if strings.HasPrefix(source, `\\`) {
+		return true
+	}
+	// A drive letter, which is absolute only with a separator after it: C:\data
+	// names the drive's root, while C:data names the drive's current directory
+	// and is resolved against the temp directory like any other relative path.
+	return isWindowsDrive(source) && len(source) > 2 && (source[2] == '\\' || source[2] == '/')
+}

--- a/docker/stack_binds_test.go
+++ b/docker/stack_binds_test.go
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package docker
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// bindManifest is one service with one volumes: entry, so a refusal can only
+// have come from the entry under test.
+func bindManifest(volumes string) string {
+	return "services:\n  app:\n    image: nginx\n    volumes: " + volumes + "\n"
+}
+
+// The refusal, in every way a manifest can write a source the loader would have
+// resolved against swarmcli's temp directory.
+//
+// The cases are the shapes rather than a sample of paths: both syntaxes, both
+// types that name a host path, and the three prefixes compose infers a bind from
+// — `.`, `~` and a drive letter. A relative source is unbindable for the same
+// reason in all of them, and covering one proves nothing about the rest.
+func TestCheckBindSourcesRefusesASourceThatIsNotAbsolute(t *testing.T) {
+	for _, tc := range []struct{ name, volumes, source string }{
+		{"a relative path", `["./data:/data"]`, "./data"},
+		{"one that climbs", `["../data:/data"]`, "../data"},
+		{"read only, like a config would be", `["./nginx.conf:/etc/nginx/nginx.conf:ro"]`, "./nginx.conf"},
+		// Expanded by the loader against the HOME of whoever ran swarmcli, so it
+		// is absolute by the time anything downstream could object, and names a
+		// directory on a machine that does not run the task.
+		{"the operator's home", `["~/data:/data"]`, "~/data"},
+		{"long syntax", `[{type: bind, source: ./data, target: /data}]`, "./data"},
+		// The type that is not a bind and names a host path anyway.
+		{"long syntax as a named pipe", `[{type: npipe, source: pipe, target: /data}]`, "pipe"},
+		// A drive letter without a separator is relative to that drive's current
+		// directory, which is why the loader resolves it like any other.
+		{"a drive-relative Windows path", `["C:data:/data"]`, "C:data"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := checkBindSources(bindManifest(tc.volumes))
+			require.Error(t, err, "want a source that is not absolute refused")
+			require.ErrorContains(t, err, `service "app"`)
+			require.ErrorContains(t, err, tc.source)
+			require.ErrorContains(t, err, "must be absolute")
+		})
+	}
+}
+
+// What still deploys. Every entry here either names a path on the node or names
+// no host path at all, and the two are told apart by the docker CLI's own parser
+// — which is the point of using it: `my.data` is a legal volume name, and a
+// guess that "it contains a dot, so it looks like a path" refuses a chart that
+// was never wrong.
+func TestCheckBindSourcesAcceptsWhatNamesTheNode(t *testing.T) {
+	for _, tc := range []struct{ name, volumes string }{
+		{"an absolute path", `["/srv/data:/data"]`},
+		{"with options", `["/srv/data:/data:ro"]`},
+		{"long syntax", `[{type: bind, source: /srv/data, target: /data}]`},
+		{"a named volume", `["data:/data"]`},
+		{"a named volume with a dot in it", `["my.data:/data"]`},
+		{"a named volume, long syntax", `[{type: volume, source: data, target: /data}]`},
+		{"an anonymous volume", `["/data"]`},
+		{"tmpfs, which has no source", `[{type: tmpfs, target: /tmp}]`},
+		{"a Windows path, from whatever OS swarmcli runs on", `['C:\data:/data']`},
+		{"a Windows named pipe", `['\\.\pipe\docker_engine:\\.\pipe\docker_engine']`},
+		{"a Windows named pipe, long syntax", `[{type: npipe, source: '\\.\pipe\docker_engine', target: '\\.\pipe\docker_engine'}]`},
+		{"no volumes at all", ``},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			manifest := "services:\n  app:\n    image: nginx\n"
+			if tc.volumes != "" {
+				manifest = bindManifest(tc.volumes)
+			}
+			require.NoError(t, checkBindSources(manifest))
+		})
+	}
+}
+
+// The classification itself, which is what the accept table above rests on: an
+// entry accepted because it was never seen as a bind proves nothing about the
+// guard. These pairs were checked against docker/cli v28.5.1's own parser
+// (loader.ParseVolume over internal/volumespec) and agree with it on every spec
+// but one — `./a:`, which volumespec rejects outright as an empty section
+// between colons, and which is refused here as a relative source instead. Both
+// refuse; only the wording differs, so the divergence costs a message and not a
+// deploy.
+func TestShortSyntaxBindSourceMirrorsCompose(t *testing.T) {
+	for _, tc := range []struct {
+		spec   string
+		source string
+		bind   bool
+	}{
+		{"./data:/d", "./data", true},
+		{"~/data:/d", "~/data", true},
+		{"/srv:/d", "/srv", true},
+		{"/srv/data:/d:ro", "/srv/data", true},
+		// A volume name, whatever punctuation it carries: compose reads the
+		// source's first character and nothing else.
+		{"data:/d", "", false},
+		{"my.data:/d", "", false},
+		{"vol.1.2:/d", "", false},
+		// An anonymous volume — a container path, no host side.
+		{"/data", "", false},
+		// The drive letter's colon is not a separator.
+		{`C:\data:/d`, `C:\data`, true},
+		{"C:data:/d", "C:data", true},
+		{`\\.\pipe\x:\\.\pipe\y`, `\\.\pipe\x`, true},
+	} {
+		t.Run(tc.spec, func(t *testing.T) {
+			source, bind := shortSyntaxBindSource(tc.spec)
+			require.Equal(t, tc.bind, bind)
+			require.Equal(t, tc.source, source)
+		})
+	}
+}
+
+// One malformed service must not hide the others. yaml.v3 returns a mapping with
+// a single non-string key as map[any]any for the whole mapping, so a guard that
+// type-asserts map[string]any sees no services at all here, reports nothing
+// wrong, and lets the deploy through — while docker normalises the key and
+// deploys the entry.
+func TestCheckBindSourcesSeesEverySiblingService(t *testing.T) {
+	err := checkBindSources("services:\n" +
+		"  1:\n    image: nginx\n" +
+		"  app:\n    image: nginx\n    volumes: [\"./data:/data\"]\n")
+	require.ErrorContains(t, err, `service "app"`)
+}
+
+// A manifest with more than one offender always refuses on the same one, so the
+// message an operator fixes against does not depend on map iteration order.
+func TestCheckBindSourcesRefusesTheFirstServiceInOrder(t *testing.T) {
+	manifest := "services:\n" +
+		"  zebra:\n    image: nginx\n    volumes: [\"./z:/z\"]\n" +
+		"  alpha:\n    image: nginx\n    volumes: [\"./a:/a\"]\n"
+	for range 5 {
+		require.ErrorContains(t, checkBindSources(manifest), `service "alpha"`)
+	}
+}
+
+// And the refusal is reached by a deploy, before the manifest is written and
+// before `docker` is executed: the context named here does not exist, so any
+// error about it is an error that ran too late.
+func TestDeployStackInContextRefusesARelativeBindSource(t *testing.T) {
+	err := DeployStackInContext(context.Background(), "no-such-context", "web",
+		bindManifest(`["./data:/data"]`), ResolveImageDefault, nil)
+	require.ErrorContains(t, err, "bind source")
+	require.ErrorContains(t, err, "must be absolute")
+}

--- a/docker/stack_deploy.go
+++ b/docker/stack_deploy.go
@@ -125,6 +125,13 @@ func DeployStackInContext(ctx context.Context, ctxName, stackName, yamlContent s
 	if err := ValidateStackYAML(yamlContent); err != nil {
 		return fmt.Errorf("validation failed: %w", err)
 	}
+	// Before writeStackTree, because the directory it creates is what a bind
+	// source that is not absolute would silently resolve against. Unwrapped: the
+	// message states the rule and names the replacement, and is all the operator
+	// gets.
+	if err := checkBindSources(yamlContent); err != nil {
+		return err
+	}
 
 	if stackName == "" {
 		return fmt.Errorf("stack name cannot be empty")


### PR DESCRIPTION
Closes #536. The last member of the class #535 closed, which #535 relocated rather than fixed.

## The defect

A swarm bind mount names a path on whichever node runs the task. The docker CLI resolves a source that is not absolute against the directory of the compose file it was handed, and swarmcli hands it a manifest it wrote to a temp directory it deletes when the deploy returns. `./data:/data` has therefore always meant `$TMPDIR/…/data` on a node that has never heard of it; `~/data` means the home directory of whoever ran swarmcli. Nothing is read client-side — this is a wrong mount, not a disclosure.

## The fix

`checkBindSources` reads the parsed manifest in `DeployStackInContext`, before `writeStackTree` creates the directory the source would have resolved against, and refuses a bind source that is not absolute — in swarmcli-cd's words verbatim:

> `service "web": bind source "./data" is relative; a swarm bind mount names a path on the node that runs the task, so it must be absolute (or use a named volume)`

At the deploy rather than beside the render, because the stacks view's three raw paths deploy operator-typed YAML from the same temp directory and have the identical defect. One choke point covers charts install/upgrade/rollback and the TUI alike.

Absolute sources stay legal and untouched, Windows-absolute included whatever OS swarmcli runs on — the path names the node, not the workstation.

## Telling a bind from a named volume

Compose decides from the source's first character (`isFilePath`, `internal/volumespec`), so `my.data:/d` is a named volume and `./data:/d` is a bind, and a drive letter's colon is not a separator. Those rules are mirrored rather than imported: `volumespec` is internal, reaching it means `cli/compose/loader`, and that pulls in three modules `go.mod` deliberately does not carry. Verified spec by spec against `loader.ParseVolume` in a throwaway module — agreement on every case but `./a:`, which the parser rejects as malformed and this refuses as relative. Both refuse; the message differs.

## Scope

Absolute bind sources are out of scope by design — a bind naming a real node path is a documented, deliberately privileged thing to do in Swarm. CE leaves that with the operator installing the chart; swarmcli-cd, reconciling charts nobody is watching, additionally requires the application's allowlist to name the path.

`C0`: no chart that worked stops working, because a relative bind source has never bound what its author meant. A stack that previously deployed — badly — is now refused, which is the point.

## Tests

`docker/stack_binds_test.go`: both syntaxes, `bind` and `npipe`, `.`/`..`/`~`/drive-relative refused; absolute, UNC, named volumes (including `my.data`), anonymous and `tmpfs` accepted; the classification table pinned against compose's own; a non-string service key proving siblings stay visible; refusal order deterministic; and one end-to-end through `DeployStackInContext` proving it precedes the exec.
