### PR TITLE
chore(github): issue templates, for one tracker instead of two

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,48 @@
+name: Bug report
+description: Report a problem with SwarmCLI
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug report.
+
+        **Do not paste internal logs, configuration files, certificates, or
+        license material.** For anything security-sensitive, see the
+        [Security Policy](https://github.com/Eldara-Tech/swarmcli/blob/main/SECURITY.md)
+        and email hello@eldara.io instead.
+  - type: input
+    id: version
+    attributes:
+      label: SwarmCLI version
+      description: Output of `swarmcli version` — please include the build it names.
+      placeholder: 1.14.0 (business build, chart engine 1.14.0)
+    validations:
+      required: true
+  - type: input
+    id: os
+    attributes:
+      label: OS / platform
+      placeholder: macOS 15.4 (arm64) / Ubuntu 24.04 (amd64) / Windows 11
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: What did you do, in order?
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behaviour
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behaviour
+      description: What happened instead? Screenshots welcome (no secrets).
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/Eldara-Tech/swarmcli/blob/main/SECURITY.md
+    about: Do not file security issues publicly. Report them privately to hello@eldara.io.
+  - name: Documentation
+    url: https://github.com/Eldara-Tech/swarmcli/tree/main/docs
+    about: Installation, licensing, configuration and troubleshooting guides.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,30 @@
+name: Feature request
+description: Suggest a feature or improvement for SwarmCLI
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the suggestion. Please describe the problem you are trying
+        to solve, not only the solution you have in mind.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What are you trying to do, and what gets in the way today?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed behaviour
+      description: How would you like SwarmCLI to behave?
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches or workarounds you have tried or thought about.
+    validations:
+      required: false


### PR DESCRIPTION
Business Edition bugs were filed on `swarmcli-be-releases`, under a routing rule that read *"file by which edition owns the feature"*. That was answerable while CE and BE were two downloads. They are one binary now, and a reporter cannot apply it.

The old tracker was already showing the seam: of seven open issues, one is *"Business Edition ships the charts CLI but the docs never mention it"* — a CE feature filed on the BE tracker — and another arrived by transfer from here.

This repository had **no issue templates at all**, so the two forms and the contact-link config are ported rather than written: same fields, same "do not paste logs, certificates or license material" notice, retargeted at this repository`s SECURITY.md and `docs/`. The version field now asks for `swarmcli version` output *including the build it names*, because one tag publishes two artefacts and which one a reporter has is usually the first question.

An `edition:be` label (already created) carries the distinction the routing rule used to, without asking the reporter to make it.

The seven open issues are transferred separately, and `swarmcli-be-releases` keeps its tracker **enabled** — every shipped BE binary prints its `/issues` URL, so disabling it would 404 for users in the field. Its templates are repointed here instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)