### PR TITLE
fix(contexts): validate the context being switched to, not the one being left

### DIFF
--- a/docker/context.go
+++ b/docker/context.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -147,30 +148,65 @@ func UseContext(contextName string) error {
 	return nil
 }
 
+// ErrContextPinnedByEnv reports a switch that could not take effect because
+// DOCKER_CONTEXT names a different context. `docker context use` writes the
+// active context to ~/.docker/config.json, but the variable is resolved ahead
+// of it, so the switch would change nothing this process observes.
+var ErrContextPinnedByEnv = errors.New("DOCKER_CONTEXT pins the Docker context")
+
+// Seams for ValidateContext, so its switch/revert bookkeeping is testable
+// without a Docker daemon. probeContextFn is the half that needs one.
+var (
+	useContextFn     = UseContext
+	resetClientFn    = ResetClient
+	currentContextFn = GetCurrentContext
+	probeContextFn   = probeActiveContext
+)
+
 // ValidateContext checks if a context switch would succeed by attempting to connect
 func ValidateContext(ctx context.Context, contextName string) error {
+	// A switch cannot take effect while DOCKER_CONTEXT names something else,
+	// so report that instead of writing config.json and claiming success.
+	// Naming the same context is not a conflict — nothing has to move.
+	if env := os.Getenv("DOCKER_CONTEXT"); env != "" && env != contextName {
+		return fmt.Errorf("%w to '%s' — unset it to switch to '%s'", ErrContextPinnedByEnv, env, contextName)
+	}
+
 	// Save current context
-	currentCtx, err := GetCurrentContext()
+	currentCtx, err := currentContextFn()
 	if err != nil {
 		return fmt.Errorf("failed to get current context: %w", err)
 	}
 
 	// Try switching to the new context
-	if err := UseContext(contextName); err != nil {
+	if err := useContextFn(contextName); err != nil {
 		return err
 	}
+	// The client is a process-wide singleton built for the context we just
+	// left. Without dropping it, every check below would describe that
+	// context and pass whatever the new one is doing.
+	resetClientFn()
 
-	// Try to create a client and ping
+	if err := probeContextFn(ctx, contextName); err != nil {
+		// Switch back to original context, and drop the client built for the
+		// one being rejected.
+		_ = useContextFn(currentCtx)
+		resetClientFn()
+		return err
+	}
+	return nil
+}
+
+// probeActiveContext connects to whichever context is now active and reports
+// whether it is reachable and part of a usable swarm. contextName names it in
+// the error text only.
+func probeActiveContext(ctx context.Context, contextName string) error {
 	cli, err := GetClient()
 	if err != nil {
-		// Switch back to original context
-		_ = UseContext(currentCtx)
 		return fmt.Errorf("failed to connect to context %s: %w", contextName, err)
 	}
 	// Verify connection with ping
 	if _, err := cli.Ping(ctx); err != nil {
-		// Switch back to original context
-		_ = UseContext(currentCtx)
 		return fmt.Errorf("failed to ping context %s: %w", contextName, err)
 	}
 
@@ -182,14 +218,11 @@ func ValidateContext(ctx context.Context, contextName string) error {
 		if IsSwarmLockedErr(err) {
 			return nil
 		}
-		_ = UseContext(currentCtx)
 		return fmt.Errorf("failed to query info for context %s: %w", contextName, err)
 	}
 	if !isUsableSwarmState(info.Swarm.LocalNodeState) {
-		_ = UseContext(currentCtx)
 		return fmt.Errorf("context %s is not part of a Docker Swarm cluster", contextName)
 	}
-
 	return nil
 }
 

--- a/docker/context_validate_test.go
+++ b/docker/context_validate_test.go
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package docker
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// validateSeams records the order of the side effects ValidateContext performs,
+// which is the whole of what it gets wrong when the client is not reset: the
+// probe has to happen *after* the switch and *after* the client is dropped, or
+// it describes the context being left rather than the one being entered.
+type validateSeams struct {
+	trace    []string
+	current  string
+	curErr   error
+	useErr   error
+	probeErr error
+}
+
+func stubValidateSeams(t *testing.T, s *validateSeams) {
+	t.Helper()
+	origUse, origReset := useContextFn, resetClientFn
+	origCurrent, origProbe := currentContextFn, probeContextFn
+	t.Cleanup(func() {
+		useContextFn, resetClientFn = origUse, origReset
+		currentContextFn, probeContextFn = origCurrent, origProbe
+	})
+
+	if s.current == "" {
+		s.current = "old"
+	}
+	useContextFn = func(name string) error {
+		s.trace = append(s.trace, "use:"+name)
+		return s.useErr
+	}
+	resetClientFn = func() { s.trace = append(s.trace, "reset") }
+	currentContextFn = func() (string, error) { return s.current, s.curErr }
+	probeContextFn = func(context.Context, string) error {
+		s.trace = append(s.trace, "probe")
+		return s.probeErr
+	}
+	// Inherited from the developer's shell, this would short-circuit the
+	// function under test.
+	t.Setenv("DOCKER_CONTEXT", "")
+}
+
+// The cached client is a process-wide singleton built for the previous
+// context. Probing before dropping it validates the context being left, which
+// is how an unreachable target used to pass.
+func TestValidateContext_DropsTheCachedClientBeforeProbing(t *testing.T) {
+	s := &validateSeams{}
+	stubValidateSeams(t, s)
+
+	require.NoError(t, ValidateContext(context.Background(), "new"))
+	require.Equal(t, []string{"use:new", "reset", "probe"}, s.trace)
+}
+
+// A target that does not answer must leave the machine exactly as it was —
+// original context current, and no client left over from the rejected one.
+func TestValidateContext_UnreachableTargetRevertsAndDropsItsClient(t *testing.T) {
+	boom := errors.New("failed to ping context new: connection refused")
+	s := &validateSeams{probeErr: boom}
+	stubValidateSeams(t, s)
+
+	err := ValidateContext(context.Background(), "new")
+	require.ErrorIs(t, err, boom, "the probe's reason must reach the caller unchanged")
+	require.Equal(t, []string{"use:new", "reset", "probe", "use:old", "reset"}, s.trace)
+}
+
+// DOCKER_CONTEXT is resolved ahead of ~/.docker/config.json, so switching
+// elsewhere would not change what this process talks to. Reporting success
+// there is the lie; refuse before touching anything.
+func TestValidateContext_RefusesWhenPinnedElsewhereByEnv(t *testing.T) {
+	s := &validateSeams{}
+	stubValidateSeams(t, s)
+	t.Setenv("DOCKER_CONTEXT", "pinned")
+
+	err := ValidateContext(context.Background(), "new")
+	require.ErrorIs(t, err, ErrContextPinnedByEnv)
+	require.Contains(t, err.Error(), "pinned")
+	require.Contains(t, err.Error(), "new")
+	require.Empty(t, s.trace, "nothing may be switched or reset when the switch cannot take effect")
+}
+
+// Pinning the very context being validated is not a conflict: the process is
+// already there, and the caller only wants to know it works.
+func TestValidateContext_EnvNamingTheSameContextIsNotAConflict(t *testing.T) {
+	s := &validateSeams{}
+	stubValidateSeams(t, s)
+	t.Setenv("DOCKER_CONTEXT", "new")
+
+	require.NoError(t, ValidateContext(context.Background(), "new"))
+	require.Equal(t, []string{"use:new", "reset", "probe"}, s.trace)
+}
+
+// Without a context to revert to there is nothing safe to do, so the switch
+// must not be attempted at all.
+func TestValidateContext_UnknownCurrentContextSwitchesNothing(t *testing.T) {
+	s := &validateSeams{curErr: errors.New("docker context show: exit 1")}
+	stubValidateSeams(t, s)
+
+	require.Error(t, ValidateContext(context.Background(), "new"))
+	require.Empty(t, s.trace)
+}
+
+// A failed `docker context use` has moved nothing, so there is nothing to
+// revert and no client to drop.
+func TestValidateContext_FailedSwitchDoesNotRevert(t *testing.T) {
+	s := &validateSeams{useErr: errors.New("no such context")}
+	stubValidateSeams(t, s)
+
+	require.Error(t, ValidateContext(context.Background(), "new"))
+	require.Equal(t, []string{"use:new"}, s.trace)
+}


### PR DESCRIPTION
Closes #563.

`ValidateContext` switched to the target context and then checked the connection through `GetClient()`, which returns a process-wide cached client. Nothing dropped that client first, so inside a running TUI — where one is always cached — the ping and the swarm-state check described the context being *left* and returned success whatever the target was doing. `:contexts` has therefore never actually validated a switch; it only looked like it did because the app's snapshot load fails afterwards and reverts, with a vaguer reason and a detour through the loading view.

## Changes

- **Reset the client immediately after the switch**, so the checks describe the context they name. `docker/client.go` already documented the requirement — "Call `ResetClient` to force a fresh client (e.g. after a context switch)" — and this was the one caller that switched without doing it.
- **Reset again after a revert**, so a rejected context does not leave its client cached for the next caller.
- **Refuse up front when `DOCKER_CONTEXT` names a different context.** The variable is resolved ahead of `~/.docker/config.json`, so `docker context use` writes a file this process ignores and the switch cannot take effect — reporting success was a second way of saying "switched" when nothing had moved. New sentinel `ErrContextPinnedByEnv`. Naming the *same* context is not a conflict and still validates, which is what the locked-swarm integration test relies on.
- The connection checks move into `probeActiveContext` **unchanged** — same order, same error strings, same locked-swarm allowance — which is what lets the switch/revert bookkeeping be tested without a daemon.

## Behaviour change worth noting at release

Switches that today succeed and are then quietly reverted by the snapshot path will now fail up front in the contexts view's error dialog, with the real reason. That is the fix, not a regression.

## Testing

Six unit tests over the seams (`docker/context_validate_test.go`), asserting the *order* of the side effects, since "probe after switch, after reset" is exactly what was wrong. Verified by mutation: removing the reset fails three of them. `go test ./...` and `golangci-lint run ./... --build-tags=integration` are green; the locked-swarm integration test compiles and its `DOCKER_CONTEXT` usage is explicitly preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
