### PR TITLE
fix(ui): fullscreen uses the whole terminal

### DIFF
--- a/app/model.go
+++ b/app/model.go
@@ -137,7 +137,7 @@ func (m *Model) switchToView(name string, data any) tea.Cmd {
 	exitCmd := m.currentView.OnExit()
 
 	newView, loadCmd := factory(m.deps, m.viewport.Width, m.viewport.Height, data)
-	resizeCmd := handleViewResize(newView, m.viewport.Width, m.viewport.Height, false)
+	resizeCmd := handleViewResize(newView, m.viewport.Width, m.viewport.Height, m.fullscreen)
 
 	// Push current view onto stack
 	m.viewStack.Push(m.currentView)
@@ -159,7 +159,7 @@ func (m *Model) replaceView(name string, data any) tea.Cmd {
 	exitCmd := m.currentView.OnExit()
 
 	newView, loadCmd := factory(m.deps, m.viewport.Width, m.viewport.Height, data)
-	resizeCmd := handleViewResize(newView, m.viewport.Width, m.viewport.Height, false)
+	resizeCmd := handleViewResize(newView, m.viewport.Width, m.viewport.Height, m.fullscreen)
 
 	m.currentView = newView
 	m.viewStack.Reset()

--- a/app/update.go
+++ b/app/update.go
@@ -11,6 +11,7 @@ import (
 	cmdpkg "github.com/Eldara-Tech/swarmcli/commands/command"
 	"github.com/Eldara-Tech/swarmcli/docker"
 	"github.com/Eldara-Tech/swarmcli/settings"
+	"github.com/Eldara-Tech/swarmcli/ui"
 	swarmlog "github.com/Eldara-Tech/swarmcli/utils/log"
 	"github.com/Eldara-Tech/swarmcli/views/commandinput"
 	"github.com/Eldara-Tech/swarmcli/views/confirmdialog"
@@ -185,13 +186,9 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 			if !m.commandInput.Visible() {
 				cmd := m.commandInput.Show()
-				// After showing the command input, trigger a resize so the current view
-				// is passed a usable height reduced by 3 lines for the command frame.
-				adjHeight := m.viewport.Height - 3
-				if adjHeight < 0 {
-					adjHeight = 0
-				}
-				resizeCmd := handleViewResize(m.currentView, m.viewport.Width, adjHeight, false)
+				// Resize with the bar now open so the view is passed a height
+				// reduced by the rows it takes.
+				resizeCmd := m.resizeToTerminal()
 				return m, tea.Batch(cmd, resizeCmd)
 			}
 			return m, nil
@@ -238,11 +235,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			if !m.searchInput.Visible() {
 				cmd := m.searchInput.Show()
-				adjHeight := m.viewport.Height - 3
-				if adjHeight < 0 {
-					adjHeight = 0
-				}
-				resizeCmd := handleViewResize(m.currentView, m.viewport.Width, adjHeight, false)
+				resizeCmd := m.resizeToTerminal()
 				return m, tea.Batch(cmd, resizeCmd)
 			}
 			return m, nil
@@ -259,7 +252,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// If visibility changed from true -> false, trigger resize to restore height
 			if prevVisible && !m.commandInput.Visible() {
 				// Command input just hid: restore the full usable viewport height.
-				resizeCmd := handleViewResize(m.currentView, m.viewport.Width, m.viewport.Height, false)
+				resizeCmd := m.resizeToTerminal()
 				return m, tea.Batch(cmd, resizeCmd)
 			}
 			return m, cmd
@@ -270,7 +263,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			prevVisible := m.searchInput.Visible()
 			cmd := m.searchInput.Update(msg)
 			if prevVisible && !m.searchInput.Visible() {
-				resizeCmd := handleViewResize(m.currentView, m.viewport.Width, m.viewport.Height, false)
+				resizeCmd := m.resizeToTerminal()
 				return m, tea.Batch(cmd, resizeCmd)
 			}
 			return m, cmd
@@ -409,6 +402,18 @@ func (m *Model) delegateToCurrentView(msg tea.Msg) tea.Cmd {
 	return tea.Batch(cmd, vpCmd)
 }
 
+// resizeToTerminal re-runs the layout for the current terminal size. Anything
+// that changes how much room the current view gets — toggling fullscreen,
+// opening or closing an input bar, navigating — goes through here rather than
+// adjusting a height by hand, so the layout mode and the input bar are only
+// ever accounted for in one place.
+func (m *Model) resizeToTerminal() tea.Cmd {
+	return m.updateForResize(tea.WindowSizeMsg{
+		Width:  m.terminalWidth,
+		Height: m.terminalHeight,
+	})
+}
+
 func (m *Model) updateForResize(msg tea.WindowSizeMsg) tea.Cmd {
 	var cmd tea.Cmd
 
@@ -420,30 +425,26 @@ func (m *Model) updateForResize(msg tea.WindowSizeMsg) tea.Cmd {
 
 	var usableWidth, usableHeight int
 	if isFullscreen {
-		// In fullscreen, use almost all space (just leave room for borders)
+		// Fullscreen draws no frame borders and no help/stack bars, so the
+		// whole terminal is usable.
 		usableWidth = msg.Width
-		usableHeight = msg.Height - 2 // Just for top/bottom borders
+		usableHeight = msg.Height
 	} else {
 		// Normal mode:
 		// - Width: subtract 4 for frame borders/padding
 		// - Height: pass full height, handleViewResize will subtract systeminfo header
 		usableWidth = msg.Width - 4
 		usableHeight = msg.Height
-		// If command input is visible, reserve 3 lines so the main view is
-		// reduced instead of moving the header. This keeps the header fixed
-		// at the top while space for the command box is deducted from the
-		// usableHeight passed to views.
-		if m.commandInput != nil && m.commandInput.Visible() {
-			usableHeight = usableHeight - 3
-			if usableHeight < 0 {
-				usableHeight = 0
-			}
-		}
-		if m.searchInput != nil && m.searchInput.Visible() {
-			usableHeight = usableHeight - 3
-			if usableHeight < 0 {
-				usableHeight = 0
-			}
+	}
+	// If an input bar is visible, reserve its lines so the main view is reduced
+	// instead of moving the header. This keeps the header fixed at the top
+	// while space for the bar is deducted from the usableHeight passed to
+	// views. View() reads the same reduced height, so it must not deduct again.
+	if (m.commandInput != nil && m.commandInput.Visible()) ||
+		(m.searchInput != nil && m.searchInput.Visible()) {
+		usableHeight = usableHeight - inputBarHeight
+		if usableHeight < 0 {
+			usableHeight = 0
 		}
 	}
 
@@ -458,14 +459,20 @@ func (m *Model) updateForResize(msg tea.WindowSizeMsg) tea.Cmd {
 	return cmd
 }
 
+// handleViewResize tells a view the height of the frame it has to fill. Views
+// size their content for the bordered frame, deducting ui.FramedChromeRows for
+// its borders.
 func handleViewResize(view view.View, width, height int, isFullscreen bool) tea.Cmd {
 	var adjustedHeight int
 	if isFullscreen {
-		// In fullscreen, subtract 1 for title line
-		adjustedHeight = height - 1
+		// Fullscreen spends ui.FullscreenChromeRows on a title line instead of
+		// those borders, so the frame it fills is that much taller than the
+		// terminal — otherwise the view holds back rows for borders that are
+		// never drawn and the bottom of the screen goes unused.
+		adjustedHeight = height + ui.FramedChromeRows - ui.FullscreenChromeRows
 	} else {
-		// Normal mode: subtract systeminfo height (6) + breadcrumb (1) = 7 lines total
-		adjustedHeight = height - 7
+		// Normal mode: subtract the help bar and the breadcrumb bar.
+		adjustedHeight = height - appChromeRows
 	}
 
 	var adjustedMsg = tea.WindowSizeMsg{
@@ -514,10 +521,7 @@ func (m *Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		// If in fullscreen, exit fullscreen first
 		if m.fullscreen {
 			m.fullscreen = false
-			cmd := m.updateForResize(tea.WindowSizeMsg{
-				Width:  m.terminalWidth,
-				Height: m.terminalHeight,
-			})
+			cmd := m.resizeToTerminal()
 			return m, cmd
 		}
 
@@ -535,7 +539,7 @@ func (m *Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			if fv, ok := m.currentView.(view.Filterable); ok {
 				fv.ClearSearchQuery()
 			}
-			resizeCmd := handleViewResize(m.currentView, m.viewport.Width, m.viewport.Height, false)
+			resizeCmd := m.resizeToTerminal()
 			return m, resizeCmd
 		}
 
@@ -617,10 +621,7 @@ func (m *Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			return m, cmd
 		}
 		m.fullscreen = !m.fullscreen
-		cmd := m.updateForResize(tea.WindowSizeMsg{
-			Width:  m.terminalWidth,
-			Height: m.terminalHeight,
-		})
+		cmd := m.resizeToTerminal()
 		return m, cmd
 	}
 
@@ -652,7 +653,7 @@ func (m *Model) goBack() tea.Cmd {
 	enterCmd := m.currentView.OnEnter()
 
 	// Optionally notify the view about terminal size again
-	resizeCmd := handleViewResize(m.currentView, m.viewport.Width, m.viewport.Height, false)
+	resizeCmd := m.resizeToTerminal()
 
 	// Execute all lifecycle commands
 	return tea.Batch(exitCmd, enterCmd, resizeCmd)

--- a/app/view.go
+++ b/app/view.go
@@ -12,13 +12,31 @@ import (
 	"github.com/charmbracelet/lipgloss"
 )
 
+// appChromeRows is what the app draws around a normal-mode view: the system
+// info help bar above it and the breadcrumb stack bar below. Fullscreen drops
+// both. The resize math in update.go deducts the same rows.
+const appChromeRows = systeminfoview.Height + 1
+
+// inputBarHeight is the framed box the ":" command bar and the "/" search bar
+// are rendered into. Both modes reserve it while one of them is open.
+const inputBarHeight = 3
+
 func (m *Model) View() string {
-	// Fullscreen mode: show only the current view (no helpbar, no stackbar)
+	title := m.currentView.FrameTitle()
+	header := m.currentView.FrameHeader()
+	content := m.currentView.FrameContent()
+	footer := m.currentView.FrameFooter()
+	// m.viewport already has the input bar's rows deducted, if one is open.
+	inputBar := m.renderInputBar()
+
+	// Fullscreen mode: show only the current view (no helpbar, no stackbar).
+	// The input bar stays: it is the only feedback for what is being typed.
 	if m.fullscreen {
-		title := m.currentView.FrameTitle()
-		header := m.currentView.FrameHeader()
-		content := m.currentView.FrameContent()
-		out := ui.RenderViewFrame(title, header, content, "", m.terminalWidth, m.terminalHeight, true)
+		out := ui.RenderViewFrame(title, header, content, footer,
+			m.terminalWidth, m.viewport.Height, true)
+		if inputBar != "" {
+			out = lipgloss.JoinVertical(lipgloss.Left, inputBar, out)
+		}
 		return m.overlayStartup(m.overlayUnlock(m.overlayAppError(m.overlayUpdate(out))))
 	}
 
@@ -42,70 +60,35 @@ func (m *Model) View() string {
 		WithViewHelp(m.currentView.ShortHelpItems()).
 		View(systemInfo, hasError)
 
-	// Build the framed view from components
-	title := m.currentView.FrameTitle()
-	header := m.currentView.FrameHeader()
-	content := m.currentView.FrameContent()
-	footer := m.currentView.FrameFooter()
-	// Subtract help bar (systeminfoview.Height) and stack bar (1 line) from the
-	// viewport height so the frame fits between chrome elements.
-	frameHeight := m.viewport.Height - systeminfoview.Height - 1
-
-	if m.commandInput.Visible() {
-		// Reserve 3 lines for the command frame so the main view shrinks.
-		const cmdFrameHeight = 3
-		frameHeight -= cmdFrameHeight
-		if frameHeight < 1 {
-			frameHeight = 1
-		}
-		framedView := ui.RenderViewFrame(title, header, content, footer, m.viewport.Width, frameHeight, false)
-
-		frameWidth := m.viewport.Width + 4
-		cmdFrame := ui.RenderFramedBoxHeight("", "", m.commandInput.View(), "", frameWidth, cmdFrameHeight)
-
-		out := lipgloss.JoinVertical(
-			lipgloss.Left,
-			help,
-			cmdFrame,
-			framedView,
-			m.renderStackBar(),
-		)
-		return m.overlayStartup(m.overlayUnlock(m.overlayAppError(m.overlayUpdate(out))))
-	}
-
-	if m.searchInput.Visible() {
-		const searchFrameHeight = 3
-		frameHeight -= searchFrameHeight
-		if frameHeight < 1 {
-			frameHeight = 1
-		}
-		framedView := ui.RenderViewFrame(title, header, content, footer, m.viewport.Width, frameHeight, false)
-
-		frameWidth := m.viewport.Width + 4
-		searchFrame := ui.RenderFramedBoxHeight("", "", m.searchInput.View(), "", frameWidth, searchFrameHeight)
-
-		out := lipgloss.JoinVertical(
-			lipgloss.Left,
-			help,
-			searchFrame,
-			framedView,
-			m.renderStackBar(),
-		)
-		return m.overlayStartup(m.overlayUnlock(m.overlayAppError(m.overlayUpdate(out))))
-	}
-
+	// Subtract help bar and stack bar from the viewport height so the frame
+	// fits between the chrome elements.
+	frameHeight := m.viewport.Height - appChromeRows
 	if frameHeight < 1 {
 		frameHeight = 1
 	}
 	framedView := ui.RenderViewFrame(title, header, content, footer, m.viewport.Width, frameHeight, false)
 
-	out := lipgloss.JoinVertical(
-		lipgloss.Left,
-		help,
-		framedView,
-		m.renderStackBar(),
-	)
+	rows := []string{help}
+	if inputBar != "" {
+		rows = append(rows, inputBar)
+	}
+	rows = append(rows, framedView, m.renderStackBar())
+
+	out := lipgloss.JoinVertical(lipgloss.Left, rows...)
 	return m.overlayStartup(m.overlayUnlock(m.overlayAppError(m.overlayUpdate(out))))
+}
+
+// renderInputBar renders whichever of the ":" command bar and the "/" search
+// bar is open, or "" when neither is. They are mutually exclusive.
+func (m *Model) renderInputBar() string {
+	switch {
+	case m.commandInput.Visible():
+		return ui.RenderFramedBoxHeight("", "", m.commandInput.View(), "", m.terminalWidth, inputBarHeight)
+	case m.searchInput.Visible():
+		return ui.RenderFramedBoxHeight("", "", m.searchInput.View(), "", m.terminalWidth, inputBarHeight)
+	default:
+		return ""
+	}
 }
 
 // hidesGlobalKeys reports whether the current view suppresses the app-level

--- a/app/view_test.go
+++ b/app/view_test.go
@@ -4,6 +4,7 @@
 package app
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -11,6 +12,7 @@ import (
 	"github.com/Eldara-Tech/swarmcli/ui"
 	"github.com/Eldara-Tech/swarmcli/views/commandinput"
 	"github.com/Eldara-Tech/swarmcli/views/confirmdialog"
+	inspectview "github.com/Eldara-Tech/swarmcli/views/inspect"
 	"github.com/Eldara-Tech/swarmcli/views/searchinput"
 	systeminfoview "github.com/Eldara-Tech/swarmcli/views/systeminfo"
 	"github.com/Eldara-Tech/swarmcli/views/unlockdialog"
@@ -163,6 +165,38 @@ func countRowsWith(out, marker string) int {
 		}
 	}
 	return n
+}
+
+// TestFullscreenFillsTheScreenWithARealViewport — the stub above rebuilds its
+// content for whatever height it is handed, so it cannot show what a real view
+// does: scroll a viewport that carries its offset across the resize. Pressing
+// "f" grew the viewport, which went on drawing the lines it drew before and
+// left the rows the toggle gained blank, until a keypress pulled the offset
+// back into range.
+func TestFullscreenFillsTheScreenWithARealViewport(t *testing.T) {
+	const width, height = 100, 40
+
+	var lines []string
+	for i := 0; i < 500; i++ {
+		lines = append(lines, fmt.Sprintf("line-%03d", i))
+	}
+	inspect := inspectview.New(width, height, inspectview.FormatRaw)
+	inspect.SetContent(strings.Join(lines, "\n"))
+
+	m := newLayoutTestModel(inspect)
+	m.updateForResize(tea.WindowSizeMsg{Width: width, Height: height})
+	for i := 0; i < 20; i++ { // page down to the end of the document
+		m.handleKey(tea.KeyMsg{Type: tea.KeyPgDown})
+	}
+
+	m.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'f'}})
+
+	out := m.View()
+	require.Equal(t, height, lipgloss.Height(out), "rendered rows")
+	// 40 rows less the fullscreen title line and the view's own header.
+	require.Equal(t, 38, countRowsWith(out, "line-"), "rows of content drawn")
+	rows := strings.Split(out, "\n")
+	require.Contains(t, rows[len(rows)-1], "line-499", "the last line should sit on the last row")
 }
 
 // TestFullscreenKeepsTheViewFooter — fullscreen used to drop the footer while

--- a/app/view_test.go
+++ b/app/view_test.go
@@ -1,0 +1,251 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package app
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/Eldara-Tech/swarmcli/docker"
+	"github.com/Eldara-Tech/swarmcli/ui"
+	"github.com/Eldara-Tech/swarmcli/views/commandinput"
+	"github.com/Eldara-Tech/swarmcli/views/confirmdialog"
+	"github.com/Eldara-Tech/swarmcli/views/searchinput"
+	systeminfoview "github.com/Eldara-Tech/swarmcli/views/systeminfo"
+	"github.com/Eldara-Tech/swarmcli/views/unlockdialog"
+	"github.com/Eldara-Tech/swarmcli/views/view"
+	"github.com/Eldara-Tech/swarmcli/views/viewstack"
+
+	"github.com/charmbracelet/bubbles/viewport"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/stretchr/testify/require"
+)
+
+// frameStubView sizes its content the way the real views do: from the frame
+// height the app hands it, minus the frame's own rows and its header/footer.
+// It always has more content than fits, so any row the layout fails to claim
+// shows up as a shortfall rather than as content running out.
+type frameStubView struct {
+	stubView
+	frameHeight int
+	header      string
+	footer      string
+}
+
+func (v *frameStubView) Update(msg tea.Msg) tea.Cmd {
+	if ws, ok := msg.(tea.WindowSizeMsg); ok {
+		v.frameHeight = ws.Height
+	}
+	return nil
+}
+
+func (v *frameStubView) FrameTitle() string  { return "Stub" }
+func (v *frameStubView) FrameHeader() string { return v.header }
+func (v *frameStubView) FrameFooter() string { return v.footer }
+
+func (v *frameStubView) FrameContent() string {
+	return ui.TrimOrPadContentToLines(strings.Repeat("row\n", 500),
+		ui.ContentRows(v.frameHeight, ui.FramedChromeRows, v.header, v.footer))
+}
+
+// stubClusterInfo is the least that lets systeminfoview render.
+type stubClusterInfo struct{}
+
+func (stubClusterInfo) GetCurrentContext() (string, error)    { return "default", nil }
+func (stubClusterInfo) GetContainerCount() (int, error)       { return 0, nil }
+func (stubClusterInfo) GetServiceCount() (int, error)         { return 0, nil }
+func (stubClusterInfo) GetSwarmCPUCapacity() (float64, error) { return 0, nil }
+func (stubClusterInfo) GetSwarmMemCapacity() (int64, error)   { return 0, nil }
+func (stubClusterInfo) GetSwarmCPUUsage() (string, error)     { return "0%", nil }
+func (stubClusterInfo) GetSwarmMemUsage() (string, error)     { return "0%", nil }
+func (stubClusterInfo) GetSwarmResourceUsage() (string, string, error) {
+	return "0%", "0%", nil
+}
+func (stubClusterInfo) GetDockerVersion() (string, error) { return "27.0.0", nil }
+
+// newLayoutTestModel builds a model complete enough to run View().
+func newLayoutTestModel(cv view.View) *Model {
+	deps := docker.Deps{ClusterInfo: stubClusterInfo{}}
+	return &Model{
+		deps:         deps,
+		viewport:     viewport.New(0, 0),
+		currentView:  cv,
+		viewStack:    viewstack.Stack{},
+		commandInput: commandinput.New(),
+		searchInput:  searchinput.New(),
+		errorDialog:  confirmdialog.New(0, 0),
+		unlockDialog: unlockdialog.New(0, 0),
+		updateDialog: confirmdialog.New(0, 0),
+		systemInfo:   systeminfoview.New(deps, "test", "ce"),
+	}
+}
+
+// TestViewFillsTerminalHeight is the guard for #560: fullscreen used to hold
+// back rows for frame borders it never draws, leaving a dead band at the
+// bottom of the terminal. Every layout must claim every row it is given.
+func TestViewFillsTerminalHeight(t *testing.T) {
+	const width, height = 100, 40
+
+	cases := []struct {
+		name           string
+		fullscreen     bool
+		header, footer string
+		openBar        func(*Model)
+	}{
+		{name: "normal", header: "hdr", footer: "ftr"},
+		{name: "fullscreen", fullscreen: true, header: "hdr", footer: "ftr"},
+		{name: "fullscreen without header or footer", fullscreen: true},
+		{name: "fullscreen with a two-line footer", fullscreen: true, header: "hdr", footer: "a\nb"},
+		{
+			name: "normal with the command bar open", header: "hdr", footer: "ftr",
+			openBar: func(m *Model) { m.commandInput.Show() },
+		},
+		{
+			name: "fullscreen with the command bar open", fullscreen: true, header: "hdr", footer: "ftr",
+			openBar: func(m *Model) { m.commandInput.Show() },
+		},
+		{
+			name: "fullscreen with the search bar open", fullscreen: true, header: "hdr", footer: "ftr",
+			openBar: func(m *Model) { m.searchInput.Show() },
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := newLayoutTestModel(&frameStubView{header: tc.header, footer: tc.footer})
+			m.fullscreen = tc.fullscreen
+			if tc.openBar != nil {
+				tc.openBar(m)
+			}
+			m.updateForResize(tea.WindowSizeMsg{Width: width, Height: height})
+
+			// What the chrome costs, stated independently of the code under
+			// test: fullscreen spends one row on its centered title, the normal
+			// layout spends six on the help bar, one on the stack bar and two on
+			// the frame's borders. Either way an open input bar costs three.
+			chrome := 1
+			if !tc.fullscreen {
+				chrome = 6 + 1 + 2
+			}
+			if tc.openBar != nil {
+				chrome += 3
+			}
+			wantContent := height - chrome - rowsIn(tc.header) - rowsIn(tc.footer)
+
+			out := m.View()
+			require.Equal(t, height, lipgloss.Height(out), "rendered rows")
+			// The view has more content than fits, so every content row it was
+			// given should carry content. Blank rows mean the layout reserved
+			// space it never used — the dead band from #560.
+			require.Equal(t, wantContent, countRowsWith(out, "row"), "rows of content drawn")
+			for i, line := range strings.Split(out, "\n") {
+				require.LessOrEqual(t, lipgloss.Width(line), width, "row %d overflows the terminal width", i)
+			}
+		})
+	}
+}
+
+// rowsIn is the number of rows a header or footer occupies; "" occupies none.
+func rowsIn(s string) int {
+	if s == "" {
+		return 0
+	}
+	return strings.Count(s, "\n") + 1
+}
+
+func countRowsWith(out, marker string) int {
+	n := 0
+	for _, row := range strings.Split(out, "\n") {
+		if strings.Contains(row, marker) {
+			n++
+		}
+	}
+	return n
+}
+
+// TestFullscreenKeepsTheViewFooter — fullscreen used to drop the footer while
+// the view still reserved its rows, so the row counter and the deploy progress
+// line vanished and their space was wasted twice over.
+func TestFullscreenKeepsTheViewFooter(t *testing.T) {
+	m := newLayoutTestModel(&frameStubView{header: "hdr", footer: "footer-marker"})
+	m.fullscreen = true
+	m.updateForResize(tea.WindowSizeMsg{Width: 100, Height: 40})
+
+	rows := strings.Split(m.View(), "\n")
+	require.Contains(t, rows[len(rows)-1], "footer-marker")
+}
+
+// TestInputBarStaysVisibleInFullscreen — ":" and "/" used to accept keystrokes
+// in fullscreen while View() returned before drawing either bar, so you typed
+// blind.
+func TestInputBarStaysVisibleInFullscreen(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		open func(*Model)
+	}{
+		{"command bar", func(m *Model) { m.commandInput.Show() }},
+		{"search bar", func(m *Model) { m.searchInput.Show() }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			m := newLayoutTestModel(&frameStubView{header: "hdr", footer: "ftr"})
+			m.fullscreen = true
+			tc.open(m)
+			m.updateForResize(tea.WindowSizeMsg{Width: 100, Height: 40})
+
+			rows := strings.Split(m.View(), "\n")
+			require.Equal(t, inputBarHeight, indexOfStubTitle(t, rows),
+				"the input bar should occupy the rows above the view")
+		})
+	}
+}
+
+// indexOfStubTitle returns the row the stub view's title line lands on.
+func indexOfStubTitle(t *testing.T, rows []string) int {
+	t.Helper()
+	for i, row := range rows {
+		if strings.Contains(row, "Stub") {
+			return i
+		}
+	}
+	t.Fatal("the view's title line is missing from the output")
+	return -1
+}
+
+// TestNavigatingInFullscreenKeepsTheFullscreenBudget — every resize outside the
+// window-size handler used to hard-code normal mode, so drilling into a view
+// while fullscreen sized it for the help and stack bars that fullscreen does
+// not draw, wasting even more of the screen than the toggle itself did.
+func TestNavigatingInFullscreenKeepsTheFullscreenBudget(t *testing.T) {
+	const name = "frame-stub"
+	view.RegisterView(name, func(docker.Deps, int, int, any) (view.View, tea.Cmd) {
+		return &frameStubView{header: "hdr", footer: "ftr"}, nil
+	})
+
+	m := newLayoutTestModel(&frameStubView{header: "hdr", footer: "ftr"})
+	m.fullscreen = true
+	m.updateForResize(tea.WindowSizeMsg{Width: 100, Height: 40})
+	m.switchToView(name, nil)
+
+	out := m.View()
+	require.Equal(t, 40, lipgloss.Height(out))
+	// 40 rows less the title, the header and the footer.
+	require.Equal(t, 37, countRowsWith(out, "row"))
+}
+
+// TestHandleViewResizeFullscreenBudget pins the contract between the resize
+// math and the fullscreen frame: the height a view is handed must leave it,
+// after the deduction every view makes for the bordered frame, exactly the
+// rows the fullscreen frame will draw.
+func TestHandleViewResizeFullscreenBudget(t *testing.T) {
+	const terminalHeight = 40
+	const header, footer = "hdr", "ftr"
+
+	v := &frameStubView{header: header, footer: footer}
+	handleViewResize(v, 100, terminalHeight, true)
+
+	require.Equal(t,
+		ui.ContentRows(terminalHeight, ui.FullscreenChromeRows, header, footer),
+		ui.ContentRows(v.frameHeight, ui.FramedChromeRows, header, footer))
+}

--- a/ui/framecalc.go
+++ b/ui/framecalc.go
@@ -7,7 +7,13 @@ import "strings"
 
 const (
 	horizontalPadding = 4
-	verticalPadding   = 2
+
+	// FramedChromeRows is what RenderViewFrame's bordered layout spends on the
+	// frame itself: the top border, which carries the title, and the bottom one.
+	FramedChromeRows = 2
+	// FullscreenChromeRows is what its borderless layout spends instead: a
+	// single centered title line.
+	FullscreenChromeRows = 1
 )
 
 // FrameSpec captures the calculated dimensions for a framed view.
@@ -45,23 +51,28 @@ func ComputeFrameDimensions(viewportWidth, viewportHeight, fallbackWidth, fallba
 		frameHeight = 20
 	}
 
-	headerLines := 0
-	if header != "" {
-		headerLines = len(strings.Split(header, "\n"))
-	}
-	footerLines := 0
-	if footer != "" {
-		footerLines = len(strings.Split(footer, "\n"))
-	}
-
-	desiredContentLines := frameHeight - verticalPadding - headerLines - footerLines
-	if desiredContentLines < 0 {
-		desiredContentLines = 0
-	}
-
 	return FrameSpec{
 		FrameWidth:          frameWidth,
 		FrameHeight:         frameHeight,
-		DesiredContentLines: desiredContentLines,
+		DesiredContentLines: ContentRows(frameHeight, FramedChromeRows, header, footer),
 	}
+}
+
+// ContentRows is the space left for content inside a frame of frameHeight rows
+// once the frame's own chrome (chromeRows) and the header and footer have taken
+// theirs. A view that renders a viewport should size that viewport to this, so
+// what the viewport scrolls is exactly what the frame draws.
+func ContentRows(frameHeight, chromeRows int, header, footer string) int {
+	rows := frameHeight - chromeRows - countRows(header) - countRows(footer)
+	if rows < 0 {
+		rows = 0
+	}
+	return rows
+}
+
+func countRows(s string) int {
+	if s == "" {
+		return 0
+	}
+	return len(strings.Split(s, "\n"))
 }

--- a/ui/framedbox.go
+++ b/ui/framedbox.go
@@ -11,19 +11,26 @@ import (
 
 // RenderViewFrame composes a complete framed view from its parts.
 // It computes frame dimensions, trims/pads content to fit, and renders
-// the bordered frame. When fullscreen is true, only a centered title
-// line and raw content are returned (no borders).
+// the bordered frame. When fullscreen is true the borders are dropped and a
+// centered title line takes their place. Either way the result occupies
+// exactly `height` rows, as long as the chrome, header and footer fit in them.
 func RenderViewFrame(title, header, content, footer string, width, height int, fullscreen bool) string {
 	if fullscreen {
-		titleText := styleFrameTitle(title)
 		titleLine := lipgloss.NewStyle().
 			Width(width).
 			Align(lipgloss.Center).
-			Render(titleText)
+			Render(styleFrameTitle(title))
+
+		rows := []string{titleLine}
 		if header != "" {
-			return titleLine + "\n" + header + "\n" + content
+			rows = append(rows, header)
 		}
-		return titleLine + "\n" + content
+		rows = append(rows, TrimOrPadContentToLines(content,
+			ContentRows(height, FullscreenChromeRows, header, footer)))
+		if footer != "" {
+			rows = append(rows, footer)
+		}
+		return strings.Join(rows, "\n")
 	}
 
 	// Pad header, content, and footer uniformly so columns align inside the frame.

--- a/ui/framedbox_test.go
+++ b/ui/framedbox_test.go
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRenderViewFrame_OccupiesExactlyHeight — the borderless fullscreen layout
+// used to emit whatever the view handed it, so a view that had held rows back
+// for borders never drawn left a dead band at the bottom of the terminal.
+func TestRenderViewFrame_OccupiesExactlyHeight(t *testing.T) {
+	long := strings.TrimSuffix(strings.Repeat("content\n", 100), "\n")
+
+	cases := []struct {
+		name           string
+		header, footer string
+		content        string
+		fullscreen     bool
+	}{
+		{name: "fullscreen, header and footer", header: "hdr", footer: "ftr", content: long, fullscreen: true},
+		{name: "fullscreen, neither", content: long, fullscreen: true},
+		{name: "fullscreen, two-line footer", header: "hdr", footer: "a\nb", content: long, fullscreen: true},
+		{name: "fullscreen, content shorter than the frame", header: "hdr", content: "one\ntwo", fullscreen: true},
+		{name: "framed, header and footer", header: "hdr", footer: "ftr", content: long},
+		{name: "framed, content shorter than the frame", header: "hdr", content: "one\ntwo"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			for _, height := range []int{5, 24, 40} {
+				out := RenderViewFrame("Title", tc.header, tc.content, tc.footer, 60, height, tc.fullscreen)
+				require.Equal(t, height, lipgloss.Height(out), "height=%d", height)
+			}
+		})
+	}
+}
+
+// TestRenderViewFrame_FullscreenKeepsHeaderAndFooter — fullscreen dropped the
+// footer while the caller had already reserved its rows.
+func TestRenderViewFrame_FullscreenKeepsHeaderAndFooter(t *testing.T) {
+	out := RenderViewFrame("Title", "the-header", "body", "the-footer", 60, 10, true)
+	rows := strings.Split(out, "\n")
+
+	require.Contains(t, rows[0], "Title")
+	require.Contains(t, rows[1], "the-header")
+	require.Contains(t, rows[len(rows)-1], "the-footer")
+}
+
+func TestContentRows_NeverNegative(t *testing.T) {
+	require.Equal(t, 0, ContentRows(1, FramedChromeRows, "hdr", "ftr"))
+	require.Equal(t, 0, ContentRows(-5, FullscreenChromeRows, "", ""))
+}

--- a/views/inspect/inspect_test.go
+++ b/views/inspect/inspect_test.go
@@ -4,6 +4,7 @@
 package inspectview
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -50,7 +51,6 @@ func TestNew(t *testing.T) {
 	m := New(80, 24, FormatYAML)
 	require.Equal(t, FormatYAML, m.Format)
 	require.Equal(t, 80, m.width)
-	require.Equal(t, 24, m.height)
 }
 
 func TestName(t *testing.T) {
@@ -154,7 +154,10 @@ func TestUpdate_WindowSizeMsg(t *testing.T) {
 	m := testModel()
 	m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
 	require.Equal(t, 120, m.viewport.Width)
-	require.Equal(t, 40, m.viewport.Height)
+	// The message carries the frame's height; the viewport gets the rows left
+	// after the two border rows and the one-line header.
+	require.Equal(t, 37, m.viewport.Height)
+	require.Len(t, strings.Split(m.FrameContent(), "\n"), 37)
 	require.True(t, m.ready)
 }
 
@@ -338,4 +341,24 @@ func TestApplySearchQuery_RawMode(t *testing.T) {
 	visible := m.visiblePlainLines()
 	require.Len(t, visible, 1)
 	require.Contains(t, visible[0], "two")
+}
+
+// TestFrameContentFillsTheFrame — the viewport used to be sized to the whole
+// frame while the frame drew three rows fewer, cutting off the bottom of the
+// document the viewport had scrolled to.
+func TestFrameContentFillsTheFrame(t *testing.T) {
+	m := testModel()
+	m.SetFormat(FormatRaw)
+	var lines []string
+	for i := 0; i < 200; i++ {
+		lines = append(lines, fmt.Sprintf("line-%03d", i))
+	}
+	m.SetContent(strings.Join(lines, "\n"))
+	m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+	m.viewport.GotoBottom()
+
+	rows := strings.Split(m.FrameContent(), "\n")
+	// 40 rows of frame less its two borders and the one-line header.
+	require.Len(t, rows, 37)
+	require.Contains(t, rows[len(rows)-1], "line-199")
 }

--- a/views/inspect/inspect_test.go
+++ b/views/inspect/inspect_test.go
@@ -362,3 +362,24 @@ func TestFrameContentFillsTheFrame(t *testing.T) {
 	require.Len(t, rows, 37)
 	require.Contains(t, rows[len(rows)-1], "line-199")
 }
+
+// TestGrowingTheFrameLeavesNoBlankRows — the viewport kept the offset it had
+// across a resize, so "f" grew it into rows it then left blank until a keypress
+// pulled the offset back into range.
+func TestGrowingTheFrameLeavesNoBlankRows(t *testing.T) {
+	m := testModel()
+	m.SetFormat(FormatRaw)
+	var lines []string
+	for i := 0; i < 200; i++ {
+		lines = append(lines, fmt.Sprintf("line-%03d", i))
+	}
+	m.SetContent(strings.Join(lines, "\n"))
+	m.Update(tea.WindowSizeMsg{Width: 120, Height: 24})
+	m.viewport.GotoBottom()
+
+	m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+
+	rows := strings.Split(m.FrameContent(), "\n")
+	require.Len(t, rows, 37)
+	require.Contains(t, rows[len(rows)-1], "line-199")
+}

--- a/views/inspect/model.go
+++ b/views/inspect/model.go
@@ -33,7 +33,6 @@ type Model struct {
 	searchMode bool
 	ready      bool
 	width      int
-	height     int
 
 	Format     Format // "yml" or "raw"
 	RawContent string
@@ -51,7 +50,6 @@ func New(width, height int, format Format) *Model {
 	return &Model{
 		viewport: vp,
 		width:    width,
-		height:   height,
 		Format:   format,
 	}
 }

--- a/views/inspect/update.go
+++ b/views/inspect/update.go
@@ -29,6 +29,12 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 		m.viewport.Height = max(1, ui.ContentRows(msg.Height, ui.FramedChromeRows, m.FrameHeader(), m.FrameFooter()))
 		m.ready = true
 		m.updateViewport()
+		// A resize changes how many lines fit, but not the offset the viewport
+		// scrolls from, so a viewport that grew keeps drawing the lines it drew
+		// before and leaves the rows it gained blank.
+		if m.viewport.PastBottom() {
+			m.viewport.GotoBottom()
+		}
 		return nil
 
 	case tea.KeyMsg:

--- a/views/inspect/update.go
+++ b/views/inspect/update.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/Eldara-Tech/swarmcli/ui"
+
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 )
@@ -21,7 +23,10 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 
 	case tea.WindowSizeMsg:
 		m.viewport.Width = msg.Width
-		m.viewport.Height = msg.Height
+		// msg.Height is the frame's height; the viewport only gets what is left
+		// after the frame's own rows and the header, so that what it scrolls is
+		// exactly what the frame draws.
+		m.viewport.Height = max(1, ui.ContentRows(msg.Height, ui.FramedChromeRows, m.FrameHeader(), m.FrameFooter()))
 		m.ready = true
 		m.updateViewport()
 		return nil

--- a/views/inspect/view.go
+++ b/views/inspect/view.go
@@ -38,16 +38,14 @@ func (m *Model) FrameHeader() string {
 
 func (m *Model) FrameFooter() string { return "" }
 
-func (m *Model) FrameContent() string {
-	header := m.FrameHeader()
-	width := m.viewport.Width
-	if width <= 0 {
-		width = 80
-	}
-	frame := ui.ComputeFrameDimensions(width, m.viewport.Height, width, m.height, header, "")
-	return ui.TrimOrPadContentToLines(m.viewport.View(), frame.DesiredContentLines)
-}
+// FrameContent returns the viewport as-is: it is already sized to the rows the
+// frame will draw.
+func (m *Model) FrameContent() string { return m.viewport.View() }
 
+// View renders the view on its own; the app composes it from the Frame* parts
+// instead. The box is drawn around the content rather than to a height, since
+// the viewport is already sized to the rows it should fill.
 func (m *Model) View() string {
-	return ui.RenderViewFrame(m.FrameTitle(), m.FrameHeader(), m.FrameContent(), m.FrameFooter(), m.viewport.Width, m.viewport.Height, false)
+	return ui.RenderFramedBox(m.FrameTitle(), m.FrameHeader(), m.FrameContent(), m.FrameFooter(),
+		m.viewport.Width+4)
 }

--- a/views/logs/logs_test.go
+++ b/views/logs/logs_test.go
@@ -5,7 +5,9 @@ package logsview
 
 import (
 	"errors"
+	"fmt"
 	"io"
+	"strings"
 	"testing"
 
 	"github.com/Eldara-Tech/swarmcli/docker"
@@ -264,7 +266,10 @@ func TestUpdate_WindowSizeMsg(t *testing.T) {
 	m := testModel()
 	m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
 	require.Equal(t, 120, m.viewport.Width)
-	require.Equal(t, 40, m.viewport.Height)
+	// The message carries the frame's height; the viewport gets the rows left
+	// after the two border rows and the one-line header.
+	require.Equal(t, 37, m.viewport.Height)
+	require.Len(t, strings.Split(m.FrameContent(), "\n"), 37)
 	require.True(t, m.ready)
 }
 
@@ -826,4 +831,22 @@ func TestSetContent_ResetsTaskSlice(t *testing.T) {
 		require.Equal(t, "", id)
 	}
 	m.mu.Unlock()
+}
+
+// TestFollowShowsTheNewestLine — the viewport used to be sized to the whole
+// frame while the frame drew fewer rows than that, so AutoScroll parked the
+// newest lines in the rows that were cut off.
+func TestFollowShowsTheNewestLine(t *testing.T) {
+	m := testModel()
+	m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+	require.True(t, m.getFollow())
+
+	for i := 0; i < 500; i++ {
+		m.Update(LineMsg{Line: fmt.Sprintf("line-%03d", i)})
+	}
+
+	rows := strings.Split(m.FrameContent(), "\n")
+	// 40 rows of frame less its two borders and the one-line header.
+	require.Len(t, rows, 37)
+	require.Contains(t, rows[len(rows)-1], "line-499")
 }

--- a/views/logs/logs_test.go
+++ b/views/logs/logs_test.go
@@ -850,3 +850,55 @@ func TestFollowShowsTheNewestLine(t *testing.T) {
 	require.Len(t, rows, 37)
 	require.Contains(t, rows[len(rows)-1], "line-499")
 }
+
+// TestResizeKeepsFollowOnTheNewestLine — the viewport kept the offset it had
+// across a resize, so "f" grew it into rows it then left blank, and leaving
+// fullscreen shrank it away from the newest lines. Both until the next line
+// arrived or a keypress clamped the offset.
+func TestResizeKeepsFollowOnTheNewestLine(t *testing.T) {
+	cases := []struct {
+		name           string
+		from, to, rows int
+	}{
+		{name: "growing into fullscreen", from: 24, to: 40, rows: 37},
+		{name: "shrinking back to normal", from: 40, to: 24, rows: 21},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := testModel()
+			m.Update(tea.WindowSizeMsg{Width: 120, Height: tc.from})
+			for i := 0; i < 500; i++ {
+				m.Update(LineMsg{Line: fmt.Sprintf("line-%03d", i)})
+			}
+
+			m.Update(tea.WindowSizeMsg{Width: 120, Height: tc.to})
+
+			rows := strings.Split(m.FrameContent(), "\n")
+			require.Len(t, rows, tc.rows)
+			require.Contains(t, rows[len(rows)-1], "line-499")
+		})
+	}
+}
+
+// TestResizeWithFollowOffClampsWithoutJumping — a resize must not drag a reader
+// who scrolled up back to the newest line, but it must still pull in an offset
+// the taller viewport has left past the end.
+func TestResizeWithFollowOffClampsWithoutJumping(t *testing.T) {
+	m := testModel()
+	m.Update(tea.WindowSizeMsg{Width: 120, Height: 24})
+	for i := 0; i < 500; i++ {
+		m.Update(LineMsg{Line: fmt.Sprintf("line-%03d", i)})
+	}
+	m.setFollow(false)
+
+	m.viewport.SetYOffset(100)
+	m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+	require.Equal(t, 100, m.viewport.YOffset)
+
+	m.viewport.GotoBottom()
+	m.Update(tea.WindowSizeMsg{Width: 120, Height: 60})
+	rows := strings.Split(m.FrameContent(), "\n")
+	require.Len(t, rows, 57)
+	require.Contains(t, rows[len(rows)-1], "line-499")
+}

--- a/views/logs/update.go
+++ b/views/logs/update.go
@@ -212,6 +212,14 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 		}
 		// reset viewport content so the internal content height updates
 		m.viewport.SetContent(m.buildContent())
+		// A resize changes how many lines fit, but not the offset the viewport
+		// scrolls from, so it keeps drawing the lines it drew before: growing
+		// leaves the rows it gained blank, shrinking cuts the newest lines off.
+		// Re-anchor while following, and otherwise only when the offset now sits
+		// past the end — a reader who scrolled up stays where they were.
+		if m.getFollow() || m.viewport.PastBottom() {
+			m.viewport.GotoBottom()
+		}
 		return nil
 
 	case tea.KeyMsg:

--- a/views/logs/update.go
+++ b/views/logs/update.go
@@ -202,7 +202,11 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 		}
 
 		m.viewport.Width = msg.Width
-		m.viewport.Height = msg.Height
+		// msg.Height is the frame's height; the viewport only gets what is left
+		// after the frame's own rows and the header. Sizing it to the frame
+		// instead would park the newest lines below the cut — GotoBottom would
+		// anchor a window taller than the rows actually drawn.
+		m.viewport.Height = max(1, ui.ContentRows(msg.Height, ui.FramedChromeRows, m.FrameHeader(), m.FrameFooter()))
 		if !m.ready {
 			m.ready = true
 		}

--- a/views/logs/view.go
+++ b/views/logs/view.go
@@ -58,14 +58,8 @@ func (m *Model) FrameContent() string {
 		width = 80
 	}
 
-	headerRendered := m.FrameHeader()
-	frame := ui.ComputeFrameDimensions(
-		width, m.viewport.Height,
-		width, m.viewport.Height,
-		headerRendered, "",
-	)
-
-	viewportContent := ui.TrimOrPadContentToLines(m.viewport.View(), frame.DesiredContentLines)
+	// The viewport is already sized to the rows the frame will draw.
+	viewportContent := m.viewport.View()
 
 	if m.getNodeSelectVisible() && m.viewport.Height >= 5 {
 		availableHeight := m.viewport.Height
@@ -76,12 +70,15 @@ func (m *Model) FrameContent() string {
 	return viewportContent
 }
 
+// View renders the view on its own; the app composes it from the Frame* parts
+// instead. The box is drawn around the content rather than to a height, since
+// the viewport is already sized to the rows it should fill.
 func (m *Model) View() string {
 	if !m.Visible {
 		return ""
 	}
-	return ui.RenderViewFrame(m.FrameTitle(), m.FrameHeader(), m.FrameContent(), m.FrameFooter(),
-		m.viewport.Width, m.viewport.Height, false)
+	return ui.RenderFramedBox(m.FrameTitle(), m.FrameHeader(), m.FrameContent(), m.FrameFooter(),
+		m.viewport.Width+4)
 }
 
 // renderNodeSelectDialog renders the node selection popup


### PR DESCRIPTION
Fixes #560.

## What was wrong

Pressing `f` left a dead band four rows deep at the bottom of the terminal. Two deductions for the frame's borders still ran in fullscreen, where `RenderViewFrame` draws no borders at all:

- `updateForResize` took two rows off the terminal height — `usableHeight = msg.Height - 2 // Just for top/bottom borders`
- every view's `FrameContent` took two more, via `ComputeFrameDimensions`' `verticalPadding`

Views with a footer lost a further row, because the fullscreen frame dropped the footer that the view had already reserved space for. Measured on a 40-row terminal, the logs view rendered 36 rows.

## What changed

The fullscreen layout now spends one row on its title line and nothing else, and `RenderViewFrame` trims or pads to exactly the height it is given **in both modes** — so no view can leave the bottom of the screen unclaimed, whatever its own sizing does. `handleViewResize` hands a fullscreen view the frame height that leaves it the whole terminal once it has made the deduction every view makes.

Three defects in the same arithmetic came with it:

- **Every resize outside the window-size handler hard-coded normal mode.** Drilling into a view, or closing an input bar, while fullscreen sized it for chrome that is not drawn — ten rows lost rather than four. They now go through `resizeToTerminal`, the one place the layout mode and the input bar are accounted for. That also fixes normal mode deducting the input bar's three rows twice, once in `updateForResize` and again in `View`.
- **`:` and `/` were invisible in fullscreen.** `View` returned before composing either bar, so the bar accepted keystrokes you could not see. Both now render in fullscreen.
- **The newest log line was never visible.** The `logs` and `inspect` viewports were sized to the whole frame while the frame drew three rows fewer, so `GotoBottom` anchored a window taller than the rows actually drawn and AutoScroll parked the newest lines in the cut-off rows. Present in normal mode too, not only fullscreen. Both viewports are now sized to the rows the frame draws, which also removes the duplicated content arithmetic from their `FrameContent`.

The fullscreen frame also renders the view's footer now (row counter, deploy progress, toasts), instead of dropping it while its rows stayed reserved.

## Verification

`go test ./...`, `go vet`, `golangci-lint run ./... --build-tags=integration` — all clean.

New guards, each confirmed to fail when the corresponding fix is reverted:

| Guard | Reverting … |
|---|---|
| `app: TestViewFillsTerminalHeight` (7 layout combinations) | the border reservation, the fullscreen trim, the double input-bar deduction |
| `app: TestFullscreenKeepsTheViewFooter` | the fullscreen footer |
| `app: TestInputBarStaysVisibleInFullscreen` | the fullscreen input bar |
| `app: TestNavigatingInFullscreenKeepsTheFullscreenBudget` | `switchToView`'s hard-coded mode |
| `app: TestHandleViewResizeFullscreenBudget` | the resize arithmetic |
| `ui: TestRenderViewFrame_OccupiesExactlyHeight` | the fullscreen trim/pad |
| `logs: TestFollowShowsTheNewestLine`, `inspect: TestFrameContentFillsTheFrame` | the viewport sizing |

`TestViewFillsTerminalHeight` counts rows that actually carry content, not just total rows — padding the reserved space with blanks looks identical to a row count and identical to the user.

Two existing assertions changed on purpose: `logs`/`inspect` `TestUpdate_WindowSizeMsg` encoded `viewport.Height == msg.Height`, which was the defect.

Not verified interactively — this was measured and asserted headlessly, not driven in a live terminal.
