### PR TITLE
feat(charts): resolve the chart the repository publishes, not the cached one

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,6 +109,7 @@ utils/log/
 | `DOCKER_CONTEXT` | Override Docker context | `docker context show` |
 | `TEST_LOG` | Enable logging in tests | unset |
 | `SWARMCLI_CHARTS_ALLOW_PLAINTEXT` | Opt out of the https-only default for chart repositories; read only by `cli`, which wires it to `charts.RepoStore.AllowPlaintext` (the `charts` package never reads the environment, so embedders keep the default) | unset (https only) |
+| `SWARMCLI_CHARTS_NO_AUTO_UPDATE` | Stop the CLI refreshing a repository index before resolving a chart from it; read only by `cli`, which wires it to `charts.RepoStore.Refresh` = `RefreshNever` (same for `--no-repo-update`). Embedders keep the `RefreshExplicit` default either way | unset (refreshes) |
 
 ## Pro Feature Boundary
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,8 @@ Helm-like chart package manager `swarmcli charts <command>`:
 # Repositories
 swarmcli charts repo add <name> <url>     # add a repo and download its index
 swarmcli charts repo list                 # list configured repos
-swarmcli charts repo update [name]        # refresh indexes (all, or one)
+swarmcli charts repo update [name]        # refresh indexes (all, or one); install
+                                          # and friends now refresh on their own
 swarmcli charts repo remove <name>        # remove a repo
 
 # Discovery

--- a/charts/README.md
+++ b/charts/README.md
@@ -476,6 +476,45 @@ or any static host. Configured repos and cached indexes live under
 repository's name is a component of its cache filename, so it is limited to
 letters, digits, `-`, `_` and `.`.
 
+### Staying current
+
+Every command that resolves a `<repo>/<chart>` reference refreshes that
+repository's index first — `install`, `upgrade`, `template`, `diff`, `show`,
+`lint` and `search`. `install foo swarmcli-charts/bar` therefore installs the
+`bar` the repository publishes, not the one the cache happened to hold when
+`repo update` was last run. `repo update` is still there and still does exactly
+what it says; you no longer have to remember it before installing.
+
+The refresh is best-effort and bounded by a short deadline. If the repository is
+unreachable the command says so and resolves from the cache — a cached index is
+a correct answer, merely possibly an old one, and refusing to install would
+trade a stale answer for no answer. If that cache is also more than a day old,
+a second line says how old, because at that point the version you get may not
+be the one you asked for.
+
+Each repository is fetched at most once per invocation, so an `apply` over
+twenty releases from one repository downloads one index.
+
+Turn it off for a single command with `--no-repo-update`, or for a machine:
+
+```bash
+export SWARMCLI_CHARTS_NO_AUTO_UPDATE=1
+```
+
+Either one means *no network*, not merely *no implicit fetch*: `apply` skips its
+own refresh too, and `outdated` reports against the cached indexes and says so.
+That is what an air-gapped or deliberately offline run wants — the same answer,
+without paying a timeout per repository to reach it. The one thing still
+fetched is a repository being added for the first time, by `repo add` or by an
+`apply` whose release file declares one this machine has never seen: there is
+no cached index to fall back to, so the alternative is not an offline answer
+but no answer.
+
+Programs embedding this package are unaffected. `RepoStore.Refresh` defaults to
+`RefreshExplicit`, which downloads only when asked (`Update`, `Add`,
+`EnsureRepos`); `cli` is what selects `RefreshAlways`. A daemon's network
+behaviour is not something a CLI convenience should change underneath it.
+
 ### Transport
 
 Repositories are **HTTPS by default**. A repository serves the tarball that
@@ -494,9 +533,10 @@ this is a default rather than a rule. Opt that machine out:
 export SWARMCLI_CHARTS_ALLOW_PLAINTEXT=1
 ```
 
-It is read once, where the CLI builds its repository store, so it covers every
-command that touches a repository — `repo add`, `repo update`, `search`,
-`install`, `upgrade`, `apply`. One line in a shell profile or a CI job's
+It is read once, where the CLI builds its repository store (the same place
+`SWARMCLI_CHARTS_NO_AUTO_UPDATE` is read), so it covers every command that
+touches a repository — `repo add`, `repo update`, `search`, `install`,
+`upgrade`, `apply`. One line in a shell profile or a CI job's
 environment restores a plaintext setup in full; nothing about it is one-way.
 Programs embedding this package get the https-only default and decide for
 themselves — the `charts` package never reads the environment.

--- a/charts/repo.go
+++ b/charts/repo.go
@@ -25,6 +25,9 @@ import (
 // httpTimeout bounds index and tarball downloads.
 const httpTimeout = 30 * time.Second
 
+// quickTimeout bounds an implicit RefreshAlways fetch. See RepoStore.quick.
+const quickTimeout = 5 * time.Second
+
 // maxIndexSize bounds an index.yaml download (defense against huge responses).
 const maxIndexSize = 16 << 20 // 16 MiB
 
@@ -34,9 +37,11 @@ const maxIndexSize = 16 << 20 // 16 MiB
 const maxChartArchiveSize = 20 << 20 // 20 MiB
 
 // staleAfter is how long a cached index may go unverified before reads of it
-// warn. Every path that resolves a chart — install, upgrade, template, search —
-// reads the cache and none of them refetches, so an unrefreshed cache answers
-// "latest" with whatever was newest when it was written, silently and for good.
+// warn. Under RefreshAlways nothing gets that far — the index is refreshed
+// before it is read — so this is what is left for the cases where it was not:
+// a refresh that failed, and a RefreshExplicit or RefreshNever store. There, an
+// unrefreshed cache answers "latest" with whatever was newest when it was
+// written, silently and for good.
 const staleAfter = 24 * time.Hour
 
 // AllowPlaintextEnv is the environment variable a host program may honour to set
@@ -46,11 +51,50 @@ const staleAfter = 24 * time.Hour
 // (yes, for an interactive user's own machine) is not automatically a daemon's.
 const AllowPlaintextEnv = "SWARMCLI_CHARTS_ALLOW_PLAINTEXT"
 
+// NoAutoUpdateEnv is the environment variable a host program may honour to
+// select RefreshNever. It lives here beside AllowPlaintextEnv so the docs and
+// the code cannot name it differently; as with that one, this package never
+// reads the environment itself.
+const NoAutoUpdateEnv = "SWARMCLI_CHARTS_NO_AUTO_UPDATE"
+
+// RefreshPolicy says when a RepoStore may download a repository index.
+//
+// Resolving a chart is otherwise a pure cache read — install, upgrade,
+// template, show, lint and search never refetch — which is how an install can
+// deploy the version that was newest whenever the cache was last written.
+type RefreshPolicy int
+
+const (
+	// RefreshExplicit downloads an index only when asked to: Update, Add and
+	// EnsureRepos. It is the zero value because it is what programs embedding
+	// this package already had, and because a daemon's network behaviour is not
+	// something a CLI convenience should change underneath it — swarmcli-cd
+	// builds a store per application on every reconcile and refreshes on its own
+	// schedule.
+	RefreshExplicit RefreshPolicy = iota
+	// RefreshAlways additionally refreshes a repository before the first read of
+	// its index in this process. An interactive user who types `install
+	// repo/chart` means the chart the repository publishes, not the one their
+	// cache happened to hold when they last ran `repo update`.
+	RefreshAlways
+	// RefreshNever downloads nothing, not even for EnsureRepos, and resolution
+	// answers out of whatever is cached. For an air-gapped or deliberately
+	// offline run, where the alternative is paying a network timeout per
+	// repository to reach the same answer.
+	RefreshNever
+)
+
 // RepoStore persists configured repositories and caches their indexes under a
 // base directory (default: the XDG state dir, ~/.local/state/swarmcli/charts).
 type RepoStore struct {
 	dir    string
 	client *http.Client
+	// quick is the client a RefreshAlways fetch uses. An implicit refresh is
+	// allowed to give up quickly because its fallback — the cached index — is a
+	// correct answer, merely possibly an old one; making an operator wait
+	// httpTimeout for that on a blackholed network would be a worse failure
+	// than the staleness the refresh exists to prevent.
+	quick *http.Client
 
 	// Warnf, when set, receives non-fatal diagnostics: a chart whose index entry
 	// publishes no digest, so its integrity could not be verified, and a
@@ -77,6 +121,19 @@ type RepoStore struct {
 	// apply resolving ten releases from one repository says it once rather than
 	// ten times.
 	warnedStale map[string]bool
+
+	// Refresh decides when this store goes to the network for an index. Its zero
+	// value is RefreshExplicit, which is what every embedder got before the
+	// policy existed. cli sets it; see the constants.
+	Refresh RefreshPolicy
+
+	// refreshed records the repositories already refreshed in this process,
+	// whether implicitly or by an explicit Update. With no staleness window
+	// to rate-limit it, this is the only thing standing between an apply
+	// resolving ten releases from one repository and ten downloads of the same
+	// index — and it is what stops apply's own EnsureRepos being followed by a
+	// second, implicit fetch of everything it just fetched.
+	refreshed map[string]bool
 }
 
 // NewRepoStore returns a store rooted at the standard charts state directory.
@@ -90,7 +147,11 @@ func NewRepoStore() (*RepoStore, error) {
 
 // NewRepoStoreAt returns a store rooted at dir (used in tests).
 func NewRepoStoreAt(dir string) *RepoStore {
-	return &RepoStore{dir: dir, client: &http.Client{Timeout: httpTimeout, CheckRedirect: checkRedirect}}
+	return &RepoStore{
+		dir:    dir,
+		client: &http.Client{Timeout: httpTimeout, CheckRedirect: checkRedirect},
+		quick:  &http.Client{Timeout: quickTimeout, CheckRedirect: checkRedirect},
+	}
 }
 
 // checkRedirect bounds redirects and refuses any hop to a non-http(s) URL,
@@ -205,7 +266,7 @@ func (s *RepoStore) Add(name, repoURL string) error {
 	repoURL = strings.TrimRight(repoURL, "/")
 	// Download and validate the index before persisting anything, so a failed
 	// download leaves no half-added repository behind.
-	idx, err := s.fetchIndex(repoURL)
+	idx, err := s.fetchIndex(repoURL, s.client)
 	if err != nil {
 		return fmt.Errorf("index download failed, repository not added: %w%s", err, githubPagesHint(repoURL))
 	}
@@ -213,14 +274,54 @@ func (s *RepoStore) Add(name, repoURL string) error {
 	if err != nil {
 		return err
 	}
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+	if err := writeCache(path, idx); err != nil {
 		return err
 	}
-	if err := os.WriteFile(path, idx, 0o644); err != nil {
-		return err
-	}
+	// Add has just been to the network for this repository, so a RefreshAlways
+	// read must not go again. This is not hypothetical: EnsureRepos adds the
+	// repositories a release file declares and then resolves charts from them
+	// in the same process.
+	s.markRefreshed(name)
 	repos = append(repos, RepoEntry{Name: name, URL: repoURL})
 	return s.save(repos)
+}
+
+// writeCache replaces a cached index in one step. os.WriteFile truncates before
+// it writes, so a reader that arrives mid-write sees an empty or half-written
+// index — and under RefreshAlways a write happens on every install, not only
+// on an explicit `repo update`, so two swarmcli processes sharing a state
+// directory (a CI matrix, an apply running beside an install) really do
+// overlap. Writing beside the target and renaming over it means a reader sees
+// either the old index or the new one, and a failed write leaves the old one
+// readable rather than a truncated file.
+//
+// The temporary file is deliberately in the same directory: os.Rename is atomic
+// only within a filesystem, and anywhere else would be a different mount on
+// somebody's machine.
+func writeCache(path string, data []byte) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+	f, err := os.CreateTemp(dir, filepath.Base(path)+".*.tmp")
+	if err != nil {
+		return err
+	}
+	tmp := f.Name()
+	defer func() { _ = os.Remove(tmp) }() // no-op once the rename succeeds
+	if _, err := f.Write(data); err != nil {
+		_ = f.Close()
+		return err
+	}
+	if err := f.Close(); err != nil {
+		return err
+	}
+	// CreateTemp makes the file 0600; the cache is world-readable like every
+	// other index this package writes.
+	if err := os.Chmod(tmp, 0o644); err != nil {
+		return err
+	}
+	return os.Rename(tmp, path)
 }
 
 // Remove deletes a repository and its cached index.
@@ -256,6 +357,10 @@ func (s *RepoStore) Remove(name string) error {
 // Update downloads and caches the index for one repository (or all when name is
 // empty) and returns the names refreshed.
 func (s *RepoStore) Update(name string) (changed, unchanged []string, err error) {
+	return s.update(name, s.client)
+}
+
+func (s *RepoStore) update(name string, client *http.Client) (changed, unchanged []string, err error) {
 	repos, err := s.List()
 	if err != nil {
 		return nil, nil, err
@@ -270,7 +375,12 @@ func (s *RepoStore) Update(name string) (changed, unchanged []string, err error)
 		if err != nil {
 			return changed, unchanged, fmt.Errorf("update '%s': %w", r.Name, err)
 		}
-		idx, err := s.fetchIndex(r.URL)
+		// Recorded before the fetch, not after, and whatever the outcome: this
+		// says "this process has already been to the network for you", which is
+		// as true of a failure as of a success. Recording only successes would
+		// make a down repository cost one timeout per chart resolved.
+		s.markRefreshed(r.Name)
+		idx, err := s.fetchIndex(r.URL, client)
 		if err != nil {
 			return changed, unchanged, fmt.Errorf("update '%s': %w", r.Name, err)
 		}
@@ -287,10 +397,7 @@ func (s *RepoStore) Update(name string) (changed, unchanged []string, err error)
 			unchanged = append(unchanged, r.Name)
 			continue
 		}
-		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-			return changed, unchanged, err
-		}
-		if err := os.WriteFile(path, idx, 0o644); err != nil {
+		if err := writeCache(path, idx); err != nil {
 			return changed, unchanged, err
 		}
 		changed = append(changed, r.Name)
@@ -307,6 +414,7 @@ func (s *RepoStore) LoadIndex(name string) (*Index, error) {
 	if err != nil {
 		return nil, err
 	}
+	s.autoRefresh(name)
 	data, err := os.ReadFile(path)
 	if os.IsNotExist(err) {
 		return nil, fmt.Errorf("no cached index for '%s'; run `charts repo update`", name)
@@ -322,9 +430,37 @@ func (s *RepoStore) LoadIndex(name string) (*Index, error) {
 	return &idx, nil
 }
 
+// autoRefresh re-downloads a repository's index before it is read, once per
+// repository per process. It is best-effort by construction: every caller has a
+// cached index to fall back on, and refusing to resolve a chart because a
+// repository was briefly unreachable would trade a stale answer for no answer.
+func (s *RepoStore) autoRefresh(name string) {
+	if s.Refresh != RefreshAlways || s.refreshed[name] {
+		return
+	}
+	// The short-deadline client, not s.client: see RepoStore.quick.
+	if _, _, err := s.update(name, s.quick); err != nil {
+		// The same sentence EnsureRepos emits for the same situation, so one
+		// thing going wrong reads as one thing wherever it is noticed.
+		s.warnf("could not refresh repository '%s' (%v); using the cached index\n", name, err)
+	}
+}
+
+// markRefreshed records that this process has already been to the network for a
+// repository. update calls it; autoRefresh reads it.
+func (s *RepoStore) markRefreshed(name string) {
+	if s.refreshed == nil {
+		s.refreshed = map[string]bool{}
+	}
+	s.refreshed[name] = true
+}
+
 // warnStale reports a cached index that has not been verified for staleAfter.
-// Resolution never refetches, so the alternative to saying so is an install that
-// quietly deploys the version that stopped being the latest days ago.
+// It is the fallback for when the refresh policy is not RefreshAlways or its
+// fetch failed: those are
+// the only paths left on which resolution answers out of a cache nobody has
+// checked, and an install that quietly deploys the version that stopped being
+// the latest days ago is what this exists to prevent.
 func (s *RepoStore) warnStale(path, name string) {
 	fi, err := os.Stat(path)
 	if err != nil {
@@ -398,6 +534,11 @@ func (s *RepoStore) EnsureRepos(specs []RepoSpec) error {
 				"refusing to repoint it — run `swarmcli charts repo remove %s` first if that is intended",
 				spec.Name, have, spec.Name)
 		default:
+			// RefreshNever means the caller has said there is no network to reach,
+			// so trying anyway buys the same cached answer one timeout later.
+			if s.Refresh == RefreshNever {
+				continue
+			}
 			// Refreshing is best-effort. Every version in the manifest is pinned,
 			// so a stale cache can only fail to resolve a chart — it can never
 			// resolve one to the wrong version. Failing the whole apply because
@@ -613,7 +754,7 @@ func githubPagesHint(repoURL string) string {
 	return fmt.Sprintf("%s https://%s.github.io/%s", base, strings.ToLower(parts[0]), parts[1])
 }
 
-func (s *RepoStore) fetchIndex(repoURL string) ([]byte, error) {
+func (s *RepoStore) fetchIndex(repoURL string, client *http.Client) ([]byte, error) {
 	// Add checks this before anything else, to fail without a round trip; the
 	// re-check is for Update, whose URLs come out of repos.json — including ones
 	// added before this store had an opinion about plain http.
@@ -621,7 +762,7 @@ func (s *RepoStore) fetchIndex(repoURL string) ([]byte, error) {
 		return nil, err
 	}
 	indexURL := strings.TrimRight(repoURL, "/") + "/index.yaml"
-	resp, err := s.client.Get(indexURL)
+	resp, err := client.Get(indexURL)
 	if err != nil {
 		return nil, fmt.Errorf("fetch %s: %w", indexURL, err)
 	}

--- a/charts/repo_test.go
+++ b/charts/repo_test.go
@@ -708,3 +708,232 @@ func TestUpdateMarksAnUnchangedIndexAsVerified(t *testing.T) {
 	require.NoError(t, err)
 	require.Empty(t, warnings, "an index just confirmed current is not stale")
 }
+
+// countingIndexServer serves an index whose body the test can change, and
+// counts index requests. The count is what the refresh-policy tests actually
+// assert: whether a fetch happened is not visible in any return value.
+func countingIndexServer(t *testing.T, body *string, up *bool, hits *int) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/index.yaml") {
+			http.NotFound(w, r)
+			return
+		}
+		*hits++
+		if !*up {
+			http.Error(w, "down", http.StatusServiceUnavailable)
+			return
+		}
+		_, _ = w.Write([]byte(*body))
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// reopen returns a second store over the same state directory. Add and a later
+// install are separate swarmcli invocations, and the once-per-process
+// bookkeeping is per store — a test that resolves through the same store Add
+// used is testing one process doing both, which is not the case being fixed.
+func reopen(t *testing.T, s *RepoStore) *RepoStore {
+	t.Helper()
+	n := NewRepoStoreAt(s.dir)
+	n.AllowPlaintext = true
+	n.Warnf = s.Warnf
+	return n
+}
+
+func indexWith(version string) string {
+	return "apiVersion: v1\nentries:\n  demo:\n    - {name: demo, version: " + version + ", urls: [\"d.tgz\"]}\n"
+}
+
+// The point of the whole feature: a resolution answers with what the repository
+// publishes now, not with what it published when the cache was written. No
+// ageing of the cache — under RefreshAlways a cache written a second ago is
+// refreshed too, and that is the behaviour being pinned down.
+func TestRefreshAlwaysResolvesWhatTheRepositoryPublishesNow(t *testing.T) {
+	body, up, hits := indexWith("0.1.0"), true, 0
+	srv := countingIndexServer(t, &body, &up, &hits)
+
+	s := newTestStore(t)
+	require.NoError(t, s.Add("eldara", srv.URL)) // caches 0.1.0
+
+	body = indexWith("0.2.0")
+
+	s = reopen(t, s)
+	s.Refresh = RefreshAlways
+	e, _, err := s.Resolve("eldara/demo", "")
+	require.NoError(t, err)
+	require.Equal(t, "0.2.0", e.Version)
+}
+
+// The embedder contract. swarmcli-cd builds a store per application on every
+// reconcile and refreshes on its own schedule; a store that was never told to
+// refresh must make no request of its own. Deleting this test is how that
+// becomes untrue by accident.
+func TestRefreshExplicitIsTheZeroValueAndFetchesNothing(t *testing.T) {
+	body, up, hits := indexWith("0.1.0"), true, 0
+	srv := countingIndexServer(t, &body, &up, &hits)
+
+	s := newTestStore(t)
+	require.NoError(t, s.Add("eldara", srv.URL))
+	require.Equal(t, 1, hits, "Add fetches once, by definition")
+
+	body = indexWith("0.2.0")
+
+	s = reopen(t, s)
+	require.Equal(t, RefreshExplicit, s.Refresh, "the zero value must be the safe one")
+	e, _, err := s.Resolve("eldara/demo", "")
+	require.NoError(t, err)
+	require.Equal(t, "0.1.0", e.Version, "an unasked store answers from the cache")
+	require.Equal(t, 1, hits, "and makes no request of its own")
+}
+
+// With no staleness window to rate-limit it, this is the only thing between an
+// apply resolving ten releases from one repository and ten downloads of the
+// same index. It is a correctness test, not a performance one.
+func TestRefreshAlwaysFetchesOncePerRepositoryPerProcess(t *testing.T) {
+	body, up, hits := indexWith("0.1.0"), true, 0
+	srv := countingIndexServer(t, &body, &up, &hits)
+
+	s := newTestStore(t)
+	require.NoError(t, s.Add("eldara", srv.URL))
+	s = reopen(t, s)
+	s.Refresh = RefreshAlways
+	hits = 0
+
+	for range 3 {
+		_, _, err := s.Resolve("eldara/demo", "")
+		require.NoError(t, err)
+	}
+	require.Equal(t, 1, hits)
+}
+
+// apply calls EnsureRepos, which refreshes every declared repository, and then
+// resolves charts from them. Without Update recording what it fetched, every
+// index would be downloaded twice per apply — green, and visible only in
+// somebody's bandwidth.
+func TestAnExplicitUpdateSuppressesTheImplicitOne(t *testing.T) {
+	body, up, hits := indexWith("0.1.0"), true, 0
+	srv := countingIndexServer(t, &body, &up, &hits)
+
+	s := newTestStore(t)
+	require.NoError(t, s.Add("eldara", srv.URL))
+	s = reopen(t, s)
+	s.Refresh = RefreshAlways
+	hits = 0
+
+	_, _, err := s.Update("")
+	require.NoError(t, err)
+	require.Equal(t, 1, hits)
+
+	_, _, err = s.Resolve("eldara/demo", "")
+	require.NoError(t, err)
+	require.Equal(t, 1, hits, "the index was already fetched in this process")
+}
+
+// A repository that is briefly unreachable must not stop a chart resolving:
+// the cache is a correct answer, merely possibly an old one, and refusing to
+// install would trade a stale answer for no answer.
+func TestRefreshFailureFallsBackToTheCache(t *testing.T) {
+	body, up, hits := indexWith("0.1.0"), true, 0
+	srv := countingIndexServer(t, &body, &up, &hits)
+
+	var warnings []string
+	s := newTestStore(t)
+	s.Warnf = func(format string, a ...any) { warnings = append(warnings, fmt.Sprintf(format, a...)) }
+	require.NoError(t, s.Add("eldara", srv.URL))
+	s = reopen(t, s)
+	s.Refresh = RefreshAlways
+	up, hits = false, 0
+
+	// Three resolutions, one attempt: recording the refresh before the fetch
+	// rather than after is what keeps a dead repository from costing a timeout
+	// per chart in the manifest.
+	for range 3 {
+		e, _, err := s.Resolve("eldara/demo", "")
+		require.NoError(t, err)
+		require.Equal(t, "0.1.0", e.Version)
+	}
+	require.Equal(t, 1, hits)
+	require.Len(t, warnings, 1)
+	require.Contains(t, warnings[0], "'eldara'")
+	require.Contains(t, warnings[0], "using the cached index")
+}
+
+// A configured repository whose cache file is gone resolves instead of telling
+// the user to run the command that would have been run for them.
+func TestRefreshAlwaysHealsAMissingCache(t *testing.T) {
+	body, up, hits := indexWith("0.1.0"), true, 0
+	srv := countingIndexServer(t, &body, &up, &hits)
+
+	s := newTestStore(t)
+	require.NoError(t, s.Add("eldara", srv.URL))
+	path, err := s.indexFile("eldara")
+	require.NoError(t, err)
+	require.NoError(t, os.Remove(path))
+
+	s = reopen(t, s)
+	s.Refresh = RefreshExplicit
+	_, err = s.LoadIndex("eldara")
+	require.ErrorContains(t, err, "no cached index")
+
+	s.Refresh = RefreshAlways
+	e, _, err := s.Resolve("eldara/demo", "")
+	require.NoError(t, err)
+	require.Equal(t, "0.1.0", e.Version)
+}
+
+// RefreshNever is what --no-repo-update sets, and it has to reach EnsureRepos:
+// an air-gapped apply would otherwise pay a network timeout per repository to
+// arrive at the cached answer it was told to use.
+func TestRefreshNeverKeepsEnsureReposOffTheNetwork(t *testing.T) {
+	body, up, hits := indexWith("0.1.0"), true, 0
+	srv := countingIndexServer(t, &body, &up, &hits)
+
+	s := newTestStore(t)
+	require.NoError(t, s.Add("eldara", srv.URL))
+	s = reopen(t, s)
+	s.Refresh = RefreshNever
+	hits = 0
+
+	require.NoError(t, s.EnsureRepos([]RepoSpec{{Name: "eldara", URL: srv.URL}}))
+	require.Equal(t, 0, hits)
+
+	e, _, err := s.Resolve("eldara/demo", "")
+	require.NoError(t, err)
+	require.Equal(t, "0.1.0", e.Version)
+}
+
+// os.WriteFile truncates before it writes, so a reader arriving mid-write saw a
+// partial index. With a refresh on every install that window is no longer
+// theoretical. Assert the two observable consequences of writing through a
+// rename: nothing is left behind, and a failed write does not destroy what was
+// already there.
+func TestWriteCacheReplacesTheIndexInOneStep(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "cache", "index-eldara.yaml")
+
+	require.NoError(t, writeCache(path, []byte("first")))
+	got, err := os.ReadFile(path)
+	require.NoError(t, err)
+	require.Equal(t, "first", string(got))
+
+	require.NoError(t, writeCache(path, []byte("second")))
+	got, err = os.ReadFile(path)
+	require.NoError(t, err)
+	require.Equal(t, "second", string(got))
+
+	entries, err := os.ReadDir(filepath.Dir(path))
+	require.NoError(t, err)
+	require.Len(t, entries, 1, "no temporary file survives a successful write")
+
+	// A directory in place of the target: the rename fails, and the point is
+	// that the failure is reported rather than leaving a truncated file.
+	blocked := filepath.Join(dir, "cache", "blocked.yaml")
+	require.NoError(t, os.Mkdir(blocked, 0o755))
+	require.Error(t, writeCache(blocked, []byte("third")))
+
+	entries, err = os.ReadDir(filepath.Dir(path))
+	require.NoError(t, err)
+	require.Len(t, entries, 2, "the failed write leaves no temporary file either")
+}

--- a/cli/apply.go
+++ b/cli/apply.go
@@ -34,7 +34,7 @@ func chartsApply(args []string) int {
 		return fail(err)
 	}
 
-	store, code := newStore()
+	store, code := newStore(f)
 	if code >= 0 {
 		return code
 	}
@@ -254,16 +254,22 @@ func reportUnmanaged(plan *charts.Plan) {
 // version its repositories offer. It is the human-facing complement to an
 // automated updater watching the release file.
 func chartsOutdated(args []string) int {
-	if _, _, err := parseArgs(args); err != nil {
+	_, f, err := parseArgs(args)
+	if err != nil {
 		return usageErr(err.Error())
 	}
-	store, code := newStore()
+	store, code := newStore(f)
 	if code >= 0 {
 		return code
 	}
 	// A read-only informational command must degrade, not fail: report against the
-	// cached indexes when the network is unavailable.
-	if _, _, err := store.Update(""); err != nil {
+	// cached indexes when the network is unavailable. --no-repo-update says the
+	// network is not to be used at all, which is the same destination without the
+	// timeout — outdated then reports against whatever is cached, which is the
+	// honest answer to "what does this machine know".
+	if f.noRepoUpdate || noAutoUpdateEnv() {
+		errf("not refreshing repositories; comparing against the cached indexes\n")
+	} else if _, _, err := store.Update(""); err != nil {
 		errf("could not refresh repositories (%v); comparing against the cached indexes\n", err)
 	}
 	indexes, err := store.Indexes()

--- a/cli/args.go
+++ b/cli/args.go
@@ -32,6 +32,9 @@ type flags struct {
 	// skipCompatCheck (--skip-compat-check) downgrades a chart's unmet
 	// swarmcliVersion requirement from a refusal to a warning.
 	skipCompatCheck bool
+	// noRepoUpdate (--no-repo-update) leaves the cached repository indexes
+	// alone, so resolution answers out of them and touches no network.
+	noRepoUpdate bool
 	// forVersion (--for-version) lints a chart against a chart-engine version
 	// other than this build's.
 	forVersion string
@@ -150,6 +153,8 @@ func parseArgs(args []string) ([]string, flags, error) {
 			f.install = true
 		case "--skip-compat-check":
 			f.skipCompatCheck = true
+		case "--no-repo-update":
+			f.noRepoUpdate = true
 		case "--for-version":
 			v, err := next()
 			if err != nil {

--- a/cli/charts.go
+++ b/cli/charts.go
@@ -111,6 +111,8 @@ Common options:
       --revision <n>    get: select a specific revision
       --purge-volumes   uninstall: also remove the release's volumes
       --diff            apply: show each changed release's manifest diff (implies --dry-run)
+      --no-repo-update  Resolve from the cached repository indexes and touch no
+                        network (also: SWARMCLI_CHARTS_NO_AUTO_UPDATE=1)
       --skip-compat-check  Proceed despite a chart's unmet swarmcliVersion constraint
       --for-version <ver>  lint: check the chart's swarmcliVersion against <ver>
                         instead of this build's chart engine
@@ -127,8 +129,14 @@ that version is the only thing that settles that.
 apply honours --wait, --timeout, --history-max and --resolve-image. It REJECTS --set,
 --set-file, --version, --reuse-values, --install, --purge-volumes, --requirements and --revision rather
 than ignoring them: the release file is the only source of truth, so a value passed
-on the command line would be a lie. outdated refreshes the repository indexes first
-and falls back to the cached ones if the network is unavailable.
+on the command line would be a lie.
+
+Resolving a <repo>/<chart> reference refreshes that repository's index first, so
+install, upgrade, template, diff, show, lint and search see what the repository
+publishes now rather than what the cache last held. Each repository is fetched at
+most once per invocation. A repository that cannot be reached is reported and the
+cached index is used. --no-repo-update skips the network entirely, for which
+outdated reports against the cached indexes and says so.
 `
 
 // chartsMain dispatches `swarmcli charts ...`.
@@ -181,14 +189,37 @@ func chartsMain(args []string) int {
 	}
 }
 
-func newStore() (*charts.RepoStore, int) {
+// newStore builds the repository store every charts subcommand resolves
+// through, and is the single place CLI policy is applied to it.
+func newStore(f flags) (*charts.RepoStore, int) {
 	s, err := charts.NewRepoStore()
 	if err != nil {
 		return nil, fail(err)
 	}
 	s.Warnf = errf
 	s.AllowPlaintext = plaintextAllowed()
+	// An interactive user who types `charts install foo repo/bar` means the bar
+	// the repository publishes, not the one their cache happened to hold when
+	// they last ran `repo update`. Programs embedding the charts package keep
+	// the explicit-only default and decide for themselves.
+	//
+	// The opt-out is RefreshNever rather than RefreshExplicit: someone passing
+	// --no-repo-update is saying "do not go to the network", and apply's
+	// EnsureRepos would otherwise still spend a timeout per repository finding
+	// out what they already told us.
+	s.Refresh = charts.RefreshAlways
+	if f.noRepoUpdate || noAutoUpdateEnv() {
+		s.Refresh = charts.RefreshNever
+	}
 	return s, -1
+}
+
+// noAutoUpdateEnv reports whether the operator turned implicit refreshes off
+// for this machine. The flag covers one invocation; this covers a CI job or an
+// air-gapped host, where every invocation would otherwise pay the timeout.
+func noAutoUpdateEnv() bool {
+	off, err := strconv.ParseBool(strings.TrimSpace(os.Getenv(charts.NoAutoUpdateEnv)))
+	return err == nil && off
 }
 
 // plaintextAllowed reports whether the operator opted this machine out of the
@@ -209,7 +240,10 @@ func chartsRepo(args []string) int {
 	if len(args) == 0 {
 		return usageErr("charts repo requires a subcommand: add|list|update|remove")
 	}
-	store, code := newStore()
+	// Explicitly opted out rather than passed a zero flags: `repo update` IS the
+	// refresh and `repo add` fetches by definition, so an implicit one before
+	// either would be a second download of the same index.
+	store, code := newStore(flags{noRepoUpdate: true})
 	if code >= 0 {
 		return code
 	}
@@ -278,7 +312,7 @@ func chartsRepo(args []string) int {
 // --- search ---
 
 func chartsSearch(args []string) int {
-	pos, _, err := parseArgs(args)
+	pos, f, err := parseArgs(args)
 	if err != nil {
 		return usageErr(err.Error())
 	}
@@ -286,7 +320,7 @@ func chartsSearch(args []string) int {
 	if len(pos) > 0 {
 		keyword = pos[0]
 	}
-	store, code := newStore()
+	store, code := newStore(f)
 	if code >= 0 {
 		return code
 	}
@@ -318,7 +352,7 @@ func chartsShow(args []string) int {
 		return usageErr(err.Error())
 	}
 	_ = pos
-	ch, _, code := loadChart(ref, f.version)
+	ch, _, code := loadChart(ref, f)
 	if code >= 0 {
 		return code
 	}
@@ -390,7 +424,7 @@ func chartsLint(args []string) int {
 	if len(pos) != 1 {
 		return usageErr("charts lint <chart>")
 	}
-	ch, _, code := loadChart(pos[0], f.version)
+	ch, _, code := loadChart(pos[0], f)
 	if code >= 0 {
 		return code
 	}
@@ -696,7 +730,7 @@ func chartsDiff(args []string) int {
 // template and diff show a manifest that could actually be deployed, install
 // and upgrade deploy it.
 func prepare(release, ref string, f flags, base map[string]any, pol compatPolicy) (manifest string, values map[string]any, rc charts.ReleaseChart, req *charts.Requirements, chartFiles map[string][]byte, code int) {
-	ch, _, c := loadChart(ref, f.version)
+	ch, _, c := loadChart(ref, f)
 	if c >= 0 {
 		return "", nil, rc, nil, nil, c
 	}
@@ -837,12 +871,12 @@ func chartsStatus(args []string) int {
 // path, otherwise a "repo/chart" reference pulled from a configured repository.
 // The resolution itself lives in charts.ChartSource, so apply and the imperative
 // commands cannot drift apart.
-func loadChart(ref, version string) (*charts.Chart, charts.ReleaseChart, int) {
-	store, code := newStore()
+func loadChart(ref string, f flags) (*charts.Chart, charts.ReleaseChart, int) {
+	store, code := newStore(f)
 	if code >= 0 {
 		return nil, charts.ReleaseChart{}, code
 	}
-	ch, err := charts.NewChartSource(store).Load(ref, version)
+	ch, err := charts.NewChartSource(store).Load(ref, f.version)
 	if err != nil {
 		return nil, charts.ReleaseChart{}, fail(err)
 	}

--- a/cli/charts_test.go
+++ b/cli/charts_test.go
@@ -466,18 +466,53 @@ func TestReportUnclaimedCoversBothLists(t *testing.T) {
 func TestNewStoreWiresThePlaintextOptOut(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 
-	s, code := newStore()
+	s, code := newStore(flags{})
 	require.Equal(t, -1, code)
 	require.False(t, s.AllowPlaintext, "https-only unless the operator says otherwise")
 
 	t.Setenv(charts.AllowPlaintextEnv, "1")
-	s, code = newStore()
+	s, code = newStore(flags{})
 	require.Equal(t, -1, code)
 	require.True(t, s.AllowPlaintext)
 
 	// Anything that is not a truthy boolean leaves the default in place, rather
 	// than any non-empty value opting out by accident.
 	t.Setenv(charts.AllowPlaintextEnv, "maybe")
-	s, _ = newStore()
+	s, _ = newStore(flags{})
 	require.False(t, s.AllowPlaintext)
+}
+
+// The CLI is where "resolve what the repository publishes now" is turned on,
+// and both opt-outs have to reach the same place — an air-gapped machine sets
+// the environment variable once, a one-off offline run passes the flag.
+func TestNewStoreWiresTheRefreshPolicy(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+
+	s, code := newStore(flags{})
+	require.Equal(t, -1, code)
+	require.Equal(t, charts.RefreshAlways, s.Refresh, "an interactive install means the current chart")
+
+	s, code = newStore(flags{noRepoUpdate: true})
+	require.Equal(t, -1, code)
+	require.Equal(t, charts.RefreshNever, s.Refresh, "--no-repo-update means no network at all")
+
+	t.Setenv(charts.NoAutoUpdateEnv, "1")
+	s, _ = newStore(flags{})
+	require.Equal(t, charts.RefreshNever, s.Refresh)
+
+	// As with the plaintext opt-out, only a truthy boolean counts: a stray
+	// non-empty value must not silently turn the feature off.
+	t.Setenv(charts.NoAutoUpdateEnv, "maybe")
+	s, _ = newStore(flags{})
+	require.Equal(t, charts.RefreshAlways, s.Refresh)
+}
+
+func TestNoRepoUpdateFlagParses(t *testing.T) {
+	_, f, err := parseArgs([]string{"--no-repo-update"})
+	require.NoError(t, err)
+	require.True(t, f.noRepoUpdate)
+
+	_, f, err = parseArgs([]string{})
+	require.NoError(t, err)
+	require.False(t, f.noRepoUpdate)
 }


### PR DESCRIPTION
## What

Resolving a `<repo>/<chart>` reference now refreshes that repository's index first, so `install`, `upgrade`, `template`, `diff`, `show`, `lint` and `search` see what the repository publishes rather than what the cache last held.

```bash
# cache predates the release; no `repo update` run
$ swarmcli charts search swarmcli-cd
NAME                          VERSION   APP VERSION
swarmcli-charts/swarmcli-cd   0.2.0     1.1.0        # was 0.1.0 / 1.0.0

$ swarmcli charts search swarmcli-cd --no-repo-update
cached index for 'swarmcli-charts' is 4 days old; run `swarmcli charts repo update` …
swarmcli-charts/swarmcli-cd   0.1.0     1.0.0
```

Follows #545, which made the staleness visible. This stops it happening.

## Why

Reported as "installing swarmcli-cd from swarmcli-charts didn't get the latest version". Only `repo update`, `outdated` and `apply` ever went to the network; everything else was a pure cache read, so an install a day after chart 0.2.0 shipped deployed 1.0.0 with nothing on screen to say so.

The hook is `RepoStore.LoadIndex`, the single point `Resolve`, `Search` and `Indexes` already funnel through. A pinned `--version` benefits too: a pin newer than the cache used to fail with `version not found`.

## Design notes

**`RefreshPolicy`, not a bool.** The opt-out has three distinct meanings and only a named type survives review:

| | behaviour | who selects it |
|---|---|---|
| `RefreshExplicit` | download only for `Update`, `Add`, `EnsureRepos` | the zero value — what every embedder had before. swarmcli-cd builds a store per application on every reconcile, and a CLI convenience must not change a daemon's network behaviour underneath it |
| `RefreshAlways` | also before the first read of an index | `cli` |
| `RefreshNever` | download nothing, `EnsureRepos` included | `--no-repo-update`, `SWARMCLI_CHARTS_NO_AUTO_UPDATE=1` |

`RefreshNever` rather than `RefreshExplicit` for the opt-out is deliberate: somebody passing `--no-repo-update` is saying *do not go to the network*, and `apply`'s `EnsureRepos` would otherwise still spend a timeout per repository finding out what they already told us.

**Once per repository per process.** With no staleness window to rate-limit it, this is the only thing between an `apply` over twenty releases and twenty downloads of one index. `Update` records what it fetched and so does `Add` — without that, every `apply` downloads each index **twice**, once in `EnsureRepos` and once on the first `LoadIndex`. Green, and visible only in somebody's bandwidth. Two tests cover it.

The record is written *before* the fetch and whatever the outcome, so a dead repository costs one timeout per invocation rather than one per chart in the manifest.

**5s deadline for an implicit fetch**, against the existing 30s for an explicit one. The fallback — the cached index — is a correct answer, merely possibly an old one, so waiting half a minute for that on a blackholed network would be a worse failure than the staleness the refresh exists to prevent.

**The cache is now written through a rename.** `os.WriteFile` truncates first, so a reader arriving mid-write saw a partial index. That window was small while writes only happened on an explicit `repo update`; this change moves a write into every install, and two swarmcli processes sharing a state directory is an ordinary CI matrix. Fixed in the two functions this PR already edits rather than filed separately.

**#545's warning stays** as the fallback, now reachable only when the policy is not `RefreshAlways` or the refresh failed — exactly when an operator needs telling the answer may be old.

## Behaviour change worth naming in the release notes

Every repo-backed command now touches the network on every run. It degrades to the cache with one warning, it is bounded at 5s, and both opt-outs restore the old behaviour exactly — but scripts wrapping `charts install` gain a dependency they did not have, and `search` refreshes every configured repository. An air-gapped runner should set `SWARMCLI_CHARTS_NO_AUTO_UPDATE=1`.

## Verification

`go test ./...` and `golangci-lint run ./...` green. Nine new tests, including the embedder contract (a store that was never asked makes zero requests — the one that must never be deleted) and the double-fetch guard.

Driven end-to-end against the live `swarmcli-charts` repo with a doctored cache: plain `search` self-corrects to 0.2.0/1.1.0; `template` renders `eldaratech/swarmcli-cd:1.1.0`; `--no-repo-update` and the env var both return the stale answer with #545's warning; an unreachable repository degrades with `could not refresh repository 'broken' (…); using the cached index` and still resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
