### PR TITLE
fix(charts): an unrefreshed index resolves latest to a version that no longer is

### DIFF
--- a/charts/repo.go
+++ b/charts/repo.go
@@ -33,6 +33,12 @@ const maxIndexSize = 16 << 20 // 16 MiB
 // can be buffered and hashed before any of it reaches the archive parser.
 const maxChartArchiveSize = 20 << 20 // 20 MiB
 
+// staleAfter is how long a cached index may go unverified before reads of it
+// warn. Every path that resolves a chart — install, upgrade, template, search —
+// reads the cache and none of them refetches, so an unrefreshed cache answers
+// "latest" with whatever was newest when it was written, silently and for good.
+const staleAfter = 24 * time.Hour
+
 // AllowPlaintextEnv is the environment variable a host program may honour to set
 // AllowPlaintext. The name lives here so the refusal message and whatever reads
 // it cannot drift, but this package never reads the environment itself: whether
@@ -66,6 +72,11 @@ type RepoStore struct {
 	// wires it to AllowPlaintextEnv so an existing plaintext setup keeps working
 	// with one deliberate, greppable opt-out rather than none.
 	AllowPlaintext bool
+
+	// warnedStale records the repositories already reported as unverified, so an
+	// apply resolving ten releases from one repository says it once rather than
+	// ten times.
+	warnedStale map[string]bool
 }
 
 // NewRepoStore returns a store rooted at the standard charts state directory.
@@ -267,6 +278,12 @@ func (s *RepoStore) Update(name string) (changed, unchanged []string, err error)
 		// payload means nothing new — report it as already up-to-date.
 		existing, _ := os.ReadFile(path)
 		if existing != nil && bytes.Equal(existing, idx) {
+			// The cache's mtime records when it was last *verified*, not last
+			// changed, because that is the question staleness asks. Skipping the
+			// touch would leave a repository that publishes rarely looking
+			// abandoned however often its index is confirmed current.
+			now := time.Now()
+			_ = os.Chtimes(path, now, now)
 			unchanged = append(unchanged, r.Name)
 			continue
 		}
@@ -297,11 +314,37 @@ func (s *RepoStore) LoadIndex(name string) (*Index, error) {
 	if err != nil {
 		return nil, err
 	}
+	s.warnStale(path, name)
 	var idx Index
 	if err := yaml.Unmarshal(data, &idx); err != nil {
 		return nil, fmt.Errorf("parse index for '%s': %w", name, err)
 	}
 	return &idx, nil
+}
+
+// warnStale reports a cached index that has not been verified for staleAfter.
+// Resolution never refetches, so the alternative to saying so is an install that
+// quietly deploys the version that stopped being the latest days ago.
+func (s *RepoStore) warnStale(path, name string) {
+	fi, err := os.Stat(path)
+	if err != nil {
+		return
+	}
+	age := time.Since(fi.ModTime())
+	if age < staleAfter || s.warnedStale[name] {
+		return
+	}
+	if s.warnedStale == nil {
+		s.warnedStale = map[string]bool{}
+	}
+	s.warnedStale[name] = true
+	days := int(age / (24 * time.Hour))
+	unit := "days"
+	if days == 1 {
+		unit = "day"
+	}
+	s.warnf("cached index for '%s' is %d %s old; run `swarmcli charts repo update` to pick up newer chart versions\n",
+		name, days, unit)
 }
 
 // Indexes returns the cached index of every configured repository, keyed by

--- a/charts/repo_test.go
+++ b/charts/repo_test.go
@@ -10,9 +10,11 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -640,4 +642,69 @@ func TestEnsureReposFailsWhenAnAbsentRepositoryCannotBeAdded(t *testing.T) {
 	repos, lerr := s.List()
 	require.NoError(t, lerr)
 	require.Empty(t, repos, "a failed add must persist nothing")
+}
+
+// age backdates a repository's cached index so it reads as unverified.
+func age(t *testing.T, s *RepoStore, name string, d time.Duration) {
+	t.Helper()
+	path, err := s.indexFile(name)
+	require.NoError(t, err)
+	when := time.Now().Add(-d)
+	require.NoError(t, os.Chtimes(path, when, when))
+}
+
+// Resolution reads the cache and never refetches, so a cache nobody has
+// refreshed keeps answering "latest" with a version that stopped being it. Say
+// so, or an install deploys the stale answer with nothing on screen to suggest
+// there is a newer chart.
+func TestResolveWarnsOnceTheCachedIndexGoesUnverified(t *testing.T) {
+	body := "apiVersion: v1\nentries:\n  demo:\n    - {name: demo, version: 0.1.0, urls: [\"d.tgz\"]}\n"
+	up := true
+	srv := newIndexServer(t, &body, &up)
+
+	var warnings []string
+	s := newTestStore(t)
+	s.Warnf = func(format string, a ...any) { warnings = append(warnings, fmt.Sprintf(format, a...)) }
+	require.NoError(t, s.Add("eldara", srv.URL))
+
+	// Just fetched: nothing to say.
+	_, _, err := s.Resolve("eldara/demo", "")
+	require.NoError(t, err)
+	require.Empty(t, warnings)
+
+	age(t, s, "eldara", 3*24*time.Hour)
+
+	// Twice: an apply resolves every release in the manifest against the same
+	// repository, and one warning per release would bury the plan it precedes.
+	for range 2 {
+		_, _, err = s.Resolve("eldara/demo", "")
+		require.NoError(t, err)
+	}
+	require.Len(t, warnings, 1)
+	require.Contains(t, warnings[0], "'eldara'")
+	require.Contains(t, warnings[0], "3 days old")
+	require.Contains(t, warnings[0], "charts repo update")
+}
+
+// A repository that publishes rarely serves the same bytes for weeks. Update
+// writes nothing in that case, so unless it records the check some other way,
+// the operator who refreshes daily is the one who gets nagged.
+func TestUpdateMarksAnUnchangedIndexAsVerified(t *testing.T) {
+	body := "apiVersion: v1\nentries:\n  demo:\n    - {name: demo, version: 0.1.0, urls: [\"d.tgz\"]}\n"
+	up := true
+	srv := newIndexServer(t, &body, &up)
+
+	var warnings []string
+	s := newTestStore(t)
+	s.Warnf = func(format string, a ...any) { warnings = append(warnings, fmt.Sprintf(format, a...)) }
+	require.NoError(t, s.Add("eldara", srv.URL))
+	age(t, s, "eldara", 3*24*time.Hour)
+
+	_, unchanged, err := s.Update("eldara")
+	require.NoError(t, err)
+	require.Equal(t, []string{"eldara"}, unchanged)
+
+	_, _, err = s.Resolve("eldara/demo", "")
+	require.NoError(t, err)
+	require.Empty(t, warnings, "an index just confirmed current is not stale")
 }


### PR DESCRIPTION
## What

`charts install`, `upgrade`, `template` and `search` resolve a chart from the **cached** repository index and never refetch it — only `charts repo update`, `charts outdated` and `charts apply` go to the network. A cache written before the newest release therefore keeps answering "latest" with the version it happens to hold, silently.

This warns when a cached index has not been verified for 24h:

```
$ swarmcli charts search swarmcli-cd
cached index for 'swarmcli-charts' is 4 days old; run `swarmcli charts repo update` to pick up newer chart versions
NAME                          VERSION   APP VERSION   DESCRIPTION
swarmcli-charts/swarmcli-cd   0.1.0     1.0.0         SwarmCLI CD — GitOps continuous delivery for Docker Swarm…
```

## Why

Reported as "installing swarmcli-cd from swarmcli-charts didn't get the latest version". Chart 0.2.0 (appVersion 1.1.0) was published 2026-08-05 10:19 UTC; the install happened the next day and deployed `eldaratech/swarmcli-cd:1.0.0`.

Everything on the publishing side was correct — verified the served `index.yaml` lists 0.2.0 first, the `swarmcli-cd-v0.2.0.tgz` is stamped `version: 0.2.0` / `appVersion: "1.1.0"`, the template renders `eldaratech/swarmcli-cd:1.1.0`, and that image's binary reports `swarmcli-cd 1.1.0`. `latestVersion` picks a proper SemVer max. The only broken part was that nothing said the cache was old.

## Notes

- **Warn, not refetch.** An install that reaches the network is a different command, and auto-refresh would break the air-gapped and CI uses that pin a version anyway. Helm has the same split (`helm repo update` is explicit).
- **`Update` now touches the cache when the served bytes are identical.** mtime has to mean *last verified*, not *last changed* — a repository that publishes rarely serves the same index for weeks, and without this the operator who refreshes daily is the one who gets nagged. `TestUpdateMarksAnUnchangedIndexAsVerified` guards it.
- **Once per repository per process.** An apply resolves every release in the manifest against the same repo; one line each would bury the plan it precedes.
- Warning text uses `'…'` per the `RepoStore.Warnf` convention (swarmcli-cd routes it into logfmt).

## Verification

`go test ./...` and `golangci-lint run ./...` green. Also driven end-to-end against the live `swarmcli-charts` repo: stale cache warns and resolves 0.1.0/1.0.0; `charts repo update` recovers 0.2.0/1.1.0; a no-op update clears the staleness without re-downloading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
