### PR TITLE
feat(cli): version reports the chart engine, and says when it is unstamped

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -126,14 +126,20 @@ gh release view v1.14.0 --repo Eldara-Tech/swarmcli
 
 curl -sSLO https://github.com/Eldara-Tech/swarmcli/releases/download/v1.14.0/swarmcli-oss_Linux_x86_64.tar.gz
 tar xzf swarmcli-oss_Linux_x86_64.tar.gz && ./swarmcli version
-# 1.14.0 (oss build)
+# 1.14.0 (oss build, chart engine 1.14.0)
 
 docker buildx imagetools inspect eldaratech/swarmcli:v1.14.0-oss
 ```
 
-`(oss build)` is the check that matters: it is stamped from the build rather
-than from anything at runtime, so it is what tells the two artefacts apart. A
-bare version string with no build marker means the ldflag did not take.
+Both halves of that line are checks. `(oss build)` is stamped from the build
+rather than from anything at runtime, so it is what tells the two artefacts
+apart; a bare version string with no build marker means the ldflag did not take.
+
+`chart engine unstamped` is a **failed release**, not a cosmetic problem. The
+engine version is what `CheckCompat` compares a chart's declared
+`swarmcliVersion` floor against, and an unstamped engine reports
+`CompatUnknown` — so every chart deploys with its floor unchecked, and nothing
+else about such a release looks wrong.
 
 After the merged tag lands, verify the consumer rather than the log — query the
 registry for every tag the release claims and compare digests, because

--- a/cli/charts_test.go
+++ b/cli/charts_test.go
@@ -31,7 +31,18 @@ func TestDispatchVersion(t *testing.T) {
 	var code int
 	o, _ := capture(t, func() { code = Dispatch([]string{"version"}, "1.2.3") })
 	require.Equal(t, 0, code)
-	require.Equal(t, "1.2.3", strings.TrimSpace(o))
+	require.Contains(t, o, "1.2.3")
+}
+
+// An unstamped engine admits every chart's declared floor unchecked, and a
+// release that has done that looks entirely normal otherwise. Saying so on the
+// version line is the only place it surfaces, so it must not degrade to silence.
+func TestDispatchVersion_UnstampedEngineSaysSo(t *testing.T) {
+	var code int
+	o, _ := capture(t, func() { code = Dispatch([]string{"version"}, "1.2.3") })
+	require.Equal(t, 0, code)
+	require.Contains(t, o, "chart engine unstamped",
+		"tests run unstamped, so this is what a build whose ldflag did not take prints")
 }
 
 // One tag publishes two artefacts under this command name, and the version
@@ -43,10 +54,10 @@ func TestDispatchVersion_NamesTheBuild(t *testing.T) {
 	defer func() { buildEdition = orig }()
 
 	for _, tc := range []struct{ edition, want string }{
-		{"", "1.2.3"},
-		{"ce", "1.2.3 (oss build)"},
-		{"be", "1.2.3 (business build)"},
-		{"nonsense", "1.2.3"},
+		{"", "1.2.3 (chart engine unstamped)"},
+		{"ce", "1.2.3 (oss build, chart engine unstamped)"},
+		{"be", "1.2.3 (business build, chart engine unstamped)"},
+		{"nonsense", "1.2.3 (chart engine unstamped)"},
 	} {
 		buildEdition = tc.edition
 		o, _ := capture(t, func() { Dispatch([]string{"version"}, "1.2.3") })

--- a/cli/dispatch.go
+++ b/cli/dispatch.go
@@ -3,6 +3,8 @@
 
 package cli
 
+import "github.com/Eldara-Tech/swarmcli/charts"
+
 const topUsage = `swarmcli — keyboard-driven Docker Swarm manager
 
 Run with no arguments to launch the interactive TUI.
@@ -43,14 +45,29 @@ var buildEdition string
 func SetEdition(e string) { buildEdition = e }
 
 // versionLine renders `swarmcli version`.
+//
+// The chart engine is reported beside the binary's own version because the two
+// can legitimately differ and only one of them governs chart compatibility: the
+// engine is this module's code, so a build that embeds swarmcli as a dependency
+// carries whichever engine it pinned, regardless of its own tag.
+//
+// `unstamped` rather than silence when the ldflag did not take. An unstamped
+// engine makes CheckCompat report CompatUnknown, so every chart's declared
+// swarmcliVersion floor is admitted unchecked — a release that has done that
+// looks entirely normal otherwise, and this is the one place it is visible.
 func versionLine(version string) string {
+	engine := charts.EngineVersion()
+	if engine == "" {
+		engine = "unstamped"
+	}
+
 	switch buildEdition {
 	case "ce":
-		return version + " (oss build)"
+		return version + " (oss build, chart engine " + engine + ")"
 	case "be":
-		return version + " (business build)"
+		return version + " (business build, chart engine " + engine + ")"
 	default:
-		return version
+		return version + " (chart engine " + engine + ")"
 	}
 }
 

--- a/docs/editions.md
+++ b/docs/editions.md
@@ -47,13 +47,19 @@ nothing at runtime can change it:
 
 ```console
 $ swarmcli version
-1.14.0 (oss build)
+1.14.0 (oss build, chart engine 1.14.0)
 ```
 
 `(business build)` is the merged artefact — **whether or not a licence
 verified**. That is exactly what distinguishes "this binary has no licensed
 code" from "this binary has no licence", and neither the edition label nor the
 absence of features answers that alone.
+
+The chart engine is reported beside it because the two can legitimately differ:
+the engine is this module's code, so a build that embeds swarmcli as a
+dependency carries whichever engine it pinned rather than its own tag. `chart
+engine unstamped` means the build's ldflag did not take, and every chart's
+declared `swarmcliVersion` floor is being admitted unchecked.
 
 **The startup log line**, for a binary you cannot re-run:
 


### PR DESCRIPTION
`swarmcli version` printed the binary's own version and nothing else, so the **chart engine** — the thing chart compatibility is actually checked against — had no CLI surface at all. It is reachable only through `charts.EngineVersion()`, an internal call.

The two can legitimately differ, and only one of them governs compatibility: the engine is this module's code, so a build embedding swarmcli as a dependency carries whichever engine it *pinned*, regardless of its own tag. That is the normal case for the Business Edition build now published into this repository's releases, and there was no way to ask a binary which engine it had.

```console
$ swarmcli version
1.14.0 (oss build, chart engine 1.14.0)
```

`unstamped` rather than silence when the ldflag did not take:

```console
$ go build -o swarmcli . && ./swarmcli version
dev (oss build, chart engine unstamped)
```

An unstamped engine makes `CheckCompat` report `CompatUnknown`, so every chart's declared `swarmcliVersion` floor is admitted **unchecked** — and a release that has done that looks entirely normal in every other respect. This line is the only place it surfaces. `swarmcli-cd version` has reported it the same way, for the same reason, since v0.1.0.

Wanted by the merged release on the `swarmcli-be` side, which needs to assert *on a built binary* that the stamp took rather than trusting the workflow that set it — the CE version does not survive into that artefact any other way, because `swarmcli` is a directory `replace` there and `go version -m` records only the placeholder ([swarmcli-be#297](https://github.com/Eldara-Tech/swarmcli-be/issues/297)).

## Verification

- `go build`, `go vet`, `gofmt -l`, `./scripts/check-spdx.sh`, full `go test ./...` — all clean.
- Stamped: `-X …charts.engineVersion=1.14.0` → `dev (oss build, chart engine 1.14.0)`.
- Unstamped: plain `go build` → `dev (oss build, chart engine unstamped)`.
- New test asserts the unstamped wording specifically, because that is the case that must not degrade to silence; the existing edition test covers all four build values.
- `RELEASING.md` and `docs/editions.md` updated, including that `chart engine unstamped` is a failed release rather than a cosmetic problem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
