### PR TITLE
feat(logs): the view's options read as a status row, not a sentence

### DIFF
--- a/ui/framedbox.go
+++ b/ui/framedbox.go
@@ -19,7 +19,7 @@ func RenderViewFrame(title, header, content, footer string, width, height int, f
 		titleLine := lipgloss.NewStyle().
 			Width(width).
 			Align(lipgloss.Center).
-			Render(styleFrameTitle(title))
+			Render(fitTitle(styleFrameTitle(title), width))
 
 		rows := []string{titleLine}
 		if header != "" {

--- a/ui/framedbox_test.go
+++ b/ui/framedbox_test.go
@@ -41,6 +41,29 @@ func TestRenderViewFrame_OccupiesExactlyHeight(t *testing.T) {
 	}
 }
 
+// TestRenderViewFrame_LongTitleKeepsTheHeight — the fullscreen title line is
+// centred in a fixed width, which wraps an over-long title onto further rows
+// and pushes the frame past the height it was given.
+func TestRenderViewFrame_LongTitleKeepsTheHeight(t *testing.T) {
+	title := strings.Repeat("Logs(a-long-stack/a-long-service)", 3)
+
+	fullscreen := RenderViewFrame(title, "hdr", "body", "ftr", 40, 8, true)
+	require.Equal(t, 8, lipgloss.Height(fullscreen))
+	for i, row := range strings.Split(fullscreen, "\n") {
+		require.LessOrEqual(t, lipgloss.Width(row), 40, "fullscreen row %d", i)
+	}
+
+	// The bordered layout draws to width+4; every row of the box, the title's
+	// top border included, has to be that same width.
+	framed := RenderViewFrame(title, "hdr", "body", "ftr", 40, 8, false)
+	require.Equal(t, 8, lipgloss.Height(framed))
+	rows := strings.Split(framed, "\n")
+	bottom := lipgloss.Width(rows[len(rows)-1])
+	for i, row := range rows {
+		require.Equal(t, bottom, lipgloss.Width(row), "framed row %d", i)
+	}
+}
+
 // TestRenderViewFrame_FullscreenKeepsHeaderAndFooter — fullscreen dropped the
 // footer while the caller had already reserved its rows.
 func TestRenderViewFrame_FullscreenKeepsHeaderAndFooter(t *testing.T) {

--- a/ui/toggles.go
+++ b/ui/toggles.go
@@ -37,14 +37,21 @@ type Toggle struct {
 	Tone  ToggleTone
 }
 
-// ToggleRow renders items as "Label:Value" spread evenly across width, so a
-// view's options read at a glance instead of hiding in prose. The result is
-// always a single line no wider than width: the row is a frame header, and a
-// header that grows a second line silently shrinks the content the frame draws.
+// toggleGap is the space between items once they all fit. The slack is not
+// handed to the gaps beyond it: on a wide terminal that pushes the items to
+// opposite edges, where they read as four unrelated labels rather than as one
+// status row. It matches the help bar's column gap.
+const toggleGap = 3
+
+// ToggleRow renders items as "Label:Value", gapped by toggleGap and centred in
+// width, so a view's options read at a glance instead of hiding in prose. The
+// result is always a single line no wider than width: the row is a frame
+// header, and a header that grows a second line silently shrinks the content
+// the frame draws.
 //
-// When the items do not fit they are dropped from the right and the cut is
-// marked with "…", rather than truncated mid-item — a value cut to "Hid" reads
-// as a state rather than as missing text.
+// A narrowing terminal closes the gaps first and only then drops items, from
+// the right, marking the cut with "…" rather than truncating mid-item — a value
+// cut to "Hid" reads as a state rather than as missing text.
 func ToggleRow(items []Toggle, width int) string {
 	if len(items) == 0 {
 		return ""
@@ -60,16 +67,20 @@ func ToggleRow(items []Toggle, width int) string {
 		total += lipgloss.Width(rendered[i])
 	}
 
-	// Everything fits: hand the slack to the gaps between items.
-	if total+len(rendered)-1 <= width {
-		return spreadRow(rendered, width, total)
+	// Everything fits at a one-space gap: take the widest gap width affords.
+	if gaps := len(rendered) - 1; total+gaps <= width {
+		gap := toggleGap
+		if gaps > 0 {
+			gap = min(toggleGap, (width-total)/gaps)
+		}
+		return centerRow(strings.Join(rendered, strings.Repeat(" ", gap)), width)
 	}
 
 	for len(rendered) > 1 {
 		rendered = rendered[:len(rendered)-1]
 		line := strings.Join(rendered, " ") + " …"
 		if lipgloss.Width(line) <= width {
-			return line
+			return centerRow(line, width)
 		}
 	}
 	return ansi.Truncate(rendered[0], width, "…")
@@ -87,27 +98,13 @@ func renderToggle(item Toggle) string {
 	return titleLabelStyle.Render(item.Label+":") + value.Render(item.Value)
 }
 
-// spreadRow distributes width-total spaces across the gaps between items, the
-// remainder going to the leftmost gaps, so the row ends flush with the right
-// edge. total is the summed width of items.
-func spreadRow(items []string, width, total int) string {
-	gaps := len(items) - 1
-	if gaps == 0 {
-		return items[0]
+// centerRow pads a row so it sits in the middle of width, under the centred
+// frame title it belongs to. There is no trailing padding: the frame pads every
+// line it draws to its own width.
+func centerRow(row string, width int) string {
+	pad := (width - lipgloss.Width(row)) / 2
+	if pad <= 0 {
+		return row
 	}
-
-	slack := width - total
-	var b strings.Builder
-	for i, item := range items {
-		b.WriteString(item)
-		if i == gaps {
-			break
-		}
-		gap := slack / gaps
-		if i < slack%gaps {
-			gap++
-		}
-		b.WriteString(strings.Repeat(" ", gap))
-	}
-	return b.String()
+	return strings.Repeat(" ", pad) + row
 }

--- a/ui/toggles.go
+++ b/ui/toggles.go
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package ui
+
+import (
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
+)
+
+// ToggleTone selects the colour a toggle's value carries.
+type ToggleTone int
+
+const (
+	// ToggleOff dims the value: the option is not engaged.
+	ToggleOff ToggleTone = iota
+	// ToggleOn highlights the value: the option is engaged.
+	ToggleOn
+	// ToggleInfo marks a value that is not a yes/no — a node name, a query.
+	ToggleInfo
+)
+
+// Toggle value styles. Labels reuse the frame title's label colour so a status
+// row reads as part of the same header as the title above it.
+var (
+	toggleOnStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("#00ff87")).Bold(true)
+	toggleOffStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("240"))
+	toggleInfoStyle = titleScopeStyle
+)
+
+// Toggle is one "Label:Value" item of a status row.
+type Toggle struct {
+	Label string
+	Value string
+	Tone  ToggleTone
+}
+
+// ToggleRow renders items as "Label:Value" spread evenly across width, so a
+// view's options read at a glance instead of hiding in prose. The result is
+// always a single line no wider than width: the row is a frame header, and a
+// header that grows a second line silently shrinks the content the frame draws.
+//
+// When the items do not fit they are dropped from the right and the cut is
+// marked with "…", rather than truncated mid-item — a value cut to "Hid" reads
+// as a state rather than as missing text.
+func ToggleRow(items []Toggle, width int) string {
+	if len(items) == 0 {
+		return ""
+	}
+	if width <= 0 {
+		width = 80
+	}
+
+	rendered := make([]string, len(items))
+	total := 0
+	for i, item := range items {
+		rendered[i] = renderToggle(item)
+		total += lipgloss.Width(rendered[i])
+	}
+
+	// Everything fits: hand the slack to the gaps between items.
+	if total+len(rendered)-1 <= width {
+		return spreadRow(rendered, width, total)
+	}
+
+	for len(rendered) > 1 {
+		rendered = rendered[:len(rendered)-1]
+		line := strings.Join(rendered, " ") + " …"
+		if lipgloss.Width(line) <= width {
+			return line
+		}
+	}
+	return ansi.Truncate(rendered[0], width, "…")
+}
+
+// renderToggle renders one "Label:Value" item, the value coloured by its tone.
+func renderToggle(item Toggle) string {
+	value := toggleOffStyle
+	switch item.Tone {
+	case ToggleOn:
+		value = toggleOnStyle
+	case ToggleInfo:
+		value = toggleInfoStyle
+	}
+	return titleLabelStyle.Render(item.Label+":") + value.Render(item.Value)
+}
+
+// spreadRow distributes width-total spaces across the gaps between items, the
+// remainder going to the leftmost gaps, so the row ends flush with the right
+// edge. total is the summed width of items.
+func spreadRow(items []string, width, total int) string {
+	gaps := len(items) - 1
+	if gaps == 0 {
+		return items[0]
+	}
+
+	slack := width - total
+	var b strings.Builder
+	for i, item := range items {
+		b.WriteString(item)
+		if i == gaps {
+			break
+		}
+		gap := slack / gaps
+		if i < slack%gaps {
+			gap++
+		}
+		b.WriteString(strings.Repeat(" ", gap))
+	}
+	return b.String()
+}

--- a/ui/toggles_test.go
+++ b/ui/toggles_test.go
@@ -33,45 +33,42 @@ func sampleToggles() []Toggle {
 	}
 }
 
-func TestToggleRow_SpreadsToWidth(t *testing.T) {
+func TestToggleRow_CentersTheBlock(t *testing.T) {
 	trueColour(t)
 
-	row := ToggleRow(sampleToggles(), 100)
+	const width = 100
+	stripped := ansi.Strip(ToggleRow(sampleToggles(), width))
 
-	require.Equal(t, 100, lipgloss.Width(row), "row should end flush with the right edge")
-	stripped := ansi.Strip(row)
+	// The items keep their own gap and the slack stays outside them: on a wide
+	// terminal a spread row puts the first and last item on opposite edges.
 	require.Regexp(t,
-		`^Autoscroll:On +Wrap:Off +Node:worker-1 +Stopped:Hidden$`,
+		`^ +Autoscroll:On {3}Wrap:Off {3}Node:worker-1 {3}Stopped:Hidden$`,
+		stripped)
+
+	left := len(stripped) - len(strings.TrimLeft(stripped, " "))
+	right := width - len(stripped)
+	require.LessOrEqual(t, abs(left-right), 1, "block is centred: %d left, %d right", left, right)
+}
+
+func TestToggleRow_TightensGapsBeforeDropping(t *testing.T) {
+	trueColour(t)
+
+	// 48 columns of items: too narrow for the full gap, wide enough to keep
+	// every item at a tighter one. An item dropped here would be information
+	// lost to spacing.
+	stripped := ansi.Strip(ToggleRow(sampleToggles(), 52))
+
+	require.NotContains(t, stripped, "…")
+	require.Regexp(t,
+		`^ *Autoscroll:On +Wrap:Off +Node:worker-1 +Stopped:Hidden$`,
 		stripped)
 }
 
-func TestToggleRow_GapsAreEven(t *testing.T) {
-	trueColour(t)
-
-	// The slack is shared out rather than parked in one gap: no two gaps may
-	// differ by more than the one-space remainder.
-	stripped := ansi.Strip(ToggleRow(sampleToggles(), 100))
-
-	var gaps []int
-	run := 0
-	for _, r := range stripped {
-		if r == ' ' {
-			run++
-			continue
-		}
-		if run > 0 {
-			gaps = append(gaps, run)
-			run = 0
-		}
+func abs(n int) int {
+	if n < 0 {
+		return -n
 	}
-	require.Len(t, gaps, 3)
-
-	widest, narrowest := gaps[0], gaps[0]
-	for _, g := range gaps {
-		widest = max(widest, g)
-		narrowest = min(narrowest, g)
-	}
-	require.LessOrEqual(t, widest-narrowest, 1)
+	return n
 }
 
 func TestToggleRow_IsAlwaysOneLine(t *testing.T) {

--- a/ui/toggles_test.go
+++ b/ui/toggles_test.go
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
+	"github.com/muesli/termenv"
+	"github.com/stretchr/testify/require"
+)
+
+// trueColour makes a test's assertions run against styled strings. The default
+// profile under `go test` is Ascii, where every style renders as plain text —
+// so a width computed with len() instead of lipgloss.Width would pass here and
+// break on a real terminal.
+func trueColour(t *testing.T) {
+	t.Helper()
+	prev := lipgloss.ColorProfile()
+	lipgloss.SetColorProfile(termenv.TrueColor)
+	t.Cleanup(func() { lipgloss.SetColorProfile(prev) })
+}
+
+func sampleToggles() []Toggle {
+	return []Toggle{
+		{Label: "Autoscroll", Value: "On", Tone: ToggleOn},
+		{Label: "Wrap", Value: "Off", Tone: ToggleOff},
+		{Label: "Node", Value: "worker-1", Tone: ToggleInfo},
+		{Label: "Stopped", Value: "Hidden", Tone: ToggleOn},
+	}
+}
+
+func TestToggleRow_SpreadsToWidth(t *testing.T) {
+	trueColour(t)
+
+	row := ToggleRow(sampleToggles(), 100)
+
+	require.Equal(t, 100, lipgloss.Width(row), "row should end flush with the right edge")
+	stripped := ansi.Strip(row)
+	require.Regexp(t,
+		`^Autoscroll:On +Wrap:Off +Node:worker-1 +Stopped:Hidden$`,
+		stripped)
+}
+
+func TestToggleRow_GapsAreEven(t *testing.T) {
+	trueColour(t)
+
+	// The slack is shared out rather than parked in one gap: no two gaps may
+	// differ by more than the one-space remainder.
+	stripped := ansi.Strip(ToggleRow(sampleToggles(), 100))
+
+	var gaps []int
+	run := 0
+	for _, r := range stripped {
+		if r == ' ' {
+			run++
+			continue
+		}
+		if run > 0 {
+			gaps = append(gaps, run)
+			run = 0
+		}
+	}
+	require.Len(t, gaps, 3)
+
+	widest, narrowest := gaps[0], gaps[0]
+	for _, g := range gaps {
+		widest = max(widest, g)
+		narrowest = min(narrowest, g)
+	}
+	require.LessOrEqual(t, widest-narrowest, 1)
+}
+
+func TestToggleRow_IsAlwaysOneLine(t *testing.T) {
+	trueColour(t)
+
+	// A frame header that grows a second line silently shrinks the content the
+	// frame draws — see ui.ContentRows.
+	for width := 1; width <= 200; width++ {
+		row := ToggleRow(sampleToggles(), width)
+		require.NotContains(t, row, "\n", "width %d", width)
+		require.LessOrEqual(t, lipgloss.Width(row), width, "width %d", width)
+	}
+}
+
+func TestToggleRow_DropsWholeItemsWhenNarrow(t *testing.T) {
+	trueColour(t)
+
+	row := ansi.Strip(ToggleRow(sampleToggles(), 30))
+
+	require.True(t, strings.HasSuffix(row, "…"), "the cut is marked: %q", row)
+	require.Contains(t, row, "Autoscroll:On")
+	require.NotContains(t, row, "Stopped", "a dropped item leaves no fragment behind")
+	require.NotContains(t, row, "Node")
+}
+
+func TestToggleRow_TruncatesASingleOverlongItem(t *testing.T) {
+	trueColour(t)
+
+	row := ToggleRow([]Toggle{{Label: "Node", Value: strings.Repeat("x", 40), Tone: ToggleInfo}}, 12)
+
+	require.Equal(t, 12, lipgloss.Width(row))
+	require.True(t, strings.HasSuffix(ansi.Strip(row), "…"))
+}
+
+func TestToggleRow_Empty(t *testing.T) {
+	require.Equal(t, "", ToggleRow(nil, 80))
+}
+
+func TestToggleRow_TonesAreDistinct(t *testing.T) {
+	trueColour(t)
+
+	row := ToggleRow(sampleToggles(), 100)
+
+	// Labels share the frame title's label colour; each tone renders its value
+	// in its own colour, so on/off is legible without reading the words.
+	require.Contains(t, row, titleLabelStyle.Render("Autoscroll:"))
+	require.Contains(t, row, toggleOnStyle.Render("On"))
+	require.Contains(t, row, toggleOffStyle.Render("Off"))
+	require.Contains(t, row, toggleInfoStyle.Render("worker-1"))
+
+	require.NotEqual(t, toggleOnStyle.Render("x"), toggleOffStyle.Render("x"))
+	require.NotEqual(t, toggleOnStyle.Render("x"), toggleInfoStyle.Render("x"))
+	require.NotEqual(t, toggleOffStyle.Render("x"), toggleInfoStyle.Render("x"))
+}

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -43,6 +43,18 @@ func styleFrameTitle(title string) string {
 	return FrameTitleStyle.Render(title)
 }
 
+// fitTitle truncates a title to the width the frame has for it. Neither layout
+// survives a title that overhangs: the bordered one clamps its padding at zero
+// and draws a top line wider than the rest of the box, and the fullscreen one
+// centres the title in a fixed width, which wraps it onto rows the frame never
+// budgeted for.
+func fitTitle(title string, width int) string {
+	if width < 1 || lipgloss.Width(title) <= width {
+		return title
+	}
+	return ansi.Truncate(title, width, "…")
+}
+
 // RenderFramedBox draws a bordered frame with title, optional header, and content.
 // If width <= 0, defaults to content width + padding.
 // ANSI sequences in content are preserved.
@@ -82,6 +94,8 @@ func RenderFramedBox(title, header, content, footer string, width int) string {
 			borderStyle.Render("┐"),
 		)
 	} else {
+		titleStyled = fitTitle(titleStyled, borderWidth)
+
 		// Top border with centered title
 		leftPad := (borderWidth - lipgloss.Width(titleStyled)) / 2
 		if leftPad < 0 {

--- a/ui/ui_test.go
+++ b/ui/ui_test.go
@@ -44,6 +44,20 @@ func TestTruncateANSIAfter_WidthAware(t *testing.T) {
 	require.Equal(t, "", TruncateANSIAfter("hi", 10))
 }
 
+func TestRenderFramedBox_TruncatesAnOverlongTitle(t *testing.T) {
+	trueColour(t)
+
+	const w = 40
+	box := RenderFramedBox(strings.Repeat("Logs(a-very-long-stack/service)", 3), "", "line", "", w)
+
+	lines := strings.Split(box, "\n")
+	require.Greater(t, len(lines), 2)
+	for i, line := range lines {
+		require.Equal(t, w, lipgloss.Width(line), "line %d must not overhang the box", i)
+	}
+	require.Contains(t, lines[0], "…", "the cut is marked")
+}
+
 // Regression for issue #369: the centered overlay must keep its left border on
 // the same display column for every row, even when the background log lines
 // contain wide characters at differing positions. The old rune-counting

--- a/views/logs/logs_test.go
+++ b/views/logs/logs_test.go
@@ -13,7 +13,10 @@ import (
 	"github.com/Eldara-Tech/swarmcli/docker"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
 	"github.com/docker/docker/api/types/swarm"
+	"github.com/muesli/termenv"
 	"github.com/stretchr/testify/require"
 )
 
@@ -446,11 +449,12 @@ func TestView_Normal(t *testing.T) {
 	m.Visible = true
 	m.viewport.Width = 80
 	m.viewport.Height = 24
-	out := m.View()
-	require.Contains(t, out, "Service: web")
-	require.Contains(t, out, "AutoScroll: on")
-	require.Contains(t, out, "wrap: on")
-	require.Contains(t, out, "Stopped: hidden")
+	out := ansi.Strip(m.View())
+	require.Contains(t, out, "Logs(web)[0]")
+	require.Contains(t, out, "Autoscroll:On")
+	require.Contains(t, out, "Wrap:On")
+	require.Contains(t, out, "Node:all")
+	require.Contains(t, out, "Stopped:Hidden")
 }
 
 func TestView_SearchMode(t *testing.T) {
@@ -460,8 +464,8 @@ func TestView_SearchMode(t *testing.T) {
 	m.viewport.Height = 24
 	m.mode = "search"
 	m.searchTerm = "test"
-	out := m.View()
-	require.Contains(t, out, "Search: test")
+	out := ansi.Strip(m.View())
+	require.Contains(t, out, "Search:test_")
 }
 
 func TestView_NodeFilter(t *testing.T) {
@@ -470,8 +474,134 @@ func TestView_NodeFilter(t *testing.T) {
 	m.viewport.Width = 80
 	m.viewport.Height = 24
 	m.setNodeFilter("worker1")
-	out := m.View()
-	require.Contains(t, out, "node: worker1")
+	out := ansi.Strip(m.View())
+	require.Contains(t, out, "Node:worker1")
+}
+
+// --- frame title / header ---
+
+func TestFrameTitle_ScopesAndCounts(t *testing.T) {
+	m := testModel()
+	m.ServiceEntry.StackName = "postgres-ha"
+	m.SetContent("one\ntwo\nthree")
+
+	require.Equal(t, "Logs(postgres-ha/web)[3]", ansi.Strip(m.FrameTitle()))
+
+	// A service in no stack keeps the scope to the service name.
+	m.ServiceEntry.StackName = ""
+	require.Equal(t, "Logs(web)[3]", ansi.Strip(m.FrameTitle()))
+}
+
+func TestFrameTitle_CountIsPostFilter(t *testing.T) {
+	m := hideStoppedModel()
+	m.mu.Lock()
+	m.lines = []string{"running line", "stopped line"}
+	m.lineTasks = []string{"task-run", "task-stop"}
+	m.lineNodes = []string{"n", "n"}
+	m.mu.Unlock()
+	m.viewport.SetContent(m.buildContent())
+
+	require.Equal(t, "Logs(web)[1]", ansi.Strip(m.FrameTitle()), "the hidden stopped line is not counted")
+
+	m.setHideStopped(false)
+	m.viewport.SetContent(m.buildContent())
+	require.Equal(t, "Logs(web)[2]", ansi.Strip(m.FrameTitle()))
+}
+
+func TestFrameTitle_ShowsTheAppFilter(t *testing.T) {
+	m := testModel()
+	m.SetContent("alpha\nbeta")
+	m.ApplySearchQuery("alp")
+
+	require.Equal(t, "Logs(web)[1] </alp>", ansi.Strip(m.FrameTitle()))
+}
+
+func TestFrameHeader_ReflectsEveryToggle(t *testing.T) {
+	trueColour(t)
+
+	m := testModel()
+	m.Visible = true
+	m.viewport.Width = 100
+
+	require.Equal(t,
+		[]string{"Autoscroll:On", "Wrap:On", "Node:all", "Stopped:Hidden"},
+		headerItems(m))
+
+	m.Update(key("s"))
+	m.Update(key("w"))
+	m.Update(key("t"))
+	m.setNodeFilter("worker1")
+
+	require.Equal(t,
+		[]string{"Autoscroll:Off", "Wrap:Off", "Node:worker1", "Stopped:Shown"},
+		headerItems(m))
+}
+
+func TestFrameHeader_ShowsSearchState(t *testing.T) {
+	m := testModel()
+	m.Visible = true
+	m.viewport.Width = 100
+	require.NotContains(t, ansi.Strip(m.FrameHeader()), "Search", "no search running, no item")
+
+	// Typing: the term so far, with a caret marking the field as live.
+	m.Update(key("ctrl+f"))
+	require.Contains(t, headerItems(m), "Search:_")
+	m.Update(key("e"))
+	require.Contains(t, headerItems(m), "Search:e_")
+
+	// Confirmed: the match counter the header used to spell out in prose.
+	m.mu.Lock()
+	m.lines = []string{"error one", "fine", "error two"}
+	m.lineNodes = []string{"", "", ""}
+	m.lineTasks = []string{"", "", ""}
+	m.mu.Unlock()
+	m.searchTerm = "error"
+	m.Update(key("enter"))
+	require.Contains(t, headerItems(m), "Search:error(1/2)")
+
+	m.Update(key("n"))
+	require.Contains(t, headerItems(m), "Search:error(2/2)")
+
+	// No matches, and a term long enough to be capped — an uncapped one would
+	// push the item past the row's width and lose it altogether.
+	m.searchTerm = "nothing-matches-at-all"
+	m.highlightContent()
+	require.Contains(t, headerItems(m), "Search:nothing-matches…(0)")
+}
+
+// TestFrameHeader_IsAlwaysOneRow — views/logs/update.go sizes the viewport to
+// what is left after the header, counting its rows. A header that wraps would
+// silently take rows off the log content.
+func TestFrameHeader_IsAlwaysOneRow(t *testing.T) {
+	trueColour(t)
+
+	m := testModel()
+	m.setNodeFilter("a-node-with-a-rather-long-hostname")
+	m.mode = "search"
+	m.searchTerm = strings.Repeat("x", 60)
+
+	for _, width := range []int{10, 20, 40, 80, 120, 200} {
+		m.viewport.Width = width
+		header := m.FrameHeader()
+		require.NotContains(t, header, "\n", "width %d", width)
+		require.LessOrEqual(t, lipgloss.Width(header), width, "width %d", width)
+	}
+}
+
+// headerItems is the frame header split back into its items, so a test names
+// the item it cares about instead of the spacing between them.
+func headerItems(m *Model) []string {
+	return strings.Fields(ansi.Strip(m.FrameHeader()))
+}
+
+// trueColour makes a test's assertions run against the styled header. The
+// default profile under `go test` is Ascii, where every style renders as plain
+// text — so nothing would exercise the ANSI-aware widths the row is built on.
+func trueColour(t *testing.T) {
+	t.Helper()
+	prev := lipgloss.ColorProfile()
+	lipgloss.SetColorProfile(termenv.TrueColor)
+	t.Cleanup(func() { lipgloss.SetColorProfile(prev) })
 }
 
 // --- buildContent tests ---

--- a/views/logs/model.go
+++ b/views/logs/model.go
@@ -30,6 +30,10 @@ type Model struct {
 	lineTasks     []string // full task ID for each line (parallel to lines), "" if unparseable
 	MaxLines      int
 	ready         bool
+	// visibleCount is how many lines passed the filters the last time content
+	// was built. Cached there rather than counted in FrameTitle, which runs on
+	// every render over a buffer of up to MaxLines.
+	visibleCount int
 
 	ServiceEntry docker.ServiceEntry
 
@@ -147,6 +151,12 @@ func (m *Model) getWrap() bool {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	return m.wrap
+}
+
+func (m *Model) getVisibleCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.visibleCount
 }
 
 func (m *Model) getHideStopped() bool {

--- a/views/logs/update.go
+++ b/views/logs/update.go
@@ -368,6 +368,7 @@ func (m *Model) buildContent() string {
 			filteredLines = append(filteredLines, line)
 		}
 	}
+	m.visibleCount = len(filteredLines)
 
 	// Join lines first
 	full := strings.Join(filteredLines, "\n")

--- a/views/logs/view.go
+++ b/views/logs/view.go
@@ -11,43 +11,79 @@ import (
 )
 
 func (m *Model) FrameTitle() string {
-	followStatus := "off"
-	if m.getFollow() {
-		followStatus = "on"
+	scope := m.ServiceEntry.ServiceName
+	if m.ServiceEntry.StackName != "" {
+		scope = m.ServiceEntry.StackName + "/" + scope
 	}
-	wrapStatus := "off"
-	if m.getWrap() {
-		wrapStatus = "on"
-	}
-	nodeFilter := m.getNodeFilter()
-	filterStatus := "all nodes"
-	if nodeFilter != "" {
-		filterStatus = fmt.Sprintf("node: %s", nodeFilter)
-	}
-	stoppedStatus := "hidden"
-	if !m.getHideStopped() {
-		stoppedStatus = "shown"
-	}
-	return fmt.Sprintf(
-		"Service: %s • AutoScroll: %s • wrap: %s • Filter: %s • Stopped: %s",
-		m.ServiceEntry.ServiceName,
-		followStatus,
-		wrapStatus,
-		filterStatus,
-		stoppedStatus,
-	)
+	return ui.ScopedTitleFiltered("Logs", scope, m.getVisibleCount(), m.getFilterQuery())
 }
 
+// FrameHeader renders the view's options as a status row, so what each toggle
+// is doing reads at a glance rather than out of a sentence in the title. It is
+// also the only place they appear in fullscreen, where the helpbar that names
+// the keys is not drawn.
 func (m *Model) FrameHeader() string {
-	header := "Logs"
-	if m.mode == "search" {
-		header = fmt.Sprintf("Logs — Search: %s", m.searchTerm)
-	} else if m.searchTerm != "" && len(m.searchMatches) > 0 {
-		matchCount := len(m.searchMatches)
-		currentMatch := m.searchIndex + 1
-		header = fmt.Sprintf("Logs — Found %d matches (viewing %d/%d) • Press 'ctrl+f' to search, 'n'/'N' to navigate", matchCount, currentMatch, matchCount)
+	node := "all"
+	if filter := m.getNodeFilter(); filter != "" {
+		node = filter
 	}
-	return ui.FrameHeaderStyle.Render(header)
+	// "Hidden" is the engaged state: hiding stopped tasks is what the toggle
+	// does, and it is the default.
+	stopped := ui.Toggle{Label: "Stopped", Value: "Shown", Tone: ui.ToggleOff}
+	if m.getHideStopped() {
+		stopped = ui.Toggle{Label: "Stopped", Value: "Hidden", Tone: ui.ToggleOn}
+	}
+
+	items := []ui.Toggle{
+		onOffToggle("Autoscroll", m.getFollow()),
+		onOffToggle("Wrap", m.getWrap()),
+		{Label: "Node", Value: node, Tone: ui.ToggleInfo},
+		stopped,
+	}
+	if search, ok := m.searchToggle(); ok {
+		items = append(items, search)
+	}
+	return ui.ToggleRow(items, m.viewport.Width)
+}
+
+func onOffToggle(label string, on bool) ui.Toggle {
+	if on {
+		return ui.Toggle{Label: label, Value: "On", Tone: ui.ToggleOn}
+	}
+	return ui.Toggle{Label: label, Value: "Off", Tone: ui.ToggleOff}
+}
+
+// maxSearchTermRunes caps the search term shown in the row. An uncapped term
+// pushes the item past the row's width, and ToggleRow drops from the right —
+// losing the very feedback the item exists to give.
+const maxSearchTermRunes = 16
+
+// searchToggle reports the "ctrl+f" search as a row item: the term while it is
+// being typed, then the match counter. It is absent when no search is running.
+// The app-level "/" filter is not here — it rides in the title, as in every
+// other view.
+func (m *Model) searchToggle() (ui.Toggle, bool) {
+	term := m.searchTerm
+	if r := []rune(term); len(r) > maxSearchTermRunes {
+		term = string(r[:maxSearchTermRunes-1]) + "…"
+	}
+
+	switch {
+	case m.mode == "search":
+		// The trailing caret marks the field as live: the term is empty for as
+		// long as it takes to type the first character.
+		return ui.Toggle{Label: "Search", Value: term + "_", Tone: ui.ToggleInfo}, true
+	case m.searchTerm == "":
+		return ui.Toggle{}, false
+	case len(m.searchMatches) == 0:
+		return ui.Toggle{Label: "Search", Value: fmt.Sprintf("%s(0)", term), Tone: ui.ToggleOff}, true
+	default:
+		return ui.Toggle{
+			Label: "Search",
+			Value: fmt.Sprintf("%s(%d/%d)", term, m.searchIndex+1, len(m.searchMatches)),
+			Tone:  ui.ToggleInfo,
+		}, true
+	}
 }
 
 func (m *Model) FrameFooter() string { return "" }


### PR DESCRIPTION
## Summary

- The log view's four toggles move out of the frame title — where they were one uniform-coloured run of prose, `Service: web • AutoScroll: on • wrap: on • Filter: all nodes • Stopped: hidden`, centred in the top border and wider than the box on most terminals — and into the header row, as labelled `Label:Value` items coloured by state: green engaged, dim not, the title's scope colour for a value that is not a yes/no. The header row previously spent itself on the word "Logs".
- The title takes the k9s `ScopedTitle` form every other list view already uses: `Logs(<stack>/<service>)[<lines>]`, with the `/` filter appended as the usual `</query>` fragment. The count is post-filter, so it tracks the node, hide-stopped and `/` filters.
- `ui.ToggleRow` is the new primitive, beside the other frame primitives in `ui/`. The items sit at a fixed gap and the block is centred under the title, so the row reads as one status line: the slack is *not* handed to the gaps, which on a wide terminal drives the first and last item to opposite edges and leaves four unrelated-looking fragments 30 columns apart. It never wraps and never overhangs: as the terminal narrows the gaps close to a single space first, and only then are items dropped from the right, the cut marked with `…` rather than truncating mid-item, where a value cut to `Hid` reads as a state. The row must stay exactly one line — `views/logs/update.go` sizes the viewport to what is left after the header, so a wrapped header silently takes rows off the log content.
- The row is also the only place the toggles appear in fullscreen, where the helpbar naming the keys is not drawn. The `ctrl+f` match counter joins it as `Search:<term>(2/7)` while a search runs.
- Also fixes an over-long title breaking the frame, which the old logs title triggered on any terminal narrower than it. Both layouts assumed a title that fits: the bordered one clamps its padding at zero and drew a top border wider than the rest of the box, and the fullscreen one centres the title in a fixed width, so lipgloss wrapped it onto rows the frame had not budgeted for — 8 rows drawn for a height of 6, undoing the guarantee #560 had just established. Both now truncate through one helper.

No keys change and no behaviour changes: the same four toggles, the same helpbar. `ui.Toggle`, `ui.ToggleTone` and `ui.ToggleRow` are additions; no exported signature is changed or removed.

Rendered at 100, 70 and 40 columns:

```
┌──────────────────────────────────────── Logs(shop/web)[1432] ────────────────────────────────────────┐
│           Autoscroll:On   Wrap:Off   Node:worker-2   Stopped:Hidden   Search:timeout(2/7)            │
│ 2026-08-13T09:14:02Z  request accepted                                                               │
└──────────────────────────────────────────────────────────────────────────────────────────────────────┘

┌───────────────────────── Logs(shop/web)[1432] ─────────────────────────┐
│         Autoscroll:On Wrap:Off Node:worker-2 Stopped:Hidden …          │
│ 2026-08-13T09:14:02Z  request accepted                                 │
└────────────────────────────────────────────────────────────────────────┘

┌────────── Logs(shop/web)[1432] ──────────┐
│  Autoscroll:On Wrap:Off Node:worker-2 …  │
│ 2026-08-13T09:14:02Z  request accepted   │
└──────────────────────────────────────────┘
```

## Test Plan

- [x] `go build ./...`
- [x] `go test ./...` — full suite green
- [x] `golangci-lint run ./...` — 0 issues
- [x] `go test ./ui/... ./views/logs/...` — covers the new `ToggleRow` (centred block, uniform gaps, gaps close before any item is dropped, always one line, drops whole items when narrow, truncates a single overlong item, empty, tones distinct), the title (scope, post-filter count, app filter), the header (reflects every toggle, search state, always one row), and the frame (`RenderFramedBox` truncates an overlong title, `RenderViewFrame` keeps its height)
- [ ] Manual: open a service's logs, toggle autoscroll / wrap / node filter / hide-stopped, confirm each value flips colour in the header row
- [ ] Manual: enter fullscreen (helpbar hidden) and confirm the toggles are still readable and the frame height is exact
- [ ] Manual: on a wide terminal, confirm the row stays a centred block under the title rather than spreading to both edges
- [ ] Manual: narrow the terminal to ~70 and ~40 columns and confirm the gaps tighten first, then items drop from the right with `…` rather than truncating mid-value, and the frame border stays intact
- [ ] Manual: `ctrl+f` search, confirm `Search:<term>(n/m)` appears in the row and `n`/`N` advance it

Fixes #561
