### PR TITLE
build(release): the oss qualifier moves to the end, so the default build lists first

### DIFF
--- a/.github/UPGRADE_NOTES.md
+++ b/.github/UPGRADE_NOTES.md
@@ -12,11 +12,11 @@ Clear it back to this comment once the GA is cut.
 about the executable changes — same name, same flags, same behaviour with no
 licence — but the artefact you get from the unsuffixed name now contains
 licensed code that is inert until a licence verifies. The wholly Apache-2.0
-build is published beside it as `swarmcli-oss`.
+build is published beside it, suffixed `oss`.
 
 | Was | Is now | The Apache-2.0 build is |
 |---|---|---|
-| `swarmcli_Linux_x86_64.tar.gz` | Business Edition build | `swarmcli-oss_Linux_x86_64.tar.gz` |
+| `swarmcli_Linux_x86_64.tar.gz` | Business Edition build | `swarmcli_Linux_x86_64_oss.tar.gz` |
 | `checksums.txt` | `checksums-merged.txt` (BE) | `checksums-oss.txt` |
 | `eldaratech/swarmcli:v1.14.0`, `:latest` | Business Edition build | `eldaratech/swarmcli:v1.14.0-oss` |
 | `brew install swarmcli` | Business Edition build | `brew install Eldara-Tech/tap/swarmcli-oss` |
@@ -35,6 +35,14 @@ they want: the plain names now resolve to a different artefact and
 `checksums-oss.txt` or `checksums-merged.txt`, which are separate files because
 a release now carries two sets of artefacts and one manifest could not say which
 set it covered.
+
+The two release candidates for this version published the Apache-2.0 archives as
+`swarmcli-oss_<OS>_<ARCH>` instead, with the qualifier at the front. Only the
+suffixed name ships in a GA: as a prefix it sorted every Apache-2.0 archive above
+every Business Edition one on the release page, and the releases index — which
+shows a release's first ten assets — then listed none of the default build at
+all. Nothing but the asset name changed; the cask, the Scoop manifest and the
+image tag are `swarmcli-oss` and `:<tag>-oss` as before.
 
 **A tag on this repository alone no longer moves `:latest`.** The unsuffixed
 image tags belong to the merged build, which is published by a second pipeline

--- a/.github/release_template.yml
+++ b/.github/release_template.yml
@@ -35,6 +35,37 @@ categories:
         - 'D0-dependency'
 change-template: '- $TITLE (#$NUMBER) @$AUTHOR '
 change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
+# The artefact legend, above the changelog because the assets list is where the
+# question gets asked. It lives here rather than in a release.yml step for two
+# reasons: the drafter re-renders this body on every run, so a legend written
+# here cannot be duplicated by a re-pushed tag, and it needs no version — it
+# names the shapes the assets take, not this release's URLs. release.yml
+# prepends any Upgrade Notes above it, and the private wrapper appends its own
+# delimited region below all of this.
+#
+# It describes the naming scheme rather than asserting both halves are present:
+# if the private tag has not run, or failed, the assets list is what says so.
+#
+# The rows are in the order the assets themselves appear. GitHub renders them
+# sorted by lower(name) in codepoint order, which is why the qualifier sits at
+# the end of the Apache-2.0 archive names — see .goreleaser.yml.
 template: |
+  ## Which download is which
+
+  One tag, two builds of the same command:
+
+  | | Contains | Licence |
+  |---|---|---|
+  | `swarmcli_<OS>_<ARCH>.tar.gz`, `eldaratech/swarmcli:<version>`, `:latest`, the `swarmcli` cask and Scoop manifest | this repository, plus licensed code that is inert until a licence verifies | this repository's code is Apache-2.0; the licensed code is proprietary |
+  | `swarmcli_<OS>_<ARCH>_oss.tar.gz`, `eldaratech/swarmcli:<version>-oss`, the `swarmcli-oss` cask and manifest | this repository, and nothing else | wholly Apache-2.0 |
+
+  The command inside both is `swarmcli`, and they differ in what the build
+  contains rather than in how it is driven — `swarmcli version` names which one
+  you are running. `checksums-merged.txt` verifies the first set and
+  `checksums-oss.txt` the second; neither is named plain `checksums.txt`, because
+  one manifest could not say which set it covered.
+
+  Full picture: [docs/editions.md](https://github.com/Eldara-Tech/swarmcli/blob/main/docs/editions.md).
+
   ## What's Changed since $PREVIOUS_TAG
   $CHANGES

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -105,12 +105,28 @@ builds:
         - ./scripts/check-oss-artefact.sh "{{ .Path }}"
 
 archives:
-  # swarmcli-oss, not swarmcli. The plain name belongs to the merged artefact,
-  # which is built from the private swarmcli-be wrapper and published into this
-  # repository's releases — so both pipelines write into the same GitHub release,
-  # and leaving the plain name here would have them overwrite each other's
-  # archives with whichever finished last. The two produce identically-named
-  # assets today, ten for ten.
+  # `_oss` at the end, not `swarmcli-oss` at the front. The plain name belongs to
+  # the merged artefact, which is built from the private swarmcli-be wrapper and
+  # published into this repository's releases — so both pipelines write into the
+  # same GitHub release, and leaving the plain name here would have them
+  # overwrite each other's archives with whichever finished last. The two
+  # produce identically-named assets today, ten for ten.
+  #
+  # Where the qualifier sits decides what a release page shows first. GitHub
+  # renders assets sorted by lower(name) in codepoint order — upload order and
+  # which pipeline finished last do not enter into it — so a `swarmcli-oss_`
+  # prefix put all eleven Apache-2.0 archives above every merged one (`-` is
+  # 0x2D, `_` is 0x5F). The releases *index* shows only the first ten assets of
+  # a release behind "Show all N assets", which meant the default artefact was
+  # not on that page at all. As a suffix, `.` (0x2E) precedes `_` (0x5F), so
+  # each merged archive sorts immediately above its -oss twin and the first
+  # artefact row is the default build. Verified by upload rather than reasoned
+  # about: probe assets list `probe_Linux_x86_64.tar.gz` before
+  # `probe_Linux_x86_64_oss.tar.gz` whatever order they are uploaded in.
+  #
+  # A prefixed `swarmcli_oss_` would NOT do this: `o` sorts after `l` but before
+  # `w`, landing the whole -oss set between the merged Linux and Windows
+  # archives.
   #
   # The binary *inside* is still `swarmcli`, and `project_name` is deliberately
   # untouched: the four builds below declare no `binary:` field, so it defaults
@@ -121,12 +137,12 @@ archives:
   # build says about itself — see docs/editions.md.
   - id: oss
     name_template: >-
-      {{ .ProjectName }}-oss_
+      {{ .ProjectName }}_
       {{- title .Os }}_
       {{- if eq .Arch "amd64" }}x86_64
       {{- else if eq .Arch "386" }}i386
       {{- else }}{{ .Arch }}{{ end }}
-      {{- if .Arm }}v{{ .Arm }}{{ end }}
+      {{- if .Arm }}v{{ .Arm }}{{ end }}_oss
     format_overrides:
       - goos: windows
         formats:

--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ Pushing a `v*` tag triggers the [release workflow](.github/workflows/release.yml
 4. Pushes a multi-arch Docker image to Docker Hub
 5. Updates the [Homebrew tap](https://github.com/Eldara-Tech/homebrew-tap) and [Scoop bucket](https://github.com/Eldara-Tech/scoop-bucket)
 
-A tag here publishes the **`-oss` half** of a release — `swarmcli-oss_*`
+A tag here publishes the **`oss` half** of a release — `swarmcli_*_oss`
 archives, `checksums-oss.txt`, `eldaratech/swarmcli:<tag>-oss`, and the
 `swarmcli-oss` cask and manifest. The unsuffixed names and `:latest` belong to
 the Business Edition build, which is tagged in a second repository at the same

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -10,13 +10,13 @@ notes from PR labels, publishes binary archives with GoReleaser, updates the
 Homebrew cask and the Scoop manifest, and pushes a multi-arch image to Docker
 Hub. Nothing is run by hand.
 
-**This repository publishes the `-oss` half of a release, not the whole of it.**
+**This repository publishes the `oss` half of a release, not the whole of it.**
 Each release carries two artefacts ([docs/editions.md](docs/editions.md)):
 
 | Artefact | Tagged in | Publishes |
 |---|---|---|
 | `swarmcli_*`, `eldaratech/swarmcli:<tag>`, `:latest`, cask + manifest `swarmcli` | the private `swarmcli-be` wrapper | into **this** repository's releases, under `RELEASE_TOKEN` |
-| `swarmcli-oss_*`, `eldaratech/swarmcli:<tag>-oss`, cask + manifest `swarmcli-oss` | here | into this repository's releases |
+| `swarmcli_*_oss`, `eldaratech/swarmcli:<tag>-oss`, cask + manifest `swarmcli-oss` | here | into this repository's releases |
 
 So a release needs **two tags, one in each repository, carrying the same version
 string** — and the public one first.
@@ -29,11 +29,17 @@ string** — and the public one first.
   after the tag it was invoked with*, so this tag creating the release first is
   what gives the private run something to add to.
 - Nothing collides, and that is by construction rather than by luck: the
-  archives here are `swarmcli-oss_*`, the checksum file is `checksums-oss.txt`,
+  archives here are `swarmcli_*_oss`, the checksum file is `checksums-oss.txt`,
   and the image tag carries an `-oss` suffix. The merged pipeline writes
   `swarmcli_*`, `checksums-merged.txt` and the unsuffixed image tags, and it
   refuses to run if this repository at the pinned tag has gone back to the plain
   archive names.
+- The qualifier is a **suffix** on the archives, and moving it to the front
+  would be a regression rather than a tidy-up. GitHub renders a release's assets
+  sorted by lower(name) in codepoint order, so `swarmcli-oss_…` put all eleven
+  archives from this repository above every artefact of the default build, and
+  the releases index — ten assets per release, then "Show all N" — showed none
+  of the default build at all. `.goreleaser.yml` carries the arithmetic.
 
 **A tag pushed here on its own no longer moves `:latest`,** and publishes no
 unsuffixed image tag at all. `:latest` is the merged artefact; two pipelines
@@ -84,7 +90,7 @@ goreleaser check
 goreleaser release --snapshot --clean --skip=docker
 ```
 
-Then read `dist/`: eleven `swarmcli-oss_*` archives plus `checksums-oss.txt`,
+Then read `dist/`: eleven `swarmcli_*_oss` archives plus `checksums-oss.txt`,
 `dist/homebrew/Casks/swarmcli-oss.rb` and `dist/scoop/swarmcli-oss.json`. The
 per-build hook runs `scripts/check-oss-artefact.sh` on every binary as it is
 produced, so a snapshot that completes has already proved the artefact claim.
@@ -94,7 +100,7 @@ Confirm the executable inside an archive is still `swarmcli`, not
 `tar xzf … swarmcli` and every documented invocation depend on it:
 
 ```bash
-tar tzf dist/swarmcli-oss_Linux_x86_64.tar.gz
+tar tzf dist/swarmcli_Linux_x86_64_oss.tar.gz
 ```
 
 Know what the rehearsal omits: `--snapshot` skips GoReleaser's git-state
@@ -122,10 +128,10 @@ Homebrew tap and the Scoop bucket.
 gh release view v1.14.0 --repo Eldara-Tech/swarmcli
 
 # The OSS half, before the merged one lands:
-#   11 archives + checksums-oss.txt, and no swarmcli_* asset yet.
+#   11 archives, every one of them ending _oss, plus checksums-oss.txt.
 
-curl -sSLO https://github.com/Eldara-Tech/swarmcli/releases/download/v1.14.0/swarmcli-oss_Linux_x86_64.tar.gz
-tar xzf swarmcli-oss_Linux_x86_64.tar.gz && ./swarmcli version
+curl -sSLO https://github.com/Eldara-Tech/swarmcli/releases/download/v1.14.0/swarmcli_Linux_x86_64_oss.tar.gz
+tar xzf swarmcli_Linux_x86_64_oss.tar.gz && ./swarmcli version
 # 1.14.0 (oss build, chart engine 1.14.0)
 
 docker buildx imagetools inspect eldaratech/swarmcli:v1.14.0-oss

--- a/docs/editions.md
+++ b/docs/editions.md
@@ -12,7 +12,7 @@ a licence. This page is what each of them is.
 | | Built from | Contains | Licence |
 |---|---|---|---|
 | `swarmcli_*` archives, `eldaratech/swarmcli:<tag>`, `:latest`, the `swarmcli` Homebrew cask and Scoop manifest | a private build wrapper around this repository | this repository, plus licensed code that is **inert** without a licence | this repository's code is Apache-2.0; the licensed code is proprietary |
-| `swarmcli-oss_*` archives, `eldaratech/swarmcli:<tag>-oss`, the `swarmcli-oss` cask and manifest | this repository, and nothing else | this repository, and nothing else | wholly Apache-2.0 |
+| `swarmcli_*_oss` archives, `eldaratech/swarmcli:<tag>-oss`, the `swarmcli-oss` cask and manifest | this repository, and nothing else | this repository, and nothing else | wholly Apache-2.0 |
 
 The command inside both archives is `swarmcli`. Every invocation in these docs,
 every script, alias and CI job is identical for the two, deliberately: the
@@ -89,7 +89,7 @@ key, and what each feature does.
 
 ```bash
 # The archive, from any release:
-curl -sSLO https://github.com/Eldara-Tech/swarmcli/releases/download/v1.14.0/swarmcli-oss_Linux_x86_64.tar.gz
+curl -sSLO https://github.com/Eldara-Tech/swarmcli/releases/download/v1.14.0/swarmcli_Linux_x86_64_oss.tar.gz
 
 # The image:
 docker pull eldaratech/swarmcli:v1.14.0-oss


### PR DESCRIPTION
A release page lists the Apache-2.0 archives above every artefact of the default
build, and the releases index lists the default build not at all. This moves the
`oss` qualifier from the front of the archive name to the end:
`swarmcli-oss_Linux_x86_64.tar.gz` becomes `swarmcli_Linux_x86_64_oss.tar.gz`.

## Why the order is what it is

GitHub renders a release's assets sorted by `lower(name)` in codepoint order.
Upload order does not enter into it, nor does which of the two pipelines finished
last — on v1.14.0-rc2, `checksums-merged.txt` was uploaded seventeen minutes
after `checksums-oss.txt` and still lists first. So the only lever is the name,
and with the qualifier at the front `-` (0x2D) beat `_` (0x5F): eleven `-oss`
archives, then the merged ones.

The releases index compounds it. Each release there shows only its first ten
assets behind a "Show all N assets" link (v1.13.0: ten of fourteen). For a
24-asset release those ten would be the two checksum files and eight `-oss`
archives — the default build appears nowhere on that page.

As a suffix, `.` (0x2E) precedes `_` (0x5F), so each merged archive sorts
immediately above its own `-oss` twin:

```
checksums-merged.txt
checksums-oss.txt
swarmcli_Darwin_all.tar.gz          <- default build
swarmcli_Darwin_all_oss.tar.gz
swarmcli_Freebsd_arm64.tar.gz       <- default build
swarmcli_Freebsd_arm64_oss.tar.gz
...
```

Verified by upload rather than reasoned about — a throwaway draft release with
three probe assets, uploaded deliberately in the wrong order, lists them
`probe-oss_Linux_x86_64.tar.gz`, `probe_Linux_x86_64.tar.gz`,
`probe_Linux_x86_64_oss.tar.gz`. That also settles the collation: the sort is
case-insensitive (mixed-case assets on public releases interleave) but
punctuation is significant and codepoint-ordered.

A prefixed `swarmcli_oss_` would not have worked: `o` sorts after `l` but before
`w`, landing the whole `-oss` set between the merged Linux and Windows archives.

## What does not change

The cask, the Scoop manifest and the image tag are `swarmcli-oss` and
`:<tag>-oss` as before — they are package identifiers, not asset names. The
executable inside the archive is still `swarmcli`, so the cask's `binary`,
Scoop's `bin` and swarmcli-charts' `tar xzf … swarmcli` are untouched.
`checksums-oss.txt` and `checksums-merged.txt` keep their names; the merged one
already sorted first.

## Timing

Before the GA, deliberately. v1.14.0-rc1 and rc2 published the prefixed names,
so landing this now means no GA ever carried them and `UPGRADE_NOTES.md` says so
in one paragraph rather than the rename costing a second announcement later.

## And the legend above the assets

Ordering answers "which is first", not "which is which", so this also ports
swarmcli-cd's artefact legend into the drafter template: a two-row table naming
what each download contains and under what licence, rendered above the changelog
on every release. It lives in `release_template.yml` rather than a `release.yml`
step because the drafter re-renders the body on every run — a legend written
there cannot be duplicated by a re-pushed tag — and because it names the shapes
the assets take rather than this release's URLs, so it needs no version. Upgrade
Notes still land above it, the Business Edition region below it.

It describes the naming scheme rather than asserting both halves are present: if
the private tag has not run, or failed, the assets list is what says so.

## Companion changes

- `Eldara-Tech/swarmcli-be` — the collision guard greps `-oss` anywhere in this
  file, which would keep passing on the cask name and the image tag, i.e. for
  the wrong reason. Tightened to read the archive template itself.
- `Eldara-Tech/swarmcli-charts` — `scripts/download-swarmcli.sh` fetches the
  Apache-2.0 asset by name.
- `Eldara-Tech/swarmcli-cd` + its wrapper — the same arrangement, the same
  rename.

## Verified

`goreleaser check`, and `goreleaser release --snapshot --clean` produces eleven
`swarmcli_*_oss` archives plus `checksums-oss.txt`, with `swarmcli` inside
`swarmcli_Linux_x86_64_oss.tar.gz`. The per-build `check-oss-artefact.sh` hook
ran on every binary as part of that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

