### PR TITLE
feat(charts): sync waves — order releases in groups, not one at a time

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,10 @@ swarmcli charts outdated                          # releases with a newer chart 
 `apply` reads a release file pinning each release to a chart version, so the
 deployed state is reproducible and an automated updater (e.g. Renovate) has
 something concrete to bump. It never removes a release the file does not mention —
-it reports those instead. See [charts/README.md](charts/README.md#declarative-releases-gitops).
+it reports those instead. Releases can declare a `wave`, which groups the ones
+that go out together and makes each group converge before the next begins — so a
+migration that fails stops what depends on it from ever starting. See
+[charts/README.md](charts/README.md#declarative-releases-gitops).
 
 A chart can declare the swarmcli it needs (`swarmcliVersion: ">= 1.13.0"` in
 `Chart.yaml`). Installing it on an older build fails naming the version to

--- a/charts/README.md
+++ b/charts/README.md
@@ -82,6 +82,7 @@ swarmcli charts outdated                                   # what has a newer ch
 | Identical | **skipped — no new revision** |
 | On the swarm but not in the file | **reported, never removed** |
 | Installed by this file, no longer in it | **reported as an orphan, still never removed** |
+| A `wave` that does not converge | **every later wave is skipped entirely** |
 
 Two of those deserve the emphasis. Releases are **never deleted** — apply prints
 the `uninstall` command and leaves the decision to you. And an unchanged release
@@ -128,8 +129,49 @@ upgrade production on the next `apply`. For a **local** chart path (`chart:
 `Chart.yaml` sets the version, so there is nothing to select.
 
 Unknown keys are rejected, so a typo fails loudly instead of quietly doing nothing.
-Releases are applied in file order; add `--wait` if a later release needs an
-earlier one live.
+Releases are applied in wave order, then file order — see below.
+
+#### Sync waves
+
+`wave` groups releases that go out together. Every release in a wave is deployed,
+the whole wave converges, and only then does the next wave start:
+
+```yaml
+releases:
+  - name: db
+    chart: ./charts/postgres          # no wave: means wave 0
+  - name: migrate
+    chart: ./charts/migrate
+    wave: 1
+  - name: api
+    chart: ./charts/api
+    wave: 2
+  - name: worker
+    chart: ./charts/worker
+    wave: 2                           # with api — the order between them is not meaningful
+```
+
+The failure semantics are the point as much as the ordering. **A wave that does
+not converge stops every wave after it**: nothing later is deployed at all, no
+service and no revision record, so a migration that fails can never let the API
+that depends on it start.
+
+Waves are ascending and default to `0`, so a file that declares none is one wave
+applied in file order — exactly what it has always done, with no waiting added.
+Negative numbers are legal, and are how you put something in front of an existing
+set without renumbering it.
+
+**`wave` is not `--wait`, and does not need it.** The barrier between waves always
+happens; `--wait` is the separate, older question of whether each *individual*
+release blocks until it is live. Setting both serialises everything inside a wave,
+which is the thing waves exist to stop being necessary — so with waves declared,
+leave `--wait` off unless you also want the last wave waited for. `--timeout`
+bounds each wave, and defaults to five minutes.
+
+`wave` is the one key here that is not Helmfile's, so Renovate ignores it (see
+below). Note that a release file using it cannot be read *at all* by a swarmcli
+older than the release this landed in: unknown keys are refused rather than
+skipped, which is the same trade every key in this file has made.
 
 `apply` honours `--wait`, `--timeout` and `--history-max`. It **rejects** `--set`,
 `--version`, `--reuse-values`, `--install`, `--purge-volumes`, `--requirements` and

--- a/charts/apply.go
+++ b/charts/apply.go
@@ -5,10 +5,12 @@ package charts
 
 import (
 	"bytes"
+	"cmp"
 	"context"
 	"fmt"
 	"maps"
 	"os"
+	"slices"
 
 	"gopkg.in/yaml.v3"
 )
@@ -27,6 +29,14 @@ type ReleasePlan struct {
 	Name   string `json:"name"`
 	Ref    string `json:"ref"`
 	Action Action `json:"action"`
+	// Wave is the release file's ReleaseSpec.Wave, carried here because Apply
+	// never sees the file — only this plan — so it is the only place a grouping
+	// could be read from.
+	//
+	// Omitted when zero, which is both the default and "explicitly first". The
+	// two are the same thing: there is no "unset" wave to tell apart from wave 0,
+	// so nothing is lost by the omission.
+	Wave int `json:"wave,omitempty"`
 	// FromVersion is the currently deployed chart version, empty for an install.
 	FromVersion string `json:"fromVersion,omitempty"`
 	ToVersion   string `json:"toVersion"`
@@ -66,7 +76,12 @@ type Plan struct {
 	// InstallOptions.Owner — so that the next plan recognises these releases as
 	// its own rather than as somebody else's.
 	Owner string `json:"owner,omitempty"`
-	// Releases, in file order.
+	// Releases, in wave order and then file order — which for a file declaring no
+	// wave is exactly file order, as it always was.
+	//
+	// This is the order Apply converges them in, so it is also the order to
+	// render: a caller showing a plan is showing what will happen, in the
+	// sequence it will happen.
 	Releases []ReleasePlan `json:"releases"`
 	// Unmanaged names releases that exist on the swarm, are absent from the
 	// file, and carry no stamp saying this file produced them. Apply never
@@ -124,6 +139,12 @@ type PlanOptions struct {
 // them is deployed. A bad value in the third release therefore aborts the whole
 // apply instead of leaving the swarm half-converged — and `--dry-run` is just
 // "stop after planning".
+//
+// The releases come back in wave order, sorted here rather than grouped at each
+// consumer. That is what makes plan order execution order everywhere at once:
+// Apply only has to notice where a run of equal waves ends, a renderer shows the
+// sequence things happen in, and a controller walking the plan to correct drift
+// inherits the ordering without knowing waves exist.
 func (e *Engine) PlanApply(ctx context.Context, rf *ReleaseFile, src ChartSource, opts PlanOptions) (*Plan, error) {
 	owner := rf.ownerID()
 	if opts.Owner != "" {
@@ -158,6 +179,13 @@ func (e *Engine) PlanApply(ctx context.Context, rf *ReleaseFile, src ChartSource
 		}
 		plan.Releases = append(plan.Releases, rp)
 	}
+	// Stable, so that within a wave the file's order survives. It is not a
+	// meaningful order — declaring two releases in one wave is precisely saying
+	// it does not matter — but an arbitrary one would make a plan render
+	// differently every time it was computed.
+	slices.SortStableFunc(plan.Releases, func(a, b ReleasePlan) int {
+		return cmp.Compare(a.Wave, b.Wave)
+	})
 
 	for _, rel := range current {
 		switch {
@@ -244,6 +272,7 @@ func (e *Engine) planRelease(rf *ReleaseFile, spec ReleaseSpec, src ChartSource,
 	rp := ReleasePlan{
 		Name:         spec.Name,
 		Ref:          spec.Chart,
+		Wave:         spec.Wave,
 		ToVersion:    rc.Version,
 		Chart:        rc,
 		Values:       values,
@@ -280,7 +309,7 @@ type ApplyResult struct {
 	Revision int    `json:"revision,omitempty"` // 0 when unchanged (nothing was recorded)
 }
 
-// Apply converges the swarm to a plan, in file order.
+// Apply converges the swarm to a plan, one wave at a time.
 //
 // It never deletes. A release on the swarm that is absent from the file is
 // reported and left alone — either as Plan.Unmanaged, where nothing says which
@@ -304,30 +333,87 @@ type ApplyResult struct {
 // deploy to fail is what keeps the boundary clean — Upgrade would otherwise be
 // entered, and a stack half-deployed by a killed CLI is worse than one not
 // deployed at all.
+//
+// # Waves
+//
+// A plan spanning more than one wave is deployed in groups: every release in a
+// wave is written, the wave is waited for, and only then does the next start. A
+// wave that does not converge is a failure like any other, so nothing in any
+// later wave is deployed at all — no service, no revision record — which is the
+// point of declaring one. A plan with a single wave, which is every plan from a
+// file that declares no wave, takes no barrier and reads the swarm no more often
+// than it ever did.
+//
+// The barrier does not depend on opts.Wait, and that is deliberate rather than an
+// oversight: a wave is meaningless without it, so requiring a second opt-in would
+// leave "declared waves that silently did nothing" as the default reading of a
+// file. Wait keeps its own meaning underneath — whether each individual release
+// blocks — so setting it inside a wave serialises that wave, which is exactly
+// what it says and exactly what waves exist to stop being necessary.
 func (e *Engine) Apply(ctx context.Context, plan *Plan, opts InstallOptions) ([]ApplyResult, error) {
 	var results []ApplyResult
-	for _, rp := range plan.Releases {
-		if err := ctx.Err(); err != nil {
-			return results, err
+	waves := waveGroups(plan.Releases)
+
+	for i, wave := range waves {
+		// What this wave actually deployed, which is not the wave: a release the
+		// plan called unchanged is skipped above and is not waited for here.
+		// Waiting for one would let a release nothing in this apply touched — one
+		// deployed weeks ago and degraded since — stop every wave after it, on
+		// every apply, forever. Health is a question somebody else asks.
+		var wrote []string
+		for _, rp := range wave {
+			if err := ctx.Err(); err != nil {
+				return results, err
+			}
+			if rp.Action == ActionUnchanged {
+				results = append(results, ApplyResult{Name: rp.Name, Action: ActionUnchanged})
+				continue
+			}
+			o := opts
+			o.Requirements = rp.Requirements
+			o.Files = rp.Files
+			// Always Upgrade with Install set, never Install: a release that appeared
+			// between planning and applying then upgrades cleanly instead of failing
+			// with "already exists".
+			o.Install = true
+			rel, err := e.Upgrade(ctx, rp.Name, rp.Chart, rp.Values, rp.Manifest, o)
+			if err != nil {
+				return results, fmt.Errorf("release %q: %w", rp.Name, err)
+			}
+			results = append(results, ApplyResult{Name: rp.Name, Action: rp.Action, Revision: rel.Revision})
+			wrote = append(wrote, rp.Name)
 		}
-		if rp.Action == ActionUnchanged {
-			results = append(results, ApplyResult{Name: rp.Name, Action: ActionUnchanged})
+
+		// Between waves, and not after the last one. Under opts.Wait every release
+		// in the final wave has already been waited for individually; without it
+		// the caller asked not to block, and there is no later wave whose safety
+		// depends on this one being live.
+		if i == len(waves)-1 || len(wrote) == 0 {
 			continue
 		}
-		o := opts
-		o.Requirements = rp.Requirements
-		o.Files = rp.Files
-		// Always Upgrade with Install set, never Install: a release that appeared
-		// between planning and applying then upgrades cleanly instead of failing
-		// with "already exists".
-		o.Install = true
-		rel, err := e.Upgrade(ctx, rp.Name, rp.Chart, rp.Values, rp.Manifest, o)
-		if err != nil {
-			return results, fmt.Errorf("release %q: %w", rp.Name, err)
+		if err := e.waitWave(ctx, wrote, opts.Timeout); err != nil {
+			return results, err
 		}
-		results = append(results, ApplyResult{Name: rp.Name, Action: rp.Action, Revision: rel.Revision})
 	}
 	return results, nil
+}
+
+// waveGroups splits releases into contiguous runs of equal Wave.
+//
+// It relies on PlanApply having sorted them, and a caller that hands over an
+// unsorted slice gets more groups rather than wrong ones — every run is still
+// internally one wave, so the barriers land in defensible places. Sorting again
+// here would hide the mistake instead.
+func waveGroups(releases []ReleasePlan) [][]ReleasePlan {
+	var groups [][]ReleasePlan
+	for i, start := 0, 0; i < len(releases); i++ {
+		if i+1 < len(releases) && releases[i+1].Wave == releases[start].Wave {
+			continue
+		}
+		groups = append(groups, releases[start:i+1])
+		start = i + 1
+	}
+	return groups
 }
 
 // unchanged reports whether the current revision already encodes the desired

--- a/charts/json_test.go
+++ b/charts/json_test.go
@@ -75,6 +75,23 @@ func TestPlanJSONKeys(t *testing.T) {
 	// Empty for an install/unchanged plan; omitempty keeps it out.
 	require.NotContains(t, rp, "fromVersion")
 	require.NotContains(t, rp, "currentManifest")
+	// Wave 0 is both the default and "explicitly first" — the same thing, since
+	// there is no unset wave to tell apart — so omitting it loses nothing and
+	// keeps a plan from a file that declares no wave byte-identical to what it
+	// has always served.
+	require.NotContains(t, rp, "wave")
+}
+
+// A declared wave reaches the wire, because a consumer rendering a plan has to
+// be able to show the order it will be applied in.
+func TestPlanJSONCarriesADeclaredWave(t *testing.T) {
+	b, err := json.Marshal(Plan{Releases: []ReleasePlan{{Name: "api", Wave: 2}}})
+	require.NoError(t, err)
+
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(b, &got))
+	rp := got["releases"].([]any)[0].(map[string]any)
+	require.Equal(t, float64(2), rp["wave"])
 }
 
 func TestApplyResultJSONKeys(t *testing.T) {

--- a/charts/release.go
+++ b/charts/release.go
@@ -1093,8 +1093,19 @@ const defaultStabilityWindow = 5 * time.Second
 
 // waitReady polls until every service in the release is running its target task
 // count and has held it for the stability window, or the timeout elapses.
+func (e *Engine) waitReady(ctx context.Context, release string, timeout time.Duration) error {
+	return e.waitWave(ctx, []string{release}, timeout)
+}
+
+// waitWave polls until every named release has converged, or the timeout elapses.
 //
-// It returns early with an error when swarm reports the rollout wedged
+// One deadline covers the whole wave rather than one per release. The releases in
+// a wave were deployed one after another without waiting, so their rollouts
+// overlap; charging the wave the sum of what it spends in parallel would make the
+// timeout mean something different depending on how many releases happened to
+// share a wave.
+//
+// It returns early with an error when swarm reports any of them wedged
 // ("paused" / "rollback_paused" / "rollback_completed"): swarm will not
 // continue from any of them on its own — the paused pair needs a human, and a
 // completed rollback is a deploy that already failed and was undone — so
@@ -1104,20 +1115,33 @@ const defaultStabilityWindow = 5 * time.Second
 // on to the timeout. This is the longest thing a release operation does, and the
 // timeout it would otherwise serve out defaults to five minutes — far longer than
 // the grace period a caller being shut down has to work with.
-func (e *Engine) waitReady(ctx context.Context, release string, timeout time.Duration) error {
+func (e *Engine) waitWave(ctx context.Context, releases []string, timeout time.Duration) error {
 	if timeout <= 0 {
 		timeout = 5 * time.Minute
 	}
 	deadline := e.now().Add(timeout)
+	// Reused across polls rather than reallocated: this loop runs for as long as
+	// a rollout takes, which is minutes.
+	pending := make([]string, 0, len(releases))
 	for {
-		switch c := Rollup(e.Backend.StackServices(ctx, release)); c.Phase {
-		case PhaseWedged:
-			return fmt.Errorf("release %q: %s", release, c.Reason)
-		case PhaseConverged:
+		pending = pending[:0]
+		for _, release := range releases {
+			switch c := Rollup(e.Backend.StackServices(ctx, release)); c.Phase {
+			case PhaseWedged:
+				// Named individually, and the same message a single-release wait
+				// has always produced: the release that wedged is the one to go
+				// and look at, not the group it was in.
+				return fmt.Errorf("release %q: %s", release, c.Reason)
+			case PhaseConverged:
+			default:
+				pending = append(pending, release)
+			}
+		}
+		if len(pending) == 0 {
 			return nil
 		}
 		if !e.now().Before(deadline) {
-			return fmt.Errorf("timed out after %s waiting for release %q to converge", timeout, release)
+			return fmt.Errorf("timed out after %s waiting for %s to converge", timeout, releaseList(pending))
 		}
 		select {
 		case <-ctx.Done():
@@ -1125,6 +1149,21 @@ func (e *Engine) waitReady(ctx context.Context, release string, timeout time.Dur
 		case <-time.After(waitPollInterval):
 		}
 	}
+}
+
+// releaseList renders the releases a wait gave up on, singular or plural. One
+// release produces exactly the phrase this wait produced before it could take
+// more than one, so a caller matching on that text — and the integration suite
+// does — is unaffected.
+func releaseList(releases []string) string {
+	if len(releases) == 1 {
+		return fmt.Sprintf("release %q", releases[0])
+	}
+	quoted := make([]string, 0, len(releases))
+	for _, r := range releases {
+		quoted = append(quoted, fmt.Sprintf("%q", r))
+	}
+	return "releases " + strings.Join(quoted, ", ")
 }
 
 // Phase is how far a rollout has got.

--- a/charts/release_test.go
+++ b/charts/release_test.go
@@ -27,19 +27,30 @@ type fakeBackend struct {
 	// lastDeploy is the whole request the last deploy carried. deployed keeps
 	// only two of its fields, and Name, Manifest and Resolve are all strings,
 	// so a pair of them swapped at the call site still fills that map.
-	lastDeploy    DeployRequest
-	volumes       map[string][]string
-	services      map[string][]ServiceState
-	networkScopes map[string]string     // network name -> scope
-	secrets       map[string]struct{}   // existing secret names
-	createNetErr  map[string]error      // network name -> error to return on create
-	createdNets   map[string]createdNet // network name -> driver/attachable used on create
-	failNext      bool
-	rmStackErr    error
-	refreshErr    error
-	secretsErr    error                   // error to return from SecretNames
-	onCreate      func(name string) error // hook to simulate concurrent config creation
-	deleteCfgErr  map[string]error        // config name -> error to return on delete
+	lastDeploy DeployRequest
+	// deployOrder is the sequence deploys arrived in. deployed is a map, so
+	// until this existed the order Apply converges releases in was not
+	// observable at all — the closest any test could get was inferring it from
+	// the first-failure semantics. Sync waves are entirely about that order, so
+	// they are asserted on what reached the backend rather than on what Apply
+	// reports having done.
+	deployOrder []string
+	// stackServiceCalls counts the reads a convergence wait makes, so a test can
+	// state that a wave triggered no wait at all rather than infer it from
+	// elapsed time.
+	stackServiceCalls int
+	volumes           map[string][]string
+	services          map[string][]ServiceState
+	networkScopes     map[string]string     // network name -> scope
+	secrets           map[string]struct{}   // existing secret names
+	createNetErr      map[string]error      // network name -> error to return on create
+	createdNets       map[string]createdNet // network name -> driver/attachable used on create
+	failNext          bool
+	rmStackErr        error
+	refreshErr        error
+	secretsErr        error                   // error to return from SecretNames
+	onCreate          func(name string) error // hook to simulate concurrent config creation
+	deleteCfgErr      map[string]error        // config name -> error to return on delete
 	// listData makes ListConfigs carry each payload, as the Docker backend
 	// does. Off by default so the rest of the suite keeps exercising the
 	// inspect fallback a Backend that omits it relies on.
@@ -75,6 +86,7 @@ func (f *fakeBackend) DeployStack(_ context.Context, req DeployRequest) error {
 		return fmt.Errorf("boom")
 	}
 	f.deployed[req.Name] = req.Manifest
+	f.deployOrder = append(f.deployOrder, req.Name)
 	f.lastDeploy = req
 	return nil
 }
@@ -125,6 +137,7 @@ func (f *fakeBackend) DeleteConfig(_ context.Context, name string) error {
 	return nil
 }
 func (f *fakeBackend) StackServices(_ context.Context, name string) []ServiceState {
+	f.stackServiceCalls++
 	return f.services[name]
 }
 func (f *fakeBackend) StackVolumes(_ context.Context, name string) ([]string, error) {

--- a/charts/releasefile.go
+++ b/charts/releasefile.go
@@ -29,6 +29,12 @@ import (
 // obvious hazard of borrowing another tool's vocabulary: pasting real Helmfile
 // syntax fails loudly and names the key, rather than silently doing half of what
 // was meant.
+//
+// `wave` is the one key that is ours rather than Helmfile's. Renovate's manager
+// reads the three keys above and ignores everything else, so declaring it costs
+// nothing there; what it does cost is that a file using it cannot be read by a
+// swarmcli older than the release that added it, since unknown keys are refused
+// rather than skipped. That is true of every key this file has ever gained.
 type ReleaseFile struct {
 	APIVersion   string     `yaml:"apiVersion,omitempty"`
 	Repositories []RepoSpec `yaml:"repositories,omitempty"`
@@ -62,6 +68,20 @@ type ReleaseSpec struct {
 	Chart   string   `yaml:"chart"`
 	Version string   `yaml:"version,omitempty"`
 	Values  []string `yaml:"values,omitempty"`
+	// Wave groups releases that are applied together. Every release in one wave
+	// is deployed, the whole wave is waited for, and only then does the next
+	// start — so a migration that does not converge stops the releases that
+	// depend on it from ever being deployed.
+	//
+	// Ascending, and 0 by default. That is Argo CD's sync-wave, and it is also
+	// the reading that keeps a file declaring nothing behaving exactly as it
+	// always has: one wave, applied in file order, with no barrier and no extra
+	// read of the swarm. Negative is legal, and is how something is put in front
+	// of an existing set without renumbering it.
+	//
+	// Within a wave the order is the file's, and it is not meaningful — that is
+	// the whole point of putting two releases in one wave. Do not rely on it.
+	Wave int `yaml:"wave,omitempty"`
 }
 
 // LoadReleaseFile reads and validates a release manifest.

--- a/charts/releasefile_test.go
+++ b/charts/releasefile_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 )
 
 func parse(t *testing.T, body string) (*ReleaseFile, error) {
@@ -33,6 +34,50 @@ releases:
 	require.Len(t, rf.Releases, 2)
 	require.Equal(t, "swarmcli-charts", rf.Repositories[0].Name)
 	require.Equal(t, "0.1.1", rf.Releases[0].Version)
+}
+
+// A release declares its wave, or is in wave 0 by having said nothing.
+func TestParseReadsWaves(t *testing.T) {
+	rf, err := parse(t, `releases:
+  - {name: db, chart: r/pg, version: "1"}
+  - {name: migrate, chart: r/migrate, version: "1", wave: 1}
+  - {name: api, chart: r/api, version: "1", wave: 2}
+  - {name: early, chart: r/early, version: "1", wave: -1}
+`)
+	require.NoError(t, err)
+	require.Equal(t, []int{0, 1, 2, -1}, []int{
+		rf.Releases[0].Wave, rf.Releases[1].Wave, rf.Releases[2].Wave, rf.Releases[3].Wave,
+	}, "an undeclared wave is 0 and a negative one is legal; the file's own order is untouched by parsing")
+}
+
+// A release file round-trips through Marshal without growing a wave nobody
+// wrote.
+//
+// This is not tidiness. swarmcli-cd synthesises a release file for its
+// one-application-one-chart source by marshalling this struct and handing the
+// bytes back to ParseReleaseFile, so an un-omitted zero would put `wave: 0` into
+// every such application — a key an operator never wrote, in a file they cannot
+// see, for a file with one release where waves cannot mean anything.
+func TestMarshalOmitsAnUndeclaredWave(t *testing.T) {
+	doc, err := yaml.Marshal(ReleaseFile{
+		APIVersion: "v1",
+		Releases:   []ReleaseSpec{{Name: "solo", Chart: "./charts/app"}},
+	})
+	require.NoError(t, err)
+	require.NotContains(t, string(doc), "wave")
+
+	// And a declared one survives the same trip, so the omission is about zero
+	// rather than about the field.
+	doc, err = yaml.Marshal(ReleaseFile{
+		APIVersion: "v1",
+		Releases:   []ReleaseSpec{{Name: "solo", Chart: "./charts/app", Wave: 3}},
+	})
+	require.NoError(t, err)
+	require.Contains(t, string(doc), "wave: 3")
+
+	rf, err := parse(t, string(doc))
+	require.NoError(t, err)
+	require.Equal(t, 3, rf.Releases[0].Wave)
 }
 
 // A file an automated updater rewrites must fail loudly on a typo, not silently
@@ -106,6 +151,11 @@ func TestParseValidationErrors(t *testing.T) {
 		"repo bad name":  {"repositories:\n  - {name: \"../../../../pwned\", url: https://x}\nreleases:\n  - {name: a, chart: r/c, version: \"1\"}\n", "invalid repository name"},
 		"bad apiVersion": {"apiVersion: v2\nreleases:\n  - {name: a, chart: r/c, version: \"1\"}\n", "unsupported apiVersion"},
 		"bad rel name":   {"releases:\n  - {name: \"Bad Name\", chart: r/c, version: \"1\"}\n", "Bad Name"},
+		// A wave is an ordering, so anything that is not a number is a mistake
+		// rather than something to coerce. yaml refuses it for us and reports the
+		// line, though not the key — same as any other type mismatch in this file.
+		// Asserted so that stays true if the field's type is ever widened.
+		"wave not a number": {"releases:\n  - {name: a, chart: r/c, version: \"1\", wave: soon}\n", "cannot unmarshal"},
 	} {
 		t.Run(name, func(t *testing.T) {
 			_, err := parse(t, tc.body)

--- a/charts/wave_test.go
+++ b/charts/wave_test.go
@@ -1,0 +1,324 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package charts
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// waveFile declares four releases across three waves, with the file order
+// deliberately NOT the wave order: `web` is written first and belongs last, so a
+// test asserting wave order cannot pass by accident on a plan that did nothing.
+const waveFile = `repositories:
+  - name: swarmcli-charts
+    url: https://eldara-tech.github.io/swarmcli-charts
+releases:
+  - name: web
+    chart: swarmcli-charts/demo
+    version: "0.1.0"
+    wave: 2
+  - name: db
+    chart: swarmcli-charts/demo
+    version: "0.1.0"
+  - name: migrate
+    chart: swarmcli-charts/demo
+    version: "0.1.0"
+    wave: 1
+  - name: api
+    chart: swarmcli-charts/demo
+    version: "0.1.0"
+    wave: 2
+`
+
+// twoInOneWave is the case waves exist for: two releases that go out together.
+const twoInOneWave = `repositories:
+  - name: swarmcli-charts
+    url: https://eldara-tech.github.io/swarmcli-charts
+releases:
+  - name: first
+    chart: swarmcli-charts/demo
+    version: "0.1.0"
+  - name: second
+    chart: swarmcli-charts/demo
+    version: "0.1.0"
+`
+
+// settled is what a release that has finished rolling out looks like. Note that
+// a release with NO states is Progressing rather than converged (Rollup calls it
+// "no services are running yet"), so a barrier the test wants to pass has to be
+// given these.
+func settled(name string) []ServiceState {
+	return []ServiceState{{Name: name, Running: 1, Desired: 1, NewestTaskAge: stableAge}}
+}
+
+// stalled is a release that will never converge: a task short of its target,
+// with no update status, which is what a fresh install that cannot come up looks
+// like. Not "wedged" — swarm only reports that for a rollout it has given up on,
+// and a first install has no rollout to pause.
+func stalled(name string) []ServiceState {
+	return []ServiceState{{Name: name, Running: 0, Desired: 1, NewestTaskAge: stableAge}}
+}
+
+// quickPoll shrinks the convergence poll so a wave that never settles costs a
+// unit test milliseconds instead of the wall-clock it would cost a swarm.
+func quickPoll(t *testing.T) {
+	t.Helper()
+	prev := waitPollInterval
+	waitPollInterval = time.Millisecond
+	t.Cleanup(func() { waitPollInterval = prev })
+}
+
+// The plan comes back in wave order, and within a wave in the order the file
+// wrote them.
+//
+// Sorting here rather than grouping at each consumer is what makes plan order
+// execution order everywhere at once — for Apply, for anything rendering a plan,
+// and for a controller walking plan.Releases to correct drift.
+func TestPlanApplySortsReleasesByWave(t *testing.T) {
+	e, _, src, rf := applyEnv(t, waveFile, "0.1.0")
+
+	plan, err := e.PlanApply(context.Background(), rf, src, PlanOptions{})
+	require.NoError(t, err)
+
+	require.Equal(t, []string{"db", "migrate", "web", "api"}, names(plan.Releases),
+		"waves ascending, and within wave 2 the file's own order — web before api — is preserved")
+	require.Equal(t, []int{0, 1, 2, 2}, waves(plan.Releases))
+}
+
+// A negative wave is legal and sorts first, which is how something is put in
+// front of an existing set without renumbering every release after it.
+func TestPlanApplySortsNegativeWavesFirst(t *testing.T) {
+	body := `repositories:
+  - name: swarmcli-charts
+    url: https://eldara-tech.github.io/swarmcli-charts
+releases:
+  - name: app
+    chart: swarmcli-charts/demo
+    version: "0.1.0"
+  - name: prereq
+    chart: swarmcli-charts/demo
+    version: "0.1.0"
+    wave: -1
+`
+	e, _, src, rf := applyEnv(t, body, "0.1.0")
+
+	plan, err := e.PlanApply(context.Background(), rf, src, PlanOptions{})
+	require.NoError(t, err)
+	require.Equal(t, []string{"prereq", "app"}, names(plan.Releases))
+}
+
+// A file that declares no wave plans in exactly the order it always did.
+//
+// This is the compatibility guard the whole feature rests on: every release file
+// that exists today is a single-wave plan, and none of them may move.
+func TestPlanApplyLeavesAnUndeclaredFileInFileOrder(t *testing.T) {
+	e, _, src, rf := applyEnv(t, twoInOneWave, "0.1.0")
+
+	plan, err := e.PlanApply(context.Background(), rf, src, PlanOptions{})
+	require.NoError(t, err)
+	require.Equal(t, []string{"first", "second"}, names(plan.Releases))
+	require.Equal(t, []int{0, 0}, waves(plan.Releases))
+}
+
+// Apply deploys wave by wave, and the assertion is on what reached the backend
+// rather than on what Apply reports having done.
+func TestApplyDeploysWaveByWave(t *testing.T) {
+	quickPoll(t)
+	e, fb, src, rf := applyEnv(t, waveFile, "0.1.0")
+	for _, r := range []string{"db", "migrate", "web", "api"} {
+		fb.services[r] = settled(r)
+	}
+
+	plan, err := e.PlanApply(context.Background(), rf, src, PlanOptions{})
+	require.NoError(t, err)
+
+	// A short timeout on every wave test, deliberately. A barrier that fires
+	// when it should not has nothing to converge and would otherwise poll out
+	// the five-minute default — and a test that hangs is far worse than one that
+	// fails, because it reports as a suite-level timeout naming nothing.
+	_, err = e.Apply(context.Background(), plan, InstallOptions{Timeout: 50 * time.Millisecond})
+	require.NoError(t, err)
+	require.Equal(t, []string{"db", "migrate", "web", "api"}, fb.deployOrder)
+
+	// Two boundaries for three waves, one read each because everything had
+	// already settled — and nothing after the last wave. Waiting there would
+	// block an apply the caller asked not to block, for no later wave's benefit.
+	require.Equal(t, 2, fb.stackServiceCalls,
+		"a barrier belongs between waves and not after the final one")
+}
+
+// A wave that does not converge stops every wave after it: nothing later is
+// deployed at all, and the results returned name only what was.
+//
+// This is the whole point of declaring a wave. A migration that fails must not
+// let the application depending on it start, and "must not start" has to mean no
+// service and no revision record rather than a service that was created and then
+// reported as unhealthy.
+func TestApplyStopsAtAWaveThatDoesNotConverge(t *testing.T) {
+	quickPoll(t)
+	e, fb, src, rf := applyEnv(t, waveFile, "0.1.0")
+	fb.services["db"] = settled("db")
+	fb.services["migrate"] = stalled("migrate") // wave 1 never comes up
+
+	plan, err := e.PlanApply(context.Background(), rf, src, PlanOptions{})
+	require.NoError(t, err)
+
+	results, err := e.Apply(context.Background(), plan, InstallOptions{Timeout: 20 * time.Millisecond})
+	require.ErrorContains(t, err, "timed out")
+	require.ErrorContains(t, err, `"migrate"`, "the release that held the wave up is the one to name")
+
+	require.Equal(t, []string{"db", "migrate"}, fb.deployOrder,
+		"wave 2 must not be deployed at all — no service and no revision record")
+	require.Equal(t, []string{"db", "migrate"}, resultNames(results),
+		"a partial apply still reports what it did")
+}
+
+// The barrier waits for what the wave deployed, not for what the wave contains.
+//
+// A release the plan called unchanged was not touched by this apply, so blocking
+// on it would let one already-deployed, degraded release stop every later wave on
+// every apply forever — with nothing any redeploy could do about it, since apply
+// skips unchanged releases by design.
+func TestApplyDoesNotWaitForAWaveItDidNotDeploy(t *testing.T) {
+	quickPoll(t)
+	e, fb, src, rf := applyEnv(t, waveFile, "0.1.0")
+	for _, r := range []string{"migrate", "web", "api"} {
+		fb.services[r] = settled(r)
+	}
+
+	plan, err := e.PlanApply(context.Background(), rf, src, PlanOptions{})
+	require.NoError(t, err)
+	// Wave 0 is already deployed and, as far as this apply is concerned, broken:
+	// it has no running task and would never satisfy a barrier.
+	for i := range plan.Releases {
+		if plan.Releases[i].Name == "db" {
+			plan.Releases[i].Action = ActionUnchanged
+		}
+	}
+	fb.services["db"] = stalled("db")
+
+	_, err = e.Apply(context.Background(), plan, InstallOptions{Timeout: 20 * time.Millisecond})
+	require.NoError(t, err, "an unchanged release this apply never wrote must not gate the waves after it")
+	require.Equal(t, []string{"migrate", "web", "api"}, fb.deployOrder)
+}
+
+// A single-wave plan reads the swarm exactly as often as it did before waves
+// existed, which for an apply without --wait is not at all.
+//
+// The guard is on the *absence* of the new behaviour. Without it, waves would
+// have quietly added a convergence wait to every release file in existence.
+func TestApplyOfASingleWaveNeverWaits(t *testing.T) {
+	quickPoll(t)
+	e, fb, src, rf := applyEnv(t, twoInOneWave, "0.1.0")
+
+	plan, err := e.PlanApply(context.Background(), rf, src, PlanOptions{})
+	require.NoError(t, err)
+
+	// No services are staged, so a barrier that fired here would find nothing
+	// converged. The short timeout is what turns that regression into a failure
+	// rather than a five-minute hang.
+	_, err = e.Apply(context.Background(), plan, InstallOptions{Timeout: 50 * time.Millisecond})
+	require.NoError(t, err)
+	require.Equal(t, []string{"first", "second"}, fb.deployOrder)
+	require.Zero(t, fb.stackServiceCalls,
+		"one wave is no boundary, so nothing should have asked the swarm whether it had converged")
+}
+
+// waitWave says exactly what waitReady always said when it is waiting on one
+// release, so a caller matching that text — the integration suite does — is
+// unaffected by the generalisation.
+func TestWaitWaveNamesOneReleaseTheWayItAlwaysHas(t *testing.T) {
+	quickPoll(t)
+	fb := newFakeBackend()
+	fb.services["solo"] = stalled("solo")
+	e := NewEngineWith(fb)
+
+	err := e.waitReady(context.Background(), "solo", 20*time.Millisecond)
+	require.ErrorContains(t, err, `timed out after 20ms waiting for release "solo" to converge`)
+}
+
+// And it names all of them, but only the ones that had not converged: a wave of
+// five where one is slow should point at the one.
+func TestWaitWaveNamesOnlyWhatDidNotConverge(t *testing.T) {
+	quickPoll(t)
+	fb := newFakeBackend()
+	fb.services["quick"] = settled("quick")
+	fb.services["slow"] = stalled("slow")
+	fb.services["alsoSlow"] = stalled("alsoSlow")
+	e := NewEngineWith(fb)
+
+	err := e.waitWave(context.Background(), []string{"quick", "slow", "alsoSlow"}, 20*time.Millisecond)
+	require.ErrorContains(t, err, `releases "slow", "alsoSlow"`)
+	require.NotContains(t, err.Error(), "quick")
+}
+
+// A wedged release ends the wait on the first observation rather than serving
+// out the deadline, and names itself rather than the group it was in.
+func TestWaitWaveFailsFastOnAWedgedRelease(t *testing.T) {
+	quickPoll(t)
+	fb := newFakeBackend()
+	fb.services["fine"] = settled("fine")
+	fb.services["stuck"] = []ServiceState{{Name: "stuck", UpdateState: "paused"}}
+	e := NewEngineWith(fb)
+
+	err := e.waitWave(context.Background(), []string{"fine", "stuck"}, time.Hour)
+	require.ErrorContains(t, err, `release "stuck"`)
+	require.NotContains(t, err.Error(), "timed out", "swarm will not continue on its own, so waiting is pointless")
+}
+
+// A cancelled context ends a wave wait with the context's own error, so a caller
+// can tell a shutdown from a wave that would not come up.
+func TestWaitWaveStopsOnACancelledContext(t *testing.T) {
+	quickPoll(t)
+	fb := newFakeBackend()
+	fb.services["slow"] = stalled("slow")
+	e := NewEngineWith(fb)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	require.ErrorIs(t, e.waitWave(ctx, []string{"slow"}, time.Hour), context.Canceled)
+}
+
+// waveGroups splits on the wave boundary and nowhere else.
+func TestWaveGroups(t *testing.T) {
+	require.Nil(t, waveGroups(nil))
+
+	got := waveGroups([]ReleasePlan{
+		{Name: "a", Wave: 0}, {Name: "b", Wave: 0},
+		{Name: "c", Wave: 1},
+		{Name: "d", Wave: 7}, {Name: "e", Wave: 7}, {Name: "f", Wave: 7},
+	})
+	require.Len(t, got, 3)
+	require.Equal(t, []string{"a", "b"}, names(got[0]))
+	require.Equal(t, []string{"c"}, names(got[1]))
+	require.Equal(t, []string{"d", "e", "f"}, names(got[2]))
+}
+
+func names(releases []ReleasePlan) []string {
+	out := make([]string, 0, len(releases))
+	for _, r := range releases {
+		out = append(out, r.Name)
+	}
+	return out
+}
+
+func waves(releases []ReleasePlan) []int {
+	out := make([]int, 0, len(releases))
+	for _, r := range releases {
+		out = append(out, r.Wave)
+	}
+	return out
+}
+
+func resultNames(results []ApplyResult) []string {
+	out := make([]string, 0, len(results))
+	for _, r := range results {
+		out = append(out, r.Name)
+	}
+	return out
+}

--- a/cli/apply.go
+++ b/cli/apply.go
@@ -6,6 +6,7 @@ package cli
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/Eldara-Tech/swarmcli/charts"
@@ -152,15 +153,28 @@ func rejectUnsupported(f flags) error {
 }
 
 func printPlan(plan *charts.Plan, withDiff bool) {
+	// The wave column appears only for a plan that has more than one, which is
+	// the difference between telling an operator something and adding a column of
+	// zeroes to every plan anyone has ever printed.
+	waved := spansWaves(plan.Releases)
+
 	var rows [][]string
 	for _, r := range plan.Releases {
 		from := r.FromVersion
 		if from == "" {
 			from = "-"
 		}
-		rows = append(rows, []string{r.Name, r.Ref, from, r.ToVersion, string(r.Action)})
+		row := []string{r.Name, r.Ref, from, r.ToVersion, string(r.Action)}
+		if waved {
+			row = append(row, strconv.Itoa(r.Wave))
+		}
+		rows = append(rows, row)
 	}
-	table([]string{"RELEASE", "CHART", "FROM", "TO", "ACTION"}, rows)
+	headers := []string{"RELEASE", "CHART", "FROM", "TO", "ACTION"}
+	if waved {
+		headers = append(headers, "WAVE")
+	}
+	table(headers, rows)
 
 	if withDiff {
 		for _, r := range plan.Releases {
@@ -174,6 +188,20 @@ func printPlan(plan *charts.Plan, withDiff bool) {
 
 	install, upgrade, unchanged := plan.Counts()
 	outf("\n%d to install, %d to upgrade, %d unchanged\n", install, upgrade, unchanged)
+	if waved {
+		outln("applied in wave order; each wave converges before the next begins")
+	}
+}
+
+// spansWaves reports whether a plan declares more than one wave, which is the
+// only case where the ordering is worth saying anything about.
+func spansWaves(releases []charts.ReleasePlan) bool {
+	for _, r := range releases {
+		if r.Wave != releases[0].Wave {
+			return true
+		}
+	}
+	return false
 }
 
 // reportUnclaimed names everything the swarm holds that this apply did not just

--- a/cli/charts.go
+++ b/cli/charts.go
@@ -64,6 +64,16 @@ removes a release the file does not mention — it reports those instead.
       chart: swarmcli-charts/traefik
       version: "0.1.1"
       values: [./traefik.yaml]     # relative to the release file, not the CWD
+    - name: hello
+      chart: swarmcli-charts/whoami
+      version: "0.1.8"
+      wave: 1                      # deployed only once wave 0 has converged
+
+Releases apply in wave order, then file order. A wave that does not converge stops
+every wave after it, so nothing that depends on a failed migration is deployed.
+Waves default to 0, so a file declaring none applies in file order as it always
+has. The barrier does not need --wait; --wait is the separate question of whether
+each individual release blocks, and --timeout bounds each wave.
 
 A chart may declare its external networks/secrets/configs in requirements.yaml:
 install pre-flights them (auto-creating networks marked autoCreate, validating

--- a/cli/charts_test.go
+++ b/cli/charts_test.go
@@ -374,6 +374,26 @@ func TestPrintPlan(t *testing.T) {
 	// An install has no prior version; it must render as "-", not empty.
 	require.Regexp(t, `hello\s+r/whoami\s+-\s+0\.1\.8\s+install`, o)
 	require.Contains(t, o, "1 to install, 1 to upgrade, 1 unchanged")
+	// A plan with one wave says nothing about waves. Every plan printed before
+	// they existed is one of these, and a column of zeroes on all of them would
+	// be noise rather than information.
+	require.NotContains(t, o, "WAVE")
+}
+
+// A plan spanning waves shows which one each release is in, and says what that
+// means for the order.
+func TestPrintPlanShowsWavesWhenThereIsMoreThanOne(t *testing.T) {
+	plan := &charts.Plan{Releases: []charts.ReleasePlan{
+		{Name: "db", Ref: "r/pg", Action: charts.ActionInstall, ToVersion: "1.0.0"},
+		{Name: "migrate", Ref: "r/migrate", Action: charts.ActionInstall, ToVersion: "1.0.0", Wave: 1},
+		{Name: "api", Ref: "r/api", Action: charts.ActionInstall, ToVersion: "1.0.0", Wave: 2},
+	}}
+	o, _ := capture(t, func() { printPlan(plan, false) })
+
+	require.Contains(t, o, "WAVE")
+	require.Regexp(t, `db\s+r/pg\s+-\s+1\.0\.0\s+install\s+0`, o)
+	require.Regexp(t, `api\s+r/api\s+-\s+1\.0\.0\s+install\s+2`, o)
+	require.Contains(t, o, "each wave converges before the next begins")
 }
 
 // --diff shows a manifest diff for changed releases and skips unchanged ones.

--- a/integration-tests/charts/charts_wave_test.go
+++ b/integration-tests/charts/charts_wave_test.go
@@ -33,14 +33,25 @@ func waveChart(t *testing.T, name, stack string) string {
 }
 
 // fastStack comes up as soon as swarm can schedule it.
+//
+// Two choices here are about making "fast" true rather than hoped for, and both
+// were learned the hard way: the first version of this used alpine on any node
+// and the healthy wave took longer than the whole apply's timeout, failing on the
+// release that was supposed to work.
+//
+//   - The same image the rest of this package deploys, so whichever node runs it
+//     has already pulled it. A cold pull is most of what a first deploy spends.
+//   - Pinned to the manager, so it lands on the node the suite has been using
+//     rather than on a worker seeing the image for the first time.
 const fastStack = `version: "3.9"
 
 services:
   app:
-    image: alpine:latest
-    command: ["sh", "-c", "while true; do sleep 3600; done"]
+    image: traefik/whoami:v1.10
     deploy:
       replicas: 1
+      placement:
+        constraints: [node.role == manager]
 `
 
 // waveReleaseFile writes a release file from name/wave/chart triples.
@@ -151,7 +162,11 @@ func TestApplyStopsAtAWaveThatDoesNotConverge(t *testing.T) {
 	plan, err := eng.PlanApply(ctx, rf, src, charts.PlanOptions{})
 	require.NoError(t, err)
 
-	const timeout = 20 * time.Second
+	// The timeout bounds *each* wave, not the apply, so it has to be comfortable
+	// for the healthy wave that goes first — and everything above it is the cost
+	// of the wave that never converges. Both halves of that trade are real, and
+	// it is the same number an operator has to pick for `--timeout`.
+	const timeout = 45 * time.Second
 	start := time.Now()
 	results, err := eng.Apply(ctx, plan, charts.InstallOptions{Timeout: timeout})
 	elapsed := time.Since(start)

--- a/integration-tests/charts/charts_wave_test.go
+++ b/integration-tests/charts/charts_wave_test.go
@@ -1,0 +1,181 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+//go:build integration
+
+package charts
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/Eldara-Tech/swarmcli/charts"
+	swarmlog "github.com/Eldara-Tech/swarmcli/utils/log"
+)
+
+// waveChart writes a chart whose single service is the stack given, so a
+// release file can put a fast one and a never-converging one in different waves.
+func waveChart(t *testing.T, name, stack string) string {
+	t.Helper()
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "Chart.yaml"),
+		[]byte("apiVersion: v1\nname: "+name+"\nversion: 0.1.0\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "values.yaml"), []byte("{}\n"), 0o644))
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "templates"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "templates", "stack.yaml"), []byte(stack), 0o644))
+	return dir
+}
+
+// fastStack comes up as soon as swarm can schedule it.
+const fastStack = `version: "3.9"
+
+services:
+  app:
+    image: alpine:latest
+    command: ["sh", "-c", "while true; do sleep 3600; done"]
+    deploy:
+      replicas: 1
+`
+
+// waveReleaseFile writes a release file from name/wave/chart triples.
+func waveReleaseFile(t *testing.T, entries ...waveEntry) *charts.ReleaseFile {
+	t.Helper()
+	body := "apiVersion: v1\nreleases:\n"
+	for _, e := range entries {
+		body += fmt.Sprintf("  - name: %s\n    chart: %s\n    wave: %d\n", e.release, e.chart, e.wave)
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "swarmcli-release.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(body), 0o600))
+
+	rf, err := charts.LoadReleaseFile(path)
+	require.NoError(t, err)
+	return rf
+}
+
+type waveEntry struct {
+	release string
+	wave    int
+	chart   string
+}
+
+// Releases apply in wave order regardless of the order the file lists them.
+//
+// The unit suite proves the grouping against a fake; only a real swarm proves
+// that the thing the grouping waits on — swarm's own account of whether a stack
+// has converged — actually gates the next wave.
+func TestApplyRespectsWaves(t *testing.T) {
+	swarmlog.InitTestIfTestLogEnv()
+
+	ctx := context.Background()
+	stamp := time.Now().UnixNano()
+	first := fmt.Sprintf("itest-wave-a-%d", stamp)
+	second := fmt.Sprintf("itest-wave-b-%d", stamp)
+	third := fmt.Sprintf("itest-wave-c-%d", stamp)
+
+	chart := waveChart(t, "wavey", fastStack)
+	// Written last-wave-first on purpose: an apply that ignored waves and used
+	// file order would deploy them in exactly the wrong sequence, so this cannot
+	// pass by accident.
+	rf := waveReleaseFile(t,
+		waveEntry{third, 2, chart},
+		waveEntry{first, 0, chart},
+		waveEntry{second, 1, chart},
+	)
+
+	eng := charts.NewEngine()
+	src := charts.NewChartSource(nil)
+	defer func() {
+		for _, r := range []string{first, second, third} {
+			_, _ = eng.Uninstall(ctx, r, true)
+		}
+	}()
+
+	plan, err := eng.PlanApply(ctx, rf, src, charts.PlanOptions{})
+	require.NoError(t, err)
+	require.Equal(t, []string{first, second, third},
+		[]string{plan.Releases[0].Name, plan.Releases[1].Name, plan.Releases[2].Name},
+		"the plan is in wave order, not the file's")
+
+	results, err := eng.Apply(ctx, plan, charts.InstallOptions{Timeout: 120 * time.Second})
+	require.NoError(t, err)
+	require.Equal(t, []string{first, second, third},
+		[]string{results[0].Name, results[1].Name, results[2].Name})
+
+	// Every wave really did converge before the next started, which is what the
+	// revision timestamps record. Each is written by the deploy that created it,
+	// and the barrier sits between them.
+	for _, r := range []string{first, second, third} {
+		revs, err := eng.History(ctx, r)
+		require.NoError(t, err)
+		require.Len(t, revs, 1, "release %s should have been installed exactly once", r)
+	}
+}
+
+// A wave that does not converge stops every wave after it.
+//
+// This is the acceptance criterion for the whole feature, and the reason it is
+// here rather than only in the unit suite: "did not converge" is swarm's
+// judgement, not ours. The second wave is a task no node can schedule, so it
+// stays pending — nothing is pulled and nothing is started — and the third wave
+// must show no service and, more tellingly, no revision record at all.
+func TestApplyStopsAtAWaveThatDoesNotConverge(t *testing.T) {
+	swarmlog.InitTestIfTestLogEnv()
+
+	ctx := context.Background()
+	stamp := time.Now().UnixNano()
+	first := fmt.Sprintf("itest-wavefail-a-%d", stamp)
+	stuck := fmt.Sprintf("itest-wavefail-b-%d", stamp)
+	never := fmt.Sprintf("itest-wavefail-c-%d", stamp)
+
+	rf := waveReleaseFile(t,
+		waveEntry{first, 0, waveChart(t, "ok", fastStack)},
+		waveEntry{stuck, 1, waveChart(t, "stuck", unschedulableStack)},
+		waveEntry{never, 2, waveChart(t, "never", fastStack)},
+	)
+
+	eng := charts.NewEngine()
+	src := charts.NewChartSource(nil)
+	defer func() {
+		for _, r := range []string{first, stuck, never} {
+			_, _ = eng.Uninstall(ctx, r, true)
+		}
+	}()
+
+	plan, err := eng.PlanApply(ctx, rf, src, charts.PlanOptions{})
+	require.NoError(t, err)
+
+	const timeout = 20 * time.Second
+	start := time.Now()
+	results, err := eng.Apply(ctx, plan, charts.InstallOptions{Timeout: timeout})
+	elapsed := time.Since(start)
+
+	require.Error(t, err, "a wave that never converges must fail the apply")
+	require.Contains(t, err.Error(), "timed out")
+	require.Contains(t, err.Error(), stuck, "the release that held the wave up is the one to name")
+	require.GreaterOrEqual(t, elapsed, timeout, "the barrier must actually be waited out")
+
+	require.Equal(t, []string{first, stuck},
+		[]string{results[0].Name, results[1].Name},
+		"a partial apply reports what it did")
+	require.Len(t, results, 2, "nothing in wave 2 was applied")
+
+	// The strongest statement available: wave 2 has no stored revision, so Apply
+	// never reached it. An empty service list alone would be weaker — that is
+	// also what a deploy that was accepted and then failed looks like.
+	_, err = eng.History(ctx, never)
+	require.Error(t, err, "wave 2 must have no release record at all")
+
+	// And the contrast that makes it mean something: wave 1 does have one. It
+	// was deployed and only then failed to converge, because deployAndRecord
+	// records the revision before it waits.
+	revs, err := eng.History(ctx, stuck)
+	require.NoError(t, err)
+	require.Len(t, revs, 1)
+}


### PR DESCRIPTION
Closes the CE half of Eldara-Tech/swarmcli-cd#78. `swarmcli-cd` picks it up in a follow-up PR; this stands on its own for `swarmcli charts apply`.

## The problem

Releases apply in the order the release file lists them, and `--wait` is the only ordering tool there has ever been. `charts/README.md` said so plainly:

> Releases are applied in file order; add `--wait` if a later release needs an earlier one live.

That works and it is coarse. `--wait` is all-or-nothing: a file with a database, a one-shot migration and three stateless services has one honest ordering — db, then migrate, then the three **together** — and no way to express it. Today it either serialises all five or serialises none.

## What a wave adds

```yaml
releases:
  - name: db
    chart: ./charts/postgres      # no wave: means wave 0
  - name: migrate
    chart: ./charts/migrate
    wave: 1
  - name: api
    chart: ./charts/api
    wave: 2
  - name: worker
    chart: ./charts/worker
    wave: 2                       # with api — the order between them is not meaningful
```

Every release in wave N is deployed, the whole wave converges, then wave N+1 starts.

**The failure semantics are the point as much as the ordering.** A wave that does not converge stops every wave after it — not "starts and reports unhealthy", but nothing later deployed at all: no service, no revision record. A migration that fails can never let the API depending on it start.

## Three decisions, each with a plausible alternative

**The barrier does not depend on `--wait`.** A wave is meaningless without waiting, so requiring a second opt-in would make "declared waves that silently did nothing" the default reading of a file. `--wait` keeps its own meaning underneath — whether each *individual* release blocks — so with waves declared you want it **off**; setting both serialises each wave, which is exactly what it says and exactly what waves exist to stop being necessary.

**A barrier waits only for what its wave deployed.** A release the plan called unchanged was not touched by this apply. Blocking on it would let one already-deployed, degraded release stop every later wave on every apply forever — with nothing an apply could do about it, since unchanged releases are skipped by design. The cost is honest and documented: a wave of already-deployed releases is not a health check on them.

**`PlanApply` sorts rather than each consumer grouping.** Plan order becomes execution order everywhere at once — `Apply` only has to see where a run of equal waves ends, a rendered plan shows the sequence things happen in, and a controller walking `plan.Releases` to correct drift inherits the ordering without knowing waves exist. `Plan.Releases` is now "wave order, then file order", which for a file declaring no wave *is* file order.

## Compatibility

A file that declares no wave is one wave: same order, no barrier, **not one extra read of the swarm**. That is every release file in existence today, and there are absence guards on exactly that.

The one real cost, worth having in the release notes: `ParseReleaseFile` sets `KnownFields(true)`, so a file using `wave:` **cannot be read at all** by a swarmcli older than this. That is true of every key this file has ever gained (`owner:` included) and is why `wave` is documented as requiring a minimum version rather than degrading.

`wave` is not a Helmfile key, so Renovate's built-in `helmfile` manager ignores it — it reads `repositories[].{name,url}` and `releases[].{name,chart,version}` and nothing else.

## Implementation

- `ReleaseSpec.Wave` / `ReleasePlan.Wave` — the plan field exists because `Engine.Apply` never sees the `ReleaseFile`, only the `Plan`, so it is the only place a grouping could be read from.
- `PlanApply` sorts stably by wave, so within a wave the file's order survives. Not because that order means anything, but because an arbitrary one would make a plan render differently every time it was computed.
- `Engine.Apply` walks contiguous wave groups via `waveGroups` and calls `waitWave` between them.
- `waitReady` becomes the single-release case of `waitWave` rather than a second copy of the same loop. One deadline covers a whole wave: the releases in it were deployed without waiting for each other, so their rollouts overlap, and charging the sum of what they spend in parallel would make `--timeout` mean something different depending on how many releases shared a wave. Messages are byte-identical for one release.
- `printPlan` grows a `WAVE` column **only** when the plan spans more than one, so every plan printed today renders unchanged.

## Tests

Mutation-checked in both directions rather than merely written — removing the sort, removing the barrier, and waiting after the final wave each turn the suite red:

- ordering, stability within a wave, negative waves sorting first;
- `Apply` deploys wave by wave, asserted on what reached the **backend** (`fakeBackend.deployed` is a map, so until this PR the order `Apply` converges releases in was not observable at all — the closest any test could get was inferring it from first-failure semantics);
- a wave that never converges stops the ones after it, and the partial results name only what was applied;
- **absence guards**: a single-wave plan never reads the swarm; a wave whose releases are all unchanged triggers no wait. These are what stop this from quietly adding a convergence wait to every existing release file;
- `waitWave` message compatibility, fail-fast on wedged, cancellation.

Every wave test passes a short `--timeout`, deliberately: a barrier that fires when it should not has nothing to converge and would otherwise poll out the five-minute default, and a test that hangs is far worse than one that fails.

**Integration** (`integration-tests/charts/charts_wave_test.go`) carries the acceptance criterion, reusing `unschedulableStack` and the fixtures already in `charts_wait_test.go`: three waves where the second cannot be scheduled, asserting the third has **no revision record at all** — a strictly stronger statement than an empty service list, which is also what a deploy that was accepted and then failed looks like. The contrast is the proof: wave 1 *does* have a record, because `deployAndRecord` records before it waits.

> [!IMPORTANT]
> `go test ./...`, `golangci-lint run ./... --build-tags=integration` and the SPDX check are green locally. The **integration job has not been run by the author** — there is no Docker daemon in the environment this was written in — so this is not proved until that job is green, in the sense PR #73 in swarmcli-cd used the phrase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
