### PR TITLE
docs(bootstrap): the managed context is switched to, not selected

### DIFF
--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -118,10 +118,13 @@ three cert files above.
 4.  Wait for the run to complete. The view reports success or the
     underlying error.
 
-5.  Switch to the new context:
-      :contexts  →  select "<original>-managed"
+5.  Nothing to do. The summary stays on screen while SwarmCLI waits for
+    the rbac-proxy it just deployed to answer, then switches to the new
+    context by itself and reloads the cluster through it.
 
-    SwarmCLI is now talking through the proxy with the admin client cert.
+    Esc stops the wait and leaves you on the original context; you can
+    switch later with :contexts. See "After bootstrap" for the cases
+    where the switch does not happen on its own.
 ```
 
 To skip the interactive prompt, pass `--port`:
@@ -191,10 +194,25 @@ The new context is also visible via:
 docker context ls
 ```
 
-Switch to it from the TUI with `:contexts`. SwarmCLI picks up the managed
-context's client certificate automatically — no environment variables to
-set. From then on, every Docker API call goes through the rbac-proxy and
-is authenticated as `admin`.
+SwarmCLI switches to it for you. A freshly deployed proxy is not reachable
+the moment the stack is deployed, so the success screen stays up while the
+new context is polled, and the switch happens once it answers — normally a
+few seconds. From then on every Docker API call goes through the rbac-proxy
+and is authenticated as `admin`; the client certificate is picked up from
+the context, with no environment variables to set.
+
+The switch does not happen on its own in three cases, each of which says so
+on the success screen and leaves you where you were:
+
+- **`DOCKER_CONTEXT` is set.** That variable takes precedence over the
+  active context, so switching would have no effect on the running session.
+  Unset it and use `:contexts`, or restart with the managed context named.
+- **The proxy never answers.** Something is wrong with the deployment or
+  the host is not reachable from your workstation — see
+  [Troubleshooting](troubleshooting.md#bootstrap).
+- **You pressed Esc** during the wait.
+
+`:contexts` remains the way to switch by hand, at any time.
 
 To add additional users with their own certificates and roles, see
 [`rbac.md`](rbac.md).

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -74,6 +74,16 @@ down (the four commands in
 re-run with `:bootstrap --host <reachable-host>` to bake the right value
 into the cert SAN and the context endpoint.
 
+**Bootstrap succeeds but does not switch to the managed context.**
+The success screen says which of the three reasons applies. If it names
+`DOCKER_CONTEXT`, that variable takes precedence over the active context, so
+`docker context use` — and therefore the switch — would not affect the running
+session; unset it and use `:contexts`. If it reports that the proxy did not
+answer, the deployment or the proxy host's reachability is the real problem —
+work through *"the new managed context cannot connect"* and *"port-in-use"*
+above. If you pressed Esc, the wait was cancelled on purpose. In every case
+`:contexts` still switches by hand.
+
 **`:bootstrap --check` reports `agent-manager: false` but `agent: true`.**
 The agent-manager service is not running on a manager. Inspect with
 `docker service ps swarmcli-infra_agent-manager` and look at the latest


### PR DESCRIPTION
`:bootstrap` now waits for the rbac-proxy it just deployed and switches to the new managed context on its own, so the two passages that told the operator to run `:contexts` themselves no longer describe what happens.

- **Walkthrough step 5** becomes "nothing to do", and says what the wait looks like and that `Esc` opts out.
- **After bootstrap** explains the wait (a freshly deployed proxy is not reachable the instant the stack is deployed) and names the three cases where the switch is declined — `DOCKER_CONTEXT` set, a proxy that never answers, `Esc` — since each one leaves the operator on the original context and reads as a failure otherwise.
- **Troubleshooting** gains the matching entry, pointing the "proxy never answered" case at the two deployment-side entries that actually explain it.

`docs/migration.md` is deliberately untouched: `--migrate` runs from the original context and preserves the managed context it already had, so it keeps today's behaviour and its "switch back if needed" line stays true.

Docs only — no code. Best merged alongside the behaviour it describes rather than well ahead of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
