### PR TITLE
build(release): publish the -oss half, and restate the pro boundary

### DIFF
--- a/.github/UPGRADE_NOTES.md
+++ b/.github/UPGRADE_NOTES.md
@@ -7,3 +7,38 @@ Markdown; the release workflow prepends it as a "## ⚠️ Upgrade Notes" sectio
 at the top of the GitHub release notes (see .github/workflows/release.yml).
 Clear it back to this comment once the GA is cut.
 -->
+
+**The download named `swarmcli` is now the Business Edition build.** Nothing
+about the executable changes — same name, same flags, same behaviour with no
+licence — but the artefact you get from the unsuffixed name now contains
+licensed code that is inert until a licence verifies. The wholly Apache-2.0
+build is published beside it as `swarmcli-oss`.
+
+| Was | Is now | The Apache-2.0 build is |
+|---|---|---|
+| `swarmcli_Linux_x86_64.tar.gz` | Business Edition build | `swarmcli-oss_Linux_x86_64.tar.gz` |
+| `checksums.txt` | `checksums-merged.txt` (BE) | `checksums-oss.txt` |
+| `eldaratech/swarmcli:v1.14.0`, `:latest` | Business Edition build | `eldaratech/swarmcli:v1.14.0-oss` |
+| `brew install swarmcli` | Business Edition build | `brew install Eldara-Tech/tap/swarmcli-oss` |
+| `scoop install swarmcli` | Business Edition build | `scoop install swarmcli-oss` |
+
+**`brew upgrade swarmcli` and `scoop update swarmcli` will move you onto the
+Business Edition build.** Neither package manager can express this as a rename,
+so this note is the only place it can be said. If you want to stay on the
+Apache-2.0 build, switch to `swarmcli-oss`. If you do nothing, the CLI keeps
+working exactly as it does today — the licensed half stays inert and the TUI
+still reports Community Edition.
+
+**Scripts that download a release asset by name need updating**, whichever build
+they want: the plain names now resolve to a different artefact and
+`checksums.txt` no longer exists. Anything verifying a download must move to
+`checksums-oss.txt` or `checksums-merged.txt`, which are separate files because
+a release now carries two sets of artefacts and one manifest could not say which
+set it covered.
+
+**A tag on this repository alone no longer moves `:latest`.** The unsuffixed
+image tags belong to the merged build, which is published by a second pipeline
+into this same release.
+
+`swarmcli version` now names which artefact you are running, and
+[docs/editions.md](../docs/editions.md) is the full picture.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,9 @@ jobs:
               - 'Dockerfile'
               - 'Dockerfile.release'
               - '.github/workflows/ci.yml'
+              # The build job runs it, so a change that weakens the guard has to
+              # run the guard.
+              - 'scripts/check-oss-artefact.sh'
 
   fmt:
     needs: [changes]
@@ -138,6 +141,14 @@ jobs:
 
       - name: Build CLI
         run: go build -v -o swarmcli .
+
+      # The same gate .goreleaser.yml runs on each published binary, run here on
+      # every change so it is not a check that only ever fires against a tag —
+      # by which point the tag cannot be moved without a human. It reads the
+      # module graph Go stamped into the binary, so it catches a private module
+      # arriving through a dependency as well as through an import.
+      - name: The build carries nothing private
+        run: ./scripts/check-oss-artefact.sh swarmcli
 
       - name: Build Docker Image
         run: docker build -t swarmcli-dev .

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -16,6 +16,12 @@ env:
   - CGO_ENABLED=0
 
 builds:
+  # Every build carries the same post hook: check-oss-artefact.sh runs on each
+  # of the binaries actually being published, rather than on a stand-in built
+  # somewhere else. What it asserts is what the -oss name claims — the main
+  # module is this repository and nothing private is linked. ci.yml runs the
+  # same script on every change, so it is not a gate that only ever fires on a
+  # tag.
   - id: linux
     goos:
       - linux
@@ -36,6 +42,9 @@ builds:
       - -X main.date={{.Date}}
       - -X github.com/Eldara-Tech/swarmcli/charts.engineVersion={{.Version}}
     main: .
+    hooks:
+      post:
+        - ./scripts/check-oss-artefact.sh "{{ .Path }}"
 
   - id: osx
     goos:
@@ -52,6 +61,9 @@ builds:
       - -X main.date={{.Date}}
       - -X github.com/Eldara-Tech/swarmcli/charts.engineVersion={{.Version}}
     main: .
+    hooks:
+      post:
+        - ./scripts/check-oss-artefact.sh "{{ .Path }}"
 
   - id: windows
     goos:
@@ -69,6 +81,9 @@ builds:
       - -X main.date={{.Date}}
       - -X github.com/Eldara-Tech/swarmcli/charts.engineVersion={{.Version}}
     main: .
+    hooks:
+      post:
+        - ./scripts/check-oss-artefact.sh "{{ .Path }}"
 
   - id: freebsd
     goos:
@@ -85,11 +100,28 @@ builds:
       - -X main.date={{.Date}}
       - -X github.com/Eldara-Tech/swarmcli/charts.engineVersion={{.Version}}
     main: .
+    hooks:
+      post:
+        - ./scripts/check-oss-artefact.sh "{{ .Path }}"
 
 archives:
-  - id: default
+  # swarmcli-oss, not swarmcli. The plain name belongs to the merged artefact,
+  # which is built from the private swarmcli-be wrapper and published into this
+  # repository's releases — so both pipelines write into the same GitHub release,
+  # and leaving the plain name here would have them overwrite each other's
+  # archives with whichever finished last. The two produce identically-named
+  # assets today, ten for ten.
+  #
+  # The binary *inside* is still `swarmcli`, and `project_name` is deliberately
+  # untouched: the four builds below declare no `binary:` field, so it defaults
+  # to the project name, and universal_binaries reads it too. Renaming the
+  # project would rename the executable and break the Homebrew cask's
+  # `binary "swarmcli"`, Scoop's `bin`, swarmcli-charts' `tar xzf … swarmcli`,
+  # and every documented invocation. What tells the artefacts apart is what the
+  # build says about itself — see docs/editions.md.
+  - id: oss
     name_template: >-
-      {{ .ProjectName }}_
+      {{ .ProjectName }}-oss_
       {{- title .Os }}_
       {{- if eq .Arch "amd64" }}x86_64
       {{- else if eq .Arch "386" }}i386
@@ -110,8 +142,15 @@ universal_binaries:
     replace: true
     name_template: "{{ .ProjectName }}"
 
+# One word longer, for the same reason the archives are. A release carries two
+# sets of artefacts, and a single `checksums.txt` would be the one file in which
+# the two pipelines silently disagree — the second run to finish replacing the
+# first's manifest, leaving half the release unverified by the file that claims
+# to cover it. The merged pipeline writes `checksums-merged.txt`; neither side
+# takes the unqualified name, so no checksum file in a release is ambiguous
+# about which artefacts it verified.
 checksum:
-  name_template: 'checksums.txt'
+  name_template: 'checksums-oss.txt'
 
 snapshot:
   version_template: "{{ incpatch .Version }}-next"
@@ -121,11 +160,13 @@ changelog:
 
 # Homebrew tap (cask)
 homebrew_casks:
-  - name: swarmcli
+  # `swarmcli-oss`, not `swarmcli`: the plain cask is written by the merged
+  # pipeline. Both install an executable called `swarmcli`, so they conflict.
+  - name: swarmcli-oss
     # Don't update the public tap for prereleases (-rc) or snapshots; GA only.
     skip_upload: "auto"
     ids:
-      - default
+      - oss
     binaries:
       - swarmcli
     repository:
@@ -134,12 +175,12 @@ homebrew_casks:
       token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
     directory: Casks
     homepage: "https://swarmcli.io"
-    description: "Docker Swarm TUI management tool"
+    description: "Docker Swarm TUI management tool (Apache-2.0 build)"
     commit_author:
       name: Eldara Tech
       email: hello@eldara.io
     conflicts:
-      - cask: swarmcli-be
+      - cask: swarmcli
     # GoReleaser binaries are not Apple-notarized; strip the Gatekeeper
     # quarantine xattr on install so the CLI runs without a security prompt.
     hooks:
@@ -152,11 +193,11 @@ homebrew_casks:
 
 # Scoop bucket for Windows
 scoops:
-  - name: swarmcli
+  - name: swarmcli-oss
     # Don't update the public bucket for prereleases (-rc) or snapshots; GA only.
     skip_upload: "auto"
     ids:
-      - default
+      - oss
     repository:
       owner: Eldara-Tech
       name: scoop-bucket
@@ -180,9 +221,25 @@ dockers_v2:
       - linux/amd64
       - linux/arm64
     tags:
-      - "{{ .Tag }}"
-      # Only move :latest for stable releases — never on -rc/-beta tags.
-      - '{{ if not .Prerelease }}latest{{ end }}'
+      # -oss, and no moving tag at all.
+      #
+      # The unsuffixed tags and :latest belong to the merged artefact, which is
+      # built from the private swarmcli-be wrapper and pushed to this same
+      # Docker Hub repository. Two pipelines writing eldaratech/swarmcli:v1.14.0
+      # would leave an operator with whichever finished last. So a tag pushed
+      # here on its own no longer moves :latest — stated in RELEASING.md rather
+      # than discovered.
+      #
+      # `{{ .Tag }}` keeps the leading `v`, which is what every one of this
+      # image's 59 published tags uses and what swarmcli-charts' docs pin.
+      # swarmcli-cd uses bare semver instead, because its Helm chart defaults
+      # image.tag to appVersion; nothing here has that constraint.
+      #
+      # No moving :oss tag either. An Apache-2.0-only deployment pins a version,
+      # which is what an air-gapped or compliance-reviewed one does anyway, and a
+      # moving tag on the artefact whose whole point is being verifiable is a way
+      # to be surprised by what is running.
+      - "{{ .Tag }}-oss"
     labels:
       org.opencontainers.image.created: "{{ .Date }}"
       org.opencontainers.image.title: "{{ .ProjectName }}"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,7 @@ cli/                       Arg-based CLI dispatch (cli.Dispatch): `charts`, `ver
 charts/                    Helm-like package manager (repos, chart rendering, releases) + declarative releases (releasefile.go, apply.go, outdated.go). charts.ChartSource (source.go) is the seam that resolves a chart ref — repo or local path — so release planning is testable without Docker, a network or a filesystem. charts.NewDockerBackend(ctxName) + NewEngineWith is the seam that targets a *specific* swarm: the default backend uses the ambient Docker context, the SDK client singleton and the shared snapshot cache, all three of which are process-global
 app/
   app.go                   Init(); triggers command autoload via _ "github.com/Eldara-Tech/swarmcli/commands" and view autoload via _ "github.com/Eldara-Tech/swarmcli/views" (view factory registry lives in views/view/registry.go)
-  hooks.go                 PreUpdateHook registration; StartupOverlay; RegisterShutdownHook / RunShutdownHooks (BE port-forward manager registers CloseAll here)
+  hooks.go                 PreUpdateHook registration; StartupOverlay; RegisterShutdownHook / RunShutdownHooks (extension builds register cleanup for long-lived resources here)
   model.go                 Central state: Model struct (viewport, currentView, viewStack, commandInput, searchInput, systemInfo)
   update.go                Main message router: navigation, resize, events, key dispatch
 views/
@@ -94,7 +94,7 @@ utils/log/
 
 ## Adding New Functionality
 
-**New command**: Create `commands/command/mycommand.go`, implement `registry.Command` (Name/Description/Execute), call `registry.Register()` in `init()`. Also implement `Spec() registry.CommandSpec` — declare every flag the command reads (`a.Has`/`a.Get`) plus `Usage`/`Examples`, or `:cmd --help` shows only a fallback and strict validation rejects the command's own flags. Aliases (`Aliaser`) inherit the primary's spec; do not add a spec to the alias. See `commands/command/docker/node/ls.go` for a zero-flag spec and `swarmcli-be/commands/pro/bootstrap.go` for the full worked example.
+**New command**: Create `commands/command/mycommand.go`, implement `registry.Command` (Name/Description/Execute), call `registry.Register()` in `init()`. Also implement `Spec() registry.CommandSpec` — declare every flag the command reads (`a.Has`/`a.Get`) plus `Usage`/`Examples`, or `:cmd --help` shows only a fallback and strict validation rejects the command's own flags. Aliases (`Aliaser`) inherit the primary's spec; do not add a spec to the alias. See `commands/command/docker/node/ls.go` for a zero-flag spec. No command in this repo declares a flag today, so for one that does, `registry/spec.go` documents `FlagSpec` field by field with examples — that type is the contract, and it is the reference an extension build writes against too.
 
 **New view**: Create `views/myview/`, implement `view.View` interface, and add a `register.go` whose `init()` calls `view.RegisterView(name, factory)`. Add its blank import to `views/autoload.go` so the package is loaded. See `views/nodes/register.go`.
 
@@ -113,7 +113,39 @@ utils/log/
 
 ## Pro Feature Boundary
 
-The OSS repo must not contain pro implementation details — no pro-specific logic, no descriptions of how pro features work internally. Generic extension points (registries, hooks, feature flags) are fine; naming specific pro features or describing their internals is not. When adding code that will be called by pro, keep it generic and document it as an extension point without referencing pro specifics.
+This repo is public. Business Edition's source is not, and the line between them
+is about **mechanism, not marketing**.
+
+**Public, and fine to write here.** What a BE feature *does*, its CLI surface,
+its flags, the operator workflow around it, and how it fails. Naming a BE
+feature is fine — `README.md` advertises several, and `app/updatenotice.go`
+ships an upsell string naming three. Generic extension points — registries,
+hooks, feature flags, the `docker` decorator seams — are the whole point of the
+two-repo model and belong here in full, including *what data* an extension may
+supply and *why the Swarm API cannot*.
+
+**Private. Must not appear in this repo, in any form, including comments and
+tests.**
+
+- The licence signature scheme, payload schema and any field of it.
+- Key custody and the verification implementation, and the dev-pubkey override
+  or any `swarmcli_devkeys` build surface.
+- The inter-component topology and `/v1/*` endpoint names — how the TUI, the
+  RBAC proxy and the per-node agents talk to each other.
+- Kernel-level mechanics behind a feature (namespace entry for port-forward).
+- mTLS bundle composition and overlay trust.
+- Threat-model reasoning: why a guard exists, and what it is defending against.
+- **Private symbol names, private file paths and private issue numbers.** This
+  one is independent of the rest: a comment saying "matches
+  `license.FeatureFoo`" or "see `swarmcli-be/commands/pro/x.go`" discloses BE's
+  internal layout *and* is unopenable by every contributor it is addressed to,
+  whether or not the mechanism behind it is secret.
+
+When adding code an extension will call, document it as an extension point and
+describe the contract, not the caller. The two feature-name constants in this
+tree (`service-health`, `volumes-all-nodes`) are shared vocabulary the seam
+cannot work without; the tier→entitlement mapping that consumes them is not
+here, and must not arrive.
 
 ## Integration Test Infrastructure
 

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,4 +1,14 @@
-FROM docker
+# Pinned by digest so the published eldaratech/swarmcli:<v>-oss image is
+# reproducible and resistant to tag-hijack on docker.io/library/docker. That
+# matters more than it used to: this image is now the artefact whose whole claim
+# is that you can check what is in it, and a moving base undercuts that.
+#
+# This is `docker:latest`, which is the **dind** image — verified: it carries the
+# same digest as `docker:dind`, while `docker:cli` is a different one. Nothing
+# here runs a daemon, so the CLI-only base would be smaller and smaller-surfaced;
+# that is a separate change, because it alters what the published image contains
+# and cannot be rehearsed without a Docker daemon.
+FROM docker:latest@sha256:e8faad5a8dc5279dff929afc5449f2791736912fff9f99351d742db2fad01b4c
 
 # dockers_v2 runs a single multi-platform buildx build and stages each
 # platform's binary under its $TARGETPLATFORM (e.g. linux/amd64/swarmcli).

--- a/README.md
+++ b/README.md
@@ -55,6 +55,12 @@ brew install swarmcli
 swarmcli
 ```
 
+`swarmcli` is the full build: everything below, plus Business Edition's
+features, which stay inert until a licence verifies. For the wholly Apache-2.0
+build, install `swarmcli-oss` instead — same executable name, same commands. See
+[docs/editions.md](docs/editions.md), and `swarmcli version` to check which one
+you have.
+
 ## Features
 
 - **Real-time Observability**: Live monitoring of Services, Tasks, Nodes, and Containers.
@@ -133,11 +139,16 @@ commercial superset that adds:
 - Interactive shell into a running service task.
 - Reveal-secret for debugging.
 
-Installs via `brew install Eldara-Tech/tap/swarmcli-be`,
-`scoop install swarmcli-be`, or `docker pull eldaratech/swarmcli-be`. The
-binary on disk is named `swarmcli` (BE is a strict superset of CE — same
-binary name, expanded feature set), so existing scripts and aliases
-continue to work.
+The binary on disk is named `swarmcli` (BE is a strict superset of CE — same
+binary name, expanded feature set), so existing scripts and aliases continue to
+work.
+
+It is not a separate download. The `swarmcli` archives, image, cask and Scoop
+manifest published from this repository's releases *are* the Business Edition
+build, carrying the licensed code inert; a licence turns it on. The wholly
+Apache-2.0 build ships beside it as `swarmcli-oss`. Which one you have is
+[docs/editions.md](docs/editions.md), and `swarmcli version` answers it
+directly.
 
 Documentation, install channels, and license sign-up are at the BE release
 repo: [Eldara-Tech/swarmcli-be-releases](https://github.com/Eldara-Tech/swarmcli-be-releases).
@@ -258,8 +269,16 @@ Pushing a `v*` tag triggers the [release workflow](.github/workflows/release.yml
 1. Injects the tag into the binary via GoReleaser ldflags (`-X main.version=1.5.0`)
 2. Builds for Linux, macOS, Windows, and FreeBSD (multiple architectures)
 3. Publishes a GitHub release with auto-generated changelog
-4. Pushes multi-arch Docker images to Docker Hub
+4. Pushes a multi-arch Docker image to Docker Hub
 5. Updates the [Homebrew tap](https://github.com/Eldara-Tech/homebrew-tap) and [Scoop bucket](https://github.com/Eldara-Tech/scoop-bucket)
+
+A tag here publishes the **`-oss` half** of a release — `swarmcli-oss_*`
+archives, `checksums-oss.txt`, `eldaratech/swarmcli:<tag>-oss`, and the
+`swarmcli-oss` cask and manifest. The unsuffixed names and `:latest` belong to
+the Business Edition build, which is tagged in a second repository at the same
+version and published into this same GitHub release. [RELEASING.md](RELEASING.md)
+is the procedure; [docs/editions.md](docs/editions.md) is what the two artefacts
+are.
 
 The in-app `Version:` header reads from the injected value. Local builds without GoReleaser show `dev`.
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,115 +1,141 @@
-# Release Process
+<!--
+SPDX-License-Identifier: Apache-2.0
+Copyright © 2026 Eldara Tech
+-->
 
-This project uses [GoReleaser](https://goreleaser.com/) to build and publish releases across multiple platforms, similar to k9s.
+# Release process
 
-## Supported Platforms
+Tagging is the whole trigger. `.github/workflows/release.yml` then drafts the
+notes from PR labels, publishes binary archives with GoReleaser, updates the
+Homebrew cask and the Scoop manifest, and pushes a multi-arch image to Docker
+Hub. Nothing is run by hand.
 
-The release process builds binaries for:
+**This repository publishes the `-oss` half of a release, not the whole of it.**
+Each release carries two artefacts ([docs/editions.md](docs/editions.md)):
 
-- **Linux**: amd64, arm64, arm (v7), 386
-- **macOS**: amd64 (Intel), arm64 (Apple Silicon)
-- **Windows**: amd64, arm64, 386
-- **FreeBSD**: amd64, arm64
+| Artefact | Tagged in | Publishes |
+|---|---|---|
+| `swarmcli_*`, `eldaratech/swarmcli:<tag>`, `:latest`, cask + manifest `swarmcli` | the private `swarmcli-be` wrapper | into **this** repository's releases, under `RELEASE_TOKEN` |
+| `swarmcli-oss_*`, `eldaratech/swarmcli:<tag>-oss`, cask + manifest `swarmcli-oss` | here | into this repository's releases |
 
-## How to Create a Release
+So a release needs **two tags, one in each repository, carrying the same version
+string** — and the public one first.
 
-### 1. Install GoReleaser
+- There is no trigger from this tag. A tag pushed here raises no event in
+  `swarmcli-be`, so nothing starts the merged build but a tag pushed there;
+  assuming otherwise produces a release that silently never built its default
+  artefact.
+- The order is not a preference. GoReleaser publishes into a release *named
+  after the tag it was invoked with*, so this tag creating the release first is
+  what gives the private run something to add to.
+- Nothing collides, and that is by construction rather than by luck: the
+  archives here are `swarmcli-oss_*`, the checksum file is `checksums-oss.txt`,
+  and the image tag carries an `-oss` suffix. The merged pipeline writes
+  `swarmcli_*`, `checksums-merged.txt` and the unsuffixed image tags, and it
+  refuses to run if this repository at the pinned tag has gone back to the plain
+  archive names.
+
+**A tag pushed here on its own no longer moves `:latest`,** and publishes no
+unsuffixed image tag at all. `:latest` is the merged artefact; two pipelines
+competing for it would leave an operator with whichever finished last.
+
+**`swarmcli-be` releases against a tag that must exist here.** Its release
+refuses to publish unless this repository already has a published release for
+the same version — including when this repository has no changes to ship, in
+which case tag the same commit as the previous release and say so in the notes.
+A BE-only patch (a compatibility-pin bump, say) still needs its counterpart
+here.
+
+## Prerequisites
+
+Repository secrets, none of which the tooling can set for itself:
+
+| Secret | |
+|---|---|
+| `DOCKERHUB_USERNAME` | Docker Hub account with push access to `eldaratech` |
+| `DOCKERHUB_TOKEN` | an access token for it, not the password |
+| `HOMEBREW_TAP_TOKEN` | `contents:write` on `Eldara-Tech/homebrew-tap` |
+| `SCOOP_BUCKET_TOKEN` | `contents:write` on `Eldara-Tech/scoop-bucket` |
+
+The GitHub release itself uses the job's own `GITHUB_TOKEN`.
+
+## Before tagging
+
+**Choose the version by hand.** release-drafter does not compute it — the
+workflow passes the pushed tag, which overrides `$RESOLVED_VERSION`. If any PR
+merged since the last GA carries `C1-breaking-change`, the tag MUST bump major:
+the changelog is type-only, with no dedicated "Breaking" section, so the label is
+the gate.
 
 ```bash
-# On macOS
-brew install goreleaser
-
-# On Linux
-go install github.com/goreleaser/goreleaser/v2@latest
+gh pr list --repo Eldara-Tech/swarmcli --state merged \
+  --label C1-breaking-change --search "merged:>=<last-GA-date>"
 ```
 
-### 2. Create and push a tag
+**Fill `.github/UPGRADE_NOTES.md`** for a breaking release, before tagging. The
+workflow prepends it as a "⚠️ Upgrade Notes" section at the top of the release
+body; it ships as an HTML-comment placeholder, which is treated as empty. Clear
+it back to the placeholder after the GA.
+
+**Rehearse.** This is the whole of it, and it takes about three minutes:
 
 ```bash
-git tag -a v0.1.0 -m "Release v0.1.0"
-git push origin v0.1.0
+goreleaser check
+goreleaser release --snapshot --clean --skip=docker
 ```
 
-### 3. Run GoReleaser locally
+Then read `dist/`: eleven `swarmcli-oss_*` archives plus `checksums-oss.txt`,
+`dist/homebrew/Casks/swarmcli-oss.rb` and `dist/scoop/swarmcli-oss.json`. The
+per-build hook runs `scripts/check-oss-artefact.sh` on every binary as it is
+produced, so a snapshot that completes has already proved the artefact claim.
+
+Confirm the executable inside an archive is still `swarmcli`, not
+`swarmcli-oss` — the Homebrew cask's `binary`, Scoop's `bin`, swarmcli-charts'
+`tar xzf … swarmcli` and every documented invocation depend on it:
 
 ```bash
-# Export GitHub token (create one at https://github.com/settings/tokens)
-export GITHUB_TOKEN="your_github_token"
-
-# Run GoReleaser
-goreleaser release --clean
+tar tzf dist/swarmcli-oss_Linux_x86_64.tar.gz
 ```
 
-This will:
-- Build binaries for all platforms
-- Create compressed archives (.tar.gz for Unix, .zip for Windows)
-- Generate checksums
-- Create a GitHub release with all artifacts
-- Generate a changelog from commit messages
+Know what the rehearsal omits: `--snapshot` skips GoReleaser's git-state
+validation entirely, so a dirty working tree passes the dry run and fails
+against a pushed tag.
 
-### 4. Find your release
-
-Go to: https://github.com/mosonyi/swarmcli/releases
-
-## Testing Locally
-
-You can test the release process locally without publishing:
+## Tagging
 
 ```bash
-# Install GoReleaser
-go install github.com/goreleaser/goreleaser/v2@latest
-
-# Test the build (snapshot mode)
-goreleaser release --snapshot --clean
-
-# Check the dist/ folder for built binaries
-ls -la dist/
+git tag -a v1.14.0 -m "Release v1.14.0"
+git push originToken v1.14.0
 ```
 
-## Version Information
+Then tag `swarmcli-be` with the same string. Keep the gap short: between the two
+the release has no default artefact and `:latest` still points at the previous
+version.
 
-Version information is embedded at build time using ldflags:
-- `version`: The git tag (e.g., v0.1.0)
-- `commit`: The git commit hash
-- `date`: The build date
+Release candidates are tagged the same way (`v1.14.0-rc1`). GoReleaser marks
+them prerelease automatically, and `skip_upload: auto` keeps an rc out of the
+Homebrew tap and the Scoop bucket.
 
-These can be accessed in the code via the variables in `main.go`.
+## Verifying
 
-## Changelog Format
-
-The changelog is automatically generated from commit messages. For best results, use conventional commit format:
-
-- `feat:` - New features
-- `fix:` - Bug fixes
-- `perf:` - Performance improvements
-- `docs:`, `test:`, `ci:`, `chore:` - Excluded from changelog
-
-Example:
 ```bash
-git commit -m "feat: add horizontal scrolling to logs view"
-git commit -m "fix: resolve alignment issue in nodes table"
+gh release view v1.14.0 --repo Eldara-Tech/swarmcli
+
+# The OSS half, before the merged one lands:
+#   11 archives + checksums-oss.txt, and no swarmcli_* asset yet.
+
+curl -sSLO https://github.com/Eldara-Tech/swarmcli/releases/download/v1.14.0/swarmcli-oss_Linux_x86_64.tar.gz
+tar xzf swarmcli-oss_Linux_x86_64.tar.gz && ./swarmcli version
+# 1.14.0 (oss build)
+
+docker buildx imagetools inspect eldaratech/swarmcli:v1.14.0-oss
 ```
 
-## Optional Enhancements
+`(oss build)` is the check that matters: it is stamped from the build rather
+than from anything at runtime, so it is what tells the two artefacts apart. A
+bare version string with no build marker means the ldflag did not take.
 
-The `.goreleaser.yml` includes commented sections for:
-
-### Homebrew Tap
-Automatically publish to a Homebrew tap for easy installation:
-```bash
-brew install mosonyi/tap/swarmcli
-```
-
-### Docker Images
-Automatically build and push Docker images to Docker Hub or GitHub Container Registry.
-
-Uncomment and configure these sections in `.goreleaser.yml` as needed.
-
-## File Sizes
-
-Release binaries are optimized with:
-- `-trimpath`: Remove file system paths from binary
-- `-s -w`: Strip debug information
-- `CGO_ENABLED=0`: Static binaries with no external dependencies
-
-This keeps binary sizes small and makes them portable across systems.
+After the merged tag lands, verify the consumer rather than the log — query the
+registry for every tag the release claims and compare digests, because
+`:latest`, the version tag and the `-oss` tag are published by two different
+pipelines and only one of them is in this repository.

--- a/cli/charts_test.go
+++ b/cli/charts_test.go
@@ -34,6 +34,26 @@ func TestDispatchVersion(t *testing.T) {
 	require.Equal(t, "1.2.3", strings.TrimSpace(o))
 }
 
+// One tag publishes two artefacts under this command name, and the version
+// string is the same for both — so `version` has to say which build it is. The
+// unset case is the one that matters most: a main that has not been taught to
+// set this must print the bare version rather than claim to be the OSS build.
+func TestDispatchVersion_NamesTheBuild(t *testing.T) {
+	orig := buildEdition
+	defer func() { buildEdition = orig }()
+
+	for _, tc := range []struct{ edition, want string }{
+		{"", "1.2.3"},
+		{"ce", "1.2.3 (oss build)"},
+		{"be", "1.2.3 (business build)"},
+		{"nonsense", "1.2.3"},
+	} {
+		buildEdition = tc.edition
+		o, _ := capture(t, func() { Dispatch([]string{"version"}, "1.2.3") })
+		require.Equal(t, tc.want, strings.TrimSpace(o), "edition %q", tc.edition)
+	}
+}
+
 func TestDispatchUnknownCommand(t *testing.T) {
 	var code int
 	capture(t, func() { code = Dispatch([]string{"frobnicate"}, "dev") })

--- a/cli/dispatch.go
+++ b/cli/dispatch.go
@@ -21,6 +21,39 @@ Run "swarmcli charts help" for chart commands.
 // compatibility is actually checked against.
 var binaryVersion string
 
+// buildEdition names which artefact this binary is, for `swarmcli version`.
+//
+// One tag publishes two of them under the same command name: this repository's
+// own build, and a build from the private extension wrapper carrying licensed
+// code that is inert without a licence. The version string is identical for
+// both, so it cannot tell them apart — see docs/editions.md.
+//
+// This is a property of the *build*, deliberately distinct from the edition
+// label the TUI shows, which follows live licence state and reads "Community
+// Edition" on an unlicensed extension build. That is the right answer for the
+// header and the wrong one here: it cannot distinguish "this binary has no
+// licensed code" from "this binary has no licence".
+//
+// Empty prints nothing, which is what every build did before this existed —
+// so a binary whose main has not been taught to set it stays silent rather
+// than claiming to be the artefact it is not.
+var buildEdition string
+
+// SetEdition records which artefact this build is (called from main).
+func SetEdition(e string) { buildEdition = e }
+
+// versionLine renders `swarmcli version`.
+func versionLine(version string) string {
+	switch buildEdition {
+	case "ce":
+		return version + " (oss build)"
+	case "be":
+		return version + " (business build)"
+	default:
+		return version
+	}
+}
+
 // Dispatch runs a non-interactive command and returns a process exit code. It
 // is invoked from main when the binary is given arguments; an empty args slice
 // is never passed (main launches the TUI in that case). version is the build
@@ -31,7 +64,7 @@ func Dispatch(args []string, version string) int {
 	case "charts":
 		return chartsMain(args[1:])
 	case "version", "--version", "-v":
-		outln(version)
+		outln(versionLine(version))
 		return 0
 	case "help", "--help", "-h":
 		out(topUsage)

--- a/docs/editions.md
+++ b/docs/editions.md
@@ -1,0 +1,127 @@
+<!--
+SPDX-License-Identifier: Apache-2.0
+Copyright © 2026 Eldara Tech
+-->
+
+# Editions: the two artefacts, and which one you have
+
+Every release publishes **two** artefacts from one tag. They are built from
+different trees, they are named differently, and one of them can be unlocked by
+a licence. This page is what each of them is.
+
+| | Built from | Contains | Licence |
+|---|---|---|---|
+| `swarmcli_*` archives, `eldaratech/swarmcli:<tag>`, `:latest`, the `swarmcli` Homebrew cask and Scoop manifest | a private build wrapper around this repository | this repository, plus licensed code that is **inert** without a licence | this repository's code is Apache-2.0; the licensed code is proprietary |
+| `swarmcli-oss_*` archives, `eldaratech/swarmcli:<tag>-oss`, the `swarmcli-oss` cask and manifest | this repository, and nothing else | this repository, and nothing else | wholly Apache-2.0 |
+
+The command inside both archives is `swarmcli`. Every invocation in these docs,
+every script, alias and CI job is identical for the two, deliberately: the
+difference between them is what the build contains, not how it is driven.
+
+## Why there are two
+
+The default artefact carries the licensed code because a single binary is the
+only arrangement in which "install a licence" is not "download a different
+product". Nothing is hidden by that — the code is compiled in and does nothing
+until a licence verifies.
+
+But a released binary that contains proprietary code cannot honestly be called
+open source, and a project whose only download is that binary has no answer when
+somebody says so. `swarmcli-oss` is the answer, and it only works if it ships
+from the first merged release rather than after somebody complains. It is also
+the artefact a distribution packager, an air-gapped compliance review and a
+contributor verifying what they built actually need.
+
+The OSS build is not a subset with features removed. It is this repository,
+which is the whole Community Edition: the TUI, the chart package manager, the
+declarative `charts apply` workflow, the CLI. Nothing that has ever shipped
+Apache-2.0 is reclaimable; the free line is drawn there or wider, never
+narrower.
+
+## Which one am I running
+
+Three signals, in descending order of how much you should trust them.
+
+**`swarmcli version`.** The strongest, because it is a property of the build and
+nothing at runtime can change it:
+
+```console
+$ swarmcli version
+1.14.0 (oss build)
+```
+
+`(business build)` is the merged artefact — **whether or not a licence
+verified**. That is exactly what distinguishes "this binary has no licensed
+code" from "this binary has no licence", and neither the edition label nor the
+absence of features answers that alone.
+
+**The startup log line**, for a binary you cannot re-run:
+
+```
+swarmcli version=1.14.0 edition=ce commit=… date=…      ← the OSS build
+swarmcli-be version=1.14.0 commit=… date=…              ← the merged build
+```
+
+The prefix is the signal, and it is written on every start, including
+non-interactive `swarmcli charts …` runs.
+
+**The edition label in the TUI header** is the weakest of the three, and is not
+a build signal at all: it follows live licence state, so the merged build with
+no valid licence reads *Community Edition* — correctly, because that is what it
+is behaving as. Do not use it to answer this question.
+
+## What a licence changes, and when
+
+A licence is installed into the swarm and read at startup. It turns features on
+in the merged build only — there is nothing in the OSS build for it to unlock,
+and installing one there changes nothing and reports nothing.
+
+The Business Edition documentation covers acquiring, installing and managing a
+key, and what each feature does.
+
+## Getting the OSS build
+
+```bash
+# The archive, from any release:
+curl -sSLO https://github.com/Eldara-Tech/swarmcli/releases/download/v1.14.0/swarmcli-oss_Linux_x86_64.tar.gz
+
+# The image:
+docker pull eldaratech/swarmcli:v1.14.0-oss
+
+# Homebrew or Scoop:
+brew install Eldara-Tech/tap/swarmcli-oss
+scoop install swarmcli-oss
+```
+
+There is deliberately no moving `:oss` image tag and no `:latest` on this half.
+A deployment that wants the verifiably-Apache-2.0 artefact pins a version, which
+is what an air-gapped or compliance-reviewed deployment does anyway — and a
+moving tag on the artefact whose whole point is being checkable is a way to be
+surprised by what is running.
+
+`checksums-oss.txt` in each release covers these artefacts;
+`checksums-merged.txt` covers the merged ones. Neither is named plain
+`checksums.txt`: a release carries two sets of artefacts, and an unqualified
+name would not say which set it verified.
+
+Building it yourself is the same thing:
+
+```bash
+go build -o swarmcli .
+```
+
+## How the claim is checked rather than remembered
+
+`swarmcli-oss` is only worth publishing while "this one is the Apache-2.0 build"
+is something you can verify rather than something we assert. So it is checked on
+the artefact, not on the source:
+[`scripts/check-oss-artefact.sh`](../scripts/check-oss-artefact.sh) reads the
+module graph Go stamped into each published binary and fails if the main module
+is not this repository or if anything private is linked. It runs from
+`.goreleaser.yml`'s per-build hook on every binary the release publishes, and
+from `ci.yml` on every change — so it is not a gate that only ever fires on a
+tag.
+
+It also fails when it cannot read a module stamp at all, rather than passing.
+A binary whose graph is unreadable looks exactly like a binary with no private
+dependencies, and that is the shape of every guard that quietly stops guarding.

--- a/features/features.go
+++ b/features/features.go
@@ -12,7 +12,7 @@ import (
 )
 
 // mu guards enabled: it is written from the Bubble Tea update goroutine
-// (ApplyLicenseState on startup / license / swarm change) and read from
+// (an extension build re-evaluating feature state) and read from
 // tea.Cmd goroutines (feature-gated data loaders), so unsynchronized access
 // would be a concurrent map read/write.
 var (

--- a/main.go
+++ b/main.go
@@ -24,6 +24,10 @@ var (
 func init() {
 	app.SetVersion(version)
 	app.SetEdition(edition)
+	// Distinct from app.SetEdition, which drives a label that follows live
+	// licence state; this one names the build and never changes. See
+	// cli.SetEdition and docs/editions.md.
+	cli.SetEdition(edition)
 	app.Init()
 	// Log version info for debugging
 	swarmlog.L().Infof("swarmcli version=%s edition=%s commit=%s date=%s", version, edition, commit, date)

--- a/scripts/check-oss-artefact.sh
+++ b/scripts/check-oss-artefact.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env sh
+# SPDX-License-Identifier: Apache-2.0
+# Copyright © 2026 Eldara Tech
+
+set -eu
+
+# The published swarmcli-oss artefact carries nothing private.
+#
+# One tag produces two artefacts: `swarmcli`, built from the private
+# swarmcli-be wrapper and carrying the licensed code inert, and `swarmcli-oss`,
+# built from this tree alone. The second one only means anything if it is
+# verifiably the second one — "the released binary is not open source" has a
+# rebuttal only while the rebuttal is checkable, and a build published under the
+# wrong name is not a thing anyone would notice by reading it.
+#
+# So this reads the module graph Go stamped into the binary itself, rather than
+# the graph the source implies. `go version -m` reports the main module and
+# every module linked into it, which is the same information a `go.mod` would
+# give and is the information that survives having been built somewhere else.
+#
+# Usage: ./scripts/check-oss-artefact.sh path/to/binary
+#
+# Run per artefact by .goreleaser.yml's post-build hook, so it sees each of the
+# published binaries and not a locally built stand-in — and by ci.yml on every
+# change, so it is not a gate that only ever runs on a tag.
+
+if [ $# -ne 1 ]; then
+  echo "usage: $0 <binary>" >&2
+  exit 2
+fi
+binary=$1
+
+main=github.com/Eldara-Tech/swarmcli
+
+# The private modules. Matched as whole module paths or as a parent of one, so
+# that `…/swarmcli` is not read as a prefix of `…/swarmcli-be` in either
+# direction — this repository's own module would otherwise match every entry.
+private='github.com/Eldara-Tech/swarmcli-be github.com/Eldara-Tech/swarmcli-cd-be'
+
+stamp=$(go version -m "$binary")
+
+# The `mod` line is the main module: what was built, as opposed to what it
+# depends on. A merged binary published under the OSS name fails here first and
+# most clearly.
+got_main=$(echo "$stamp" | awk '$1 == "mod" { print $2; exit }')
+if [ "$got_main" != "$main" ]; then
+  echo "$binary was built from '$got_main', not from '$main'."
+  echo "The swarmcli-oss artefact is this repository's own build; see docs/editions.md."
+  exit 1
+fi
+
+fail=0
+deps=$(echo "$stamp" | awk '$1 == "dep" || $1 == "=>" { print $2 }')
+
+# Not zero, because a stamp this script cannot read would otherwise pass as a
+# binary with no private dependencies — which is the shape of every guard that
+# stops guarding.
+if [ -z "$deps" ]; then
+  echo "$binary reports no linked modules at all; this check read nothing and asserted nothing."
+  exit 1
+fi
+
+for module in $private; do
+  for dep in $deps; do
+    case "$dep" in
+    "$module" | "$module"/*)
+      echo "$binary links $dep, which is not Apache-2.0 and is not this repository's."
+      fail=1
+      ;;
+    esac
+  done
+done
+
+if [ "$fail" -ne 0 ]; then
+  echo
+  echo "This artefact is published as the wholly Apache-2.0 one. Whatever pulled"
+  echo "a private module in has to come out, or the artefact has to stop claiming"
+  echo "to be that."
+  exit 1
+fi
+
+echo "$binary: $main, $(echo "$deps" | wc -l | tr -d ' ') linked modules, none private."

--- a/settings/settings.go
+++ b/settings/settings.go
@@ -12,7 +12,7 @@ import (
 	"path/filepath"
 )
 
-// Overridable for tests (mirrors the seams in swarmcli-be's nudge throttle).
+// Overridable for tests.
 var (
 	userHomeDirFn = os.UserHomeDir
 	readFileFn    = os.ReadFile

--- a/test-setup/testenv.sh
+++ b/test-setup/testenv.sh
@@ -59,8 +59,8 @@ wait_for_manager() {
 # `docker swarm join`. Those joins are asynchronous: before this gate, `up`
 # returned as soon as the manager API was reachable, so `deploy` (worker image
 # distribution) and the integration tests frequently ran against an
-# effectively single-node swarm — the global agent landed on the manager only
-# and worker-placement tests had nothing to exercise. Blocking here makes the
+# effectively single-node swarm, so worker-placement tests had nothing to
+# exercise. Blocking here makes the
 # swarm match its declared topology so those tests are real, not skipped.
 #
 # Expected worker count is derived from the compose file (one per

--- a/views/services/footer.go
+++ b/views/services/footer.go
@@ -10,9 +10,8 @@ import (
 
 // serviceHealthFeature gates the per-container HEALTH/PORTS enrichment. The base
 // build never enables it, so CE always shows the upsell footer hint; an
-// extension build enabling it (via the license reconciler) both lights up the
-// HEALTH column and suppresses the hint — mirroring the volumes
-// "volumes-all-nodes" pattern. Matches license.FeatureServiceHealth.
+// extension build enabling it both lights up the HEALTH column and suppresses
+// the hint — mirroring the volumes "volumes-all-nodes" pattern.
 const serviceHealthFeature = "service-health"
 
 // serviceHealthUpsellHint advertises the Business Edition capability in the

--- a/views/systeminfo/systeminfo_test.go
+++ b/views/systeminfo/systeminfo_test.go
@@ -284,7 +284,6 @@ func TestUpdate_LatestVersionMsg(t *testing.T) {
 
 // Regression: long version+latest combinations must render in the fixed
 // systeminfo height without lipgloss wrapping the value onto a new line.
-// See https://github.com/Eldara-Tech/swarmcli-be/issues/93.
 func TestView_VersionLineDoesNotWrap_LongVersions(t *testing.T) {
 	cases := []struct {
 		name    string


### PR DESCRIPTION
Prerequisite for the merged release: one tag, two artefacts, both published into this repository's GitHub release. This is the CE/BE counterpart of what `swarmcli-cd` / `swarmcli-cd-be` shipped on 2026-08-05.

Two commits, both confined to this repository, both prerequisites for everything downstream.

## `build(release)` — the `-oss` half

`swarmcli-be` will publish its archives, image tags, cask and Scoop manifest into *this* repository's releases under the unsuffixed names. It cannot, while both pipelines name their output identically — and they do, **ten assets for ten**: same `project_name`, same archive `name_template`, both writing `checksums.txt`. With `replace_existing_artifacts` on, the second run to finish would silently overwrite the first's Apache-2.0 binaries and the manifest that verifies them.

So the OSS half moves off the plain names: `swarmcli-oss_*`, `checksums-oss.txt`, `eldaratech/swarmcli:<tag>-oss`, cask and manifest `swarmcli-oss`. The `docker` job drops `:latest` and the unsuffixed tag entirely.

**`project_name` is deliberately not renamed.** The four builds declare no `binary:` field, so it defaults to the project name and `universal_binaries` reads it too — renaming the project would rename the *executable* and break the cask's `binary "swarmcli"`, Scoop's `bin`, `swarmcli-charts`' `tar xzf … swarmcli`, and every documented invocation. Only the archive and checksum templates move.

`scripts/check-oss-artefact.sh` is what makes `-oss` a claim the build proves rather than a label: it reads the module graph Go stamped into each published binary and fails if the main module is not this repository or if anything private is linked — and fails when it can read no stamp at all, because an unreadable graph looks exactly like a clean one.

`swarmcli version` now names the artefact. Nothing else on the CLI could: one tag, two artefacts, same command name, same version string. It is a property of the build, separate from the TUI's edition label, which follows live licence state and reads "Community Edition" on an unlicensed merged build — the right answer for the header, the wrong one here.

## `chore(boundary)` — the pro line is about mechanism, not marketing

The Pro Feature Boundary forbade "naming specific pro features". `README.md` advertises four, and `app/updatenotice.go` ships an upsell string naming three *inside the binary*. A rule four files contradict is not one anyone consults, which is how the half that matters stopped being enforced.

Restated as what is actually defended, and swept: `setns`, `netns`, `nsenter`, `ptrace`, `wss://`, `agent-manager`, `TierFeatures`, `SWARMCLI_LICENSE_PUBKEY` and every devkeys build tag appear **nowhere** in this tree, and the seams are clean — the feature registry is a bare `string→bool` map and `RegisterGatedAction`'s guard is a plain `func() bool`.

What had leaked is a category no previous wording covered: **private symbol names, file paths and issue numbers**. Eight comment fixes, no behaviour change. The one that is a plain defect rather than a policy question: `CLAUDE.md` sent every contributor to `swarmcli-be/commands/pro/bootstrap.go` "for the full worked example" — a file none of them can open. It now points at `registry/spec.go`, which documents `FlagSpec` field by field.

`testenv.sh`'s worker-wait rationale claimed the gate mattered because "the global agent landed on the manager only". `test-setup/test-stack.yml` declares no global service — the sentence was imported from the BE integration environment, so it was both a disclosure and simply wrong as documentation of this repo's test setup.

## Verification

- `goreleaser check`, then `goreleaser release --snapshot --clean --skip=docker`: 11 `swarmcli-oss_*` archives, `checksums-oss.txt`, `Casks/swarmcli-oss.rb`, `scoop/swarmcli-oss.json`, post hook fired on every binary.
- `tar tzf dist/swarmcli-oss_Linux_x86_64.tar.gz` → the file inside is still `swarmcli`.
- `check-oss-artefact.sh` proven **in both directions**: passes this repository's binary, fails a real `swarmcli-be` one.
- `swarmcli version` → `dev (oss build)`; new test covers unset / `ce` / `be` / unrecognised.
- `go build ./...`, `go vet ./...`, `gofmt -l`, `./scripts/check-spdx.sh`, full `go test ./...`, `golangci-lint run ./...` → 0 issues.
- Base image digest verified against the registry: `docker:latest` and `docker:dind` share a digest; `docker:cli` differs. Pinned to what it already resolves to, so the image contents do not change.

## What this does not do

`:latest` and the unsuffixed image tag stop being published by this repository. Until `swarmcli-be` ships its half, a tag here produces a release whose default download is absent and leaves `:latest` on the previous version. That is stated in `RELEASING.md` and is why the two tags go close together.

Switching the release image from the `dind` base to `cli` is left out: it changes what the published image contains and cannot be rehearsed without a Docker daemon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
