### PR TITLE
feat(contexts): update a context's host, keeping its TLS material

### DIFF
--- a/commands/api/parse_test.go
+++ b/commands/api/parse_test.go
@@ -159,6 +159,30 @@ func TestParseInput_UnknownFlagRejected(t *testing.T) {
 	require.Contains(t, err.Error(), "unknown flag --bogus for :node")
 }
 
+// ":contexts" is the first command declaring a flag, so its spec is what lets
+// --host through strict validation and consume the following token.
+func TestParseInput_ContextsUpdateFlags(t *testing.T) {
+	cmd, a, err := ParseInput("contexts update prod --host tcp://10.0.0.7:2376")
+	require.NoError(t, err)
+	require.Equal(t, "contexts", cmd.Name())
+	require.Equal(t, []string{"update", "prod"}, a.Positionals)
+	require.Equal(t, "tcp://10.0.0.7:2376", a.Get("host"))
+
+	_, _, err = ParseInput("contexts update prod --hosts tcp://10.0.0.7:2376")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unknown flag --hosts for :contexts")
+}
+
+// Aliases resolve to the primary's spec, so :ctx accepts --host too.
+func TestParseInput_ContextAliasesInheritFlags(t *testing.T) {
+	for _, name := range []string{"context", "ctx"} {
+		_, a, err := ParseInput(name + " update prod --host tcp://10.0.0.7:2376")
+		require.NoError(t, err, name)
+		require.Equal(t, "tcp://10.0.0.7:2376", a.Get("host"), name)
+		require.Equal(t, []string{"update", "prod"}, a.Positionals, name)
+	}
+}
+
 func TestParseInput_PassthroughSkipsValidation(t *testing.T) {
 	// bootstrap (OSS stub) is Passthrough: --upgrade is not rejected and
 	// --help is not intercepted; everything reaches Execute.

--- a/commands/command/contexts.go
+++ b/commands/command/contexts.go
@@ -4,12 +4,26 @@
 package command
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/Eldara-Tech/swarmcli/args"
+	"github.com/Eldara-Tech/swarmcli/docker"
 	"github.com/Eldara-Tech/swarmcli/registry"
 	contextsview "github.com/Eldara-Tech/swarmcli/views/contexts"
 	"github.com/Eldara-Tech/swarmcli/views/view"
 
 	tea "github.com/charmbracelet/bubbletea"
+)
+
+// updateSubcommand turns the command into an in-place edit instead of a
+// navigation to the contexts view.
+const updateSubcommand = "update"
+
+// Seams, so the subcommand is testable without a Docker CLI.
+var (
+	updateContextEndpoint = docker.UpdateContextEndpoint
+	activeContextName     = docker.GetContextFromEnv
 )
 
 type Contexts struct{}
@@ -19,20 +33,79 @@ func (Contexts) Description() string { return "List and switch Docker contexts" 
 
 func (Contexts) Spec() registry.CommandSpec {
 	return registry.CommandSpec{
+		Usage: "[update <name> --host <endpoint>]",
 		Detail: "Opens the Docker context list, where you can switch the " +
 			"active context (which reloads the cluster) and create, " +
-			"inspect, edit, delete, import or export contexts.",
-		Examples: []string{":contexts"},
+			"inspect, edit, delete, import or export contexts.\n\n" +
+			"With 'update <name>', repoints that context at another " +
+			"endpoint in place, keeping any TLS material it already has. " +
+			"Everything else about the context is left as it is; press 'e' " +
+			"in the context list to edit its description.",
+		Flags: []registry.FlagSpec{
+			{
+				Name:        "host",
+				TakesValue:  true,
+				Placeholder: "<endpoint>",
+				Description: "Docker endpoint to point the context at, e.g. tcp://10.0.0.7:2376",
+			},
+		},
+		Examples: []string{
+			":contexts",
+			":context update prod --host tcp://10.0.0.7:2376",
+		},
 	}
 }
 
 func (Contexts) Execute(ctx any, args args.Args) tea.Cmd {
+	if len(args.Positionals) > 0 {
+		return updateContextCmd(args)
+	}
 	return func() tea.Msg {
 		return view.NavigateToMsg{
 			ViewName: contextsview.ViewName,
 			Payload:  nil,
 		}
 	}
+}
+
+// updateContextCmd runs ':context update <name> --host <endpoint>'. Docker
+// replaces a context's whole endpoint on update, so the docker package's
+// update is what carries the stored TLS material across a host change.
+func updateContextCmd(a args.Args) tea.Cmd {
+	return func() tea.Msg {
+		name, err := updateTarget(a)
+		if err != nil {
+			return view.AppErrorMsg{Error: err.Error()}
+		}
+
+		host := strings.TrimSpace(a.Get("host"))
+		if err := updateContextEndpoint(name, "", host); err != nil {
+			return view.AppErrorMsg{Error: fmt.Sprintf("Failed to update context '%s': %v", name, err)}
+		}
+
+		// A moved endpoint leaves the cached client and snapshot describing a
+		// daemon we are no longer pointing at, so the active context has to be
+		// reconnected to. The contexts view takes the same path after an edit.
+		if active, err := activeContextName(); err == nil && active == name {
+			return contextsview.ContextChangedNotification{}
+		}
+		return view.AppInfoMsg{Message: fmt.Sprintf("Updated context '%s' — host is now %s", name, host)}
+	}
+}
+
+// updateTarget validates the subcommand's arguments and returns the context to
+// update.
+func updateTarget(a args.Args) (string, error) {
+	if a.Positionals[0] != updateSubcommand {
+		return "", fmt.Errorf("unknown subcommand '%s' — usage: :contexts [update <name> --host <endpoint>]", a.Positionals[0])
+	}
+	if len(a.Positionals) != 2 {
+		return "", fmt.Errorf("one context name is required — usage: :context update <name> --host <endpoint>")
+	}
+	if strings.TrimSpace(a.Get("host")) == "" {
+		return "", fmt.Errorf("--host needs an endpoint, e.g. --host tcp://10.0.0.7:2376")
+	}
+	return a.Positionals[1], nil
 }
 
 var contextsCmd = Contexts{}

--- a/commands/command/contexts_test.go
+++ b/commands/command/contexts_test.go
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package command
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/Eldara-Tech/swarmcli/args"
+	contextsview "github.com/Eldara-Tech/swarmcli/views/contexts"
+	"github.com/Eldara-Tech/swarmcli/views/view"
+
+	"github.com/stretchr/testify/require"
+)
+
+// stubUpdate replaces the Docker seams for one test, recording the call.
+func stubUpdate(t *testing.T, active string, err error) *[]string {
+	t.Helper()
+	calls := &[]string{}
+	origUpdate, origActive := updateContextEndpoint, activeContextName
+	t.Cleanup(func() { updateContextEndpoint, activeContextName = origUpdate, origActive })
+
+	updateContextEndpoint = func(name, description, host string) error {
+		*calls = append(*calls, fmt.Sprintf("%s|%s|%s", name, description, host))
+		return err
+	}
+	activeContextName = func() (string, error) { return active, nil }
+	return calls
+}
+
+// updateArgs is what api.ParseInput hands Execute for
+// ':context update <name> --host <endpoint>'.
+func updateArgs(positionals []string, host string) args.Args {
+	a := args.Args{Positionals: positionals, Flags: map[string]string{}}
+	if host != "" {
+		a.Flags["host"] = host
+	}
+	return a
+}
+
+func TestContexts_NoArgs_Navigates(t *testing.T) {
+	msg := contextsCmd.Execute(nil, args.Args{})()
+	require.IsType(t, view.NavigateToMsg{}, msg)
+	require.Equal(t, contextsview.ViewName, msg.(view.NavigateToMsg).ViewName)
+}
+
+func TestContexts_Update_CallsDocker(t *testing.T) {
+	calls := stubUpdate(t, "other", nil)
+	msg := contextsCmd.Execute(nil, updateArgs([]string{"update", "prod"}, "tcp://10.0.0.7:2376"))()
+	require.Equal(t, []string{"prod||tcp://10.0.0.7:2376"}, *calls)
+	require.IsType(t, view.AppInfoMsg{}, msg)
+	require.Contains(t, msg.(view.AppInfoMsg).Message, "tcp://10.0.0.7:2376")
+}
+
+// The cached client was built for the endpoint that just moved, so the app has
+// to rebuild it — the same path a context switch takes.
+func TestContexts_Update_ActiveContext_Reconnects(t *testing.T) {
+	stubUpdate(t, "prod", nil)
+	msg := contextsCmd.Execute(nil, updateArgs([]string{"update", "prod"}, "tcp://10.0.0.7:2376"))()
+	require.IsType(t, contextsview.ContextChangedNotification{}, msg)
+}
+
+func TestContexts_Update_ReportsFailure(t *testing.T) {
+	stubUpdate(t, "prod", fmt.Errorf("context 'prod' does not exist"))
+	msg := contextsCmd.Execute(nil, updateArgs([]string{"update", "prod"}, "tcp://10.0.0.7:2376"))()
+	require.IsType(t, view.AppErrorMsg{}, msg)
+	require.Contains(t, msg.(view.AppErrorMsg).Error, "does not exist")
+}
+
+func TestContexts_Update_ArgumentErrors(t *testing.T) {
+	for name, tc := range map[string]struct {
+		positionals []string
+		host        string
+		want        string
+	}{
+		"unknown subcommand": {[]string{"delete", "prod"}, "tcp://h:2376", "unknown subcommand 'delete'"},
+		"no name":            {[]string{"update"}, "tcp://h:2376", "one context name is required"},
+		"extra positional":   {[]string{"update", "prod", "extra"}, "tcp://h:2376", "one context name is required"},
+		"no host":            {[]string{"update", "prod"}, "", "--host needs an endpoint"},
+		"blank host":         {[]string{"update", "prod"}, "   ", "--host needs an endpoint"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			calls := stubUpdate(t, "other", nil)
+			msg := contextsCmd.Execute(nil, updateArgs(tc.positionals, tc.host))()
+			require.IsType(t, view.AppErrorMsg{}, msg)
+			require.Contains(t, msg.(view.AppErrorMsg).Error, tc.want)
+			require.Empty(t, *calls, "Docker must not be called for a rejected invocation")
+		})
+	}
+}

--- a/docker/context.go
+++ b/docker/context.go
@@ -30,6 +30,60 @@ type ContextInfo struct {
 	Error       string
 }
 
+// DefaultContextName is Docker's built-in context.
+const DefaultContextName = "default"
+
+// ErrDefaultContextImmutable reports an update aimed at the built-in context.
+// `default` is a name the context store reserves and refuses to write
+// (docker/cli cli/context/store.ValidateContextName), so such an update can
+// only fail.
+var ErrDefaultContextImmutable = errors.New(
+	"the default context cannot be edited — create a context to point at another host")
+
+// dockerEndpointName is the key Docker files a context's Docker endpoint
+// under, both in `docker context inspect` output and as the directory holding
+// that endpoint's TLS material inside the context store.
+const dockerEndpointName = "docker"
+
+// The names the context store writes its copies of the TLS material under
+// (docker/cli cli/context/tlsdata.go).
+const (
+	tlsCAFile   = "ca.pem"
+	tlsCertFile = "cert.pem"
+	tlsKeyFile  = "key.pem"
+)
+
+// ContextEndpoint is a context's stored Docker endpoint. The cert fields point
+// at the context store's own copies of the TLS material: the store keeps the
+// bytes rather than the paths a context was created from, so those copies are
+// the only reference an update can re-supply. They are empty for a context
+// with no TLS material, such as an ssh:// endpoint.
+type ContextEndpoint struct {
+	Host          string
+	SkipTLSVerify bool
+	CAFile        string
+	CertFile      string
+	KeyFile       string
+}
+
+// HasTLS reports whether the endpoint carries a complete set of TLS material.
+func (e ContextEndpoint) HasTLS() bool {
+	return e.CAFile != "" && e.CertFile != "" && e.KeyFile != ""
+}
+
+// contextEndpointInspect is the subset of `docker context inspect` describing
+// the Docker endpoint and where the context store keeps its TLS material.
+type contextEndpointInspect struct {
+	Endpoints map[string]struct {
+		Host          string `json:"Host"`
+		SkipTLSVerify bool   `json:"SkipTLSVerify"`
+	} `json:"Endpoints"`
+	TLSMaterial map[string][]string `json:"TLSMaterial"`
+	Storage     struct {
+		TLSPath string `json:"TLSPath"`
+	} `json:"Storage"`
+}
+
 // contextListItem represents a single context from docker context ls --format json
 type contextListItem struct {
 	Name           string `json:"Name"`
@@ -236,6 +290,43 @@ func InspectContext(contextName string) (string, error) {
 	return string(output), nil
 }
 
+// InspectContextEndpoint returns the Docker endpoint stored for a context.
+func InspectContextEndpoint(contextName string) (ContextEndpoint, error) {
+	inspectJSON, err := InspectContext(contextName)
+	if err != nil {
+		return ContextEndpoint{}, err
+	}
+	return parseContextEndpoint(contextName, inspectJSON)
+}
+
+// parseContextEndpoint reads a single context out of `docker context inspect`
+// output, resolving its TLS material to paths inside the context store.
+func parseContextEndpoint(contextName, inspectJSON string) (ContextEndpoint, error) {
+	var inspected []contextEndpointInspect
+	if err := json.Unmarshal([]byte(inspectJSON), &inspected); err != nil {
+		return ContextEndpoint{}, fmt.Errorf("failed to parse inspect output for context '%s': %w", contextName, err)
+	}
+	if len(inspected) == 0 {
+		return ContextEndpoint{}, fmt.Errorf("context '%s' was not found", contextName)
+	}
+
+	meta := inspected[0].Endpoints[dockerEndpointName]
+	endpoint := ContextEndpoint{Host: meta.Host, SkipTLSVerify: meta.SkipTLSVerify}
+
+	tlsDir := filepath.Join(inspected[0].Storage.TLSPath, dockerEndpointName)
+	for _, file := range inspected[0].TLSMaterial[dockerEndpointName] {
+		switch file {
+		case tlsCAFile:
+			endpoint.CAFile = filepath.Join(tlsDir, file)
+		case tlsCertFile:
+			endpoint.CertFile = filepath.Join(tlsDir, file)
+		case tlsKeyFile:
+			endpoint.KeyFile = filepath.Join(tlsDir, file)
+		}
+	}
+	return endpoint, nil
+}
+
 // ExportContext exports a Docker context to a tar file in /tmp
 func ExportContext(contextName string) (string, error) {
 	filePath := fmt.Sprintf("/tmp/%s.tar", filepath.Base(contextName))
@@ -395,82 +486,69 @@ func CreateContextWithCertFiles(name, description, dockerHost, caFile, certFile,
 	return nil
 }
 
-// UpdateContextDescription updates only the description of a Docker context
-func UpdateContextDescription(name, description string) error {
+// UpdateContextEndpoint updates a Docker context's description and host. An
+// empty value leaves that field as it is.
+//
+// Changing the host carries the context's existing TLS material forward.
+// `docker context update` does not merge: it replaces the whole endpoint and
+// resets the stored TLS material to exactly what --docker names, so a bare
+// host= would delete a TLS context's certificates (docker/cli
+// cli/command/context/update.go).
+//
+// Docker ignores an empty --description, so a description cannot be cleared
+// this way. A caller that lets a user empty the field must say so rather than
+// report a success that changed nothing.
+func UpdateContextEndpoint(name, description, dockerHost string) error {
 	if name == "" {
 		return fmt.Errorf("context name is required")
 	}
-
-	args := []string{"context", "update", name}
-
-	// Add description (even if empty, to allow clearing)
-	args = append(args, "--description", description)
-
-	cmd := exec.Command("docker", args...)
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		// Include Docker's error message if available
-		if len(output) > 0 {
-			// Clean up Docker's error message
-			errMsg := strings.TrimSpace(string(output))
-			errMsg = strings.ReplaceAll(errMsg, "\n", " ")
-			return fmt.Errorf("%s", errMsg)
-		}
-		return fmt.Errorf("failed to update context %s: %w", name, err)
+	if name == DefaultContextName {
+		return ErrDefaultContextImmutable
 	}
 
-	return nil
+	// Only a host change replaces the endpoint, so only then is the stored
+	// material at stake — and worth an inspect.
+	var endpoint ContextEndpoint
+	if dockerHost != "" {
+		var err error
+		endpoint, err = InspectContextEndpoint(name)
+		if err != nil {
+			return err
+		}
+	}
+
+	return runContextUpdate(name, updateContextArgs(name, description, dockerHost, endpoint))
 }
 
-// UpdateContextWithCertFiles updates a Docker context with specific certificate file paths
-func UpdateContextWithCertFiles(name, description, dockerHost, caFile, certFile, keyFile string, skipTLSVerify bool) error {
-	if name == "" {
-		return fmt.Errorf("context name is required")
-	}
-
-	// Validate certificate files
-	if err := validateTLSFiles(caFile, certFile, keyFile); err != nil {
-		return err
-	}
-
+// updateContextArgs builds the argv for `docker context update`. endpoint
+// supplies the TLS material to re-state alongside a new host; it is ignored
+// when the host is unchanged, because then no --docker is passed and Docker
+// leaves the endpoint alone.
+func updateContextArgs(name, description, dockerHost string, endpoint ContextEndpoint) []string {
 	args := []string{"context", "update", name}
 
-	// Add description if provided (even if empty, to allow clearing)
 	if description != "" {
 		args = append(args, "--description", description)
 	}
-
-	// Build docker endpoint configuration if host or certs provided
-	if dockerHost != "" || caFile != "" {
-		dockerConfig := ""
-
-		// Add host if provided
-		if dockerHost != "" {
-			dockerConfig = "host=" + dockerHost
-		}
-
-		// Add TLS options with individual cert files
-		if caFile != "" && certFile != "" && keyFile != "" {
-			if dockerConfig != "" {
-				dockerConfig += ","
-			}
-			dockerConfig += "ca=" + caFile
-			dockerConfig += ",cert=" + certFile
-			dockerConfig += ",key=" + keyFile
-		}
-
-		if skipTLSVerify {
-			if dockerConfig != "" {
-				dockerConfig += ","
-			}
-			dockerConfig += "skip-tls-verify=true"
-		}
-
-		if dockerConfig != "" {
-			args = append(args, "--docker", dockerConfig)
-		}
+	if dockerHost == "" {
+		return args
 	}
 
+	dockerConfig := "host=" + dockerHost
+	if endpoint.HasTLS() {
+		dockerConfig += ",ca=" + endpoint.CAFile
+		dockerConfig += ",cert=" + endpoint.CertFile
+		dockerConfig += ",key=" + endpoint.KeyFile
+	}
+	if endpoint.SkipTLSVerify {
+		dockerConfig += ",skip-tls-verify=true"
+	}
+	return append(args, "--docker", dockerConfig)
+}
+
+// runContextUpdate runs `docker context update`, preferring Docker's own error
+// text over the exit status.
+func runContextUpdate(name string, args []string) error {
 	cmd := exec.Command("docker", args...)
 	output, err := cmd.CombinedOutput()
 	if err != nil {

--- a/docker/context_ops.go
+++ b/docker/context_ops.go
@@ -19,8 +19,7 @@ type ContextOps interface {
 	CreateContext(name, dockerHost string) error
 	CreateContextWithTLS(name, dockerHost, tlsPath string, skipTLSVerify bool) error
 	CreateContextWithCertFiles(name, description, dockerHost, caFile, certFile, keyFile string, skipTLSVerify bool) error
-	UpdateContextDescription(name, description string) error
-	UpdateContextWithCertFiles(name, description, dockerHost, caFile, certFile, keyFile string, skipTLSVerify bool) error
+	UpdateContextEndpoint(name, description, dockerHost string) error
 }
 
 type defaultContextOps struct{}
@@ -61,9 +60,6 @@ func (defaultContextOps) CreateContextWithTLS(name, dockerHost, tlsPath string, 
 func (defaultContextOps) CreateContextWithCertFiles(name, description, dockerHost, caFile, certFile, keyFile string, skipTLSVerify bool) error {
 	return CreateContextWithCertFiles(name, description, dockerHost, caFile, certFile, keyFile, skipTLSVerify)
 }
-func (defaultContextOps) UpdateContextDescription(name, description string) error {
-	return UpdateContextDescription(name, description)
-}
-func (defaultContextOps) UpdateContextWithCertFiles(name, description, dockerHost, caFile, certFile, keyFile string, skipTLSVerify bool) error {
-	return UpdateContextWithCertFiles(name, description, dockerHost, caFile, certFile, keyFile, skipTLSVerify)
+func (defaultContextOps) UpdateContextEndpoint(name, description, dockerHost string) error {
+	return UpdateContextEndpoint(name, description, dockerHost)
 }

--- a/docker/context_update_test.go
+++ b/docker/context_update_test.go
@@ -1,0 +1,180 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package docker
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// Captured from `docker context inspect`, so the shape these tests read is the
+// one Docker writes rather than one we remembered.
+const (
+	inspectTLSContext = `[{"Name":"probe","Metadata":{"Description":"probe"},` +
+		`"Endpoints":{"docker":{"Host":"tcp://10.0.0.7:2376","SkipTLSVerify":true}},` +
+		`"TLSMaterial":{"docker":["ca.pem","cert.pem","key.pem"]},` +
+		`"Storage":{"MetadataPath":"/home/u/.docker/contexts/meta/93f5","TLSPath":"/home/u/.docker/contexts/tls/93f5"}}]`
+
+	inspectPlainContext = `[{"Name":"plain","Metadata":{},` +
+		`"Endpoints":{"docker":{"Host":"ssh://user@10.0.0.7","SkipTLSVerify":false}},` +
+		`"TLSMaterial":{},"Storage":{"MetadataPath":"/home/u/.docker/contexts/meta/aa01","TLSPath":"/home/u/.docker/contexts/tls/aa01"}}]`
+
+	inspectDefaultContext = `[{"Name":"default","Metadata":{},` +
+		`"Endpoints":{"docker":{"Host":"unix:///var/run/docker.sock","SkipTLSVerify":false}},` +
+		`"TLSMaterial":{},"Storage":{"MetadataPath":"<IN MEMORY>","TLSPath":"<IN MEMORY>"}}]`
+)
+
+func TestParseContextEndpoint_TLS(t *testing.T) {
+	endpoint, err := parseContextEndpoint("probe", inspectTLSContext)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if endpoint.Host != "tcp://10.0.0.7:2376" {
+		t.Errorf("host = %q", endpoint.Host)
+	}
+	if !endpoint.SkipTLSVerify {
+		t.Error("SkipTLSVerify was dropped")
+	}
+	if !endpoint.HasTLS() {
+		t.Fatalf("expected TLS material, got %+v", endpoint)
+	}
+	// The store's own copies are the only reference an update can re-supply.
+	if endpoint.CAFile != "/home/u/.docker/contexts/tls/93f5/docker/ca.pem" {
+		t.Errorf("ca = %q", endpoint.CAFile)
+	}
+	if endpoint.CertFile != "/home/u/.docker/contexts/tls/93f5/docker/cert.pem" {
+		t.Errorf("cert = %q", endpoint.CertFile)
+	}
+	if endpoint.KeyFile != "/home/u/.docker/contexts/tls/93f5/docker/key.pem" {
+		t.Errorf("key = %q", endpoint.KeyFile)
+	}
+}
+
+func TestParseContextEndpoint_NoTLSMaterial(t *testing.T) {
+	for name, inspectJSON := range map[string]string{
+		"ssh":     inspectPlainContext,
+		"default": inspectDefaultContext,
+	} {
+		t.Run(name, func(t *testing.T) {
+			endpoint, err := parseContextEndpoint(name, inspectJSON)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if endpoint.HasTLS() {
+				t.Errorf("invented TLS material: %+v", endpoint)
+			}
+			if endpoint.CAFile != "" || endpoint.CertFile != "" || endpoint.KeyFile != "" {
+				t.Errorf("expected no cert paths, got %+v", endpoint)
+			}
+		})
+	}
+}
+
+func TestParseContextEndpoint_Errors(t *testing.T) {
+	if _, err := parseContextEndpoint("broken", "not json"); err == nil {
+		t.Error("expected an error for unparseable output")
+	}
+	if _, err := parseContextEndpoint("missing", "[]"); err == nil {
+		t.Error("expected an error for an empty inspect result")
+	}
+}
+
+// A host change must restate the TLS material: `docker context update`
+// replaces the whole endpoint and resets the stored material to exactly what
+// the argv names, so a bare host= deletes a TLS context's certificates.
+func TestUpdateContextArgs_HostCarriesTLSMaterial(t *testing.T) {
+	endpoint := ContextEndpoint{
+		Host:          "tcp://old:2376",
+		SkipTLSVerify: true,
+		CAFile:        "/store/ca.pem",
+		CertFile:      "/store/cert.pem",
+		KeyFile:       "/store/key.pem",
+	}
+	args := updateContextArgs("prod", "", "tcp://new:2376", endpoint)
+
+	config := dockerFlagValue(t, args)
+	for _, want := range []string{
+		"host=tcp://new:2376",
+		"ca=/store/ca.pem",
+		"cert=/store/cert.pem",
+		"key=/store/key.pem",
+		"skip-tls-verify=true",
+	} {
+		if !strings.Contains(config, want) {
+			t.Errorf("--docker %q is missing %q", config, want)
+		}
+	}
+}
+
+func TestUpdateContextArgs_HostWithoutTLSMaterial(t *testing.T) {
+	args := updateContextArgs("prod", "", "ssh://user@new", ContextEndpoint{Host: "ssh://user@old"})
+	if config := dockerFlagValue(t, args); config != "host=ssh://user@new" {
+		t.Errorf("--docker = %q, want a bare host", config)
+	}
+}
+
+// Without a host change there is no --docker, which is what leaves an existing
+// endpoint — and its TLS material — untouched.
+func TestUpdateContextArgs_DescriptionOnly(t *testing.T) {
+	endpoint := ContextEndpoint{
+		Host:     "tcp://old:2376",
+		CAFile:   "/store/ca.pem",
+		CertFile: "/store/cert.pem",
+		KeyFile:  "/store/key.pem",
+	}
+	args := updateContextArgs("prod", "staging swarm", "", endpoint)
+
+	for i, arg := range args {
+		if arg == "--docker" {
+			t.Fatalf("description-only update passed --docker %q", args[i+1])
+		}
+	}
+	if got := flagValue(args, "--description"); got != "staging swarm" {
+		t.Errorf("--description = %q", got)
+	}
+}
+
+// Docker ignores an empty --description, so passing one would be a request
+// that silently does nothing.
+func TestUpdateContextArgs_EmptyDescriptionOmitted(t *testing.T) {
+	args := updateContextArgs("prod", "", "", ContextEndpoint{})
+	for _, arg := range args {
+		if arg == "--description" {
+			t.Fatal("an empty description must not be passed to Docker")
+		}
+	}
+	if strings.Join(args, " ") != "context update prod" {
+		t.Errorf("args = %v", args)
+	}
+}
+
+func TestUpdateContextEndpoint_Rejects(t *testing.T) {
+	if err := UpdateContextEndpoint("", "", "tcp://new:2376"); err == nil {
+		t.Error("expected an error for an empty name")
+	}
+	err := UpdateContextEndpoint(DefaultContextName, "", "tcp://new:2376")
+	if !errors.Is(err, ErrDefaultContextImmutable) {
+		t.Errorf("err = %v, want ErrDefaultContextImmutable", err)
+	}
+}
+
+// dockerFlagValue returns the single --docker value, failing if there is none.
+func dockerFlagValue(t *testing.T, args []string) string {
+	t.Helper()
+	value := flagValue(args, "--docker")
+	if value == "" {
+		t.Fatalf("no --docker in %v", args)
+	}
+	return value
+}
+
+func flagValue(args []string, flag string) string {
+	for i, arg := range args {
+		if arg == flag && i+1 < len(args) {
+			return args[i+1]
+		}
+	}
+	return ""
+}

--- a/integration-tests/docker/context_update_test.go
+++ b/integration-tests/docker/context_update_test.go
@@ -194,7 +194,7 @@ func writePEM(t *testing.T, path string, block *pem.Block) {
 	if err != nil {
 		t.Fatalf("creating %s: %v", path, err)
 	}
-	defer file.Close()
+	defer func() { _ = file.Close() }()
 	if err := pem.Encode(file, block); err != nil {
 		t.Fatalf("writing %s: %v", path, err)
 	}

--- a/integration-tests/docker/context_update_test.go
+++ b/integration-tests/docker/context_update_test.go
@@ -1,0 +1,201 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+//go:build integration
+
+package docker
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/Eldara-Tech/swarmcli/docker"
+)
+
+// The context these tests create and remove. Every case works on its own
+// throwaway context, never on the one the suite runs against.
+const probeContext = "swarmcli-context-update-probe"
+
+// TestUpdateContextEndpoint_PreservesTLSMaterial is the regression guard for
+// the reason this update is not a bare `--docker host=…`: Docker replaces a
+// context's whole endpoint and resets its TLS material to exactly what the
+// command names, so omitting the certificates deletes them.
+func TestUpdateContextEndpoint_PreservesTLSMaterial(t *testing.T) {
+	requireDocker(t)
+	certs := writeTLSMaterial(t)
+	createProbeContext(t, "tcp://127.0.0.1:2376", certs)
+
+	if err := docker.UpdateContextEndpoint(probeContext, "", "tcp://10.0.0.7:2376"); err != nil {
+		t.Fatalf("UpdateContextEndpoint failed: %v", err)
+	}
+
+	endpoint, err := docker.InspectContextEndpoint(probeContext)
+	if err != nil {
+		t.Fatalf("InspectContextEndpoint failed: %v", err)
+	}
+	if endpoint.Host != "tcp://10.0.0.7:2376" {
+		t.Errorf("host = %q, want the updated endpoint", endpoint.Host)
+	}
+	if !endpoint.HasTLS() {
+		t.Fatalf("the update deleted the TLS material: %+v", endpoint)
+	}
+	// The paths are the store's own copies, so compare the bytes rather than
+	// trusting that the files are merely present.
+	for name, stored := range map[string]string{
+		"ca.pem":   endpoint.CAFile,
+		"cert.pem": endpoint.CertFile,
+		"key.pem":  endpoint.KeyFile,
+	} {
+		want, err := os.ReadFile(filepath.Join(certs, name))
+		if err != nil {
+			t.Fatalf("reading %s: %v", name, err)
+		}
+		got, err := os.ReadFile(stored)
+		if err != nil {
+			t.Fatalf("reading stored %s: %v", name, err)
+		}
+		if string(got) != string(want) {
+			t.Errorf("%s changed across the update", name)
+		}
+	}
+}
+
+// A description-only update must not touch the endpoint at all.
+func TestUpdateContextEndpoint_DescriptionKeepsEndpoint(t *testing.T) {
+	requireDocker(t)
+	certs := writeTLSMaterial(t)
+	createProbeContext(t, "tcp://127.0.0.1:2376", certs)
+
+	if err := docker.UpdateContextEndpoint(probeContext, "renamed", ""); err != nil {
+		t.Fatalf("UpdateContextEndpoint failed: %v", err)
+	}
+
+	endpoint, err := docker.InspectContextEndpoint(probeContext)
+	if err != nil {
+		t.Fatalf("InspectContextEndpoint failed: %v", err)
+	}
+	if endpoint.Host != "tcp://127.0.0.1:2376" {
+		t.Errorf("host = %q, want it unchanged", endpoint.Host)
+	}
+	if !endpoint.HasTLS() {
+		t.Errorf("the TLS material did not survive a description change: %+v", endpoint)
+	}
+}
+
+// A context with no TLS material updates to a bare host.
+func TestUpdateContextEndpoint_WithoutTLSMaterial(t *testing.T) {
+	requireDocker(t)
+	createProbeContext(t, "tcp://127.0.0.1:2375", "")
+
+	if err := docker.UpdateContextEndpoint(probeContext, "", "ssh://user@10.0.0.7"); err != nil {
+		t.Fatalf("UpdateContextEndpoint failed: %v", err)
+	}
+
+	endpoint, err := docker.InspectContextEndpoint(probeContext)
+	if err != nil {
+		t.Fatalf("InspectContextEndpoint failed: %v", err)
+	}
+	if endpoint.Host != "ssh://user@10.0.0.7" {
+		t.Errorf("host = %q, want the updated endpoint", endpoint.Host)
+	}
+	if endpoint.HasTLS() {
+		t.Errorf("invented TLS material: %+v", endpoint)
+	}
+}
+
+func TestUpdateContextEndpoint_RefusesDefault(t *testing.T) {
+	requireDocker(t)
+	if err := docker.UpdateContextEndpoint(docker.DefaultContextName, "", "tcp://10.0.0.7:2376"); err == nil {
+		t.Fatal("expected the built-in context to be refused")
+	}
+}
+
+func requireDocker(t *testing.T) {
+	t.Helper()
+	if _, err := exec.LookPath("docker"); err != nil {
+		t.Skip("docker not available; skipping integration test")
+	}
+}
+
+// createProbeContext creates the throwaway context, with TLS material when
+// certsDir is set, and removes it when the test ends.
+func createProbeContext(t *testing.T, host, certsDir string) {
+	t.Helper()
+	remove := func() { _ = exec.Command("docker", "context", "rm", "-f", probeContext).Run() }
+	remove()
+
+	endpoint := "host=" + host
+	if certsDir != "" {
+		endpoint += ",ca=" + filepath.Join(certsDir, "ca.pem")
+		endpoint += ",cert=" + filepath.Join(certsDir, "cert.pem")
+		endpoint += ",key=" + filepath.Join(certsDir, "key.pem")
+	}
+	out, err := exec.Command("docker", "context", "create", probeContext, "--docker", endpoint).CombinedOutput()
+	if err != nil {
+		t.Fatalf("creating the probe context failed: %v: %s", err, out)
+	}
+	t.Cleanup(remove)
+}
+
+// writeTLSMaterial writes a self-signed CA and client keypair, which is all
+// Docker checks when it stores endpoint TLS material.
+func writeTLSMaterial(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	writeSelfSigned(t, filepath.Join(dir, "ca.pem"), "", "probe-ca")
+	writeSelfSigned(t, filepath.Join(dir, "cert.pem"), filepath.Join(dir, "key.pem"), "probe-client")
+	return dir
+}
+
+func writeSelfSigned(t *testing.T, certPath, keyPath, commonName string) {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generating key: %v", err)
+	}
+	template := x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: commonName},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, &template, &template, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("creating certificate: %v", err)
+	}
+	writePEM(t, certPath, &pem.Block{Type: "CERTIFICATE", Bytes: der})
+
+	if keyPath == "" {
+		return
+	}
+	keyDER, err := x509.MarshalPKCS8PrivateKey(key)
+	if err != nil {
+		t.Fatalf("marshalling key: %v", err)
+	}
+	writePEM(t, keyPath, &pem.Block{Type: "PRIVATE KEY", Bytes: keyDER})
+}
+
+func writePEM(t *testing.T, path string, block *pem.Block) {
+	t.Helper()
+	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
+	if err != nil {
+		t.Fatalf("creating %s: %v", path, err)
+	}
+	defer file.Close()
+	if err := pem.Encode(file, block); err != nil {
+		t.Fatalf("writing %s: %v", path, err)
+	}
+}

--- a/views/contexts/messages.go
+++ b/views/contexts/messages.go
@@ -70,8 +70,11 @@ type ContextCreatedMsg struct {
 
 type ContextUpdatedMsg struct {
 	ContextName string
-	Success     bool
-	Error       error
+	// Reconnect reports that the active context's endpoint moved, so the
+	// cached Docker client and snapshot have to be rebuilt.
+	Reconnect bool
+	Success   bool
+	Error     error
 }
 
 // ContextChangedNotification is sent to notify the app that the Docker context has changed
@@ -287,13 +290,17 @@ func (m *Model) createContextWithCertFilesCmd(name, description, dockerHost, caF
 	}
 }
 
-// updateContextDescriptionCmd updates only the description of an existing Docker context
-func (m *Model) updateContextDescriptionCmd(name, description string) tea.Cmd {
+// updateContextEndpointCmd updates an existing Docker context's description
+// and, when dockerHost is set, its endpoint. isCurrent says whether the
+// context is the active one, which decides whether a moved endpoint has to be
+// reconnected to.
+func (m *Model) updateContextEndpointCmd(name, description, dockerHost string, isCurrent bool) tea.Cmd {
 	contextOps := m.deps.Contexts
 	return func() tea.Msg {
-		err := contextOps.UpdateContextDescription(name, description)
+		err := contextOps.UpdateContextEndpoint(name, description, dockerHost)
 		return ContextUpdatedMsg{
 			ContextName: name,
+			Reconnect:   err == nil && isCurrent && dockerHost != "",
 			Success:     err == nil,
 			Error:       err,
 		}

--- a/views/contexts/model.go
+++ b/views/contexts/model.go
@@ -70,7 +70,12 @@ type Model struct {
 	lastCertBrowserPath   string // Remember last directory used in cert file browser
 	editDialogActive      bool
 	editContextName       string // Name of context being edited (immutable)
+	editContextDesc       string // Description the dialog opened with
+	editContextHost       string // Host the dialog opened with
+	editContextCurrent    bool   // Whether the context being edited is the active one
 	editDescInput         textinput.Model
+	editHostInput         textinput.Model
+	editInputFocus        int // 0 = description, 1 = host
 }
 
 func New() *Model {
@@ -122,6 +127,12 @@ func New() *Model {
 	editDescInput.CharLimit = 200
 	editDescInput.Width = 50
 
+	editHostInput := textinput.New()
+	editHostInput.Placeholder = "tcp://host:2376"
+	editHostInput.Prompt = "Host: "
+	editHostInput.CharLimit = 256
+	editHostInput.Width = 50
+
 	// Initialize an internal viewport for the filterable list
 	vp := viewport.New(80, 20)
 	vp.SetContent("")
@@ -141,6 +152,7 @@ func New() *Model {
 		createCertInput:  createCertInput,
 		createKeyInput:   createKeyInput,
 		editDescInput:    editDescInput,
+		editHostInput:    editHostInput,
 		sortField:        SortByName,
 		sortAscending:    true,
 	}
@@ -430,7 +442,36 @@ func (m *Model) updateCreateFocus() {
 		m.createKeyInput.Focus()
 		// case 3 is the TLS checkbox, no focus needed
 	}
-} // ShortHelpItems returns the help items for the view
+}
+
+// updateEditFocus updates focus state for edit dialog inputs
+func (m *Model) updateEditFocus() {
+	m.editDescInput.Blur()
+	m.editHostInput.Blur()
+
+	switch m.editInputFocus {
+	case 0:
+		m.editDescInput.Focus()
+	case 1:
+		m.editHostInput.Focus()
+	}
+}
+
+// closeEditDialog clears the edit dialog's state.
+func (m *Model) closeEditDialog() {
+	m.editDialogActive = false
+	m.editContextName = ""
+	m.editContextDesc = ""
+	m.editContextHost = ""
+	m.editContextCurrent = false
+	m.editInputFocus = 0
+	m.editDescInput.Blur()
+	m.editDescInput.SetValue("")
+	m.editHostInput.Blur()
+	m.editHostInput.SetValue("")
+}
+
+// ShortHelpItems returns the help items for the view
 func (m *Model) ShortHelpItems() []helpbar.HelpEntry {
 	return []helpbar.HelpEntry{
 		{Key: "↑/↓", Desc: "Navigate"},

--- a/views/contexts/model_test.go
+++ b/views/contexts/model_test.go
@@ -29,8 +29,7 @@ type mockContextOps struct {
 	createContextFn              func(name, dockerHost string) error
 	createContextWithTLSFn       func(name, dockerHost, tlsPath string, skipTLSVerify bool) error
 	createContextWithCertFilesFn func(name, description, dockerHost, caFile, certFile, keyFile string, skipTLSVerify bool) error
-	updateContextDescriptionFn   func(name, description string) error
-	updateContextWithCertFilesFn func(name, description, dockerHost, caFile, certFile, keyFile string, skipTLSVerify bool) error
+	updateContextEndpointFn      func(name, description, dockerHost string) error
 }
 
 func (m *mockContextOps) ListContexts() ([]docker.ContextInfo, error) {
@@ -69,11 +68,8 @@ func (m *mockContextOps) CreateContextWithTLS(name, dockerHost, tlsPath string, 
 func (m *mockContextOps) CreateContextWithCertFiles(name, description, dockerHost, caFile, certFile, keyFile string, skipTLSVerify bool) error {
 	return m.createContextWithCertFilesFn(name, description, dockerHost, caFile, certFile, keyFile, skipTLSVerify)
 }
-func (m *mockContextOps) UpdateContextDescription(name, description string) error {
-	return m.updateContextDescriptionFn(name, description)
-}
-func (m *mockContextOps) UpdateContextWithCertFiles(name, description, dockerHost, caFile, certFile, keyFile string, skipTLSVerify bool) error {
-	return m.updateContextWithCertFilesFn(name, description, dockerHost, caFile, certFile, keyFile, skipTLSVerify)
+func (m *mockContextOps) UpdateContextEndpoint(name, description, dockerHost string) error {
+	return m.updateContextEndpointFn(name, description, dockerHost)
 }
 
 // Verify interface compliance
@@ -135,8 +131,7 @@ func noopContextOps() *mockContextOps {
 		createContextFn:              func(_, _ string) error { return nil },
 		createContextWithTLSFn:       func(_, _, _ string, _ bool) error { return nil },
 		createContextWithCertFilesFn: func(_, _, _, _, _, _ string, _ bool) error { return nil },
-		updateContextDescriptionFn:   func(_, _ string) error { return nil },
-		updateContextWithCertFilesFn: func(_, _, _, _, _, _ string, _ bool) error { return nil },
+		updateContextEndpointFn:      func(_, _, _ string) error { return nil },
 	}
 }
 
@@ -172,6 +167,21 @@ func fakeContexts(names ...string) []docker.ContextInfo {
 		}
 	}
 	return ctxs
+}
+
+// batchMsgs runs a command and returns every message it produced, flattening a
+// tea.Batch so a test can assert on one member of it.
+func batchMsgs(cmd tea.Cmd) []tea.Msg {
+	msg := runCmd(cmd)
+	batch, ok := msg.(tea.BatchMsg)
+	if !ok {
+		return []tea.Msg{msg}
+	}
+	msgs := make([]tea.Msg, 0, len(batch))
+	for _, c := range batch {
+		msgs = append(msgs, runCmd(c))
+	}
+	return msgs
 }
 
 func loadContexts(m *Model, ctxs []docker.ContextInfo) {

--- a/views/contexts/update.go
+++ b/views/contexts/update.go
@@ -6,6 +6,7 @@ package contexts
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/Eldara-Tech/swarmcli/docker"
 	"github.com/Eldara-Tech/swarmcli/ui/dialog"
 	"github.com/Eldara-Tech/swarmcli/views/confirmdialog"
 	helpview "github.com/Eldara-Tech/swarmcli/views/help"
@@ -238,15 +239,22 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 			return nil
 		}
 		// Success - close edit dialog and clear fields
-		m.editDialogActive = false
-		m.editContextName = ""
-		m.editDescInput.Blur()
-		m.editDescInput.SetValue("")
+		m.closeEditDialog()
 		m.SetError("")
 		m.SetSuccess("Updated context: " + msg.ContextName)
 		// Refresh the list to show the updated context
 		m.SetLoading(true)
-		return m.loadContextsCmd()
+		if !msg.Reconnect {
+			return m.loadContextsCmd()
+		}
+		// The active context's endpoint moved, so the cached client and
+		// snapshot describe a daemon we are no longer pointing at. This is the
+		// path a switch takes. No PreviousContext: there is nothing to roll
+		// back to, since the context we would return to is the one that moved.
+		return tea.Batch(
+			m.loadContextsCmd(),
+			func() tea.Msg { return ContextChangedNotification{} },
+		)
 
 	case confirmdialog.ResultMsg:
 		if msg.Confirmed {
@@ -534,25 +542,53 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 					return nil
 				}
 
-				// Get description value
 				description := strings.TrimSpace(m.editDescInput.Value())
+				host := strings.TrimSpace(m.editHostInput.Value())
 
-				// Update only the description (no host or cert changes)
-				return m.updateContextDescriptionCmd(m.editContextName, description)
+				if host == "" {
+					m.SetError("Host is required")
+					return nil
+				}
+				// Docker ignores an empty --description, so accepting this
+				// would report an update that never happened.
+				if description == "" && m.editContextDesc != "" {
+					m.SetError("Docker cannot clear a description — recreate the context to remove it")
+					return nil
+				}
+				if description == m.editContextDesc && host == m.editContextHost {
+					m.closeEditDialog()
+					m.SetError("")
+					return nil
+				}
+
+				m.SetError("")
+				m.SetSuccess("")
+				// The endpoint only has to be replaced when the host moved.
+				if host == m.editContextHost {
+					host = ""
+				}
+				return m.updateContextEndpointCmd(m.editContextName, description, host, m.editContextCurrent)
+
+			case "tab", "shift+tab", "up", "down":
+				m.editInputFocus = 1 - m.editInputFocus
+				m.updateEditFocus()
+				return nil
 
 			case "esc":
 				// Cancel edit dialog
-				m.editDialogActive = false
-				m.editContextName = ""
-				m.editDescInput.Blur()
-				m.editDescInput.SetValue("")
+				m.closeEditDialog()
 				m.SetError("")
 				return nil
 
 			default:
-				// Update the description textinput
+				// Update the focused textinput
 				var cmd tea.Cmd
-				m.editDescInput, cmd = m.editDescInput.Update(msg)
+				switch m.editInputFocus {
+				case 0:
+					m.editDescInput, cmd = m.editDescInput.Update(msg)
+				case 1:
+					m.editHostInput, cmd = m.editHostInput.Update(msg)
+				}
 				return cmd
 			}
 		}
@@ -784,16 +820,29 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 			return LoadFilesCmd(homeDir)
 
 		case "e":
-			// Edit selected context (description only)
+			// Edit selected context (description and host)
 			ctx, ok := m.GetSelectedContext()
 			if !ok {
 				return nil
 			}
-			// Open edit dialog with current description
+			// Docker reserves the name, so an update can only fail — say why
+			// up front instead of opening a form that cannot be saved.
+			if ctx.Name == docker.DefaultContextName {
+				m.SetError(docker.ErrDefaultContextImmutable.Error())
+				m.SetSuccess("")
+				m.errorDialogActive = true
+				return nil
+			}
+			// Open edit dialog with the current values
 			m.editDialogActive = true
 			m.editContextName = ctx.Name
-			m.editDescInput.Focus()
+			m.editContextDesc = ctx.Description
+			m.editContextHost = ctx.DockerHost
+			m.editContextCurrent = ctx.Current
+			m.editInputFocus = 0
 			m.editDescInput.SetValue(ctx.Description)
+			m.editHostInput.SetValue(ctx.DockerHost)
+			m.updateEditFocus()
 			m.SetError("")
 			m.SetSuccess("")
 			return textinput.Blink

--- a/views/contexts/update_test.go
+++ b/views/contexts/update_test.go
@@ -154,6 +154,18 @@ func TestUpdate_ContextUpdated_Success(t *testing.T) {
 	require.Contains(t, m.GetSuccess(), "ctx1")
 	require.True(t, m.IsLoading())
 	require.NotNil(t, cmd)
+	// Nothing moved under the active client, so no reconnect is requested.
+	require.NotContains(t, batchMsgs(cmd), ContextChangedNotification{})
+}
+
+// A moved endpoint on the active context has to reach the app layer, which is
+// what drops the cached client and snapshot built for the old daemon.
+func TestUpdate_ContextUpdated_Reconnects(t *testing.T) {
+	m := testModel()
+	m.editDialogActive = true
+	m.editContextName = "ctx1"
+	cmd := m.Update(ContextUpdatedMsg{ContextName: "ctx1", Reconnect: true, Success: true})
+	require.Contains(t, batchMsgs(cmd), ContextChangedNotification{})
 }
 
 func TestUpdate_ContextUpdated_Error(t *testing.T) {
@@ -389,7 +401,19 @@ func TestKey_Edit_OpensDialog(t *testing.T) {
 	cmd := m.Update(key("e"))
 	require.True(t, m.editDialogActive)
 	require.Equal(t, "ctx1", m.editContextName)
+	require.Equal(t, "desc-ctx1", m.editDescInput.Value())
+	require.Equal(t, "tcp://ctx1:2375", m.editHostInput.Value())
 	require.NotNil(t, cmd) // textinput.Blink
+}
+
+// Docker reserves the name, so the form would never save.
+func TestKey_Edit_DefaultContext_Refused(t *testing.T) {
+	m := testModel()
+	loadContexts(m, fakeContexts(docker.DefaultContextName))
+	m.Update(key("e"))
+	require.False(t, m.editDialogActive)
+	require.True(t, m.errorDialogActive)
+	require.Equal(t, docker.ErrDefaultContextImmutable.Error(), m.GetError())
 }
 
 func TestKey_Delete_CurrentContext_Error(t *testing.T) {
@@ -706,26 +730,101 @@ func TestEditDialog_Esc_Closes(t *testing.T) {
 	require.Equal(t, "", m.editContextName)
 }
 
+// editing opens the dialog on the first context and applies edits to it.
+func editing(t *testing.T, ops *mockContextOps, edit func(m *Model)) tea.Msg {
+	t.Helper()
+	m := testModel(func(m *Model) { m.deps.Contexts = ops })
+	loadContexts(m, fakeContexts("ctx1", "ctx2"))
+	m.Update(key("e"))
+	edit(m)
+	return runCmd(m.Update(key("enter")))
+}
+
 func TestEditDialog_Enter_Submit(t *testing.T) {
-	var updatedName, updatedDesc string
+	var updatedName, updatedDesc, updatedHost string
 	ops := noopContextOps()
-	ops.updateContextDescriptionFn = func(name, desc string) error {
-		updatedName = name
-		updatedDesc = desc
+	ops.updateContextEndpointFn = func(name, desc, host string) error {
+		updatedName, updatedDesc, updatedHost = name, desc, host
 		return nil
 	}
-	m := testModel(func(m *Model) {
-		m.deps.Contexts = ops
+	msg := editing(t, ops, func(m *Model) {
+		m.editDescInput.SetValue("new desc")
+		m.editHostInput.SetValue("tcp://10.0.0.7:2376")
 	})
-	m.editDialogActive = true
-	m.editContextName = "ctx1"
-	m.editDescInput.SetValue("new desc")
-	cmd := m.Update(key("enter"))
-	require.NotNil(t, cmd)
-	msg := runCmd(cmd)
 	require.IsType(t, ContextUpdatedMsg{}, msg)
 	require.Equal(t, "ctx1", updatedName)
 	require.Equal(t, "new desc", updatedDesc)
+	require.Equal(t, "tcp://10.0.0.7:2376", updatedHost)
+	// fakeContexts marks the first context current, and its endpoint moved.
+	require.True(t, msg.(ContextUpdatedMsg).Reconnect)
+}
+
+// An unchanged host must not reach Docker: passing --docker replaces the whole
+// endpoint and resets the TLS material stored for it.
+func TestEditDialog_Enter_DescriptionOnly_LeavesEndpointAlone(t *testing.T) {
+	var updatedHost string
+	called := false
+	ops := noopContextOps()
+	ops.updateContextEndpointFn = func(_, _, host string) error {
+		called, updatedHost = true, host
+		return nil
+	}
+	msg := editing(t, ops, func(m *Model) { m.editDescInput.SetValue("new desc") })
+	require.True(t, called)
+	require.Equal(t, "", updatedHost)
+	require.False(t, msg.(ContextUpdatedMsg).Reconnect)
+}
+
+// Docker ignores an empty --description, so reporting success would be a lie.
+func TestEditDialog_Enter_ClearDescription_Refused(t *testing.T) {
+	ops := noopContextOps()
+	ops.updateContextEndpointFn = func(_, _, _ string) error {
+		t.Fatal("update must not be attempted")
+		return nil
+	}
+	m := testModel(func(m *Model) { m.deps.Contexts = ops })
+	loadContexts(m, fakeContexts("ctx1"))
+	m.Update(key("e"))
+	m.editDescInput.SetValue("")
+	require.Nil(t, m.Update(key("enter")))
+	require.Contains(t, m.GetError(), "cannot clear a description")
+	require.True(t, m.editDialogActive)
+}
+
+func TestEditDialog_Enter_HostRequired(t *testing.T) {
+	m := testModel()
+	loadContexts(m, fakeContexts("ctx1"))
+	m.Update(key("e"))
+	m.editHostInput.SetValue("")
+	require.Nil(t, m.Update(key("enter")))
+	require.Contains(t, m.GetError(), "Host is required")
+	require.True(t, m.editDialogActive)
+}
+
+func TestEditDialog_Enter_NoChanges_Closes(t *testing.T) {
+	ops := noopContextOps()
+	ops.updateContextEndpointFn = func(_, _, _ string) error {
+		t.Fatal("update must not be attempted")
+		return nil
+	}
+	m := testModel(func(m *Model) { m.deps.Contexts = ops })
+	loadContexts(m, fakeContexts("ctx1"))
+	m.Update(key("e"))
+	require.Nil(t, m.Update(key("enter")))
+	require.False(t, m.editDialogActive)
+}
+
+func TestEditDialog_Tab_MovesFocus(t *testing.T) {
+	m := testModel()
+	loadContexts(m, fakeContexts("ctx1"))
+	m.Update(key("e"))
+	require.Equal(t, 0, m.editInputFocus)
+	m.Update(key("tab"))
+	require.Equal(t, 1, m.editInputFocus)
+	require.True(t, m.editHostInput.Focused())
+	m.Update(key("tab"))
+	require.Equal(t, 0, m.editInputFocus)
+	require.True(t, m.editDescInput.Focused())
 }
 
 func TestEditDialog_Enter_ClearsError(t *testing.T) {

--- a/views/contexts/view.go
+++ b/views/contexts/view.go
@@ -312,12 +312,13 @@ func (m *Model) renderCreateDialog() string {
 	return dialog.BorderStyle.Render(content)
 }
 
-// renderEditDialog renders the edit context dialog (description only)
+// renderEditDialog renders the edit context dialog (description and host)
 func (m *Model) renderEditDialog() string {
 	var lines []string
 	lines = append(lines, dialog.TitleStyle.Render(" Edit Context: "+m.editContextName+" "))
 	lines = append(lines, dialog.ItemStyle.Render(""))
 	lines = append(lines, dialog.ItemStyle.Render(m.editDescInput.View()))
+	lines = append(lines, dialog.ItemStyle.Render(m.editHostInput.View()))
 
 	// Show error message if present
 	errorMsg := m.GetError()
@@ -338,8 +339,9 @@ func (m *Model) renderEditDialog() string {
 			dialog.KeyStyle.Render("<Enter>"),
 			dialog.KeyStyle.Render("<Esc>"))
 	} else {
-		helpText = fmt.Sprintf(" %s Update • %s Cancel",
+		helpText = fmt.Sprintf(" %s Update • %s Navigate • %s Cancel",
 			dialog.KeyStyle.Render("<Enter>"),
+			dialog.KeyStyle.Render("<Tab/↑/↓>"),
 			dialog.KeyStyle.Render("<Esc>"))
 	}
 	lines = append(lines, dialog.HelpStyle.Render(helpText))

--- a/views/contexts/view_test.go
+++ b/views/contexts/view_test.go
@@ -156,6 +156,25 @@ func TestView_CreateDialog_TLSEnabled(t *testing.T) {
 	require.Contains(t, out, "TLS")
 }
 
+func TestRenderEditDialog_ShowsBothFields(t *testing.T) {
+	m := testModel()
+	loadContexts(m, fakeContexts("ctx1"))
+	m.Update(key("e"))
+
+	out := ansi.Strip(m.renderEditDialog())
+	require.Contains(t, out, "ctx1")
+	require.Contains(t, out, "desc-ctx1")
+	require.Contains(t, out, "tcp://ctx1:2375")
+
+	widest := 0
+	for _, line := range strings.Split(out, "\n") {
+		if w := lipgloss.Width(line); w > widest {
+			widest = w
+		}
+	}
+	require.LessOrEqual(t, widest, 80, "the edit dialog must fit an 80-column terminal:\n%s", out)
+}
+
 // --- #525: the browse hint, and the width it is laid out around ---
 
 func TestRenderCreateDialog_ShowsBrowseHintOnFocusedCertField(t *testing.T) {


### PR DESCRIPTION
Closes #570.

`docker context update <name> --docker "host=…"` does not merge. It replaces the
whole Docker endpoint and then resets the stored TLS material to exactly what
the command named, so passing a bare `host=` deletes a TLS context's
certificates — which is what the issue reporter hit ("the IP update worked but
TLS silently disappeared"). Reproduced against Docker before writing anything:

```
$ docker context create probe --docker "host=tcp://127.0.0.1:2376,ca=…,cert=…,key=…"
$ docker context inspect probe   # TLSMaterial: {"docker":["ca.pem","cert.pem","key.pem"]}
$ docker context update probe --docker "host=tcp://127.0.0.1:2377"
$ docker context inspect probe   # TLSMaterial: {}   ← the whole TLS dir is gone
```

The certificates a context was created from are not recorded anywhere; the
store keeps its own copies of the bytes. So the material an update re-supplies
comes from the store itself: `docker context inspect` reports `Storage.TLSPath`
and the filenames under it, and `docker context update` reads those files
before it clears the directory, which makes pointing `ca=`/`cert=`/`key=` back
at them safe. `SkipTLSVerify` rides along the same way.

## What this adds

* `docker.UpdateContextEndpoint(name, description, host)` — updates a context,
  carrying its TLS material across a host change. It replaces
  `UpdateContextWithCertFiles`, which built exactly the destructive bare-`host=`
  argv and had had no caller since #129, and `UpdateContextDescription`.
* `docker.InspectContextEndpoint` / `ContextEndpoint` — the stored endpoint,
  with the cert paths resolved into the context store.
* The contexts view's edit dialog (`e`) gains a **Host** field beside the
  description, both prefilled; `Tab`/`↑`/`↓` move between them.
* `:context update <name> --host <endpoint>` does the same from the command bar
  (`:contexts` / `:ctx` too — aliases inherit the spec). This is the first
  command in the repo to declare a flag, so `registry.FlagSpec` gets its first
  real use.
* When the endpoint of the **active** context moves, the app reconnects: the
  cached Docker client and snapshot were built for the daemon we just left, so
  the update takes the same path a context switch does.

## Two smaller fixes in the same code

* `docker context update default` can only ever fail — `default` is a reserved
  name. The dialog now says so instead of opening a form that cannot be saved,
  and the docker layer refuses it for every caller.
* Docker **ignores an empty `--description`**, so the old dialog reported
  "Updated context" while the description stayed as it was. Nothing passes an
  empty `--description` any more, and emptying the field is refused with the
  reason.

## Not included

`--description` on the command bar: the `:` parser splits on whitespace and does
not honour quotes, so a multi-word description cannot be expressed there. It
stays a dialog-only field.

## Verification

* Unit tests over the argv builder and the inspect parsing, including the two
  cases that define the feature: a host change restates ca/cert/key, and a
  description-only update passes no `--docker` at all.
* Integration tests (`integration-tests/docker/`) create a throwaway TLS
  context against a real Docker CLI and assert the stored material is
  byte-identical after a host change.
* Both were mutation-checked: reintroducing the bare-`host=` argv turns the
  unit test *and* the integration test red.

## Note for review

`ContextOps` loses two methods and gains one. Nothing in swarmcli, swarmcli-be
or swarmcli-cd referenced the removed exported functions, and no user-facing
behaviour regresses, so this is labelled `C0-breaks-nothing` — say the word if
you would rather treat an exported-symbol removal as `C1`.
