### PR TITLE
build(release): the -oss image drops the container runtime it never ran

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,9 +165,17 @@ jobs:
       # an ordinary one here. amd64 only, because what this catches is a base
       # image that cannot run the binary at all, and that is not architecture-
       # specific.
+      #
+      # Built here rather than reusing the binary from "Build CLI" above, and the
+      # difference is the whole point: that step leaves CGO on, so on a runner
+      # with gcc it links against glibc, and an Alpine base answers `exec
+      # /swarmcli: no such file or directory`. .goreleaser.yml sets
+      # CGO_ENABLED=0, so a probe that does not is not rehearsing the release —
+      # it is testing a binary the release never builds.
       - name: The release image builds and the binary runs in it
         run: |
-          mkdir -p linux/amd64 && cp swarmcli linux/amd64/swarmcli
+          mkdir -p linux/amd64
+          CGO_ENABLED=0 go build -o linux/amd64/swarmcli .
           docker build -f Dockerfile.release --build-arg TARGETPLATFORM=linux/amd64 -t swarmcli-release-probe .
           got=$(docker run --rm swarmcli-release-probe version)
           echo "$got"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,3 +152,37 @@ jobs:
 
       - name: Build Docker Image
         run: docker build -t swarmcli-dev .
+
+      # Dockerfile.release has been in this job's paths filter all along while
+      # the step above built the *other* Dockerfile, so nothing has ever built
+      # the file that produces the published image — and #548 was deferred out of
+      # #547 precisely because a base change "cannot be rehearsed without a
+      # Docker daemon". There is one here.
+      #
+      # goreleaser's dockers_v2 stages each platform's binary under its
+      # $TARGETPLATFORM before building, so that layout has to be faked for a
+      # plain `docker build`; TARGETPLATFORM is an automatic arg under buildx and
+      # an ordinary one here. amd64 only, because what this catches is a base
+      # image that cannot run the binary at all, and that is not architecture-
+      # specific.
+      - name: The release image builds and the binary runs in it
+        run: |
+          mkdir -p linux/amd64 && cp swarmcli linux/amd64/swarmcli
+          docker build -f Dockerfile.release --build-arg TARGETPLATFORM=linux/amd64 -t swarmcli-release-probe .
+          got=$(docker run --rm swarmcli-release-probe version)
+          echo "$got"
+          # Positive control: a check that passes because it read nothing is the
+          # failure mode this step exists to avoid.
+          case "$got" in
+            *"chart engine"*) ;;
+            *) echo "::error::'swarmcli version' produced no recognisable output in the release image (got: ${got:-<nothing>})"; exit 1 ;;
+          esac
+          # The two things the base must still provide: TLS roots for chart
+          # repositories, and an ssh binary for `ssh://` Docker contexts. Both
+          # come from the base image, so a narrower one silently breaking either
+          # is exactly what this guards.
+          docker run --rm --entrypoint sh swarmcli-release-probe -c 'test -s /etc/ssl/certs/ca-certificates.crt && command -v ssh >/dev/null' || {
+            echo "::error::the release image lost ca-certificates or openssh-client — chart repositories over HTTPS and ssh:// contexts would fail at runtime, with nothing at build time to say so"
+            exit 1
+          }
+          echo "the release image runs, reports a chart engine, and keeps its TLS roots and ssh client"

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,8 @@
 .devcontainer/shared/*
 
 dist/
+# the $TARGETPLATFORM staging directory a Dockerfile.release build needs
+linux/
 
 debug.log
 swarmcli

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -3,12 +3,20 @@
 # matters more than it used to: this image is now the artefact whose whole claim
 # is that you can check what is in it, and a moving base undercuts that.
 #
-# This is `docker:latest`, which is the **dind** image — verified: it carries the
-# same digest as `docker:dind`, while `docker:cli` is a different one. Nothing
-# here runs a daemon, so the CLI-only base would be smaller and smaller-surfaced;
-# that is a separate change, because it alters what the published image contains
-# and cannot be rehearsed without a Docker daemon.
-FROM docker:latest@sha256:e8faad5a8dc5279dff929afc5449f2791736912fff9f99351d742db2fad01b4c
+# `docker:29-cli`, not `docker:latest`. The latter resolves to the same digest as
+# `docker:dind` — it is the full Docker-in-Docker image, carrying dockerd,
+# containerd, runc, iptables and the storage drivers. None of that is ever
+# executed here: this image copies in one static binary, sets it as the
+# entrypoint, and the published `docker run` recipe mounts the host's daemon
+# socket. On the artefact whose whole claim is that you can check what is in it,
+# an unused container runtime is 71 MiB and a great deal of surface for nothing.
+#
+# Nothing is lost by narrowing, and that is checkable rather than hoped: the
+# official `dind` image is itself built `FROM docker:29-cli`, so the CLI variant
+# is a strict subset. It is where `ca-certificates` (chart repositories over
+# HTTPS), `openssh-client` (`ssh://` Docker contexts) and `git` are installed;
+# the daemon stack is what the dind layers add on top. See #548.
+FROM docker:29-cli@sha256:27a51d5ab1cd38d9eeaba7b415b8c07bc10c31e1cf1ec8d78f6413fcfab3f44f
 
 # dockers_v2 runs a single multi-platform buildx build and stages each
 # platform's binary under its $TARGETPLATFORM (e.g. linux/amd64/swarmcli).


### PR DESCRIPTION
Closes #548, before the v1.14.0 tag — because v1.14.0 is the first release that
publishes `-oss` at all, and whatever base that image gets is the base it has for
that version forever.

## The change

`FROM docker:latest@sha256:e8faad…` → `FROM docker:29-cli@sha256:27a51d…`.

`docker:latest` is the **dind** image; the digests confirm it, and #548 recorded
them. So the published `eldaratech/swarmcli:<v>-oss` shipped dockerd, containerd,
runc, iptables and the storage drivers, none of it ever executed — the image
copies in one static binary, sets it as the entrypoint, and the documented
`docker run` recipe mounts the host's socket.

**137 → 66 MiB compressed** (amd64, measured from the registry manifests).

## Why nothing is lost, checkably

The official `dind` image is built **`FROM docker:29-cli`** — the CLI variant is a
strict subset by construction, so there is nothing in it that dind had and it
does not. The three packages that matter are installed in the CLI layer:
`ca-certificates` (chart repositories over HTTPS), `openssh-client` (`ssh://`
Docker contexts — the upstream Dockerfile's own comment cites `DOCKER_HOST=ssh://`
for it) and `git`. The daemon stack is what dind layers on top.

The digest is a multi-arch OCI index covering `linux/amd64` and `linux/arm64`,
which is what `dockers_v2` builds, and Dependabot's `docker` ecosystem already
tracks this directory monthly.

## The part that is not the one-liner

#547 deferred this because a base change "cannot be rehearsed without a Docker
daemon". There is one — in CI — and it was not being used: **`Dockerfile.release`
has been in the `build` job's paths filter all along, while the step that filter
gates runs `docker build .`, which is the *other* Dockerfile.** Nothing has ever
built the file that produces the published image. This change would have shipped
on exactly the evidence that made #548 necessary.

So there is now a step that stages the binary under its `$TARGETPLATFORM` the way
`dockers_v2` does, builds `Dockerfile.release`, runs `version` in it — asserting
the output is *recognisable*, not merely non-empty — and then asserts the base
still provides TLS roots and an `ssh` binary. A narrower base silently breaking
either is the failure mode a base change has, and it now fires on every change
rather than against a tag nobody can move.

## What still needs a human

CI covers build + run + `version` + the two base packages, on amd64. It cannot
cover the last line of #548's verify list, which needs a real swarm:

```sh
docker build -f Dockerfile.release --build-arg TARGETPLATFORM=linux/amd64 -t swarmcli-release-probe .   # after: go build -o swarmcli . && mkdir -p linux/amd64 && cp swarmcli linux/amd64/
docker run --rm -it -v /var/run/docker.sock:/var/run/docker.sock -v $HOME/.docker/contexts:/root/.docker/contexts swarmcli-release-probe
```

The TUI should reach the swarm over the mounted socket, and over an `ssh://`
context if you have one to hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
