### PR TITLE
docs(features): how to leave the shell, and the picker's real cancel key

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -20,7 +20,33 @@ inside one of the service's running tasks.
 
 If the service has multiple replicas, a picker dialog lists each running
 task ("Replica N — hostname"). Use the arrow keys to choose, `Enter` to
-confirm, `q` to cancel. Single-replica services skip the picker.
+confirm, `Esc` to cancel. Single-replica services skip the picker.
+
+### Working in the shell
+
+The shell takes over your terminal for the session — it is not drawn inside
+the SwarmCLI TUI. Your terminal's own scrollback, text selection and copy
+therefore work as they always do: scroll up with the mouse wheel (or your
+terminal's scrollback keys, e.g. `Shift+PageUp`), select across more than a
+screenful of output, and copy normally. Full-screen programs in the container
+(`vim`, `htop`, `less`) work too, because keystrokes pass straight through.
+
+A one-line header, black on green, marks the start of the session and then
+scrolls away with the output like any other line:
+
+```
+<<SWC-Shell>> Service: <stack>/<service> | Host: <node>        ctrl+] exit
+```
+
+To leave the shell:
+
+- **`Ctrl+]`** detaches immediately and returns to the TUI. Use this when a
+  program is in the foreground or the shell is unresponsive.
+- **`Ctrl+D`**, or typing **`exit`**, quits the remote shell the usual way,
+  which also returns you to the TUI.
+
+Every other key — `Ctrl+C`, `Ctrl+Z`, arrows, tab — goes to the remote shell
+unchanged.
 
 ### What happens when you press `x`
 
@@ -49,8 +75,8 @@ SwarmCLI:
 SWARMCLI_SHELL_CMD=/usr/bin/zsh swarmcli
 ```
 
-Once attached, the TUI propagates terminal resizes to the remote PTY via
-control messages; window-resize handling is automatic.
+Once attached, SwarmCLI propagates terminal resizes to the remote PTY
+automatically as you resize your window.
 
 ### Failure modes
 


### PR DESCRIPTION
Carries over [swarmcli-be-releases#17](https://github.com/Eldara-Tech/swarmcli-be-releases/pull/17), opened 2026-07-15 against the copy of `features.md` that lived there, held until the terminal handover shipped, and then stranded when the page moved here (#550) — its base is now a pointer file, so it cannot be merged where it was written. The handover shipped in swarmcli-be v1.13.0, so the hold no longer applies.

Three things, all user-facing behaviour:

**The docs never said how to *leave* a shell.** The session takes over the real terminal rather than being drawn inside the TUI — which is what makes scrollback, selection and copy work natively, and lets `vim` and `htop` run — but it also means the usual TUI keys do not apply and every key except one goes to the remote shell. `Ctrl+]` detaches; `Ctrl+D` or `exit` quits. Nothing said so.

**The replica picker cancels on `Esc`, not `q`.** That line was wrong before the handover landed, and is wrong in this repository today.

**The resize note described mechanism**, not behaviour — "propagates terminal resizes to the remote PTY via control messages" — which is the sort of sentence the boundary in CLAUDE.md now asks not to write. What an operator needs is that resizing the window works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)