### PR TITLE
feat(charts): read-only :charts TUI browser for chart releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,12 @@ swarmcli charts apply -f swarmcli-release.yaml --diff   # preview, never deploys
 swarmcli charts outdated                          # releases with a newer chart available
 ```
 
+The TUI has a **read-only** browser for what those commands installed: `:charts`
+lists every release with its revision, recorded status and live rollout health,
+expands one in place to its revision history and services, and diffs any two
+consecutive revisions. Everything that changes a release stays on the command
+line above; the view names the command for you.
+
 `apply` reads a release file pinning each release to a chart version, so the
 deployed state is reproducible and an automated updater (e.g. Renovate) has
 something concrete to bump. It never removes a release the file does not mention —
@@ -245,6 +251,7 @@ TEST_LOG=1 ./test-setup/testenv.sh test
 | `:secret`  | Navigate to Secret    |
 | `:network` | Navigate to Networks  |
 | `:volume`  | Navigate to Volumes   |
+| `:charts`  | Browse chart releases |
 | `l`      | View Logs               |
 | `s`      | Scale Service           |
 | `r`      | Restart Service         |

--- a/app/update.go
+++ b/app/update.go
@@ -593,6 +593,17 @@ func (m *Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				return m, cmd
 			}
 		}
+		// Check if the current view has an expanded row to step out of first
+		// (charts: from a child row back to the release, then collapse it)
+		if expandableView, ok := m.currentView.(interface {
+			IsRowExpanded() bool
+		}); ok {
+			if expandableView.IsRowExpanded() {
+				// Let the view handle esc to walk back out of the expansion
+				cmd := m.currentView.Update(msg)
+				return m, cmd
+			}
+		}
 		// Check if services view is in stack services mode
 		if servicesView, ok := m.currentView.(interface {
 			IsInStackServicesView() bool

--- a/charts/README.md
+++ b/charts/README.md
@@ -39,6 +39,13 @@ swarmcli charts list
 swarmcli charts uninstall my-traefik
 ```
 
+The TUI complements this with a **read-only** browser, `:charts`: the installed
+releases with their revision, recorded status and live rollout health, expandable
+in place to the revision history and running services, with a diff between any
+two consecutive revisions. It changes nothing — install, upgrade, rollback and
+uninstall are the commands above — but it is the fastest way to see what a swarm
+is actually running, and it names the command for whatever you reach for next.
+
 A chart reference is either a configured `repo/chart` or a local path to a chart
 directory or packaged `.tgz`. **`--version` selects a version from a repository
 index, so it applies only to a `repo/chart` reference** — a local chart carries its

--- a/charts/README.md
+++ b/charts/README.md
@@ -122,7 +122,7 @@ and replaced it in 3.0 for the same reason. The `apply/` prefix keeps a manifest
 applied from the command line from colliding with a controller that happened to
 pick the same name. The controller is the other side of that: a library consumer
 passes its own id as `PlanOptions.Owner` and plans against it instead, so the
-releases it installed under `cd/<app>` read back as its own.
+releases it installed under its own `cd/…` ids read back as its own.
 
 `owner:` is optional and has **no default**. A derived one would either change
 between a laptop and a CI checkout (a path hash) or be shared by every repository

--- a/charts/release.go
+++ b/charts/release.go
@@ -711,6 +711,20 @@ func (e *Engine) List(ctx context.Context) ([]Release, error) {
 	return out, nil
 }
 
+// AllRevisions returns every stored revision, grouped by release name and
+// ascending within each group, with display statuses derived the same way
+// History derives them.
+//
+// It exists for a caller that needs the current revision of every release AND
+// the history of any of them — a browser view, where List followed by a
+// History per expanded release would decode every stored revision twice.
+// Unlike List, nothing is filtered: a release whose current revision is
+// uninstalled is present, because a caller asking for all revisions is asking
+// about the record, not about what is deployed.
+func (e *Engine) AllRevisions(ctx context.Context) (map[string][]Release, error) {
+	return e.allRevisions(ctx)
+}
+
 // Status returns the current release plus live service states for its stack.
 func (e *Engine) Status(ctx context.Context, release string) (*Release, []ServiceState, error) {
 	revs, err := e.revisions(ctx, release)

--- a/charts/release_test.go
+++ b/charts/release_test.go
@@ -556,6 +556,50 @@ func TestListReturnsCurrentRevisions(t *testing.T) {
 	require.Equal(t, "b", list[1].Name)
 }
 
+// AllRevisions is List's counterpart for a caller that needs the current
+// revision of every release AND the history of any of them from one read. The
+// two differ in exactly two ways, and both are the point: nothing is filtered,
+// and lower revisions carry their derived status.
+func TestAllRevisionsReturnsEveryRevisionUnfiltered(t *testing.T) {
+	fb := newFakeBackend()
+	e := testEngine(fb)
+	ctx := context.Background()
+
+	_, err := e.Install(ctx, "a", ReleaseChart{Name: "ca", Version: "1"}, nil, "services:\n  s:\n    image: x\n", InstallOptions{})
+	require.NoError(t, err)
+	_, err = e.Upgrade(ctx, "a", ReleaseChart{Name: "ca", Version: "2"}, nil, "services:\n  s:\n    image: y\n", InstallOptions{})
+	require.NoError(t, err)
+	_, err = e.Install(ctx, "b", ReleaseChart{Name: "cb", Version: "1"}, nil, "services:\n  s:\n    image: x\n", InstallOptions{})
+	require.NoError(t, err)
+
+	// A record another producer left in StatusUninstalled. List hides it;
+	// AllRevisions must not, because a caller asking for every revision is
+	// asking about the record, not about what is deployed.
+	gone := &Release{Name: "c", Revision: 1, Status: StatusUninstalled, Chart: ReleaseChart{Name: "cc", Version: "1"}}
+	fb.configs[releaseConfigName("c", 1)] = fakeConfig{
+		data:   mustGzipRelease(t, gone),
+		labels: map[string]string{LabelType: TypeRelease},
+	}
+
+	all, err := e.AllRevisions(ctx)
+	require.NoError(t, err)
+	require.Len(t, all, 3)
+
+	require.Len(t, all["a"], 2)
+	require.Equal(t, 1, all["a"][0].Revision, "revisions are ascending")
+	require.Equal(t, 2, all["a"][1].Revision)
+	require.Equal(t, StatusSuperseded, all["a"][0].Status, "a lower deployed revision reads as superseded")
+	require.Equal(t, StatusDeployed, all["a"][1].Status)
+
+	require.Len(t, all["b"], 1)
+	require.Len(t, all["c"], 1)
+	require.Equal(t, StatusUninstalled, all["c"][0].Status)
+
+	list, err := e.List(ctx)
+	require.NoError(t, err)
+	require.Len(t, list, 2, "List still hides the uninstalled release AllRevisions reports")
+}
+
 // Reading release history is the engine's hottest path — every List, Status,
 // Install, Upgrade, Rollback and GetRevision walks it, and a GitOps controller
 // walks it on a timer. When the Backend's listing carries the payload, that walk

--- a/commands/api/parse_test.go
+++ b/commands/api/parse_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	_ "github.com/Eldara-Tech/swarmcli/commands/command"
+	_ "github.com/Eldara-Tech/swarmcli/commands/command/charts"
 	_ "github.com/Eldara-Tech/swarmcli/commands/command/docker"
 	_ "github.com/Eldara-Tech/swarmcli/commands/command/docker/config"
 	_ "github.com/Eldara-Tech/swarmcli/commands/command/docker/network"
@@ -157,6 +158,19 @@ func TestParseInput_UnknownFlagRejected(t *testing.T) {
 	_, _, err := ParseInput("node --bogus")
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "unknown flag --bogus for :node")
+}
+
+// :charts takes no flags, so its declared-but-flagless spec must reject every
+// one of them. A command that declares no spec at all skips validateFlags
+// instead, which is the failure this guards against.
+func TestParseInput_ChartsIsStrict(t *testing.T) {
+	cmd, _, err := ParseInput("charts")
+	require.NoError(t, err)
+	require.Equal(t, "charts", cmd.Name())
+
+	_, _, err = ParseInput("charts --bogus")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unknown flag --bogus for :charts")
 }
 
 func TestParseInput_PassthroughSkipsValidation(t *testing.T) {

--- a/commands/autoload.go
+++ b/commands/autoload.go
@@ -5,6 +5,7 @@ package commands
 
 import (
 	_ "github.com/Eldara-Tech/swarmcli/commands/command"
+	_ "github.com/Eldara-Tech/swarmcli/commands/command/charts"
 	_ "github.com/Eldara-Tech/swarmcli/commands/command/docker"
 	_ "github.com/Eldara-Tech/swarmcli/commands/command/docker/config"
 	_ "github.com/Eldara-Tech/swarmcli/commands/command/docker/network"

--- a/commands/command/charts/ls.go
+++ b/commands/command/charts/ls.go
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package charts
+
+import (
+	"github.com/Eldara-Tech/swarmcli/args"
+	"github.com/Eldara-Tech/swarmcli/registry"
+	chartsview "github.com/Eldara-Tech/swarmcli/views/charts"
+	"github.com/Eldara-Tech/swarmcli/views/view"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+type ChartsLs struct{}
+
+func (ChartsLs) Name() string        { return "charts" }
+func (ChartsLs) Description() string { return "browse chart releases" }
+
+func (ChartsLs) Spec() registry.CommandSpec {
+	return registry.CommandSpec{
+		Detail: "Opens the chart releases browser: every installed release " +
+			"with its revision, recorded status and live rollout health. " +
+			"The view is read-only — installing, upgrading, rolling back and " +
+			"uninstalling run from the command line, as `swarmcli charts " +
+			"<command>`.",
+		Examples: []string{":charts"},
+	}
+}
+
+func (ChartsLs) Execute(ctx any, args args.Args) tea.Cmd {
+	return func() tea.Msg {
+		return view.NavigateToMsg{
+			ViewName: chartsview.ViewName,
+			Payload:  nil,
+		}
+	}
+}
+
+// chartAlias is the ":chart" alias for ":charts". It inherits Description,
+// Execute and Spec from the embedded primary; AliasOf folds it under "charts"
+// in the command list and help.
+type chartAlias struct{ ChartsLs }
+
+func (chartAlias) Name() string    { return "chart" }
+func (chartAlias) AliasOf() string { return "charts" }
+
+func init() {
+	registry.Register(ChartsLs{})
+	registry.Register(chartAlias{})
+}

--- a/commands/command/charts/ls_test.go
+++ b/commands/command/charts/ls_test.go
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package charts
+
+import (
+	"testing"
+
+	"github.com/Eldara-Tech/swarmcli/args"
+	"github.com/Eldara-Tech/swarmcli/registry"
+	chartsview "github.com/Eldara-Tech/swarmcli/views/charts"
+	"github.com/Eldara-Tech/swarmcli/views/view"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestChartsCommandNavigatesToTheView(t *testing.T) {
+	cmd, ok := registry.Get("charts")
+	require.True(t, ok, ":charts must be registered")
+
+	msg := cmd.Execute(nil, args.Args{})()
+	nav, ok := msg.(view.NavigateToMsg)
+	require.True(t, ok, "expected navigation, got %T", msg)
+	require.Equal(t, chartsview.ViewName, nav.ViewName)
+}
+
+func TestChartAliasResolvesToTheSameView(t *testing.T) {
+	alias, ok := registry.Get("chart")
+	require.True(t, ok, ":chart must be registered")
+	require.Equal(t, "charts", alias.(registry.Aliaser).AliasOf())
+
+	nav := alias.Execute(nil, args.Args{})().(view.NavigateToMsg)
+	require.Equal(t, chartsview.ViewName, nav.ViewName)
+}
+
+// The spec is what makes strict flag validation and the per-command help
+// screen work at all: a command that declares none skips validateFlags
+// entirely and falls back to generic help. The parse half of that is asserted
+// in commands/api, which cannot be imported here — it pulls in the autoload
+// package that registers this command.
+func TestSpecIsDeclaredAndFlagless(t *testing.T) {
+	spec, hasSpec := registry.SpecOf(ChartsLs{})
+	require.True(t, hasSpec)
+	require.NotEmpty(t, spec.Detail)
+	require.Empty(t, spec.Flags, ":charts reads no flags")
+
+	aliasSpec, hasAliasSpec := registry.SpecOf(chartAlias{})
+	require.True(t, hasAliasSpec, "the alias inherits the primary's spec")
+	require.Equal(t, spec.Detail, aliasSpec.Detail)
+}

--- a/integration-tests/charts/charts_browser_test.go
+++ b/integration-tests/charts/charts_browser_test.go
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+//go:build integration
+
+package charts
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/Eldara-Tech/swarmcli/charts"
+	swarmlog "github.com/Eldara-Tech/swarmcli/utils/log"
+)
+
+// renderRevision renders the demo chart at a replica count, as an install or
+// upgrade would.
+func renderRevision(t *testing.T, ch *charts.Chart, release string, rev int, replicas string) (string, map[string]any) {
+	t.Helper()
+	values, err := charts.MergeValues(ch.Values, nil, []string{"replicas=" + replicas})
+	require.NoError(t, err)
+	manifest, err := charts.Render(ch, charts.RenderContext{
+		Values:  values,
+		Release: charts.ReleaseMeta{Name: release, Namespace: release, Revision: rev},
+		Chart:   charts.ChartMeta{Name: ch.Metadata.Name, Version: ch.Metadata.Version},
+	})
+	require.NoError(t, err)
+	return manifest, values
+}
+
+// TestChartsBrowserReadPath exercises what the :charts view renders, against a
+// real swarm: AllRevisions for the rows and the expansion, and Rollup over the
+// live service states for the health column.
+//
+// The view itself is covered by unit tests that need no Docker. What cannot be
+// faked is whether these two engine reads agree with a swarm that really has a
+// release on it — a rollout that reads converged here is the assertion the
+// health column ultimately rests on.
+func TestChartsBrowserReadPath(t *testing.T) {
+	swarmlog.InitTestIfTestLogEnv()
+
+	ctx := context.Background()
+	release := fmt.Sprintf("itest-browser-%d", time.Now().UnixNano())
+
+	ch, err := charts.LoadChartDir(writeDemoChart(t))
+	require.NoError(t, err)
+	rc := charts.ReleaseChart{Name: ch.Metadata.Name, Version: ch.Metadata.Version}
+
+	eng := charts.NewEngine()
+	defer func() { _, _ = eng.Uninstall(ctx, release, true) }()
+
+	manifest, values := renderRevision(t, ch, release, 1, "1")
+	_, err = eng.Install(ctx, release, rc, values, manifest,
+		charts.InstallOptions{Wait: true, Timeout: 90 * time.Second})
+	require.NoError(t, err)
+
+	upManifest, upValues := renderRevision(t, ch, release, 2, "2")
+	_, err = eng.Upgrade(ctx, release, rc, upValues, upManifest,
+		charts.InstallOptions{Wait: true, Timeout: 90 * time.Second})
+	require.NoError(t, err)
+
+	// One read gives the list rows and every expanded release's history.
+	all, err := eng.AllRevisions(ctx)
+	require.NoError(t, err)
+	revs := all[release]
+	require.Len(t, revs, 2, "the expansion shows both revisions")
+	require.Equal(t, 1, revs[0].Revision, "ascending, as the expansion renders them")
+	require.Equal(t, 2, revs[1].Revision)
+	require.Equal(t, charts.StatusSuperseded, revs[0].Status,
+		"the older revision reads superseded in the expansion")
+	require.Equal(t, charts.StatusDeployed, revs[1].Status)
+
+	// Both manifests are stored, which is what makes the in-view diff possible
+	// without a chart, a re-render or a network.
+	require.NotEqual(t, revs[0].Manifest, revs[1].Manifest)
+	require.Contains(t, revs[0].Manifest, "replicas: 1")
+	require.Contains(t, revs[1].Manifest, "replicas: 2")
+
+	// The health column: a rollout that finished must read converged, since
+	// both deploys above ran with --wait.
+	states := eng.Backend.StackServices(ctx, release)
+	require.NotEmpty(t, states, "the expansion lists the running services")
+	conv := charts.Rollup(states)
+	require.Equal(t, charts.PhaseConverged, conv.Phase,
+		"a waited rollout must read converged: %s", conv.Reason)
+	require.Empty(t, conv.Reason, "a converged release has nothing to explain")
+}

--- a/ui/components/filterable/list/filerablelist.go
+++ b/ui/components/filterable/list/filerablelist.go
@@ -122,6 +122,43 @@ func (f *FilterableList[T]) ScrollLeft() {
 
 func (f *FilterableList[T]) ScrollRight() {
 	f.columnScroll += 5
+	if end := f.maxColumnScroll(); f.columnScroll > end {
+		f.columnScroll = end
+	}
+}
+
+// maxColumnScroll is the offset at which the widest overflowing flex cell on the
+// selected row ends exactly at its right edge.
+//
+// Without it the offset climbs for as long as the key is pressed, and once it
+// passes the end of the text the cells render blank — which reads as the data
+// disappearing rather than as the end of it, and takes as many presses back to
+// undo as it took to get there.
+func (f *FilterableList[T]) maxColumnScroll() int {
+	widths := f.ColWidths()
+	if f.Columns == nil || len(widths) != len(f.Columns) {
+		return 0
+	}
+	if f.Cursor < 0 || f.Cursor >= len(f.Filtered) {
+		return 0
+	}
+	item := f.Filtered[f.Cursor]
+	widest := 0
+	for i, c := range f.Columns {
+		if !c.Flex {
+			continue
+		}
+		// The cell width RenderRow lays this column out in: its share less the
+		// gap, and less column 0's leading space.
+		cw := widths[i] - ColGap
+		if i == 0 {
+			cw--
+		}
+		if over := displayWidth(c.Cell(item)) - cw; over > widest {
+			widest = over
+		}
+	}
+	return widest
 }
 
 func (f *FilterableList[T]) ResetColumnScroll() {

--- a/ui/components/filterable/list/layout.go
+++ b/ui/components/filterable/list/layout.go
@@ -14,10 +14,26 @@ import (
 // derive widths, the header, and each row from the same set so they can never
 // drift out of alignment.
 type Column[T any] struct {
-	Label    string         // header label; also the no-truncate width floor
-	MinWidth int            // declared content floor (excludes the inter-column gap)
-	Flex     bool           // absorbs leftover slack; horizontally scrolls when truncated on a selected row
-	Cell     func(T) string // extracts the plain cell text (the closure may capture model state)
+	Label    string // header label; also the no-truncate width floor
+	MinWidth int    // declared content floor (excludes the inter-column gap)
+	// Flex marks a column as elastic downwards: it gives up width first when the
+	// terminal is too narrow, and horizontally scrolls when truncated on a
+	// selected row.
+	Flex bool
+	// Grow marks the column that absorbs leftover width when the terminal is
+	// wider than the content needs.
+	//
+	// It is separate from Flex because the two are not the same property, and a
+	// table of short values makes that obvious: flexing NAME so a long one can
+	// scroll on an 80-column terminal also hands it half the slack on a
+	// 200-column one, opening a void in the middle of every row. Declaring Grow
+	// on the trailing column instead puts the leftover after the last cell,
+	// where it reads as margin.
+	//
+	// When no column declares Grow the Flex columns absorb the slack, which is
+	// what every view did before Grow existed.
+	Grow bool
+	Cell func(T) string // extracts the plain cell text (the closure may capture model state)
 }
 
 // ColGap is the guaranteed minimum space between adjacent columns, baked into
@@ -88,6 +104,8 @@ func LayoutWidths[T any](cols []Column[T], items []T, totalWidth, sortCol int) [
 	content := make([]int, n)
 	floors := make([]int, n)
 	flex := make([]bool, n)
+	grow := make([]bool, n)
+	anyGrow := false
 	sum := 0
 	for i, c := range cols {
 		// Floor: the header label is never truncated by the renderer, so a column
@@ -115,6 +133,8 @@ func LayoutWidths[T any](cols []Column[T], items []T, totalWidth, sortCol int) [
 		floors[i] = fl
 		content[i] = w
 		flex[i] = c.Flex
+		grow[i] = c.Grow
+		anyGrow = anyGrow || c.Grow
 		sum += w
 	}
 
@@ -128,8 +148,13 @@ func LayoutWidths[T any](cols []Column[T], items []T, totalWidth, sortCol int) [
 	need := sum + ColGap*n
 	switch {
 	case need < totalWidth:
-		// Hand the leftover to flex columns (first flex column via the remainder).
-		distributeSlack(content, flex, totalWidth-need)
+		// Hand the leftover to the Grow columns, falling back to the Flex ones
+		// for a view that declares none — see Column.Grow.
+		absorb := grow
+		if !anyGrow {
+			absorb = flex
+		}
+		distributeSlack(content, absorb, totalWidth-need)
 	case need > totalWidth:
 		shrinkColumns(content, floors, flex, need-totalWidth)
 	}

--- a/ui/components/filterable/list/layout.go
+++ b/ui/components/filterable/list/layout.go
@@ -87,6 +87,47 @@ func ColumnDefs[T any](cols []Column[T]) []ColumnDef {
 	return defs
 }
 
+// NaturalWidth is the width the table wants: every column at its content size,
+// plus the gaps, with nothing stretched or squeezed. LayoutWidths returns
+// exactly this when totalWidth equals it.
+//
+// A view uses it to decide whether a terminal has room to spare — for an extra
+// column it only shows when there is genuine surplus, rather than one that
+// squeezes every other column to fit.
+func NaturalWidth[T any](cols []Column[T], items []T, sortCol int) int {
+	n := len(cols)
+	if n == 0 {
+		return 0
+	}
+	sum := 0
+	for i, c := range cols {
+		sum += naturalColWidth(c, items, i == sortCol)
+	}
+	return sum + 1 + ColGap*n // +1 for column 0's leading space
+}
+
+// naturalColWidth is one column's content size: the widest of its label (plus
+// the sort indicator when active), its declared minimum, and any cell.
+func naturalColWidth[T any](c Column[T], items []T, sorted bool) int {
+	fl := displayWidth(c.Label)
+	if sorted {
+		fl += 2 // " ▲"/" ▼"
+	}
+	if fl < c.MinWidth {
+		fl = c.MinWidth
+	}
+	if fl < 3 {
+		fl = 3
+	}
+	w := fl
+	for _, it := range items {
+		if cw := displayWidth(c.Cell(it)); cw > w {
+			w = cw
+		}
+	}
+	return w
+}
+
 // LayoutWidths sizes columns to their content so wide terminals no longer
 // truncate while space sits empty, and guarantees at least one space between
 // columns. sortCol is the index of the active sort column (-1 for none) so its

--- a/ui/components/filterable/list/layout_test.go
+++ b/ui/components/filterable/list/layout_test.go
@@ -110,3 +110,53 @@ func TestScrollWindow_RuneAware(t *testing.T) {
 	// Windowed content still truncates with an ellipsis when more remains.
 	require.Equal(t, "bcde…", ScrollWindow("abcdefgh", 1, 5))
 }
+
+// growCols separates the two elasticities: NAME gives up width when squeezed
+// and scrolls when truncated, while the trailing column takes the leftover.
+func growCols() []Column[row] {
+	return []Column[row]{
+		{Label: "NAME", MinWidth: 4, Flex: true, Cell: func(r row) string { return r.a }},
+		{Label: "KIND", MinWidth: 4, Cell: func(r row) string { return r.b }},
+		{Label: "LABELS", MinWidth: 6, Grow: true, Cell: func(r row) string { return r.c }},
+	}
+}
+
+// Slack goes to the Grow column, so the columns before it stay put however wide
+// the terminal gets. A table of short values is where that matters: growing a
+// middle column opens a void in the middle of every row.
+func TestLayoutWidths_GrowAbsorbsSlackNotFlex(t *testing.T) {
+	items := []row{{a: "short", b: "kind", c: "x=1"}}
+
+	narrow := LayoutWidths(growCols(), items, 60, -1)
+	wide := LayoutWidths(growCols(), items, 200, -1)
+
+	require.Equal(t, narrow[0], wide[0], "the flex column must not absorb slack")
+	require.Equal(t, narrow[1], wide[1])
+	require.Greater(t, wide[2], narrow[2], "the grow column takes it instead")
+	require.Equal(t, 200, sum(wide), "and the row still spans the width")
+}
+
+// A view that declares no Grow keeps the behaviour it had before Grow existed,
+// so adding the field changed nothing for the views already using Flex.
+func TestLayoutWidths_FlexStillAbsorbsWhenNoGrowDeclared(t *testing.T) {
+	items := []row{{a: "short", b: "kind", c: "x=1"}}
+
+	narrow := LayoutWidths(testCols(), items, 60, -1)
+	wide := LayoutWidths(testCols(), items, 200, -1)
+
+	require.Greater(t, wide[0], narrow[0], "the flex columns still share the slack")
+	require.Greater(t, wide[2], narrow[2])
+	require.Equal(t, 200, sum(wide))
+}
+
+// Grow is about width the table does not need; it must not rescue a column from
+// shrinking when the terminal is too narrow for the content.
+func TestLayoutWidths_GrowColumnStillShrinksWhenNarrow(t *testing.T) {
+	items := []row{{a: "a-fairly-long-name-here", b: "kind", c: "team=platform,env=prod"}}
+
+	w := LayoutWidths(growCols(), items, 40, -1)
+	require.LessOrEqual(t, sum(w), 40)
+	for i, c := range growCols() {
+		require.GreaterOrEqual(t, w[i]-ColGap, displayWidth(c.Label), "column %d must still fit its label", i)
+	}
+}

--- a/ui/components/filterable/list/layout_test.go
+++ b/ui/components/filterable/list/layout_test.go
@@ -160,3 +160,27 @@ func TestLayoutWidths_GrowColumnStillShrinksWhenNarrow(t *testing.T) {
 		require.GreaterOrEqual(t, w[i]-ColGap, displayWidth(c.Label), "column %d must still fit its label", i)
 	}
 }
+
+// NaturalWidth must be the width at which LayoutWidths neither stretches nor
+// squeezes, or a view asking "have I room to spare?" gets a wrong answer.
+func TestNaturalWidth_IsTheNoStretchNoSqueezeWidth(t *testing.T) {
+	items := []row{{a: "some-name", b: "kind", c: "team=platform"}}
+
+	for _, cols := range [][]Column[row]{testCols(), growCols()} {
+		natural := NaturalWidth(cols, items, -1)
+		require.Equal(t, natural, sum(LayoutWidths(cols, items, natural, -1)),
+			"at the natural width the layout is an identity")
+
+		// One cell narrower and something must give; one wider and the slack
+		// has to land somewhere.
+		require.Equal(t, natural-1, sum(LayoutWidths(cols, items, natural-1, -1)))
+		require.Equal(t, natural+10, sum(LayoutWidths(cols, items, natural+10, -1)))
+	}
+}
+
+// The sort indicator widens its column, so a view must get the same answer the
+// layout will act on.
+func TestNaturalWidth_AccountsForTheSortIndicator(t *testing.T) {
+	items := []row{{a: "x", b: "y", c: "z"}}
+	require.Greater(t, NaturalWidth(testCols(), items, 0), NaturalWidth(testCols(), items, -1))
+}

--- a/ui/components/filterable/list/layout_test.go
+++ b/ui/components/filterable/list/layout_test.go
@@ -111,6 +111,33 @@ func TestScrollWindow_RuneAware(t *testing.T) {
 	require.Equal(t, "bcde…", ScrollWindow("abcdefgh", 1, 5))
 }
 
+// Scrolling right stops where the text does.
+//
+// The offset used to climb for as long as the key was pressed, and once it
+// passed the end of the string every flex cell on the row rendered blank —
+// which reads as the data disappearing rather than as the end of it, and takes
+// as many presses to undo as it took to cause.
+func TestScrollRightStopsAtTheEndOfTheText(t *testing.T) {
+	const name = "a-name-far-wider-than-its-column"
+	f := FilterableList[row]{
+		Columns:  testCols(),
+		Filtered: []row{{a: name, b: "kind", c: "x=1"}},
+		Header:   &HeaderConfig{Columns: ColumnDefs(testCols())},
+	}
+	f.SetOuterSize(40, 10)
+
+	for range 50 {
+		f.ScrollRight()
+	}
+
+	// Column 0 carries the leading space as well as the gap.
+	nameWidth := f.ColWidths()[0] - ColGap - 1
+	require.Equal(t, len(name)-nameWidth, f.columnScroll,
+		"the offset stops with the last window ending at the end of the text")
+	require.Contains(t, f.RenderRow(f.Filtered[0], true), "its-column",
+		"so the tail is on screen rather than scrolled past")
+}
+
 // growCols separates the two elasticities: NAME gives up width when squeezed
 // and scrolls when truncated, while the trailing column takes the leftover.
 func growCols() []Column[row] {

--- a/views/autoload.go
+++ b/views/autoload.go
@@ -5,6 +5,7 @@
 package views
 
 import (
+	_ "github.com/Eldara-Tech/swarmcli/views/charts"
 	_ "github.com/Eldara-Tech/swarmcli/views/configs"
 	_ "github.com/Eldara-Tech/swarmcli/views/contexts"
 	_ "github.com/Eldara-Tech/swarmcli/views/help"

--- a/views/charts/charts.go
+++ b/views/charts/charts.go
@@ -11,6 +11,11 @@ import swarmlog "github.com/Eldara-Tech/swarmcli/utils/log"
 
 const ViewName = "charts"
 
+// readOnlyHint is always on screen. The view deliberately cannot change a
+// release, and an operator should learn where that lives without having to
+// press a key and be told no.
+const readOnlyHint = "Read-only · manage releases with `swarmcli charts install|upgrade|rollback|uninstall`"
+
 func l() *swarmlog.SwarmLogger {
 	return swarmlog.L().With("views", "charts")
 }

--- a/views/charts/charts.go
+++ b/views/charts/charts.go
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+// Package chartsview is the read-only browser for chart releases.
+//
+// The package directory is views/charts but the package is chartsview, so that
+// the release engine it reads from keeps the plain `charts` identifier.
+package chartsview
+
+import swarmlog "github.com/Eldara-Tech/swarmcli/utils/log"
+
+const ViewName = "charts"
+
+func l() *swarmlog.SwarmLogger {
+	return swarmlog.L().With("views", "charts")
+}
+
+// displayOrDash renders an em-dash for empty optional fields.
+func displayOrDash(s string) string {
+	if s == "" {
+		return "—"
+	}
+	return s
+}

--- a/views/charts/charts.go
+++ b/views/charts/charts.go
@@ -14,7 +14,10 @@ const ViewName = "charts"
 // readOnlyHint is always on screen. The view deliberately cannot change a
 // release, and an operator should learn where that lives without having to
 // press a key and be told no.
-const readOnlyHint = "Read-only · manage releases with `swarmcli charts install|upgrade|rollback|uninstall`"
+// It is kept short enough to survive an 80-column frame: the full command list
+// overflowed the border and read as a truncated sentence, and `?` carries the
+// verbs anyway.
+const readOnlyHint = "Read-only · change releases with `swarmcli charts` (? for how)"
 
 func l() *swarmlog.SwarmLogger {
 	return swarmlog.L().With("views", "charts")

--- a/views/charts/columns_test.go
+++ b/views/charts/columns_test.go
@@ -5,6 +5,7 @@ package chartsview
 
 import (
 	"testing"
+	"time"
 
 	"github.com/Eldara-Tech/swarmcli/charts"
 
@@ -92,8 +93,7 @@ func TestWideTerminalDoesNotSpreadTheColumns(t *testing.T) {
 		"whoami":   deployed("whoami", "whoami", "0.1.9"),
 	}
 	positions := func(width int) map[string]int {
-		m := testModel()
-		m.list.Viewport.Width = width
+		m := sized(testModel(), width, 24)
 		loadReleases(t, m, short, nil)
 		header := m.list.RenderHeader()
 		out := map[string]int{}
@@ -103,16 +103,81 @@ func TestWideTerminalDoesNotSpreadTheColumns(t *testing.T) {
 		return out
 	}
 
-	narrow := positions(100)
+	// Both widths carry the same column set (short values, so DETAIL and OWNER
+	// are affordable at each), and the columns before the growing one must not
+	// drift apart between them.
+	narrow := positions(150)
 	wide := positions(240)
 	require.Equal(t, narrow, wide,
-		"a wider terminal must add margin after the last column, not between the others")
+		"a wider terminal must feed the growing column, not spread the others")
 
 	// And the row still spans the frame, so the selection highlight does too.
-	m := testModel()
-	m.list.Viewport.Width = 240
+	m := sized(testModel(), 240, 24)
 	loadReleases(t, m, short, nil)
-	require.Equal(t, 240, lipgloss.Width(m.list.RenderRow(m.list.Filtered[0], true)))
+	require.Equal(t, 240, lipgloss.Width(m.list.RenderRow(m.list.Filtered[0], true)),
+		"and the row still spans the frame, so the selection highlight does too")
+}
+
+// Surplus width buys information, not air.
+//
+// Two earlier attempts were wrong in opposite directions: sharing the slack
+// between NAME and CHART opened voids in the middle of every row, and giving it
+// to no one left half a wide terminal dead. The column set is responsive
+// instead — each tier of width adds a column that has something to say.
+func TestWiderTerminalsAddColumnsRatherThanPadding(t *testing.T) {
+	labels := func(width int) []string {
+		m := sized(testModel(), width, 24)
+		loadReleases(t, m,
+			map[string][]charts.Release{"app": deployed("app", "c", "1.0.0")},
+			map[string][]charts.ServiceState{"app": {converged("app_web")}})
+		out := make([]string, 0, len(m.list.Columns))
+		for _, c := range m.list.Columns {
+			out = append(out, c.Label)
+		}
+		return out
+	}
+
+	base := []string{"NAME", "REV", "STATUS", "HEALTH", "CHART", "LATEST", "UPDATED"}
+	require.Equal(t, base, labels(80), "a narrow terminal shows the compact set")
+	require.Equal(t, append(append([]string{}, base...), "DETAIL"), labels(120))
+	require.Equal(t, append(append([]string{}, base...), "OWNER", "DETAIL"), labels(190))
+}
+
+// The extra column must be earned, never taken from the others: adding DETAIL
+// by squeezing NAME and CHART would trade a readable name for a truncated
+// explanation.
+func TestTheDetailColumnNeverSqueezesTheOthers(t *testing.T) {
+	long := map[string][]charts.Release{
+		"a-release-with-a-really-quite-long-name": deployed("a-release-with-a-really-quite-long-name", "some-long-chart-name", "1.2.3"),
+	}
+
+	withoutDetail := sized(testModel(), 100, 24)
+	loadReleases(t, withoutDetail, long, nil)
+	require.False(t, withoutDetail.hasDetailColumn(),
+		"the long name eats the surplus, so DETAIL must stand down")
+
+	// Widen until it is affordable; the name must still be intact.
+	withDetail := sized(testModel(), 190, 24)
+	loadReleases(t, withDetail, long, nil)
+	require.True(t, withDetail.hasDetailColumn())
+	require.Contains(t, withDetail.View(), "a-release-with-a-really-quite-long-name",
+		"DETAIL was added out of surplus, not out of NAME")
+}
+
+// DETAIL is the one column allowed to give way, so a terminal between the tiers
+// truncates the explanation rather than the identity.
+func TestOnlyDetailTruncatesWhenSpaceIsTight(t *testing.T) {
+	m := sized(testModel(), 118, 24)
+	loadReleases(t, m,
+		map[string][]charts.Release{"app": deployed("app", "chartname", "1.0.0")},
+		map[string][]charts.ServiceState{"app": {{
+			Name: "app_web", Running: 1, Desired: 4, NewestTaskAge: time.Hour,
+		}}})
+	require.True(t, m.hasDetailColumn())
+
+	out := m.View()
+	require.Contains(t, out, "chartname-1.0.0", "the chart ref is intact")
+	require.Contains(t, out, "app", "the name is intact")
 }
 
 // The sort arrow must land on the column the sort field names, or the header

--- a/views/charts/columns_test.go
+++ b/views/charts/columns_test.go
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package chartsview
+
+import (
+	"testing"
+
+	"github.com/Eldara-Tech/swarmcli/charts"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/stretchr/testify/require"
+)
+
+// longName overflows the NAME column on a narrow terminal and fits on a wide one.
+const longName = "release_with_a_fairly_long_descriptive_name"
+
+func twoReleases() map[string][]charts.Release {
+	return map[string][]charts.Release{
+		longName: deployed(longName, "some-long-chart-name", "1.2.3"),
+		"z2":     deployed("z2", "c", "1.0.0"),
+	}
+}
+
+func itemNamed(m *Model, name string) releaseItem {
+	for _, r := range m.list.Filtered {
+		if r.Name == name {
+			return r
+		}
+	}
+	return releaseItem{}
+}
+
+func TestHeaderAndRowAligned(t *testing.T) {
+	for _, w := range []int{60, 120, 220} {
+		m := testModel()
+		m.list.Viewport.Width = w
+		loadReleases(t, m, twoReleases(), nil)
+
+		header := m.list.RenderHeader()
+		row := m.list.RenderItem(m.list.Filtered[0], false, 0)
+		require.Equal(t, lipgloss.Width(header), lipgloss.Width(row),
+			"header and row widths must match at width %d", w)
+	}
+}
+
+func TestContentAwareNameWideTerminal(t *testing.T) {
+	m := testModel()
+	m.list.Viewport.Width = 220
+	loadReleases(t, m, twoReleases(), nil)
+	row := m.list.RenderItem(itemNamed(m, longName), false, 0)
+	require.Contains(t, row, longName, "full name must be visible on a wide terminal")
+}
+
+func TestArrowScrollMovesWindow(t *testing.T) {
+	m := testModel()
+	m.list.Viewport.Width = 70 // narrow → flex columns overflow
+	loadReleases(t, m, twoReleases(), nil)
+	before := m.list.RenderItem(itemNamed(m, longName), true, 0)
+	m.Update(key("right"))
+	after := m.list.RenderItem(itemNamed(m, longName), true, 0)
+	require.NotEqual(t, before, after, "right arrow should shift the truncated cell window")
+}
+
+func TestResetScrollOnCursorMove(t *testing.T) {
+	m := testModel()
+	m.list.Viewport.Width = 70
+	loadReleases(t, m, twoReleases(), nil)
+	m.Update(key("right"))
+	m.Update(key("right"))
+	scrolled := m.list.RenderItem(itemNamed(m, longName), true, 0)
+
+	m.Update(key("down"))
+	m.Update(key("up"))
+
+	require.NotEqual(t, scrolled, m.list.RenderItem(itemNamed(m, longName), true, 0),
+		"scroll offset must reset when the cursor moves")
+}
+
+// The sort arrow must land on the column the sort field names, or the header
+// tells the operator something false.
+func TestSortIndicatorTracksTheSortField(t *testing.T) {
+	m := testModel()
+	cols := m.buildColumns()
+	for field, want := range map[SortField]string{
+		SortByName:     "NAME",
+		SortByRevision: "REV",
+		SortByStatus:   "STATUS",
+		SortByHealth:   "HEALTH",
+		SortByChart:    "CHART",
+		SortByUpdated:  "UPDATED",
+	} {
+		m.sortField = field
+		require.Equal(t, want, cols[m.sortColumnIndex()].Label)
+	}
+}

--- a/views/charts/columns_test.go
+++ b/views/charts/columns_test.go
@@ -63,6 +63,40 @@ func TestArrowScrollMovesWindow(t *testing.T) {
 	require.NotEqual(t, before, after, "right arrow should shift the truncated cell window")
 }
 
+// The OWNER cell names the tool that installed the release, and drops the half
+// of the stamp that only repeats the row it is drawn on.
+func TestOwnerColumnNamesTheControllerAndDropsTheResourceHalf(t *testing.T) {
+	m := sized(testModel(), 200, 24)
+	owned := rev("whoami", 1, charts.StatusDeployed, "whoami", "0.1.9")
+	owned.Owner = "cd/default/whoami:release/whoami"
+	loadReleases(t, m, map[string][]charts.Release{"whoami": {owned}},
+		map[string][]charts.ServiceState{"whoami": {converged("whoami_web")}})
+
+	row := m.list.RenderItem(m.list.Filtered[0], false, 0)
+	require.Contains(t, row, "swarmcli-cd/default/whoami")
+	require.NotContains(t, row, ":release/whoami", "the resource half is the NAME column again")
+}
+
+// An owner wider than its column is reachable with ←/→, and stays reachable:
+// the arrow stops where the text ends instead of scrolling the cell off it.
+func TestArrowScrollReachesTheOwnerAndStopsAtItsEnd(t *testing.T) {
+	// Wide enough for the OWNER column, too narrow for this owner to fit in it.
+	m := sized(testModel(), 130, 24)
+	owned := rev("app", 1, charts.StatusDeployed, "c", "1.0.0")
+	owned.Owner = "cd/prod-cluster/eldara-renovate-and-friends:release/app"
+	loadReleases(t, m, map[string][]charts.Release{"app": {owned}},
+		map[string][]charts.ServiceState{"app": {converged("app_web")}})
+
+	require.NotContains(t, m.list.RenderItem(m.list.Filtered[0], true, 0), "and-friends",
+		"the owner must start out truncated, or this proves nothing")
+
+	for range 20 {
+		m.Update(key("right"))
+	}
+	require.Contains(t, m.list.RenderItem(m.list.Filtered[0], true, 0), "and-friends",
+		"the arrow reaches the end of the owner, and stops there rather than past it")
+}
+
 func TestResetScrollOnCursorMove(t *testing.T) {
 	m := testModel()
 	m.list.Viewport.Width = 70

--- a/views/charts/columns_test.go
+++ b/views/charts/columns_test.go
@@ -77,6 +77,44 @@ func TestResetScrollOnCursorMove(t *testing.T) {
 		"scroll offset must reset when the cursor moves")
 }
 
+// Widening the terminal must not push the columns apart.
+//
+// Release names and chart refs are short, so flexing them meant a 200-column
+// terminal handed each half the leftover and opened a void in the middle of
+// every row. Only the trailing column grows, so every column up to it sits at
+// the same place whatever the width.
+func TestWideTerminalDoesNotSpreadTheColumns(t *testing.T) {
+	// Short values on purpose: that is when growing a middle column shows as a
+	// void. Both widths are wider than the natural content, so nothing shrinks
+	// and any difference is growth.
+	short := map[string][]charts.Release{
+		"openclaw": deployed("openclaw", "openclaw", "0.1.0"),
+		"whoami":   deployed("whoami", "whoami", "0.1.9"),
+	}
+	positions := func(width int) map[string]int {
+		m := testModel()
+		m.list.Viewport.Width = width
+		loadReleases(t, m, short, nil)
+		header := m.list.RenderHeader()
+		out := map[string]int{}
+		for _, col := range []string{"REV", "STATUS", "HEALTH", "CHART", "LATEST"} {
+			out[col] = columnOf(t, header, col)
+		}
+		return out
+	}
+
+	narrow := positions(100)
+	wide := positions(240)
+	require.Equal(t, narrow, wide,
+		"a wider terminal must add margin after the last column, not between the others")
+
+	// And the row still spans the frame, so the selection highlight does too.
+	m := testModel()
+	m.list.Viewport.Width = 240
+	loadReleases(t, m, short, nil)
+	require.Equal(t, 240, lipgloss.Width(m.list.RenderRow(m.list.Filtered[0], true)))
+}
+
 // The sort arrow must land on the column the sort field names, or the header
 // tells the operator something false.
 func TestSortIndicatorTracksTheSortField(t *testing.T) {

--- a/views/charts/expansion.go
+++ b/views/charts/expansion.go
@@ -4,8 +4,8 @@
 package chartsview
 
 import (
-	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/Eldara-Tech/swarmcli/charts"
 
@@ -57,10 +57,40 @@ var (
 	childSelectedStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("230")).Background(lipgloss.Color("24")).Bold(true)
 )
 
-const (
-	revisionFormat = "    %-4s %-11s %-26s %-17s %s"
-	serviceFormat  = "    %-26s %-12s %-10s %s"
+// Child blocks are laid out at fixed widths rather than through the
+// content-aware column layout, which sizes the release row above them.
+var (
+	revisionCols = []int{4, 11, 26, 17, 30}
+	serviceCols  = []int{26, 12, 10, 0}
 )
+
+// childLine joins cells at fixed widths, padding by DISPLAY COLUMNS.
+//
+// fmt's "%-12s" pads by bytes, and these cells carry multi-byte runes as a
+// matter of course — displayOrDash emits an em-dash for every empty optional
+// field, which is three bytes and one column. Padding that by bytes shifts
+// every later cell two columns left of its header.
+func childLine(cells []string, widths []int) string {
+	var b strings.Builder
+	b.WriteString("    ")
+	for i, cell := range cells {
+		w := 0
+		if i < len(widths) {
+			w = widths[i]
+		}
+		if w == 0 { // last column: no padding, no truncation
+			b.WriteString(cell)
+			break
+		}
+		cell = truncate(cell, w)
+		b.WriteString(cell)
+		for pad := w - lipgloss.Width(cell); pad > 0; pad-- {
+			b.WriteByte(' ')
+		}
+		b.WriteByte(' ')
+	}
+	return b.String()
+}
 
 // expansionBlock renders an expanded release's child lines and reports, for
 // each selectable child, which line it landed on.
@@ -68,9 +98,9 @@ const (
 // The two are returned together on purpose: the scroll math needs a child's
 // line index, and deriving it separately from a second count of headers and
 // rows is how the two silently drift apart.
-func expansionBlock(it releaseItem, selectedChild int) (lines []string, childLine []int) {
+func expansionBlock(it releaseItem, selectedChild int) (lines []string, childLines []int) {
 	rows := it.children()
-	childLine = make([]int, len(rows))
+	childLines = make([]int, len(rows))
 
 	line := func(s string) { lines = append(lines, s) }
 	style := func(idx int, s string) string {
@@ -80,34 +110,36 @@ func expansionBlock(it releaseItem, selectedChild int) (lines []string, childLin
 		return childStyle.Render(s)
 	}
 
-	line(childHeaderStyle.Render(fmt.Sprintf(revisionFormat, "REV", "STATUS", "CHART", "UPDATED", "OWNER")))
+	line(childHeaderStyle.Render(childLine(
+		[]string{"REV", "STATUS", "CHART", "UPDATED", "OWNER"}, revisionCols)))
 	for n, rev := range it.Revisions {
-		childLine[n] = len(lines)
-		line(style(n, fmt.Sprintf(revisionFormat,
+		childLines[n] = len(lines)
+		line(style(n, childLine([]string{
 			strconv.Itoa(rev.Revision),
-			truncate(rev.Status, 11),
-			truncate(rev.Chart.Name+"-"+rev.Chart.Version, 26),
+			rev.Status,
+			rev.Chart.Name + "-" + rev.Chart.Version,
 			formatCreated(parseCreated(rev.Created)),
-			truncate(displayOrDash(rev.Owner), 30),
-		)))
+			displayOrDash(rev.Owner),
+		}, revisionCols)))
 	}
 
-	line(childHeaderStyle.Render(fmt.Sprintf(serviceFormat, "SERVICE", "MODE", "REPLICAS", "STATUS")))
+	line(childHeaderStyle.Render(childLine(
+		[]string{"SERVICE", "MODE", "REPLICAS", "STATUS"}, serviceCols)))
 	if len(it.Services) == 0 {
 		line(childStyle.Render("    (no services)"))
-		return lines, childLine
+		return lines, childLines
 	}
 	for n, svc := range it.Services {
 		idx := len(it.Revisions) + n
-		childLine[idx] = len(lines)
-		line(style(idx, fmt.Sprintf(serviceFormat,
-			truncate(svc.Name, 26),
-			truncate(displayOrDash(svc.Mode), 12),
-			truncate(displayOrDash(svc.Replicas), 10),
+		childLines[idx] = len(lines)
+		line(style(idx, childLine([]string{
+			svc.Name,
+			displayOrDash(svc.Mode),
+			displayOrDash(svc.Replicas),
 			displayOrDash(svc.Status),
-		)))
+		}, serviceCols)))
 	}
-	return lines, childLine
+	return lines, childLines
 }
 
 // truncate shortens s to max display columns, with an ellipsis when it had to

--- a/views/charts/expansion.go
+++ b/views/charts/expansion.go
@@ -5,9 +5,9 @@ package chartsview
 
 import (
 	"strconv"
-	"strings"
 
 	"github.com/Eldara-Tech/swarmcli/charts"
+	filterlist "github.com/Eldara-Tech/swarmcli/ui/components/filterable/list"
 
 	"github.com/charmbracelet/lipgloss"
 )
@@ -57,39 +57,51 @@ var (
 	childSelectedStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("230")).Background(lipgloss.Color("24")).Bold(true)
 )
 
-// Child blocks are laid out at fixed widths rather than through the
-// content-aware column layout, which sizes the release row above them.
-var (
-	revisionCols = []int{4, 11, 26, 17, 30}
-	serviceCols  = []int{26, 12, 10, 0}
-)
+// childIndent is the space the child block is inset by, so the expansion reads
+// as belonging to the release above it.
+const childIndent = "    "
 
-// childLine joins cells at fixed widths, padding by DISPLAY COLUMNS.
+// revisionColumns and serviceColumns describe the two child blocks.
 //
-// fmt's "%-12s" pads by bytes, and these cells carry multi-byte runes as a
-// matter of course — displayOrDash emits an em-dash for every empty optional
-// field, which is three bytes and one column. Padding that by bytes shifts
-// every later cell two columns left of its header.
-func childLine(cells []string, widths []int) string {
-	var b strings.Builder
-	b.WriteString("    ")
-	for i, cell := range cells {
-		w := 0
-		if i < len(widths) {
-			w = widths[i]
-		}
-		if w == 0 { // last column: no padding, no truncation
-			b.WriteString(cell)
-			break
-		}
-		cell = truncate(cell, w)
-		b.WriteString(cell)
-		for pad := w - lipgloss.Width(cell); pad > 0; pad-- {
-			b.WriteByte(' ')
-		}
-		b.WriteByte(' ')
+// They go through the same content-aware layout as the release row rather than
+// carrying hardcoded widths. Fixed widths overflowed a narrow frame — the OWNER
+// stamp ran into the border and was cut mid-word by the frame rather than
+// truncated — and they padded by bytes, so an em-dash shifted every later cell
+// two columns off its header.
+func revisionColumns() []filterlist.Column[charts.Release] {
+	return []filterlist.Column[charts.Release]{
+		{Label: "REV", MinWidth: 3, Cell: func(r charts.Release) string { return strconv.Itoa(r.Revision) }},
+		{Label: "STATUS", MinWidth: 6, Cell: func(r charts.Release) string { return displayOrDash(r.Status) }},
+		{Label: "CHART", MinWidth: 5, Flex: true, Cell: func(r charts.Release) string {
+			return r.Chart.Name + "-" + r.Chart.Version
+		}},
+		{Label: "UPDATED", MinWidth: 16, Cell: func(r charts.Release) string { return formatCreated(parseCreated(r.Created)) }},
+		{Label: "OWNER", MinWidth: 5, Flex: true, Grow: true, Cell: func(r charts.Release) string {
+			return displayOrDash(r.Owner)
+		}},
 	}
-	return b.String()
+}
+
+func serviceColumns() []filterlist.Column[charts.ServiceState] {
+	return []filterlist.Column[charts.ServiceState]{
+		{Label: "SERVICE", MinWidth: 7, Flex: true, Cell: func(s charts.ServiceState) string { return s.Name }},
+		{Label: "MODE", MinWidth: 4, Cell: func(s charts.ServiceState) string { return displayOrDash(s.Mode) }},
+		{Label: "REPLICAS", MinWidth: 8, Cell: func(s charts.ServiceState) string { return displayOrDash(s.Replicas) }},
+		{Label: "STATUS", MinWidth: 6, Flex: true, Grow: true, Cell: func(s charts.ServiceState) string {
+			return displayOrDash(s.Status)
+		}},
+	}
+}
+
+// childWidth is the width a child row has to work with: the frame's content
+// area less the indent. Zero or less means "unknown", and the block falls back
+// to its natural size rather than collapsing to nothing.
+func childWidth(total int) int {
+	w := total - len(childIndent)
+	if w < 20 {
+		return 0
+	}
+	return w
 }
 
 // expansionBlock renders an expanded release's child lines and reports, for
@@ -98,7 +110,7 @@ func childLine(cells []string, widths []int) string {
 // The two are returned together on purpose: the scroll math needs a child's
 // line index, and deriving it separately from a second count of headers and
 // rows is how the two silently drift apart.
-func expansionBlock(it releaseItem, selectedChild int) (lines []string, childLines []int) {
+func expansionBlock(it releaseItem, selectedChild, width int) (lines []string, childLines []int) {
 	rows := it.children()
 	childLines = make([]int, len(rows))
 
@@ -110,51 +122,49 @@ func expansionBlock(it releaseItem, selectedChild int) (lines []string, childLin
 		return childStyle.Render(s)
 	}
 
-	line(childHeaderStyle.Render(childLine(
-		[]string{"REV", "STATUS", "CHART", "UPDATED", "OWNER"}, revisionCols)))
+	w := childWidth(width)
+	revCols := revisionColumns()
+	revWidths := layoutOrNatural(revCols, it.Revisions, w)
+	line(childHeaderStyle.Render(childIndent + headerRow(revCols, revWidths)))
 	for n, rev := range it.Revisions {
 		childLines[n] = len(lines)
-		line(style(n, childLine([]string{
-			strconv.Itoa(rev.Revision),
-			rev.Status,
-			rev.Chart.Name + "-" + rev.Chart.Version,
-			formatCreated(parseCreated(rev.Created)),
-			displayOrDash(rev.Owner),
-		}, revisionCols)))
+		line(style(n, childIndent+filterlist.RenderRow(revCols, revWidths, rev, 0, false)))
 	}
 
-	line(childHeaderStyle.Render(childLine(
-		[]string{"SERVICE", "MODE", "REPLICAS", "STATUS"}, serviceCols)))
+	svcCols := serviceColumns()
+	svcWidths := layoutOrNatural(svcCols, it.Services, w)
+	line(childHeaderStyle.Render(childIndent + headerRow(svcCols, svcWidths)))
 	if len(it.Services) == 0 {
-		line(childStyle.Render("    (no services)"))
+		line(childStyle.Render(childIndent + "(no services)"))
 		return lines, childLines
 	}
 	for n, svc := range it.Services {
 		idx := len(it.Revisions) + n
 		childLines[idx] = len(lines)
-		line(style(idx, childLine([]string{
-			svc.Name,
-			displayOrDash(svc.Mode),
-			displayOrDash(svc.Replicas),
-			displayOrDash(svc.Status),
-		}, serviceCols)))
+		line(style(idx, childIndent+filterlist.RenderRow(svcCols, svcWidths, svc, 0, false)))
 	}
 	return lines, childLines
 }
 
-// truncate shortens s to max display columns, with an ellipsis when it had to
-// cut. Child blocks are laid out at fixed widths rather than through the
-// content-aware column layout, which sizes the release row above them.
-func truncate(s string, max int) string {
-	if max <= 0 {
-		return ""
+// headerRow renders the column labels through the very same RenderRow the data
+// rows use, by swapping each Cell for its own Label. Alignment between a child
+// header and its rows is then true by construction rather than by two pieces of
+// formatting code agreeing.
+func headerRow[T any](cols []filterlist.Column[T], widths []int) string {
+	hdr := make([]filterlist.Column[T], len(cols))
+	for i, c := range cols {
+		label := c.Label
+		hdr[i] = filterlist.Column[T]{Label: c.Label, MinWidth: c.MinWidth, Cell: func(T) string { return label }}
 	}
-	r := []rune(s)
-	if len(r) <= max {
-		return s
+	var zero T
+	return filterlist.RenderRow(hdr, widths, zero, 0, false)
+}
+
+// layoutOrNatural sizes the child columns to the width available, or to their
+// content when the width is unknown.
+func layoutOrNatural[T any](cols []filterlist.Column[T], items []T, width int) []int {
+	if width <= 0 {
+		width = filterlist.NaturalWidth(cols, items, -1)
 	}
-	if max <= 3 {
-		return string(r[:max])
-	}
-	return string(r[:max-3]) + "..."
+	return filterlist.LayoutWidths(cols, items, width, -1)
 }

--- a/views/charts/expansion.go
+++ b/views/charts/expansion.go
@@ -77,7 +77,7 @@ func revisionColumns() []filterlist.Column[charts.Release] {
 		}},
 		{Label: "UPDATED", MinWidth: 16, Cell: func(r charts.Release) string { return formatCreated(parseCreated(r.Created)) }},
 		{Label: "OWNER", MinWidth: 5, Flex: true, Grow: true, Cell: func(r charts.Release) string {
-			return displayOrDash(r.Owner)
+			return ownerCell(r.Owner, r.Name)
 		}},
 	}
 }

--- a/views/charts/expansion.go
+++ b/views/charts/expansion.go
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package chartsview
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/Eldara-Tech/swarmcli/charts"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+// noChild is the childIndex when the release row itself is selected.
+const noChild = -1
+
+type childKind int
+
+const (
+	childRevision childKind = iota
+	childService
+)
+
+// childRow is one selectable line inside an expanded release. The column
+// headers between the blocks are rendered but not selectable, so a child's
+// index is not its line.
+type childRow struct {
+	kind childKind
+	rev  charts.Release
+	svc  charts.ServiceState
+	// prev is the revision immediately below rev, for the diff. Its zero value
+	// means rev is the first, which diffs against nothing.
+	prev charts.Release
+}
+
+// children flattens an expanded release into its selectable rows: every stored
+// revision ascending, then the live services.
+func (i releaseItem) children() []childRow {
+	rows := make([]childRow, 0, len(i.Revisions)+len(i.Services))
+	for n, rev := range i.Revisions {
+		row := childRow{kind: childRevision, rev: rev}
+		if n > 0 {
+			row.prev = i.Revisions[n-1]
+		}
+		rows = append(rows, row)
+	}
+	for _, svc := range i.Services {
+		rows = append(rows, childRow{kind: childService, svc: svc})
+	}
+	return rows
+}
+
+var (
+	childHeaderStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("8")).Italic(true)
+	childStyle         = lipgloss.NewStyle().Foreground(lipgloss.Color("7"))
+	childSelectedStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("230")).Background(lipgloss.Color("24")).Bold(true)
+)
+
+const (
+	revisionFormat = "    %-4s %-11s %-26s %-17s %s"
+	serviceFormat  = "    %-26s %-12s %-10s %s"
+)
+
+// expansionBlock renders an expanded release's child lines and reports, for
+// each selectable child, which line it landed on.
+//
+// The two are returned together on purpose: the scroll math needs a child's
+// line index, and deriving it separately from a second count of headers and
+// rows is how the two silently drift apart.
+func expansionBlock(it releaseItem, selectedChild int) (lines []string, childLine []int) {
+	rows := it.children()
+	childLine = make([]int, len(rows))
+
+	line := func(s string) { lines = append(lines, s) }
+	style := func(idx int, s string) string {
+		if idx == selectedChild {
+			return childSelectedStyle.Render(s)
+		}
+		return childStyle.Render(s)
+	}
+
+	line(childHeaderStyle.Render(fmt.Sprintf(revisionFormat, "REV", "STATUS", "CHART", "UPDATED", "OWNER")))
+	for n, rev := range it.Revisions {
+		childLine[n] = len(lines)
+		line(style(n, fmt.Sprintf(revisionFormat,
+			strconv.Itoa(rev.Revision),
+			truncate(rev.Status, 11),
+			truncate(rev.Chart.Name+"-"+rev.Chart.Version, 26),
+			formatCreated(parseCreated(rev.Created)),
+			truncate(displayOrDash(rev.Owner), 30),
+		)))
+	}
+
+	line(childHeaderStyle.Render(fmt.Sprintf(serviceFormat, "SERVICE", "MODE", "REPLICAS", "STATUS")))
+	if len(it.Services) == 0 {
+		line(childStyle.Render("    (no services)"))
+		return lines, childLine
+	}
+	for n, svc := range it.Services {
+		idx := len(it.Revisions) + n
+		childLine[idx] = len(lines)
+		line(style(idx, fmt.Sprintf(serviceFormat,
+			truncate(svc.Name, 26),
+			truncate(displayOrDash(svc.Mode), 12),
+			truncate(displayOrDash(svc.Replicas), 10),
+			displayOrDash(svc.Status),
+		)))
+	}
+	return lines, childLine
+}
+
+// truncate shortens s to max display columns, with an ellipsis when it had to
+// cut. Child blocks are laid out at fixed widths rather than through the
+// content-aware column layout, which sizes the release row above them.
+func truncate(s string, max int) string {
+	if max <= 0 {
+		return ""
+	}
+	r := []rune(s)
+	if len(r) <= max {
+		return s
+	}
+	if max <= 3 {
+		return string(r[:max])
+	}
+	return string(r[:max-3]) + "..."
+}

--- a/views/charts/expansion_test.go
+++ b/views/charts/expansion_test.go
@@ -306,7 +306,7 @@ func TestChildLineIndexesMatchTheRenderedLines(t *testing.T) {
 	require.True(t, ok)
 
 	rows := sel.children()
-	lines, childLine := expansionBlock(sel, noChild)
+	lines, childLine := expansionBlock(sel, noChild, m.contentWidth())
 	require.Len(t, childLine, len(rows))
 
 	for i, row := range rows {
@@ -408,7 +408,7 @@ func TestRevisionRowShowsTheOwnerStamp(t *testing.T) {
 
 	sel, _ := m.selected()
 	require.Equal(t, "plain", sel.Name)
-	block, childLines := expansionBlock(sel, noChild)
+	block, childLines := expansionBlock(sel, noChild, m.contentWidth())
 	require.Equal(t,
 		columnOf(t, block[0], "OWNER"),
 		columnOf(t, block[childLines[0]], "—"),
@@ -427,7 +427,7 @@ func TestChildRowsAlignWithTheirHeadersDespiteMultibyteCells(t *testing.T) {
 	m.Update(key("enter"))
 
 	sel, _ := m.selected()
-	block, childLines := expansionBlock(sel, noChild)
+	block, childLines := expansionBlock(sel, noChild, m.contentWidth())
 
 	svcHeader := ""
 	for _, line := range block {
@@ -442,4 +442,44 @@ func TestChildRowsAlignWithTheirHeadersDespiteMultibyteCells(t *testing.T) {
 		columnOf(t, svcHeader, "STATUS"),
 		columnOf(t, svcRow, "running"),
 		"STATUS must start at the same column as the value under it")
+}
+
+// The child block must fit the frame it is drawn in.
+//
+// It used to be laid out at fixed widths, so on a narrow terminal it ran past
+// the border and the OWNER stamp was cut mid-word by the frame rather than
+// truncated — and since the DETAIL and OWNER columns are dropped at those
+// widths, expanding the release was the only way left to read it.
+func TestChildBlockFitsTheFrameAtEveryWidth(t *testing.T) {
+	for _, w := range []int{200, 120, 90, 70, 60} {
+		m := sized(testModel(), w, 12)
+		owned := rev("app", 1, charts.StatusDeployed, "chartname", "1.0.0")
+		owned.Owner = "apply/prod-swarm:release/app"
+		loadReleases(t, m, map[string][]charts.Release{"app": {owned}},
+			map[string][]charts.ServiceState{"app": {converged("app_web")}})
+		m.Update(key("enter"))
+
+		block, _ := expansionBlock(m.list.Filtered[0], noChild, m.contentWidth())
+		for i, line := range block {
+			require.LessOrEqual(t, lipgloss.Width(line), w,
+				"width %d: child line %d overflows the frame", w, i)
+		}
+		require.Contains(t, m.View(), "OWNER", "width %d: the header survives", w)
+	}
+}
+
+// At the widths where OWNER is not a column of its own, expanding a release is
+// how you read the stamp — so it has to be legible there, not clipped.
+func TestOwnerIsReadableByExpandingWhenTheColumnIsGone(t *testing.T) {
+	m := sized(testModel(), 90, 12)
+	owned := rev("app", 1, charts.StatusDeployed, "chartname", "1.0.0")
+	owned.Owner = "apply/prod-swarm:release/app"
+	loadReleases(t, m, map[string][]charts.Release{"app": {owned}},
+		map[string][]charts.ServiceState{"app": {converged("app_web")}})
+
+	require.False(t, m.hasDetailColumn(), "90 columns drops the optional columns")
+	require.NotContains(t, m.View(), "apply/prod-swarm:release/app", "not on the release row")
+
+	m.Update(key("enter"))
+	require.Contains(t, m.View(), "apply/prod-swarm:release/app", "but the expansion shows it in full")
 }

--- a/views/charts/expansion_test.go
+++ b/views/charts/expansion_test.go
@@ -1,0 +1,340 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package chartsview
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/Eldara-Tech/swarmcli/charts"
+	inspectview "github.com/Eldara-Tech/swarmcli/views/inspect"
+	servicesview "github.com/Eldara-Tech/swarmcli/views/services"
+	"github.com/Eldara-Tech/swarmcli/views/view"
+
+	"github.com/stretchr/testify/require"
+)
+
+// twoRevs is a release upgraded once, with one service running.
+func twoRevs(t *testing.T, m *Model) {
+	t.Helper()
+	loadReleases(t, m,
+		map[string][]charts.Release{"app": {
+			rev("app", 1, charts.StatusSuperseded, "c", "1.0.0"),
+			rev("app", 2, charts.StatusDeployed, "c", "2.0.0"),
+		}},
+		map[string][]charts.ServiceState{"app": {converged("app_web")}})
+}
+
+func TestEnterExpandsAndCollapses(t *testing.T) {
+	m := sized(testModel(), 120, 24)
+	twoRevs(t, m)
+
+	require.False(t, m.isExpanded())
+	m.Update(key("enter"))
+	require.True(t, m.isExpanded())
+
+	out := m.View()
+	require.Contains(t, out, "superseded", "the older revision")
+	require.Contains(t, out, "app_web", "the live service")
+	require.Contains(t, out, "OWNER")
+
+	m.Update(key("enter"))
+	require.False(t, m.isExpanded())
+	require.NotContains(t, m.View(), "app_web")
+}
+
+// Down walks into the children before moving on; up mirrors it, so both
+// directions traverse the same sequence of rows.
+func TestChildNavigationIsSymmetric(t *testing.T) {
+	m := sized(testModel(), 120, 24)
+	twoRevs(t, m)
+	m.Update(key("enter"))
+
+	require.Equal(t, noChild, m.childIndex)
+	for want := 0; want < 3; want++ { // 2 revisions + 1 service
+		m.Update(key("down"))
+		require.Equal(t, want, m.childIndex)
+	}
+	m.Update(key("down"))
+	require.Equal(t, 2, m.childIndex, "the last child must not run past the end of a single release")
+
+	for want := 1; want >= 0; want-- {
+		m.Update(key("up"))
+		require.Equal(t, want, m.childIndex)
+	}
+	m.Update(key("up"))
+	require.Equal(t, noChild, m.childIndex, "up from the first child returns to the release row")
+}
+
+func TestDownFromTheLastChildMovesToTheNextRelease(t *testing.T) {
+	m := sized(testModel(), 120, 24)
+	loadReleases(t, m, map[string][]charts.Release{
+		"a": deployed("a", "c", "1.0.0"),
+		"b": deployed("b", "c", "1.0.0"),
+	}, nil)
+
+	m.Update(key("enter")) // expand "a"
+	m.Update(key("down"))  // its only child: the "(no services)" block has none, so revision 1
+	require.Equal(t, 0, m.childIndex)
+
+	m.Update(key("down"))
+	require.Equal(t, "b", m.list.Filtered[m.list.Cursor].Name)
+	require.Equal(t, noChild, m.childIndex)
+}
+
+// Moving up into an expanded release lands on its last child, not its header
+// row, or the two directions would visit different rows.
+func TestUpEntersThePreviousReleaseAtItsLastChild(t *testing.T) {
+	m := sized(testModel(), 120, 24)
+	loadReleases(t, m, map[string][]charts.Release{
+		"a": deployed("a", "c", "1.0.0"),
+		"b": deployed("b", "c", "1.0.0"),
+	}, nil)
+
+	m.Update(key("enter")) // expand "a"
+	m.Update(key("down"))  // into a's child
+	m.Update(key("down"))  // onto b
+	require.Equal(t, "b", m.list.Filtered[m.list.Cursor].Name)
+
+	m.Update(key("up"))
+	require.Equal(t, "a", m.list.Filtered[m.list.Cursor].Name)
+	require.Equal(t, 0, m.childIndex, "expected a's last child")
+}
+
+// esc walks back out one level at a time. The app only forwards esc when
+// IsRowExpanded says there is somewhere to go.
+func TestEscWalksBackOutOfTheExpansion(t *testing.T) {
+	m := sized(testModel(), 120, 24)
+	twoRevs(t, m)
+
+	require.False(t, m.IsRowExpanded(), "with nothing expanded esc must pop the view instead")
+
+	m.Update(key("enter"))
+	m.Update(key("down"))
+	require.True(t, m.IsRowExpanded())
+
+	m.Update(key("esc"))
+	require.Equal(t, noChild, m.childIndex, "first esc returns to the release row")
+	require.True(t, m.isExpanded())
+	require.True(t, m.IsRowExpanded())
+
+	m.Update(key("esc"))
+	require.False(t, m.isExpanded(), "second esc collapses the release")
+	require.False(t, m.IsRowExpanded(), "a third esc belongs to the app")
+}
+
+// Expansion must not disable the command bar: that would be the cost of
+// routing esc through CapturesInput instead of its own probe.
+func TestExpansionDoesNotCaptureInput(t *testing.T) {
+	m := sized(testModel(), 120, 24)
+	twoRevs(t, m)
+	m.Update(key("enter"))
+	m.Update(key("down"))
+	require.False(t, m.CapturesInput())
+}
+
+func TestInspectActsOnTheSelectedRevision(t *testing.T) {
+	m := sized(testModel(), 120, 24)
+	twoRevs(t, m)
+	m.Update(key("enter"))
+	m.Update(key("down")) // revision 1
+
+	payload := runCmd(m.Update(key("i"))).(view.NavigateToMsg).Payload.(map[string]any)
+	require.Contains(t, payload["title"], "rev 1")
+	require.Contains(t, payload["json"], "c:1.0.0")
+
+	m.Update(key("down")) // revision 2
+	payload = runCmd(m.Update(key("v"))).(view.NavigateToMsg).Payload.(map[string]any)
+	require.Contains(t, payload["title"], "rev 2")
+	require.Contains(t, payload["json"], "replicas: 2")
+}
+
+func TestDiffComparesAgainstThePreviousRevision(t *testing.T) {
+	m := sized(testModel(), 120, 24)
+	twoRevs(t, m)
+	m.Update(key("enter"))
+	m.Update(key("down")) // revision 1
+	m.Update(key("down")) // revision 2
+
+	nav := runCmd(m.Update(key("d"))).(view.NavigateToMsg)
+	require.Equal(t, inspectview.ViewName, nav.ViewName)
+	payload := nav.Payload.(map[string]any)
+	require.Contains(t, payload["title"], "rev 1 → rev 2")
+	require.Equal(t, inspectview.FormatRaw, payload["format"],
+		"a diff is not a YAML document; the tree view would eat the +/- prefixes")
+
+	diff := payload["json"].(string)
+	require.Contains(t, diff, "- "+"    image: c:1.0.0", "the outgoing image, marked removed")
+	require.Contains(t, diff, "+ "+"    image: c:2.0.0", "the incoming image, marked added")
+	require.Contains(t, diff, "  "+"  app:", "unchanged lines carry a blank marker")
+}
+
+func TestDiffOfTheFirstRevisionSaysSo(t *testing.T) {
+	m := sized(testModel(), 120, 24)
+	twoRevs(t, m)
+	m.Update(key("enter"))
+	m.Update(key("down")) // revision 1
+
+	payload := runCmd(m.Update(key("d"))).(view.NavigateToMsg).Payload.(map[string]any)
+	require.Contains(t, payload["title"], "first revision")
+	diff := payload["json"].(string)
+	require.Contains(t, diff, "+ services:", "everything is an addition")
+	require.NotContains(t, diff, "- ", "there is no previous revision to remove anything from")
+}
+
+func TestDiffDoesNothingOnAServiceRow(t *testing.T) {
+	m := sized(testModel(), 120, 24)
+	twoRevs(t, m)
+	m.Update(key("enter"))
+	m.Update(key("down"))
+	m.Update(key("down"))
+	m.Update(key("down")) // the service row
+
+	child, ok := m.selectedChild()
+	require.True(t, ok)
+	require.Equal(t, childService, child.kind)
+	require.Nil(t, m.Update(key("d")))
+}
+
+func TestEnterOnAServiceRowDrillsIntoIt(t *testing.T) {
+	m := sized(testModel(), 120, 24)
+	twoRevs(t, m)
+	m.Update(key("enter"))
+	m.Update(key("down"))
+	m.Update(key("down"))
+	m.Update(key("down")) // the service row
+
+	nav := runCmd(m.Update(key("enter"))).(view.NavigateToMsg)
+	require.Equal(t, servicesview.ViewName, nav.ViewName)
+	require.Equal(t, map[string]any{
+		"stackName": "app", "selectServiceName": "app_web",
+	}, nav.Payload)
+	require.True(t, m.isExpanded(), "drilling in must not also collapse the row")
+}
+
+// A background poll must not disturb what the operator has open.
+func TestExpansionSurvivesAReload(t *testing.T) {
+	m := sized(testModel(), 120, 24)
+	twoRevs(t, m)
+	m.Update(key("enter"))
+	m.Update(key("down"))
+	require.Equal(t, 0, m.childIndex)
+
+	twoRevs(t, m)
+	require.True(t, m.isExpanded())
+	require.Equal(t, 0, m.childIndex)
+}
+
+// A reload can land on a release with fewer children than the last one had.
+func TestChildSelectionIsClampedWhenChildrenShrink(t *testing.T) {
+	m := sized(testModel(), 120, 24)
+	twoRevs(t, m)
+	m.Update(key("enter"))
+	for i := 0; i < 3; i++ {
+		m.Update(key("down"))
+	}
+	require.Equal(t, 2, m.childIndex)
+
+	// Same release, one revision and no services.
+	loadReleases(t, m, map[string][]charts.Release{"app": deployed("app", "c", "1.0.0")}, nil)
+	require.Equal(t, 0, m.childIndex, "the selection must land inside the shorter release")
+
+	child, ok := m.selectedChild()
+	require.True(t, ok)
+	require.Equal(t, childRevision, child.kind)
+}
+
+func TestFilteringDropsTheChildSelection(t *testing.T) {
+	m := sized(testModel(), 120, 24)
+	loadReleases(t, m, map[string][]charts.Release{
+		"app":   deployed("app", "c", "1.0.0"),
+		"other": deployed("other", "c", "1.0.0"),
+	}, nil)
+	m.Update(key("enter"))
+	m.Update(key("down"))
+	require.Equal(t, 0, m.childIndex)
+
+	m.ApplySearchQuery("other")
+	require.Equal(t, noChild, m.childIndex)
+	require.Nil(t, m.Update(key("d")), "no child is selected, so nothing to diff")
+}
+
+// The whole point of taking the offset over: a child below the fold must still
+// be rendered. Assert on the line carrying content, not on the row count — a
+// padded layout has the same number of rows either way.
+func TestSelectedChildStaysOnScreenInAShortViewport(t *testing.T) {
+	m := sized(testModel(), 120, 6)
+
+	svcs := make([]charts.ServiceState, 0, 12)
+	for _, n := range []string{"s01", "s02", "s03", "s04", "s05", "s06", "s07", "s08", "s09", "s10", "s11", "s12"} {
+		svcs = append(svcs, converged(n))
+	}
+	loadReleases(t, m,
+		map[string][]charts.Release{"app": deployed("app", "c", "1.0.0")},
+		map[string][]charts.ServiceState{"app": svcs})
+
+	m.Update(key("enter"))
+	for i := 0; i < 13; i++ { // 1 revision + 12 services
+		m.Update(key("down"))
+	}
+	child, ok := m.selectedChild()
+	require.True(t, ok)
+	require.Equal(t, "s12", child.svc.Name, "the fixture must actually reach the last service")
+
+	require.Contains(t, m.View(), "s12", "the selected child scrolled out of view")
+}
+
+// expansionBlock returns the rendered lines and each child's line index
+// together so the scroll math cannot disagree with the renderer about how tall
+// a release is. Hold them to that.
+func TestChildLineIndexesMatchTheRenderedLines(t *testing.T) {
+	m := sized(testModel(), 120, 24)
+	twoRevs(t, m)
+	sel, ok := m.selected()
+	require.True(t, ok)
+
+	rows := sel.children()
+	lines, childLine := expansionBlock(sel, noChild)
+	require.Len(t, childLine, len(rows))
+
+	for i, row := range rows {
+		require.Less(t, childLine[i], len(lines))
+		want := row.svc.Name
+		if row.kind == childRevision {
+			want = row.rev.Chart.Name + "-" + row.rev.Chart.Version
+		}
+		require.Contains(t, lines[childLine[i]], want,
+			"child %d claims line %d, which holds something else", i, childLine[i])
+	}
+
+	m.expanded[sel.Name] = true
+	require.Equal(t, 1+len(lines), m.itemLineCount(sel))
+}
+
+func TestExpansionSaysWhenThereAreNoServices(t *testing.T) {
+	m := sized(testModel(), 120, 24)
+	loadReleases(t, m, map[string][]charts.Release{"app": deployed("app", "c", "1.0.0")}, nil)
+	m.Update(key("enter"))
+	require.Contains(t, m.View(), "(no services)")
+}
+
+// A release with no owner stamp reads as unowned rather than as a blank cell.
+func TestRevisionRowShowsTheOwnerStamp(t *testing.T) {
+	m := sized(testModel(), 120, 24)
+	owned := rev("app", 1, charts.StatusDeployed, "c", "1.0.0")
+	owned.Owner = "apply/prod-swarm:release/app"
+	loadReleases(t, m, map[string][]charts.Release{
+		"app":   {owned},
+		"plain": deployed("plain", "c", "1.0.0"),
+	}, nil)
+
+	m.Update(key("enter"))
+	require.Contains(t, m.View(), "apply/prod-swarm:release/app")
+
+	m.Update(key("esc"))
+	m.Update(key("down"))
+	m.Update(key("enter"))
+	block, _ := expansionBlock(m.list.Filtered[m.list.Cursor], noChild)
+	require.Contains(t, strings.Join(block, "\n"), "—")
+}

--- a/views/charts/expansion_test.go
+++ b/views/charts/expansion_test.go
@@ -4,6 +4,7 @@
 package chartsview
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -12,8 +13,18 @@ import (
 	servicesview "github.com/Eldara-Tech/swarmcli/views/services"
 	"github.com/Eldara-Tech/swarmcli/views/view"
 
+	"github.com/charmbracelet/lipgloss"
 	"github.com/stretchr/testify/require"
 )
+
+// columnOf is the display column at which needle starts in line, so an
+// alignment assertion compares rendered columns rather than byte offsets.
+func columnOf(t *testing.T, line, needle string) int {
+	t.Helper()
+	i := strings.Index(line, needle)
+	require.GreaterOrEqual(t, i, 0, "%q not found in %q", needle, line)
+	return lipgloss.Width(line[:i])
+}
 
 // twoRevs is a release upgraded once, with one service running.
 func twoRevs(t *testing.T, m *Model) {
@@ -312,6 +323,64 @@ func TestChildLineIndexesMatchTheRenderedLines(t *testing.T) {
 	require.Equal(t, 1+len(lines), m.itemLineCount(sel))
 }
 
+// A page is a screenful of rendered lines. Counting items would skip several
+// screens whenever a release is expanded, because one item can be many lines.
+func TestPageDownCountsRenderedLinesNotItems(t *testing.T) {
+	m := sized(testModel(), 120, 20)
+
+	all := map[string][]charts.Release{}
+	svcs := map[string][]charts.ServiceState{}
+	for i := 0; i < 40; i++ {
+		n := fmt.Sprintf("r%02d", i)
+		all[n] = deployed(n, "c", "1.0.0")
+		svcs[n] = []charts.ServiceState{converged(n + "_web")}
+	}
+	loadReleases(t, m, all, svcs)
+
+	// Collapsed: a page moves roughly one screenful of rows.
+	budget := m.contentLines()
+	m.Update(key("pgdown"))
+	collapsed := m.list.Cursor
+	require.Positive(t, collapsed)
+	require.LessOrEqual(t, collapsed, budget)
+	require.Less(t, collapsed, len(m.list.Filtered)-1,
+		"the fixture must not let the page reach the end, or nothing is compared")
+
+	// Expand the first release; it now occupies several lines, so the same
+	// key must not travel as far through the list.
+	m.list.Cursor = 0
+	m.childIndex = noChild
+	m.Update(key("enter"))
+	require.Greater(t, m.itemLineCount(m.list.Filtered[0]), 1)
+
+	m.Update(key("pgdown"))
+	require.Less(t, m.list.Cursor, collapsed,
+		"an expanded release consumes part of the page")
+
+	used := 0
+	for i := 0; i < m.list.Cursor; i++ {
+		used += m.itemLineCount(m.list.Filtered[i])
+	}
+	require.LessOrEqual(t, used, budget, "a page must not overshoot the screen")
+}
+
+func TestPageAlwaysMovesAtLeastOneRow(t *testing.T) {
+	// A viewport so short that a single expanded release exceeds a whole page.
+	m := sized(testModel(), 120, 8)
+	loadReleases(t, m, map[string][]charts.Release{
+		"a": deployed("a", "c", "1.0.0"),
+		"b": deployed("b", "c", "1.0.0"),
+	}, map[string][]charts.ServiceState{
+		"b": {converged("s1"), converged("s2"), converged("s3"), converged("s4")},
+	})
+	m.Update(key("down"))
+	m.Update(key("enter")) // expand "b", taller than the page
+	m.list.Cursor = 0
+
+	m.Update(key("pgdown"))
+	require.Equal(t, 1, m.list.Cursor, "the key must not become a no-op")
+}
+
 func TestExpansionSaysWhenThereAreNoServices(t *testing.T) {
 	m := sized(testModel(), 120, 24)
 	loadReleases(t, m, map[string][]charts.Release{"app": deployed("app", "c", "1.0.0")}, nil)
@@ -319,7 +388,8 @@ func TestExpansionSaysWhenThereAreNoServices(t *testing.T) {
 	require.Contains(t, m.View(), "(no services)")
 }
 
-// A release with no owner stamp reads as unowned rather than as a blank cell.
+// A release with no owner stamp reads as unowned rather than as a blank cell,
+// and the dash must be in the OWNER column — not merely somewhere in the block.
 func TestRevisionRowShowsTheOwnerStamp(t *testing.T) {
 	m := sized(testModel(), 120, 24)
 	owned := rev("app", 1, charts.StatusDeployed, "c", "1.0.0")
@@ -335,6 +405,41 @@ func TestRevisionRowShowsTheOwnerStamp(t *testing.T) {
 	m.Update(key("esc"))
 	m.Update(key("down"))
 	m.Update(key("enter"))
-	block, _ := expansionBlock(m.list.Filtered[m.list.Cursor], noChild)
-	require.Contains(t, strings.Join(block, "\n"), "—")
+
+	sel, _ := m.selected()
+	require.Equal(t, "plain", sel.Name)
+	block, childLines := expansionBlock(sel, noChild)
+	require.Equal(t,
+		columnOf(t, block[0], "OWNER"),
+		columnOf(t, block[childLines[0]], "—"),
+		"the unowned dash must sit under the OWNER header")
+}
+
+// Every cell in the child blocks is padded to a display width, but the em-dash
+// displayOrDash emits for an empty optional field is three bytes wide. Byte
+// padding therefore shifts every later cell left of its own header.
+func TestChildRowsAlignWithTheirHeadersDespiteMultibyteCells(t *testing.T) {
+	m := sized(testModel(), 140, 24)
+	loadReleases(t, m,
+		map[string][]charts.Release{"app": deployed("app", "c", "1.0.0")},
+		// No Mode and no Replicas: two em-dashes before STATUS.
+		map[string][]charts.ServiceState{"app": {{Name: "app_web", Status: "running"}}})
+	m.Update(key("enter"))
+
+	sel, _ := m.selected()
+	block, childLines := expansionBlock(sel, noChild)
+
+	svcHeader := ""
+	for _, line := range block {
+		if strings.Contains(line, "SERVICE") {
+			svcHeader = line
+		}
+	}
+	require.NotEmpty(t, svcHeader)
+	svcRow := block[childLines[len(sel.Revisions)]]
+
+	require.Equal(t,
+		columnOf(t, svcHeader, "STATUS"),
+		columnOf(t, svcRow, "running"),
+		"STATUS must start at the same column as the value under it")
 }

--- a/views/charts/expansion_test.go
+++ b/views/charts/expansion_test.go
@@ -400,7 +400,7 @@ func TestRevisionRowShowsTheOwnerStamp(t *testing.T) {
 	}, nil)
 
 	m.Update(key("enter"))
-	require.Contains(t, m.View(), "apply/prod-swarm:release/app")
+	require.Contains(t, m.View(), "apply/prod-swarm")
 
 	m.Update(key("esc"))
 	m.Update(key("down"))
@@ -478,8 +478,8 @@ func TestOwnerIsReadableByExpandingWhenTheColumnIsGone(t *testing.T) {
 		map[string][]charts.ServiceState{"app": {converged("app_web")}})
 
 	require.False(t, m.hasDetailColumn(), "90 columns drops the optional columns")
-	require.NotContains(t, m.View(), "apply/prod-swarm:release/app", "not on the release row")
+	require.NotContains(t, m.View(), "apply/prod-swarm", "not on the release row")
 
 	m.Update(key("enter"))
-	require.Contains(t, m.View(), "apply/prod-swarm:release/app", "but the expansion shows it in full")
+	require.Contains(t, m.View(), "apply/prod-swarm", "but the expansion shows it in full")
 }

--- a/views/charts/help.go
+++ b/views/charts/help.go
@@ -17,6 +17,7 @@ func GetChartsHelpContent() []helpview.HelpCategory {
 				{Keys: "<v>", Description: "Show the stored values"},
 				{Keys: "<s>", Description: "Show the release's services"},
 				{Keys: "</>", Description: "Filter releases"},
+				{Keys: "<←/→>", Description: "Scroll a cell too wide for its column on the selected row"},
 				{Keys: "<?>", Description: "Open this help"},
 			},
 		},
@@ -28,7 +29,7 @@ func GetChartsHelpContent() []helpview.HelpCategory {
 				{Keys: "STATUS", Description: "The recorded state of the release: what we wrote when we deployed"},
 				{Keys: "HEALTH", Description: "What the swarm is doing now: converged, progressing or wedged"},
 				{Keys: "DETAIL", Description: "Why it is not converged, or what it runs. Shown when the terminal has room"},
-				{Keys: "OWNER", Description: "The `charts apply` manifest that installed it. Shown on a wide terminal"},
+				{Keys: "OWNER", Description: "What installed it: `apply/<owner>` a release file, `swarmcli-cd/<controller>/<app>` the controller. Shown on a wide terminal"},
 			},
 		},
 		{

--- a/views/charts/help.go
+++ b/views/charts/help.go
@@ -21,6 +21,14 @@ func GetChartsHelpContent() []helpview.HelpCategory {
 			},
 		},
 		{
+			Title: "The UPD column",
+			Items: []helpview.HelpItem{
+				{Keys: "0.2.0", Description: "A newer chart version is published in a cached repository index"},
+				{Keys: "—", Description: "Nothing newer, or the chart is in no index (a local chart)"},
+				{Keys: "?", Description: "No cached index to compare against — run `swarmcli charts repo update`"},
+			},
+		},
+		{
 			Title: "Sorting",
 			Items: []helpview.HelpItem{
 				{Keys: "<shift+n>", Description: "Order by Name"},
@@ -30,6 +38,20 @@ func GetChartsHelpContent() []helpview.HelpCategory {
 				{Keys: "<shift+c>", Description: "Order by Chart"},
 				{Keys: "<shift+u>", Description: "Order by Updated"},
 				{Keys: "(repeat key)", Description: "Toggle ascending/descending"},
+			},
+		},
+		{
+			// This view never changes a release. The commands that do are
+			// listed here rather than left for the operator to remember,
+			// because "the CLI does it" is not an answer without the verb.
+			Title: "Chart operations (CLI only)",
+			Items: []helpview.HelpItem{
+				{Keys: "<u>", Description: "Show the `charts upgrade` command for this release"},
+				{Keys: "<r>", Description: "Show the `charts rollback` command for this release"},
+				{Keys: "<ctrl+d>", Description: "Show the `charts uninstall` command for this release"},
+				{Keys: "install", Description: "swarmcli charts install <release> <repo/chart>"},
+				{Keys: "apply", Description: "swarmcli charts apply -f swarmcli-release.yaml"},
+				{Keys: "repo update", Description: "swarmcli charts repo update  (populates the UPD column)"},
 			},
 		},
 		{

--- a/views/charts/help.go
+++ b/views/charts/help.go
@@ -21,7 +21,7 @@ func GetChartsHelpContent() []helpview.HelpCategory {
 			},
 		},
 		{
-			Title: "The UPD column",
+			Title: "The LATEST column",
 			Items: []helpview.HelpItem{
 				{Keys: "0.2.0", Description: "A newer chart version is published in a cached repository index"},
 				{Keys: "—", Description: "Nothing newer, or the chart is in no index (a local chart)"},
@@ -51,7 +51,7 @@ func GetChartsHelpContent() []helpview.HelpCategory {
 				{Keys: "<ctrl+d>", Description: "Show the `charts uninstall` command for this release"},
 				{Keys: "install", Description: "swarmcli charts install <release> <repo/chart>"},
 				{Keys: "apply", Description: "swarmcli charts apply -f swarmcli-release.yaml"},
-				{Keys: "repo update", Description: "swarmcli charts repo update  (populates the UPD column)"},
+				{Keys: "repo update", Description: "swarmcli charts repo update  (populates the LATEST column)"},
 			},
 		},
 		{

--- a/views/charts/help.go
+++ b/views/charts/help.go
@@ -21,6 +21,17 @@ func GetChartsHelpContent() []helpview.HelpCategory {
 			},
 		},
 		{
+			// The set is responsive, so an operator on a narrow terminal does
+			// not go looking for a column that is not there.
+			Title: "Columns",
+			Items: []helpview.HelpItem{
+				{Keys: "STATUS", Description: "The recorded state of the release: what we wrote when we deployed"},
+				{Keys: "HEALTH", Description: "What the swarm is doing now: converged, progressing or wedged"},
+				{Keys: "DETAIL", Description: "Why it is not converged, or what it runs. Shown when the terminal has room"},
+				{Keys: "OWNER", Description: "The `charts apply` manifest that installed it. Shown on a wide terminal"},
+			},
+		},
+		{
 			Title: "The LATEST column",
 			Items: []helpview.HelpItem{
 				{Keys: "0.2.0", Description: "A newer chart version is published in a cached repository index"},

--- a/views/charts/help.go
+++ b/views/charts/help.go
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package chartsview
+
+import (
+	helpview "github.com/Eldara-Tech/swarmcli/views/help"
+)
+
+// GetChartsHelpContent returns categorized help for the charts view.
+func GetChartsHelpContent() []helpview.HelpCategory {
+	return []helpview.HelpCategory{
+		{
+			Title: "General",
+			Items: []helpview.HelpItem{
+				{Keys: "<i>", Description: "Show the rendered manifest"},
+				{Keys: "<v>", Description: "Show the stored values"},
+				{Keys: "<s>", Description: "Show the release's services"},
+				{Keys: "</>", Description: "Filter releases"},
+				{Keys: "<?>", Description: "Open this help"},
+			},
+		},
+		{
+			Title: "Sorting",
+			Items: []helpview.HelpItem{
+				{Keys: "<shift+n>", Description: "Order by Name"},
+				{Keys: "<shift+r>", Description: "Order by Revision"},
+				{Keys: "<shift+s>", Description: "Order by Status"},
+				{Keys: "<shift+h>", Description: "Order by Health (worst first)"},
+				{Keys: "<shift+c>", Description: "Order by Chart"},
+				{Keys: "<shift+u>", Description: "Order by Updated"},
+				{Keys: "(repeat key)", Description: "Toggle ascending/descending"},
+			},
+		},
+		{
+			Title: "Navigation",
+			Items: []helpview.HelpItem{
+				{Keys: "<↑/↓>", Description: "Move cursor"},
+				{Keys: "<pgup>", Description: "Page up"},
+				{Keys: "<pgdown>", Description: "Page down"},
+				{Keys: "<esc/q>", Description: "Back"},
+			},
+		},
+	}
+}

--- a/views/charts/item.go
+++ b/views/charts/item.go
@@ -4,6 +4,7 @@
 package chartsview
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/Eldara-Tech/swarmcli/charts"
@@ -98,4 +99,26 @@ func (i releaseItem) healthRank() int {
 	default:
 		return 2
 	}
+}
+
+// detail is the trailing column: why the release is not converged, or what it
+// is running when it is. It is the one genuinely long, variable-length field a
+// release has, so it is what a wide terminal should spend its width on.
+func (i releaseItem) detail() string {
+	if !i.HasHealth {
+		return "—"
+	}
+	if i.Health.Reason != "" {
+		return i.Health.Reason
+	}
+	running, desired := 0, 0
+	for _, s := range i.Services {
+		running += s.Running + s.Completed
+		desired += s.Desired
+	}
+	svc := "services"
+	if len(i.Services) == 1 {
+		svc = "service"
+	}
+	return fmt.Sprintf("%d %s · %d/%d tasks running", len(i.Services), svc, running, desired)
 }

--- a/views/charts/item.go
+++ b/views/charts/item.go
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package chartsview
+
+import (
+	"time"
+
+	"github.com/Eldara-Tech/swarmcli/charts"
+)
+
+// releaseItem is one row: every stored revision of a release, plus the live
+// state the records cannot tell you.
+//
+// The revisions are held rather than flattened into display strings because
+// inspecting a manifest or values reads them straight off the record — the
+// same read that produced the row, so nothing is fetched twice.
+type releaseItem struct {
+	Name string
+	// Revisions is ascending and never empty for a constructed item.
+	Revisions []charts.Release
+	// Created is the current revision's timestamp, parsed once at load; the
+	// zero value when it was missing or malformed.
+	Created time.Time
+
+	// Health is what the swarm is doing now, and HasHealth reports whether it
+	// applies. It and the stored status disagree exactly when it matters — a
+	// release reading deployed whose rollout is wedged.
+	Health    charts.Convergence
+	HasHealth bool
+
+	// Services backs the health rollup.
+	Services []charts.ServiceState
+}
+
+func (i releaseItem) FilterValue() string { return i.Name }
+
+// current is the highest stored revision. The zero Release for an item with no
+// revisions, which readReleases never produces but a zero-value item is.
+func (i releaseItem) current() charts.Release {
+	if len(i.Revisions) == 0 {
+		return charts.Release{}
+	}
+	return i.Revisions[len(i.Revisions)-1]
+}
+
+func (i releaseItem) revision() int  { return i.current().Revision }
+func (i releaseItem) status() string { return i.current().Status }
+
+// chartRef is "name-version", as `charts list` prints it.
+func (i releaseItem) chartRef() string {
+	c := i.current().Chart
+	if c.Name == "" && c.Version == "" {
+		return "—"
+	}
+	return c.Name + "-" + c.Version
+}
+
+// health derives the convergence phase for a release's current revision.
+//
+// Only a deployed record gets one. Rollup on no services reports "progressing:
+// no services are running yet", which is the right answer for a --wait deploy
+// and a wrong one on a browser row for a release that failed or never
+// installed — those have no rollout in flight to be progressing through.
+func health(rel charts.Release, svcs []charts.ServiceState) (charts.Convergence, bool) {
+	if rel.Status != charts.StatusDeployed {
+		return charts.Convergence{}, false
+	}
+	return charts.Rollup(svcs), true
+}
+
+// healthLabel is the HEALTH cell.
+func (i releaseItem) healthLabel() string {
+	if !i.HasHealth {
+		return "—"
+	}
+	return string(i.Health.Phase)
+}
+
+// healthRank orders the HEALTH column so that ascending is worst-first: a
+// wedged release is the one worth looking at, and sorting it to the bottom
+// would be the wrong default for the first press of the sort key.
+func (i releaseItem) healthRank() int {
+	if !i.HasHealth {
+		return 3
+	}
+	switch i.Health.Phase {
+	case charts.PhaseWedged:
+		return 0
+	case charts.PhaseProgressing:
+		return 1
+	default:
+		return 2
+	}
+}

--- a/views/charts/item.go
+++ b/views/charts/item.go
@@ -31,6 +31,12 @@ type releaseItem struct {
 
 	// Services backs the health rollup.
 	Services []charts.ServiceState
+
+	// Latest is the newest version of this chart in a cached repository index,
+	// when that is newer than what is installed. Empty otherwise, which covers
+	// both "already current" and "this chart is in no index" — a local chart
+	// has nothing to be outdated against.
+	Latest string
 }
 
 func (i releaseItem) FilterValue() string { return i.Name }

--- a/views/charts/messages.go
+++ b/views/charts/messages.go
@@ -44,7 +44,7 @@ type SpinnerTickMsg time.Time
 type ReleasesLoadedMsg struct {
 	Releases []releaseItem
 	// HaveIndexes reports whether there were cached repository indexes to
-	// compare versions against. Without them the UPD column is empty for every
+	// compare versions against. Without them the LATEST column is empty for every
 	// release, which must not read as "everything is up to date".
 	HaveIndexes bool
 	Err         error

--- a/views/charts/messages.go
+++ b/views/charts/messages.go
@@ -7,10 +7,12 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/Eldara-Tech/swarmcli/charts"
 	"github.com/Eldara-Tech/swarmcli/core/primitives/hash"
+	"github.com/Eldara-Tech/swarmcli/utils/textdiff"
 	inspectview "github.com/Eldara-Tech/swarmcli/views/inspect"
 	"github.com/Eldara-Tech/swarmcli/views/view"
 
@@ -183,6 +185,36 @@ func (m *Model) inspectRevisionCmd(release string, rev charts.Release) tea.Cmd {
 				"title":  fmt.Sprintf("Release: %s (rev %d) — manifest", release, rev.Revision),
 				"json":   rev.Manifest,
 				"format": inspectview.FormatYAML,
+			},
+		}
+	}
+}
+
+// diffRevisionCmd shows what a revision changed against the one below it.
+//
+// Both manifests are already in hand — every revision record stores the
+// document it deployed — so this needs no chart, no re-render and no network,
+// which is what `charts diff upgrade` cannot say.
+func (m *Model) diffRevisionCmd(release string, child childRow) tea.Cmd {
+	return func() tea.Msg {
+		cur := child.rev
+		prev := child.prev
+		title := fmt.Sprintf("Release: %s — rev %d → rev %d", release, prev.Revision, cur.Revision)
+		if prev.Revision == 0 {
+			title = fmt.Sprintf("Release: %s — rev %d (first revision)", release, cur.Revision)
+		}
+		out := textdiff.Lines(prev.Manifest, cur.Manifest)
+		if strings.TrimSpace(out) == "" {
+			out = "# No changes."
+		}
+		return view.NavigateToMsg{
+			ViewName: inspectview.ViewName,
+			Payload: map[string]any{
+				"title": title,
+				"json":  out,
+				// Raw: a diff is not a YAML document, and the tree view would
+				// refuse it or, worse, parse away the +/- prefixes.
+				"format": inspectview.FormatRaw,
 			},
 		}
 	}

--- a/views/charts/messages.go
+++ b/views/charts/messages.go
@@ -1,0 +1,225 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package chartsview
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/Eldara-Tech/swarmcli/charts"
+	"github.com/Eldara-Tech/swarmcli/core/primitives/hash"
+	inspectview "github.com/Eldara-Tech/swarmcli/views/inspect"
+	"github.com/Eldara-Tech/swarmcli/views/view"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"gopkg.in/yaml.v3"
+)
+
+// PollInterval matches the other resource views.
+const PollInterval = 5 * time.Second
+
+// loadTimeout bounds one read of the release records. The whole read is a
+// single Docker config listing plus cached snapshot reads, so this is a
+// backstop against an unreachable daemon rather than a working budget.
+const loadTimeout = 10 * time.Second
+
+type TickMsg time.Time
+
+// PollRetryMsg signals that polling found no changes; the Update handler
+// schedules the next tick.
+type PollRetryMsg struct{}
+
+type SpinnerTickMsg time.Time
+
+// ReleasesLoadedMsg carries a completed read of the release records.
+type ReleasesLoadedMsg struct {
+	Releases []releaseItem
+	Err      error
+}
+
+// spinnerTickInterval is a var, not a const, so tests can shrink it: a tea.Tick
+// cmd invoked synchronously blocks for the full interval.
+var spinnerTickInterval = 80 * time.Millisecond
+
+func tickCmd() tea.Cmd {
+	return tea.Tick(PollInterval, func(t time.Time) tea.Msg { return TickMsg(t) })
+}
+
+func spinnerTickCmd() tea.Cmd {
+	return tea.Tick(spinnerTickInterval, func(t time.Time) tea.Msg { return SpinnerTickMsg(t) })
+}
+
+func (m *Model) loadReleasesCmd() tea.Cmd {
+	ops := m.ops
+	return func() tea.Msg {
+		items, err := readReleases(ops)
+		if err != nil {
+			return ReleasesLoadedMsg{Err: err}
+		}
+		return ReleasesLoadedMsg{Releases: items}
+	}
+}
+
+// checkReleasesCmd reloads only when something a reader would notice changed.
+func (m *Model) checkReleasesCmd(lastHash uint64) tea.Cmd {
+	ops := m.ops
+	return func() tea.Msg {
+		items, err := readReleases(ops)
+		if err != nil {
+			return ReleasesLoadedMsg{Err: err}
+		}
+		newHash, hErr := hash.Compute(stableReleases(items))
+		if hErr != nil {
+			l().Errorf("Error computing hash: %v", hErr)
+			return PollRetryMsg{}
+		}
+		if newHash != lastHash {
+			return ReleasesLoadedMsg{Releases: items}
+		}
+		return PollRetryMsg{}
+	}
+}
+
+// readReleases builds the rows: one config listing for every record, then one
+// cached-snapshot read per release for the live half.
+func readReleases(ops releaseOps) ([]releaseItem, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), loadTimeout)
+	defer cancel()
+
+	all, err := ops.AllRevisions(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read chart releases: %w", err)
+	}
+
+	items := make([]releaseItem, 0, len(all))
+	for name, revs := range all {
+		if len(revs) == 0 {
+			continue
+		}
+		cur := revs[len(revs)-1]
+		// An uninstalled record is history, not a release: AllRevisions keeps
+		// it deliberately, and this view is a list of what is installed.
+		if cur.Status == charts.StatusUninstalled {
+			continue
+		}
+		svcs := ops.ServiceStates(ctx, name)
+		conv, ok := health(cur, svcs)
+		items = append(items, releaseItem{
+			Name:      name,
+			Revisions: revs,
+			Created:   parseCreated(cur.Created),
+			Health:    conv,
+			HasHealth: ok,
+			Services:  svcs,
+		})
+	}
+	sort.Slice(items, func(i, j int) bool { return items[i].Name < items[j].Name })
+	return items, nil
+}
+
+// parseCreated returns the zero time for a record whose timestamp is missing or
+// malformed, which the CREATED cell renders as an em-dash.
+func parseCreated(s string) time.Time {
+	t, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		return time.Time{}
+	}
+	return t
+}
+
+// stableReleases projects the fields that define a meaningful change.
+//
+// Convergence.Reason is deliberately excluded: while a service serves out its
+// stability window the reason counts down in milliseconds, so hashing it would
+// report a change on every single poll and defeat the gate entirely. The phase
+// is what a reader sees change.
+func stableReleases(items []releaseItem) []stableRelease {
+	out := make([]stableRelease, len(items))
+	for i, it := range items {
+		s := stableRelease{
+			Name:     it.Name,
+			Revision: it.revision(),
+			Status:   it.status(),
+			Chart:    it.chartRef(),
+			Created:  it.Created,
+			Phase:    string(it.Health.Phase),
+		}
+		for _, svc := range it.Services {
+			s.Services = append(s.Services, stableService{
+				Name: svc.Name, Replicas: svc.Replicas, Status: svc.Status,
+			})
+		}
+		out[i] = s
+	}
+	return out
+}
+
+type stableRelease struct {
+	Name     string
+	Revision int
+	Status   string
+	Chart    string
+	Created  time.Time
+	Phase    string
+	Services []stableService
+}
+
+type stableService struct {
+	Name     string
+	Replicas string
+	Status   string
+}
+
+// inspectRevisionCmd opens a stored revision's rendered manifest.
+func (m *Model) inspectRevisionCmd(release string, rev charts.Release) tea.Cmd {
+	return func() tea.Msg {
+		return view.NavigateToMsg{
+			ViewName: inspectview.ViewName,
+			Payload: map[string]any{
+				"title":  fmt.Sprintf("Release: %s (rev %d) — manifest", release, rev.Revision),
+				"json":   rev.Manifest,
+				"format": inspectview.FormatYAML,
+			},
+		}
+	}
+}
+
+// inspectValuesCmd opens a stored revision's values.
+func (m *Model) inspectValuesCmd(release string, rev charts.Release) tea.Cmd {
+	return func() tea.Msg {
+		title := fmt.Sprintf("Release: %s (rev %d) — values", release, rev.Revision)
+		if len(rev.Values) == 0 {
+			return view.NavigateToMsg{
+				ViewName: inspectview.ViewName,
+				Payload: map[string]any{
+					"title":  title,
+					"json":   "# This revision stored no values.",
+					"format": inspectview.FormatRaw,
+				},
+			}
+		}
+		out, err := yaml.Marshal(rev.Values)
+		if err != nil {
+			return view.NavigateToMsg{
+				ViewName: inspectview.ViewName,
+				Payload: map[string]any{
+					"title":  title,
+					"json":   fmt.Sprintf("# Error rendering values:\n# %v", err),
+					"format": inspectview.FormatRaw,
+				},
+			}
+		}
+		return view.NavigateToMsg{
+			ViewName: inspectview.ViewName,
+			Payload: map[string]any{
+				"title":  title,
+				"json":   string(out),
+				"format": inspectview.FormatYAML,
+			},
+		}
+	}
+}

--- a/views/charts/messages.go
+++ b/views/charts/messages.go
@@ -40,7 +40,11 @@ type SpinnerTickMsg time.Time
 // ReleasesLoadedMsg carries a completed read of the release records.
 type ReleasesLoadedMsg struct {
 	Releases []releaseItem
-	Err      error
+	// HaveIndexes reports whether there were cached repository indexes to
+	// compare versions against. Without them the UPD column is empty for every
+	// release, which must not read as "everything is up to date".
+	HaveIndexes bool
+	Err         error
 }
 
 // spinnerTickInterval is a var, not a const, so tests can shrink it: a tea.Tick
@@ -58,11 +62,11 @@ func spinnerTickCmd() tea.Cmd {
 func (m *Model) loadReleasesCmd() tea.Cmd {
 	ops := m.ops
 	return func() tea.Msg {
-		items, err := readReleases(ops)
+		items, haveIndexes, err := readReleases(ops)
 		if err != nil {
 			return ReleasesLoadedMsg{Err: err}
 		}
-		return ReleasesLoadedMsg{Releases: items}
+		return ReleasesLoadedMsg{Releases: items, HaveIndexes: haveIndexes}
 	}
 }
 
@@ -70,7 +74,7 @@ func (m *Model) loadReleasesCmd() tea.Cmd {
 func (m *Model) checkReleasesCmd(lastHash uint64) tea.Cmd {
 	ops := m.ops
 	return func() tea.Msg {
-		items, err := readReleases(ops)
+		items, haveIndexes, err := readReleases(ops)
 		if err != nil {
 			return ReleasesLoadedMsg{Err: err}
 		}
@@ -80,21 +84,22 @@ func (m *Model) checkReleasesCmd(lastHash uint64) tea.Cmd {
 			return PollRetryMsg{}
 		}
 		if newHash != lastHash {
-			return ReleasesLoadedMsg{Releases: items}
+			return ReleasesLoadedMsg{Releases: items, HaveIndexes: haveIndexes}
 		}
 		return PollRetryMsg{}
 	}
 }
 
 // readReleases builds the rows: one config listing for every record, then one
-// cached-snapshot read per release for the live half.
-func readReleases(ops releaseOps) ([]releaseItem, error) {
+// cached-snapshot read per release for the live half, then an offline join
+// against the cached repository indexes.
+func readReleases(ops releaseOps) ([]releaseItem, bool, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), loadTimeout)
 	defer cancel()
 
 	all, err := ops.AllRevisions(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read chart releases: %w", err)
+		return nil, false, fmt.Errorf("failed to read chart releases: %w", err)
 	}
 
 	items := make([]releaseItem, 0, len(all))
@@ -120,7 +125,20 @@ func readReleases(ops releaseOps) ([]releaseItem, error) {
 		})
 	}
 	sort.Slice(items, func(i, j int) bool { return items[i].Name < items[j].Name })
-	return items, nil
+
+	currents := make([]charts.Release, 0, len(items))
+	for _, it := range items {
+		currents = append(currents, it.current())
+	}
+	entries, haveIndexes := ops.Outdated(currents)
+	latest := make(map[string]string, len(entries))
+	for _, e := range entries {
+		latest[e.Release] = e.Latest
+	}
+	for i := range items {
+		items[i].Latest = latest[items[i].Name]
+	}
+	return items, haveIndexes, nil
 }
 
 // parseCreated returns the zero time for a record whose timestamp is missing or
@@ -149,6 +167,7 @@ func stableReleases(items []releaseItem) []stableRelease {
 			Chart:    it.chartRef(),
 			Created:  it.Created,
 			Phase:    string(it.Health.Phase),
+			Latest:   it.Latest,
 		}
 		for _, svc := range it.Services {
 			s.Services = append(s.Services, stableService{
@@ -167,6 +186,7 @@ type stableRelease struct {
 	Chart    string
 	Created  time.Time
 	Phase    string
+	Latest   string
 	Services []stableService
 }
 

--- a/views/charts/messages.go
+++ b/views/charts/messages.go
@@ -21,8 +21,11 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// PollInterval matches the other resource views.
-const PollInterval = 5 * time.Second
+// PollInterval matches the other resource views. It is a var, not a const, so
+// tests can shrink it: a tea.Tick cmd invoked synchronously blocks for the full
+// interval, and a test that runs one to see what it scheduled would otherwise
+// sit here for five seconds.
+var PollInterval = 5 * time.Second
 
 // loadTimeout bounds one read of the release records. The whole read is a
 // single Docker config listing plus cached snapshot reads, so this is a

--- a/views/charts/model.go
+++ b/views/charts/model.go
@@ -1,0 +1,190 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package chartsview
+
+import (
+	"strings"
+	"time"
+
+	filterlist "github.com/Eldara-Tech/swarmcli/ui/components/filterable/list"
+	"github.com/Eldara-Tech/swarmcli/views/helpbar"
+
+	"github.com/charmbracelet/bubbles/viewport"
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+type SortField int
+
+const (
+	SortByName SortField = iota
+	SortByRevision
+	SortByStatus
+	SortByHealth
+	SortByChart
+	SortByUpdated
+)
+
+type state int
+
+const (
+	stateLoading state = iota
+	stateReady
+	stateError
+)
+
+type Model struct {
+	ops           releaseOps
+	list          filterlist.FilterableList[releaseItem]
+	width         int
+	height        int
+	firstResize   bool
+	lastSnapshot  uint64
+	visible       bool
+	sortField     SortField
+	sortAscending bool
+
+	resetCursorOnNextLoad bool
+
+	state state
+	err   error
+
+	errorDialogActive bool
+
+	spinner int
+
+	toastMessage string
+	toastUntil   time.Time
+}
+
+func New(width, height int) *Model {
+	vp := viewport.New(width, height)
+	vp.SetContent("")
+
+	m := &Model{
+		ops:           newEngineOps(),
+		width:         width,
+		height:        height,
+		firstResize:   true,
+		state:         stateLoading,
+		visible:       true,
+		sortField:     SortByName,
+		sortAscending: true,
+	}
+
+	cols := m.buildColumns()
+	list := filterlist.FilterableList[releaseItem]{
+		Viewport: vp,
+		Match: func(r releaseItem, query string) bool {
+			q := strings.ToLower(query)
+			return strings.Contains(strings.ToLower(r.Name), q) ||
+				strings.Contains(strings.ToLower(r.chartRef()), q)
+		},
+		Columns: cols,
+		Header: &filterlist.HeaderConfig{
+			Columns: filterlist.ColumnDefs(cols),
+			SortIndicator: func() (int, bool) {
+				return m.sortColumnIndex(), m.sortAscending
+			},
+		},
+		Footer: &filterlist.FooterConfig{
+			ItemLabel: "Release",
+			Override: func(cursor, filteredCount int, mode filterlist.ModeType, query string) string {
+				return m.renderFooter()
+			},
+		},
+	}
+	// Non-nil slices so the renderer pads content while loading.
+	list.Items = []releaseItem{}
+	list.Filtered = []releaseItem{}
+	list.SetOuterSize(width, height)
+
+	m.list = list
+	m.setRenderItem()
+	return m
+}
+
+func (m *Model) Name() string { return ViewName }
+
+func (m *Model) Init() tea.Cmd {
+	return tea.Batch(tickCmd(), spinnerTickCmd(), m.loadReleasesCmd())
+}
+
+// HasActiveFilter reports whether a filter query is active.
+func (m *Model) HasActiveFilter() bool { return m.list.Query != "" }
+
+// CapturesInput reports whether the view is currently capturing all input.
+func (m *Model) CapturesInput() bool { return m.errorDialogActive }
+
+// ApplySearchQuery sets the filter query on the release list (app-level "/").
+func (m *Model) ApplySearchQuery(query string) {
+	m.list.Query = query
+	m.list.ApplyFilter()
+	m.applySorting()
+}
+
+// ClearSearchQuery clears the active filter.
+func (m *Model) ClearSearchQuery() {
+	m.list.Query = ""
+	m.list.ApplyFilter()
+	m.list.Cursor = 0
+	m.list.Viewport.GotoTop()
+	m.applySorting()
+}
+
+func (m *Model) ShortHelpItems() []helpbar.HelpEntry {
+	return []helpbar.HelpEntry{
+		{Key: "↑/↓", Desc: "Navigate"},
+		{Key: "i", Desc: "Manifest"},
+		{Key: "v", Desc: "Values"},
+		{Key: "s", Desc: "Services"},
+		{Key: "/", Desc: "Filter"},
+		{Key: "?", Desc: "Help"},
+		{Key: "esc", Desc: "Back"},
+	}
+}
+
+func (m *Model) showToast(msg string) {
+	if msg == "" {
+		return
+	}
+	m.toastMessage = msg
+	d := 2 * time.Second
+	if strings.Contains(msg, "\n") {
+		d = 5 * time.Second
+	}
+	m.toastUntil = time.Now().Add(d)
+}
+
+func (m *Model) SetVisible(visible bool) { m.visible = visible }
+
+func (m *Model) SetSize(width, height int) {
+	m.width = width
+	m.height = height
+	m.list.Viewport.Width = width
+	m.list.Viewport.Height = height
+	m.list.SetOuterSize(width, height)
+}
+
+func (m *Model) OnEnter() tea.Cmd {
+	m.visible = true
+	m.resetCursorOnNextLoad = true
+	m.list.Cursor = 0
+	m.list.Viewport.YOffset = 0
+	return m.loadReleasesCmd()
+}
+
+func (m *Model) OnExit() tea.Cmd {
+	m.visible = false
+	return nil
+}
+
+func (m *Model) HasErrors() bool { return false }
+
+// selected returns the release under the cursor, or false if the list is empty.
+func (m *Model) selected() (releaseItem, bool) {
+	if m.list.Cursor < 0 || m.list.Cursor >= len(m.list.Filtered) {
+		return releaseItem{}, false
+	}
+	return m.list.Filtered[m.list.Cursor], true
+}

--- a/views/charts/model.go
+++ b/views/charts/model.go
@@ -213,6 +213,7 @@ func (m *Model) SetSize(width, height int) {
 	m.list.Viewport.Width = width
 	m.list.Viewport.Height = height
 	m.list.SetOuterSize(width, height)
+	m.refreshColumns()
 	m.confirmDialog.Width = width
 	m.confirmDialog.Height = height
 }

--- a/views/charts/model.go
+++ b/views/charts/model.go
@@ -46,6 +46,13 @@ type Model struct {
 
 	resetCursorOnNextLoad bool
 
+	// expanded tracks which releases show their revisions and services inline,
+	// keyed by release name so a background reload cannot collapse them.
+	expanded map[string]bool
+	// childIndex is the selected child within the expanded release under the
+	// cursor, or noChild when the release row itself is selected.
+	childIndex int
+
 	state state
 	err   error
 
@@ -70,6 +77,8 @@ func New(width, height int) *Model {
 		visible:       true,
 		sortField:     SortByName,
 		sortAscending: true,
+		expanded:      map[string]bool{},
+		childIndex:    noChild,
 	}
 
 	cols := m.buildColumns()
@@ -120,6 +129,7 @@ func (m *Model) CapturesInput() bool { return m.errorDialogActive }
 func (m *Model) ApplySearchQuery(query string) {
 	m.list.Query = query
 	m.list.ApplyFilter()
+	m.childIndex = noChild
 	m.applySorting()
 }
 
@@ -128,6 +138,7 @@ func (m *Model) ClearSearchQuery() {
 	m.list.Query = ""
 	m.list.ApplyFilter()
 	m.list.Cursor = 0
+	m.childIndex = noChild
 	m.list.Viewport.GotoTop()
 	m.applySorting()
 }
@@ -135,8 +146,10 @@ func (m *Model) ClearSearchQuery() {
 func (m *Model) ShortHelpItems() []helpbar.HelpEntry {
 	return []helpbar.HelpEntry{
 		{Key: "↑/↓", Desc: "Navigate"},
+		{Key: "enter", Desc: "Expand"},
 		{Key: "i", Desc: "Manifest"},
 		{Key: "v", Desc: "Values"},
+		{Key: "d", Desc: "Diff"},
 		{Key: "s", Desc: "Services"},
 		{Key: "/", Desc: "Filter"},
 		{Key: "?", Desc: "Help"},
@@ -187,4 +200,36 @@ func (m *Model) selected() (releaseItem, bool) {
 		return releaseItem{}, false
 	}
 	return m.list.Filtered[m.list.Cursor], true
+}
+
+// isExpanded reports whether the release under the cursor shows its children.
+func (m *Model) isExpanded() bool {
+	sel, ok := m.selected()
+	return ok && m.expanded[sel.Name]
+}
+
+// selectedChild returns the child row under the cursor, if one is selected.
+func (m *Model) selectedChild() (childRow, bool) {
+	if m.childIndex == noChild {
+		return childRow{}, false
+	}
+	sel, ok := m.selected()
+	if !ok || !m.expanded[sel.Name] {
+		return childRow{}, false
+	}
+	rows := sel.children()
+	if m.childIndex < 0 || m.childIndex >= len(rows) {
+		return childRow{}, false
+	}
+	return rows[m.childIndex], true
+}
+
+// IsRowExpanded tells the app that esc has somewhere to go inside this view:
+// back to the release row from a child, then collapsing the release. Without
+// it the app's esc chain would pop straight out of the view.
+//
+// Deliberately not routed through CapturesInput, which the ":" handler also
+// consults and which would disable the command bar while a row is expanded.
+func (m *Model) IsRowExpanded() bool {
+	return m.childIndex != noChild || m.isExpanded()
 }

--- a/views/charts/model.go
+++ b/views/charts/model.go
@@ -53,6 +53,11 @@ type Model struct {
 	// cursor, or noChild when the release row itself is selected.
 	childIndex int
 
+	// haveIndexes reports whether any cached repository index backed the last
+	// read. Without one the UPD column is empty for every release, which must
+	// not be mistaken for "everything is up to date".
+	haveIndexes bool
+
 	state state
 	err   error
 

--- a/views/charts/model.go
+++ b/views/charts/model.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	filterlist "github.com/Eldara-Tech/swarmcli/ui/components/filterable/list"
+	"github.com/Eldara-Tech/swarmcli/views/confirmdialog"
 	"github.com/Eldara-Tech/swarmcli/views/helpbar"
 
 	"github.com/charmbracelet/bubbles/viewport"
@@ -46,6 +47,11 @@ type Model struct {
 
 	resetCursorOnNextLoad bool
 
+	// pendingSelect is a release a cross-link asked for, applied once the first
+	// read lands — the view is empty when the factory runs, so there is nothing
+	// to select yet.
+	pendingSelect string
+
 	// expanded tracks which releases show their revisions and services inline,
 	// keyed by release name so a background reload cannot collapse them.
 	expanded map[string]bool
@@ -62,6 +68,10 @@ type Model struct {
 	err   error
 
 	errorDialogActive bool
+
+	// confirmDialog is only ever used in InfoMode: this view has nothing to
+	// confirm, only blocked actions to explain.
+	confirmDialog *confirmdialog.Model
 
 	spinner int
 
@@ -84,6 +94,7 @@ func New(width, height int) *Model {
 		sortAscending: true,
 		expanded:      map[string]bool{},
 		childIndex:    noChild,
+		confirmDialog: confirmdialog.New(width, height),
 	}
 
 	cols := m.buildColumns()
@@ -128,7 +139,7 @@ func (m *Model) Init() tea.Cmd {
 func (m *Model) HasActiveFilter() bool { return m.list.Query != "" }
 
 // CapturesInput reports whether the view is currently capturing all input.
-func (m *Model) CapturesInput() bool { return m.errorDialogActive }
+func (m *Model) CapturesInput() bool { return m.errorDialogActive || m.confirmDialog.Visible }
 
 // ApplySearchQuery sets the filter query on the release list (app-level "/").
 func (m *Model) ApplySearchQuery(query string) {
@@ -182,13 +193,20 @@ func (m *Model) SetSize(width, height int) {
 	m.list.Viewport.Width = width
 	m.list.Viewport.Height = height
 	m.list.SetOuterSize(width, height)
+	m.confirmDialog.Width = width
+	m.confirmDialog.Height = height
 }
 
 func (m *Model) OnEnter() tea.Cmd {
 	m.visible = true
-	m.resetCursorOnNextLoad = true
-	m.list.Cursor = 0
-	m.list.Viewport.YOffset = 0
+	// A cross-link's requested release outranks the usual jump to the top:
+	// the app calls OnEnter after the factory, so resetting here would undo
+	// the selection the payload asked for.
+	if m.pendingSelect == "" {
+		m.resetCursorOnNextLoad = true
+		m.list.Cursor = 0
+		m.list.Viewport.YOffset = 0
+	}
 	return m.loadReleasesCmd()
 }
 

--- a/views/charts/model.go
+++ b/views/charts/model.go
@@ -60,7 +60,7 @@ type Model struct {
 	childIndex int
 
 	// haveIndexes reports whether any cached repository index backed the last
-	// read. Without one the UPD column is empty for every release, which must
+	// read. Without one the LATEST column is empty for every release, which must
 	// not be mistaken for "everything is up to date".
 	haveIndexes bool
 

--- a/views/charts/model.go
+++ b/views/charts/model.go
@@ -73,6 +73,11 @@ type Model struct {
 	// confirm, only blocked actions to explain.
 	confirmDialog *confirmdialog.Model
 
+	// tickScheduled guards the poll ticker. Exactly one tick may be
+	// outstanding: every place that re-arms is a chain, and two chains do not
+	// merely double the poll rate, they each double again on every beat.
+	tickScheduled bool
+
 	spinner int
 
 	toastMessage string
@@ -132,7 +137,22 @@ func New(width, height int) *Model {
 func (m *Model) Name() string { return ViewName }
 
 func (m *Model) Init() tea.Cmd {
-	return tea.Batch(tickCmd(), spinnerTickCmd(), m.loadReleasesCmd())
+	return tea.Batch(m.armTick(), spinnerTickCmd(), m.loadReleasesCmd())
+}
+
+// armTick schedules the next poll, unless one is already scheduled.
+//
+// The guard is the whole point. A tick that both starts a poll and re-arms,
+// while the poll's result re-arms too, produces two successors per beat — and
+// each of those does the same, so an idle view climbs to thousands of
+// concurrent reads within a minute. Re-arming only after the poll's result has
+// the further benefit that two polls can never overlap.
+func (m *Model) armTick() tea.Cmd {
+	if m.tickScheduled {
+		return nil
+	}
+	m.tickScheduled = true
+	return tickCmd()
 }
 
 // HasActiveFilter reports whether a filter query is active.
@@ -206,8 +226,12 @@ func (m *Model) OnEnter() tea.Cmd {
 		m.resetCursorOnNextLoad = true
 		m.list.Cursor = 0
 		m.list.Viewport.YOffset = 0
+		// The child selection belongs to whichever release the cursor was on.
+		// Leaving it set while the cursor moves to the top highlights nothing
+		// on screen and swallows the operator's next esc.
+		m.childIndex = noChild
 	}
-	return m.loadReleasesCmd()
+	return tea.Batch(m.loadReleasesCmd(), m.armTick())
 }
 
 func (m *Model) OnExit() tea.Cmd {

--- a/views/charts/model_test.go
+++ b/views/charts/model_test.go
@@ -240,8 +240,8 @@ func TestHealthSurfacesAWedgedRollout(t *testing.T) {
 	require.True(t, ok)
 	require.Equal(t, charts.PhaseWedged, sel.Health.Phase)
 	require.Equal(t, "wedged", sel.healthLabel())
-	require.Contains(t, m.selectedReason(), "rollback paused",
-		"the footer must say why, not just that something is wrong")
+	require.Contains(t, m.View(), "rollback paused",
+		"the view must say why, not just that something is wrong")
 	require.Equal(t, charts.StatusDeployed, sel.status(),
 		"the stored record still reads deployed — that divergence is the point")
 }

--- a/views/charts/model_test.go
+++ b/views/charts/model_test.go
@@ -24,6 +24,10 @@ import (
 type mockOps struct {
 	allRevisionsFn  func(ctx context.Context) (map[string][]charts.Release, error)
 	serviceStatesFn func(ctx context.Context, release string) []charts.ServiceState
+	// indexes is the cached repository state, keyed by chart name → newest
+	// version. Nil means no index at all, which is a different answer from an
+	// index in which nothing is newer.
+	indexes map[string]string
 }
 
 func (m *mockOps) AllRevisions(ctx context.Context) (map[string][]charts.Release, error) {
@@ -35,6 +39,26 @@ func (m *mockOps) ServiceStates(ctx context.Context, release string) []charts.Se
 		return nil
 	}
 	return m.serviceStatesFn(ctx, release)
+}
+
+// Outdated mirrors charts.Outdated's contract closely enough for the view:
+// only a strictly newer version is reported, and a chart in no index is not.
+func (m *mockOps) Outdated(rels []charts.Release) ([]charts.OutdatedEntry, bool) {
+	if m.indexes == nil {
+		return nil, false
+	}
+	var out []charts.OutdatedEntry
+	for _, r := range rels {
+		latest, ok := m.indexes[r.Chart.Name]
+		if !ok || latest == r.Chart.Version {
+			continue
+		}
+		out = append(out, charts.OutdatedEntry{
+			Release: r.Name, Chart: r.Chart.Name,
+			Installed: r.Chart.Version, Latest: latest,
+		})
+	}
+	return out, true
 }
 
 func noopOps() *mockOps {
@@ -108,13 +132,20 @@ func converged(name string) charts.ServiceState {
 }
 
 // loadReleases drives a completed read into the model, skipping the async load.
-func loadReleases(t *testing.T, m *Model, all map[string][]charts.Release, svcs map[string][]charts.ServiceState) {
+// The optional index maps chart name → newest published version; omitting it
+// means this machine has no cached repository index at all.
+func loadReleases(t *testing.T, m *Model, all map[string][]charts.Release, svcs map[string][]charts.ServiceState, indexes ...map[string]string) {
 	t.Helper()
+	var index map[string]string
+	if len(indexes) > 0 {
+		index = indexes[0]
+	}
 	m.ops = &mockOps{
 		allRevisionsFn: func(_ context.Context) (map[string][]charts.Release, error) { return all, nil },
 		serviceStatesFn: func(_ context.Context, release string) []charts.ServiceState {
 			return svcs[release]
 		},
+		indexes: index,
 	}
 	msg := runCmd(m.loadReleasesCmd())
 	loaded, ok := msg.(ReleasesLoadedMsg)

--- a/views/charts/model_test.go
+++ b/views/charts/model_test.go
@@ -155,6 +155,15 @@ func loadReleases(t *testing.T, m *Model, all map[string][]charts.Release, svcs 
 	m.Update(loaded)
 }
 
+// fastPoll shrinks the poll interval for a test that executes a returned tick
+// cmd. tea.Tick sleeps, so running one at the real interval stalls the suite.
+func fastPoll(t *testing.T) {
+	t.Helper()
+	original := PollInterval
+	PollInterval = time.Millisecond
+	t.Cleanup(func() { PollInterval = original })
+}
+
 func names(m *Model) []string {
 	out := make([]string, 0, len(m.list.Filtered))
 	for _, r := range m.list.Filtered {
@@ -472,6 +481,91 @@ func TestUnparseableCreatedRendersADash(t *testing.T) {
 
 	require.True(t, m.list.Filtered[0].Created.IsZero())
 	require.Equal(t, "—", formatCreated(m.list.Filtered[0].Created))
+}
+
+// A tick must schedule exactly one successor, or the ticker multiplies and the
+// poll rate doubles on every beat.
+func TestTickAlwaysSchedulesExactlyOneSuccessor(t *testing.T) {
+	fastPoll(t)
+	m := testModel()
+	loadReleases(t, m, map[string][]charts.Release{"app": deployed("app", "c", "1.0.0")}, nil)
+
+	// Ready and visible: a poll plus exactly one re-arm.
+	require.Equal(t, 1, countTicks(m.Update(TickMsg(time.Now()))))
+
+	// A poll that found nothing new re-arms the ticker and nothing else.
+	require.Equal(t, 1, countTicks(m.Update(PollRetryMsg{})))
+
+	// Hidden: still exactly one, or the ticker dies while off screen.
+	m.SetVisible(false)
+	require.Equal(t, 1, countTicks(m.Update(TickMsg(time.Now()))))
+}
+
+// countTicks runs a cmd — flattening a tea.Batch — and counts how many of the
+// messages it produces are TickMsg. More than one means the ticker multiplies
+// and the poll rate doubles on every beat.
+func countTicks(cmd tea.Cmd) int {
+	if cmd == nil {
+		return 0
+	}
+	n := 0
+	var walk func(tea.Cmd)
+	walk = func(c tea.Cmd) {
+		if c == nil {
+			return
+		}
+		switch msg := c().(type) {
+		case tea.BatchMsg:
+			for _, sub := range msg {
+				walk(sub)
+			}
+		case TickMsg:
+			n++
+		}
+	}
+	walk(cmd)
+	return n
+}
+
+// While the view is off screen or showing an error, the ticker keeps beating
+// but must not poll: the data would be thrown away, and an error dialog would
+// be fighting a refresh behind it.
+func TestTickDoesNotPollWhenHiddenOrErrored(t *testing.T) {
+	fastPoll(t)
+	m := testModel()
+	loadReleases(t, m, map[string][]charts.Release{"app": deployed("app", "c", "1.0.0")}, nil)
+
+	m.ops = &mockOps{allRevisionsFn: func(_ context.Context) (map[string][]charts.Release, error) {
+		t.Error("the view must not poll while hidden or errored")
+		return nil, nil
+	}}
+
+	m.SetVisible(false)
+	runCmd(m.Update(TickMsg(time.Now())))
+
+	m.SetVisible(true)
+	m.errorDialogActive = true
+	runCmd(m.Update(TickMsg(time.Now())))
+}
+
+func TestResizeKeepsTheViewportAnchoredOnFirstSize(t *testing.T) {
+	m := testModel()
+	loadReleases(t, m, map[string][]charts.Release{
+		"a": deployed("a", "c", "1.0.0"),
+		"b": deployed("b", "c", "1.0.0"),
+	}, nil)
+
+	m.list.Viewport.YOffset = 7
+	m.Update(tea.WindowSizeMsg{Width: 100, Height: 30})
+	require.Equal(t, 0, m.list.Viewport.YOffset, "the first resize anchors to the top")
+	require.Equal(t, 100, m.width)
+
+	// Later resizes only re-anchor while the cursor is at the top, so a
+	// scrolled list is not yanked back under the operator.
+	m.Update(key("down"))
+	m.list.Viewport.YOffset = 5
+	m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+	require.Equal(t, 5, m.list.Viewport.YOffset)
 }
 
 func TestCursorSurvivesAReloadThatReordersNothing(t *testing.T) {

--- a/views/charts/model_test.go
+++ b/views/charts/model_test.go
@@ -485,67 +485,127 @@ func TestUnparseableCreatedRendersADash(t *testing.T) {
 
 // A tick must schedule exactly one successor, or the ticker multiplies and the
 // poll rate doubles on every beat.
-func TestTickAlwaysSchedulesExactlyOneSuccessor(t *testing.T) {
-	fastPoll(t)
-	m := testModel()
-	loadReleases(t, m, map[string][]charts.Release{"app": deployed("app", "c", "1.0.0")}, nil)
-
-	// Ready and visible: a poll plus exactly one re-arm.
-	require.Equal(t, 1, countTicks(m.Update(TickMsg(time.Now()))))
-
-	// A poll that found nothing new re-arms the ticker and nothing else.
-	require.Equal(t, 1, countTicks(m.Update(PollRetryMsg{})))
-
-	// Hidden: still exactly one, or the ticker dies while off screen.
-	m.SetVisible(false)
-	require.Equal(t, 1, countTicks(m.Update(TickMsg(time.Now()))))
-}
-
-// countTicks runs a cmd — flattening a tea.Batch — and counts how many of the
-// messages it produces are TickMsg. More than one means the ticker multiplies
-// and the poll rate doubles on every beat.
-func countTicks(cmd tea.Cmd) int {
-	if cmd == nil {
-		return 0
-	}
-	n := 0
-	var walk func(tea.Cmd)
-	walk = func(c tea.Cmd) {
+// drive models the bubbletea runtime for one round: run each pending command,
+// flattening tea.Batch — whose inner commands the runtime runs, not the caller
+// — feed every resulting message back into Update, and return the commands
+// that came out. It reports how many TickMsgs fired during the round.
+//
+// Flattening is the whole reason this exists. Asserting on the command Update
+// returns cannot see past a batch, so a test written that way passes whatever
+// the batch contains.
+func drive(m *Model, pending []tea.Cmd) (next []tea.Cmd, ticks int) {
+	var run func(c tea.Cmd)
+	run = func(c tea.Cmd) {
 		if c == nil {
 			return
 		}
-		switch msg := c().(type) {
-		case tea.BatchMsg:
-			for _, sub := range msg {
-				walk(sub)
+		msg := c()
+		if batch, ok := msg.(tea.BatchMsg); ok {
+			for _, sub := range batch {
+				run(sub)
 			}
-		case TickMsg:
-			n++
+			return
+		}
+		if _, ok := msg.(TickMsg); ok {
+			ticks++
+		}
+		if cmd := m.Update(msg); cmd != nil {
+			next = append(next, cmd)
 		}
 	}
-	walk(cmd)
-	return n
+	for _, c := range pending {
+		run(c)
+	}
+	return next, ticks
 }
 
-// While the view is off screen or showing an error, the ticker keeps beating
-// but must not poll: the data would be thrown away, and an error dialog would
-// be fighting a refresh behind it.
-func TestTickDoesNotPollWhenHiddenOrErrored(t *testing.T) {
+// The poll loop must be a loop, not a tree. A tick that starts a poll and
+// re-arms, while the poll's result re-arms too, yields two successors per beat
+// — and each of those does the same, so an idle view climbs into thousands of
+// concurrent reads within a minute.
+func TestPollLoopDoesNotMultiply(t *testing.T) {
+	fastPoll(t)
+	m := testModel()
+	// Steady state: the poll finds exactly what is loaded, so it reports no
+	// change. That is what a browser left open does all day.
+	all := map[string][]charts.Release{"app": deployed("app", "c", "1.0.0")}
+	loadReleases(t, m, all, nil)
+
+	sawRetry := false
+	m.ops = &mockOps{allRevisionsFn: func(_ context.Context) (map[string][]charts.Release, error) {
+		sawRetry = true
+		return all, nil
+	}}
+
+	// The model already armed a tick when the load landed; this is that one.
+	pending := []tea.Cmd{tickCmd()}
+	for round := 0; round < 12; round++ {
+		var ticks int
+		pending, ticks = drive(m, pending)
+		require.LessOrEqual(t, len(pending), 1,
+			"round %d: %d commands in flight — the loop has branched", round, len(pending))
+		require.LessOrEqual(t, ticks, 1, "round %d fired %d ticks", round, ticks)
+		time.Sleep(2 * time.Millisecond)
+	}
+	require.True(t, sawRetry, "the fixture must actually poll, or this proves nothing")
+	require.Len(t, pending, 1, "and the loop must still be alive at the end")
+}
+
+// While the view is off screen or showing an error dialog, the ticker keeps
+// beating but must not poll: the data would be thrown away, and a refresh
+// would be fighting the dialog in front of it.
+func TestTickDoesNotPollWhenHiddenOrDialogIsUp(t *testing.T) {
 	fastPoll(t)
 	m := testModel()
 	loadReleases(t, m, map[string][]charts.Release{"app": deployed("app", "c", "1.0.0")}, nil)
 
 	m.ops = &mockOps{allRevisionsFn: func(_ context.Context) (map[string][]charts.Release, error) {
-		t.Error("the view must not poll while hidden or errored")
+		t.Error("the view must not poll while hidden or showing a dialog")
 		return nil, nil
 	}}
 
-	m.SetVisible(false)
-	runCmd(m.Update(TickMsg(time.Now())))
+	for _, hide := range []func(){
+		func() { m.SetVisible(false); m.errorDialogActive = false },
+		func() { m.SetVisible(true); m.errorDialogActive = true },
+	} {
+		hide()
+		m.tickScheduled = true // the chain the model is already running
+		pending := []tea.Cmd{tickCmd()}
+		for round := 0; round < 3; round++ {
+			pending, _ = drive(m, pending)
+			require.Len(t, pending, 1, "the ticker must stay alive so it can resume")
+			time.Sleep(2 * time.Millisecond)
+		}
+	}
+}
 
-	m.SetVisible(true)
-	m.errorDialogActive = true
-	runCmd(m.Update(TickMsg(time.Now())))
+// One unreadable release record fails the whole listing. A view that stopped
+// polling on the first failure would stay blank until the operator navigated
+// out and back in.
+func TestPollingResumesAfterAFailedFirstLoad(t *testing.T) {
+	fastPoll(t)
+	m := testModel()
+
+	m.Update(ReleasesLoadedMsg{Err: errors.New("docker unreachable")})
+	require.Equal(t, stateError, m.state)
+	require.True(t, m.errorDialogActive)
+
+	// The operator dismisses the dialog; the daemon comes back.
+	m.Update(key("esc"))
+	all := map[string][]charts.Release{"app": deployed("app", "c", "1.0.0")}
+	m.ops = &mockOps{allRevisionsFn: func(_ context.Context) (map[string][]charts.Release, error) {
+		return all, nil
+	}}
+
+	pending := []tea.Cmd{tickCmd()}
+	for round := 0; round < 4 && m.state != stateReady; round++ {
+		pending, _ = drive(m, pending)
+		time.Sleep(2 * time.Millisecond)
+	}
+
+	require.Equal(t, stateReady, m.state, "the view must recover on its own")
+	require.Equal(t, []string{"app"}, names(m))
+	require.NoError(t, m.err)
 }
 
 func TestResizeKeepsTheViewportAnchoredOnFirstSize(t *testing.T) {

--- a/views/charts/model_test.go
+++ b/views/charts/model_test.go
@@ -1,0 +1,459 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package chartsview
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/Eldara-Tech/swarmcli/charts"
+	inspectview "github.com/Eldara-Tech/swarmcli/views/inspect"
+	servicesview "github.com/Eldara-Tech/swarmcli/views/services"
+	"github.com/Eldara-Tech/swarmcli/views/view"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/stretchr/testify/require"
+)
+
+// --- mocks ---
+
+type mockOps struct {
+	allRevisionsFn  func(ctx context.Context) (map[string][]charts.Release, error)
+	serviceStatesFn func(ctx context.Context, release string) []charts.ServiceState
+}
+
+func (m *mockOps) AllRevisions(ctx context.Context) (map[string][]charts.Release, error) {
+	return m.allRevisionsFn(ctx)
+}
+
+func (m *mockOps) ServiceStates(ctx context.Context, release string) []charts.ServiceState {
+	if m.serviceStatesFn == nil {
+		return nil
+	}
+	return m.serviceStatesFn(ctx, release)
+}
+
+func noopOps() *mockOps {
+	return &mockOps{
+		allRevisionsFn: func(_ context.Context) (map[string][]charts.Release, error) {
+			return nil, nil
+		},
+	}
+}
+
+// --- helpers ---
+
+func key(s string) tea.KeyMsg {
+	switch s {
+	case "enter":
+		return tea.KeyMsg{Type: tea.KeyEnter}
+	case "esc":
+		return tea.KeyMsg{Type: tea.KeyEsc}
+	case "up":
+		return tea.KeyMsg{Type: tea.KeyUp}
+	case "down":
+		return tea.KeyMsg{Type: tea.KeyDown}
+	case "left":
+		return tea.KeyMsg{Type: tea.KeyLeft}
+	case "right":
+		return tea.KeyMsg{Type: tea.KeyRight}
+	}
+	return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(s)}
+}
+
+func runCmd(cmd tea.Cmd) tea.Msg {
+	if cmd == nil {
+		return nil
+	}
+	return cmd()
+}
+
+func testModel(opts ...func(*Model)) *Model {
+	m := New(120, 24)
+	m.ops = noopOps()
+	for _, o := range opts {
+		o(m)
+	}
+	return m
+}
+
+// rev builds one stored revision.
+func rev(name string, n int, status, chartName, version string) charts.Release {
+	return charts.Release{
+		Name:     name,
+		Revision: n,
+		Status:   status,
+		Chart:    charts.ReleaseChart{Name: chartName, Version: version},
+		Manifest: fmt.Sprintf("services:\n  app:\n    image: %s:%s\n", chartName, version),
+		Values:   map[string]any{"replicas": n},
+		Created:  time.Date(2026, 8, 10+n, 12, 0, 0, 0, time.UTC).Format(time.RFC3339),
+	}
+}
+
+// deployed is a single-revision release in the ordinary healthy shape.
+func deployed(name, chartName, version string) []charts.Release {
+	return []charts.Release{rev(name, 1, charts.StatusDeployed, chartName, version)}
+}
+
+// converged is a service that has held parity past its stability window.
+func converged(name string) charts.ServiceState {
+	return charts.ServiceState{
+		Name: name, Mode: "replicated", Replicas: "1/1", Status: "running",
+		Running: 1, Desired: 1, NewestTaskAge: time.Hour,
+	}
+}
+
+// loadReleases drives a completed read into the model, skipping the async load.
+func loadReleases(t *testing.T, m *Model, all map[string][]charts.Release, svcs map[string][]charts.ServiceState) {
+	t.Helper()
+	m.ops = &mockOps{
+		allRevisionsFn: func(_ context.Context) (map[string][]charts.Release, error) { return all, nil },
+		serviceStatesFn: func(_ context.Context, release string) []charts.ServiceState {
+			return svcs[release]
+		},
+	}
+	msg := runCmd(m.loadReleasesCmd())
+	loaded, ok := msg.(ReleasesLoadedMsg)
+	require.True(t, ok, "expected ReleasesLoadedMsg, got %T", msg)
+	require.NoError(t, loaded.Err)
+	m.Update(loaded)
+}
+
+func names(m *Model) []string {
+	out := make([]string, 0, len(m.list.Filtered))
+	for _, r := range m.list.Filtered {
+		out = append(out, r.Name)
+	}
+	return out
+}
+
+// --- Tests ---
+
+func TestNewStartsLoading(t *testing.T) {
+	m := testModel()
+	require.Equal(t, stateLoading, m.state)
+	require.Equal(t, ViewName, m.Name())
+	require.NotNil(t, m.list.Items, "a nil item slice makes the renderer skip padding")
+}
+
+func TestLoadSortsByNameAndDerivesHealth(t *testing.T) {
+	m := testModel()
+	loadReleases(t, m,
+		map[string][]charts.Release{
+			"zebra": deployed("zebra", "cz", "1.0.0"),
+			"alpha": deployed("alpha", "ca", "2.0.0"),
+		},
+		map[string][]charts.ServiceState{
+			"alpha": {converged("alpha_web")},
+			// zebra reports no services: still rolling out.
+		})
+
+	require.Equal(t, stateReady, m.state)
+	require.Equal(t, []string{"alpha", "zebra"}, names(m))
+	require.Equal(t, charts.PhaseConverged, m.list.Filtered[0].Health.Phase)
+	require.Equal(t, charts.PhaseProgressing, m.list.Filtered[1].Health.Phase)
+	require.Equal(t, "ca-2.0.0", m.list.Filtered[0].chartRef())
+}
+
+// The uninstalled record AllRevisions deliberately keeps is history, not an
+// installed release, so the browser must not list it.
+func TestUninstalledReleasesAreNotListed(t *testing.T) {
+	m := testModel()
+	loadReleases(t, m, map[string][]charts.Release{
+		"live": deployed("live", "cl", "1.0.0"),
+		"gone": {rev("gone", 1, charts.StatusUninstalled, "cg", "1.0.0")},
+	}, nil)
+
+	require.Equal(t, []string{"live"}, names(m))
+}
+
+// HEALTH answers "what is the swarm doing"; it is meaningless for a record that
+// never got as far as a rollout, and Rollup would call that "progressing".
+func TestHealthOnlyAppliesToADeployedRecord(t *testing.T) {
+	m := testModel()
+	loadReleases(t, m, map[string][]charts.Release{
+		"broken":  {rev("broken", 1, charts.StatusFailed, "cb", "1.0.0")},
+		"pending": {rev("pending", 1, charts.StatusPendingInstall, "cp", "1.0.0")},
+	}, nil)
+
+	for _, it := range m.list.Filtered {
+		require.False(t, it.HasHealth, "release %q must not carry a health phase", it.Name)
+		require.Equal(t, "—", it.healthLabel())
+	}
+}
+
+func TestHealthSurfacesAWedgedRollout(t *testing.T) {
+	m := testModel()
+	loadReleases(t, m,
+		map[string][]charts.Release{"app": deployed("app", "ca", "1.0.0")},
+		map[string][]charts.ServiceState{"app": {{
+			Name: "app_web", Running: 1, Desired: 1,
+			UpdateState: "rollback_paused", NewestTaskAge: time.Hour,
+		}}})
+
+	sel, ok := m.selected()
+	require.True(t, ok)
+	require.Equal(t, charts.PhaseWedged, sel.Health.Phase)
+	require.Equal(t, "wedged", sel.healthLabel())
+	require.Contains(t, m.selectedReason(), "rollback paused",
+		"the footer must say why, not just that something is wrong")
+	require.Equal(t, charts.StatusDeployed, sel.status(),
+		"the stored record still reads deployed — that divergence is the point")
+}
+
+func TestFilterMatchesNameAndChart(t *testing.T) {
+	m := testModel()
+	loadReleases(t, m, map[string][]charts.Release{
+		"alpha": deployed("alpha", "traefik", "1.0.0"),
+		"beta":  deployed("beta", "whoami", "1.0.0"),
+	}, nil)
+
+	m.ApplySearchQuery("whoami")
+	require.Equal(t, []string{"beta"}, names(m), "the query must match the chart, not only the name")
+
+	m.ApplySearchQuery("alph")
+	require.Equal(t, []string{"alpha"}, names(m))
+
+	m.ClearSearchQuery()
+	require.Len(t, m.list.Filtered, 2)
+	require.Equal(t, 0, m.list.Cursor)
+}
+
+// Ascending health puts the release worth looking at first.
+func TestSortByHealthIsWorstFirst(t *testing.T) {
+	m := testModel()
+	loadReleases(t, m,
+		map[string][]charts.Release{
+			"ok":      deployed("ok", "c", "1.0.0"),
+			"slow":    deployed("slow", "c", "1.0.0"),
+			"stuck":   deployed("stuck", "c", "1.0.0"),
+			"unknown": {rev("unknown", 1, charts.StatusFailed, "c", "1.0.0")},
+		},
+		map[string][]charts.ServiceState{
+			"ok":   {converged("ok_web")},
+			"slow": {{Name: "slow_web", Running: 1, Desired: 3, NewestTaskAge: time.Hour}},
+			"stuck": {{
+				Name: "stuck_web", Running: 1, Desired: 1,
+				UpdateState: "paused", NewestTaskAge: time.Hour,
+			}},
+		})
+
+	m.Update(key("H"))
+	require.Equal(t, []string{"stuck", "slow", "ok", "unknown"}, names(m))
+
+	m.Update(key("H")) // repeat toggles direction
+	require.Equal(t, []string{"unknown", "ok", "slow", "stuck"}, names(m))
+}
+
+func TestSortByRevisionAndUpdated(t *testing.T) {
+	m := testModel()
+	loadReleases(t, m, map[string][]charts.Release{
+		"one": {rev("one", 1, charts.StatusDeployed, "c", "1.0.0")},
+		"two": {
+			rev("two", 1, charts.StatusSuperseded, "c", "1.0.0"),
+			rev("two", 2, charts.StatusDeployed, "c", "2.0.0"),
+		},
+	}, nil)
+
+	m.Update(key("R"))
+	require.Equal(t, []string{"one", "two"}, names(m))
+	m.Update(key("R"))
+	require.Equal(t, []string{"two", "one"}, names(m))
+
+	// rev() dates each revision later than the last, so "two" is the newer.
+	m.Update(key("U"))
+	require.Equal(t, []string{"one", "two"}, names(m))
+	m.Update(key("U"))
+	require.Equal(t, []string{"two", "one"}, names(m))
+}
+
+// The row carries the current revision, so the release's chart columns and the
+// manifest shown by `i` come from the same record.
+func TestInspectOpensTheCurrentRevisionsManifest(t *testing.T) {
+	m := testModel()
+	loadReleases(t, m, map[string][]charts.Release{
+		"app": {
+			rev("app", 1, charts.StatusSuperseded, "c", "1.0.0"),
+			rev("app", 2, charts.StatusDeployed, "c", "2.0.0"),
+		},
+	}, nil)
+
+	msg := runCmd(m.Update(key("i")))
+	nav, ok := msg.(view.NavigateToMsg)
+	require.True(t, ok, "expected navigation, got %T", msg)
+	require.Equal(t, inspectview.ViewName, nav.ViewName)
+
+	payload := nav.Payload.(map[string]any)
+	require.Contains(t, payload["title"], "rev 2")
+	require.Contains(t, payload["json"], "c:2.0.0", "the manifest must be the current revision's")
+	require.Equal(t, inspectview.FormatYAML, payload["format"])
+}
+
+func TestValuesOpensStoredValues(t *testing.T) {
+	m := testModel()
+	loadReleases(t, m, map[string][]charts.Release{"app": deployed("app", "c", "1.0.0")}, nil)
+
+	payload := runCmd(m.Update(key("v"))).(view.NavigateToMsg).Payload.(map[string]any)
+	require.Contains(t, payload["title"], "values")
+	require.Contains(t, payload["json"], "replicas: 1")
+}
+
+func TestValuesSaysSoWhenTheRevisionStoredNone(t *testing.T) {
+	m := testModel()
+	bare := rev("app", 1, charts.StatusDeployed, "c", "1.0.0")
+	bare.Values = nil
+	loadReleases(t, m, map[string][]charts.Release{"app": {bare}}, nil)
+
+	payload := runCmd(m.Update(key("v"))).(view.NavigateToMsg).Payload.(map[string]any)
+	require.Contains(t, payload["json"], "stored no values")
+	require.Equal(t, inspectview.FormatRaw, payload["format"])
+}
+
+func TestServicesDrillDownScopesToTheReleaseStack(t *testing.T) {
+	m := testModel()
+	loadReleases(t, m, map[string][]charts.Release{"app": deployed("app", "c", "1.0.0")}, nil)
+
+	nav := runCmd(m.Update(key("s"))).(view.NavigateToMsg)
+	require.Equal(t, servicesview.ViewName, nav.ViewName)
+	require.Equal(t, map[string]any{"stackName": "app"}, nav.Payload)
+}
+
+func TestKeysOnAnEmptyListDoNotPanic(t *testing.T) {
+	m := testModel()
+	loadReleases(t, m, nil, nil)
+	for _, k := range []string{"i", "v", "s", "up", "down", "pgup", "pgdown", "N", "H"} {
+		require.Nil(t, runCmd(m.Update(key(k))), "key %q on an empty list", k)
+	}
+}
+
+func TestHelpKeyOpensTheCheatSheet(t *testing.T) {
+	m := testModel()
+	nav := runCmd(m.Update(key("?"))).(view.NavigateToMsg)
+	require.Equal(t, "help", nav.ViewName)
+	require.NotEmpty(t, nav.Payload)
+}
+
+// A read failure with good data on screen must not blank the view: one
+// unreadable record fails the whole listing, and that must not cost the
+// operator everything the last poll showed.
+func TestRefreshFailureKeepsTheLastGoodData(t *testing.T) {
+	m := testModel()
+	loadReleases(t, m, map[string][]charts.Release{"app": deployed("app", "c", "1.0.0")}, nil)
+
+	m.Update(ReleasesLoadedMsg{Err: errors.New("decode release config 'x': boom")})
+
+	require.Equal(t, stateReady, m.state)
+	require.Equal(t, []string{"app"}, names(m))
+	require.False(t, m.errorDialogActive)
+	require.Contains(t, m.baseFooter(), "Refresh failed")
+}
+
+func TestFirstLoadFailureShowsTheError(t *testing.T) {
+	m := testModel()
+	m.Update(ReleasesLoadedMsg{Err: errors.New("docker unreachable")})
+
+	require.Equal(t, stateError, m.state)
+	require.True(t, m.errorDialogActive)
+	require.True(t, m.CapturesInput())
+
+	m.Update(key("esc"))
+	require.False(t, m.errorDialogActive)
+}
+
+// The poll gate must not fire on a reason that counts down in milliseconds, or
+// it would report a change on every tick and never save anything.
+func TestPollGateIgnoresACountingDownReason(t *testing.T) {
+	within := charts.ServiceState{
+		Name: "app_web", Running: 1, Desired: 1,
+		Monitor: time.Hour, NewestTaskAge: time.Minute,
+	}
+	later := within
+	later.NewestTaskAge = 2 * time.Minute
+
+	build := func(s charts.ServiceState) []releaseItem {
+		relRev := rev("app", 1, charts.StatusDeployed, "c", "1.0.0")
+		conv, ok := health(relRev, []charts.ServiceState{s})
+		return []releaseItem{{
+			Name: "app", Revisions: []charts.Release{relRev},
+			Health: conv, HasHealth: ok, Services: []charts.ServiceState{s},
+		}}
+	}
+
+	a, b := build(within), build(later)
+	require.NotEqual(t, a[0].Health.Reason, b[0].Health.Reason,
+		"the fixture must actually differ, or this test proves nothing")
+	require.Equal(t, stableReleases(a), stableReleases(b))
+}
+
+func TestPollGateNoticesAPhaseChange(t *testing.T) {
+	relRev := rev("app", 1, charts.StatusDeployed, "c", "1.0.0")
+	build := func(s charts.ServiceState) []releaseItem {
+		conv, ok := health(relRev, []charts.ServiceState{s})
+		return []releaseItem{{
+			Name: "app", Revisions: []charts.Release{relRev},
+			Health: conv, HasHealth: ok, Services: []charts.ServiceState{s},
+		}}
+	}
+	healthy := build(converged("app_web"))
+	wedged := build(charts.ServiceState{
+		Name: "app_web", Running: 1, Desired: 1,
+		UpdateState: "paused", NewestTaskAge: time.Hour,
+	})
+	require.NotEqual(t, stableReleases(healthy), stableReleases(wedged))
+}
+
+func TestCheckReportsNoChangeWhenNothingMoved(t *testing.T) {
+	m := testModel()
+	loadReleases(t, m, map[string][]charts.Release{"app": deployed("app", "c", "1.0.0")},
+		map[string][]charts.ServiceState{"app": {converged("app_web")}})
+
+	msg := runCmd(m.checkReleasesCmd(m.lastSnapshot))
+	require.IsType(t, PollRetryMsg{}, msg)
+}
+
+func TestCheckReloadsWhenARevisionLands(t *testing.T) {
+	m := testModel()
+	loadReleases(t, m, map[string][]charts.Release{"app": deployed("app", "c", "1.0.0")}, nil)
+
+	m.ops = &mockOps{allRevisionsFn: func(_ context.Context) (map[string][]charts.Release, error) {
+		return map[string][]charts.Release{"app": {
+			rev("app", 1, charts.StatusSuperseded, "c", "1.0.0"),
+			rev("app", 2, charts.StatusDeployed, "c", "2.0.0"),
+		}}, nil
+	}}
+	msg := runCmd(m.checkReleasesCmd(m.lastSnapshot))
+	loaded, ok := msg.(ReleasesLoadedMsg)
+	require.True(t, ok, "expected a reload, got %T", msg)
+	require.Equal(t, 2, loaded.Releases[0].revision())
+}
+
+// A malformed timestamp must degrade to a dash, not to a misleading date.
+func TestUnparseableCreatedRendersADash(t *testing.T) {
+	m := testModel()
+	odd := rev("app", 1, charts.StatusDeployed, "c", "1.0.0")
+	odd.Created = "not-a-timestamp"
+	loadReleases(t, m, map[string][]charts.Release{"app": {odd}}, nil)
+
+	require.True(t, m.list.Filtered[0].Created.IsZero())
+	require.Equal(t, "—", formatCreated(m.list.Filtered[0].Created))
+}
+
+func TestCursorSurvivesAReloadThatReordersNothing(t *testing.T) {
+	m := testModel()
+	all := map[string][]charts.Release{
+		"a": deployed("a", "c", "1.0.0"),
+		"b": deployed("b", "c", "1.0.0"),
+		"c": deployed("c", "c", "1.0.0"),
+	}
+	loadReleases(t, m, all, nil)
+	m.Update(key("down"))
+	require.Equal(t, "b", m.list.Filtered[m.list.Cursor].Name)
+
+	loadReleases(t, m, all, nil)
+	require.Equal(t, "b", m.list.Filtered[m.list.Cursor].Name,
+		"a background refresh must not move the operator's selection")
+}

--- a/views/charts/model_test.go
+++ b/views/charts/model_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/Eldara-Tech/swarmcli/charts"
+	"github.com/Eldara-Tech/swarmcli/views/confirmdialog"
 	inspectview "github.com/Eldara-Tech/swarmcli/views/inspect"
 	servicesview "github.com/Eldara-Tech/swarmcli/views/services"
 	"github.com/Eldara-Tech/swarmcli/views/view"
@@ -488,3 +489,7 @@ func TestCursorSurvivesAReloadThatReordersNothing(t *testing.T) {
 	require.Equal(t, "b", m.list.Filtered[m.list.Cursor].Name,
 		"a background refresh must not move the operator's selection")
 }
+
+// dismiss is the confirm dialog's own result message, which the app loop
+// delivers back to the view after an esc.
+func dismiss() confirmdialog.ResultMsg { return confirmdialog.ResultMsg{} }

--- a/views/charts/ops.go
+++ b/views/charts/ops.go
@@ -5,6 +5,7 @@ package chartsview
 
 import (
 	"context"
+	"sync"
 
 	"github.com/Eldara-Tech/swarmcli/charts"
 )
@@ -26,6 +27,10 @@ type releaseOps interface {
 	// the shared Docker snapshot cache, so calling it once per release costs
 	// one snapshot and N in-memory filters.
 	ServiceStates(ctx context.Context, release string) []charts.ServiceState
+	// Outdated joins the installed releases against the cached repository
+	// indexes. haveIndexes reports whether there was anything to compare
+	// against, so the view can say "no indexes" rather than "up to date".
+	Outdated(rels []charts.Release) (entries []charts.OutdatedEntry, haveIndexes bool)
 }
 
 // engineOps binds releaseOps to the ambient release engine.
@@ -34,14 +39,70 @@ type releaseOps interface {
 // snapshot cache, both of which the TUI's context switcher already resets, so
 // the view follows the active context with no extra wiring. Pinning a context
 // name would bypass that cache and re-snapshot on every read.
-type engineOps struct{ engine *charts.Engine }
+type engineOps struct {
+	engine *charts.Engine
 
-func newEngineOps() releaseOps { return engineOps{engine: charts.NewEngine()} }
+	// indexes are the cached repository indexes, read once per view. Loading
+	// them is disk I/O and YAML parsing, and the poll runs every few seconds,
+	// so re-reading them on every tick would be pure waste. The cost is that a
+	// `charts repo update` in another terminal shows up the next time the view
+	// is opened, which is also what the column claims: it compares against
+	// what this machine has cached.
+	once        sync.Once
+	indexes     map[string]*charts.Index
+	haveIndexes bool
+}
 
-func (o engineOps) AllRevisions(ctx context.Context) (map[string][]charts.Release, error) {
+func newEngineOps() releaseOps { return &engineOps{engine: charts.NewEngine()} }
+
+func (o *engineOps) AllRevisions(ctx context.Context) (map[string][]charts.Release, error) {
 	return o.engine.AllRevisions(ctx)
 }
 
-func (o engineOps) ServiceStates(ctx context.Context, release string) []charts.ServiceState {
+func (o *engineOps) ServiceStates(ctx context.Context, release string) []charts.ServiceState {
 	return o.engine.Backend.StackServices(ctx, release)
+}
+
+func (o *engineOps) Outdated(rels []charts.Release) ([]charts.OutdatedEntry, bool) {
+	o.once.Do(o.loadIndexes)
+	if !o.haveIndexes {
+		return nil, false
+	}
+	return charts.Outdated(rels, o.indexes), true
+}
+
+// loadIndexes reads the cached repository indexes and nothing else.
+//
+// RefreshNever is the point: this is a browser, and a view that polls must not
+// reach the network behind the operator's back. The store's own timeouts would
+// not save it either — none of RepoStore's methods take a context, so a fetch
+// here could not be cancelled when the view is closed.
+func (o *engineOps) loadIndexes() {
+	store, err := newRepoStore()
+	if err != nil {
+		l().Warnf("ChartsView: no chart repository state: %v", err)
+		return
+	}
+	indexes, err := store.Indexes()
+	if err != nil {
+		l().Warnf("ChartsView: could not read the cached repository indexes: %v", err)
+		return
+	}
+	o.indexes = indexes
+	o.haveIndexes = len(indexes) > 0
+}
+
+// newRepoStore builds the offline-only repository store this view reads.
+//
+// It is a function of its own so the policy is assertable: RefreshNever is the
+// load-bearing line here, and every other policy would let a poll running
+// every few seconds fetch an index over the network on its own initiative.
+func newRepoStore() (*charts.RepoStore, error) {
+	store, err := charts.NewRepoStore()
+	if err != nil {
+		return nil, err
+	}
+	store.Refresh = charts.RefreshNever
+	store.Warnf = func(format string, a ...any) { l().Warnf(format, a...) }
+	return store, nil
 }

--- a/views/charts/ops.go
+++ b/views/charts/ops.go
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package chartsview
+
+import (
+	"context"
+
+	"github.com/Eldara-Tech/swarmcli/charts"
+)
+
+// releaseOps is the read-only slice of the release engine this view needs.
+//
+// It is declared here rather than added to docker.Deps alongside the other op
+// interfaces because charts imports docker: a docker.ChartOps returning a
+// charts.Release would close an import cycle. Declaring it at the consumer is
+// the idiomatic placement anyway, and the view is mocked by assigning this
+// field directly.
+type releaseOps interface {
+	// AllRevisions returns every stored revision grouped by release name,
+	// ascending. One call serves both the list and any expanded release's
+	// history; List followed by a History per release would decode every
+	// stored revision twice.
+	AllRevisions(ctx context.Context) (map[string][]charts.Release, error)
+	// ServiceStates returns the live state of a release's services. It reads
+	// the shared Docker snapshot cache, so calling it once per release costs
+	// one snapshot and N in-memory filters.
+	ServiceStates(ctx context.Context, release string) []charts.ServiceState
+}
+
+// engineOps binds releaseOps to the ambient release engine.
+//
+// Ambient is deliberate: NewEngine goes through the shared Docker client and
+// snapshot cache, both of which the TUI's context switcher already resets, so
+// the view follows the active context with no extra wiring. Pinning a context
+// name would bypass that cache and re-snapshot on every read.
+type engineOps struct{ engine *charts.Engine }
+
+func newEngineOps() releaseOps { return engineOps{engine: charts.NewEngine()} }
+
+func (o engineOps) AllRevisions(ctx context.Context) (map[string][]charts.Release, error) {
+	return o.engine.AllRevisions(ctx)
+}
+
+func (o engineOps) ServiceStates(ctx context.Context, release string) []charts.ServiceState {
+	return o.engine.Backend.StackServices(ctx, release)
+}

--- a/views/charts/ops_test.go
+++ b/views/charts/ops_test.go
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package chartsview
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/Eldara-Tech/swarmcli/charts"
+
+	"github.com/stretchr/testify/require"
+)
+
+// seedRepoCache points the charts state directory at a temp dir holding one
+// configured repository and its cached index, exactly as `charts repo add`
+// would have left it.
+func seedRepoCache(t *testing.T, chart string, versions ...string) string {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", dir)
+
+	base := filepath.Join(dir, "swarmcli", "charts")
+	require.NoError(t, os.MkdirAll(filepath.Join(base, "cache"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(base, "repos.json"),
+		[]byte(`[{"name":"testrepo","url":"https://charts.example.com"}]`), 0o600))
+
+	index := "apiVersion: v1\nentries:\n  " + chart + ":\n"
+	for _, v := range versions {
+		index += "    - name: " + chart + "\n      version: \"" + v + "\"\n"
+	}
+	require.NoError(t, os.WriteFile(
+		filepath.Join(base, "cache", "index-testrepo.yaml"), []byte(index), 0o600))
+	return base
+}
+
+// The view polls every few seconds, and RepoStore's methods take no context, so
+// a fetch started here could not even be cancelled when the view closes. The
+// policy is what keeps that from happening, so assert the policy.
+func TestRepoStoreNeverGoesToTheNetwork(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+
+	store, err := newRepoStore()
+	require.NoError(t, err)
+	require.Equal(t, charts.RefreshNever, store.Refresh,
+		"any other policy lets the poll fetch an index on its own initiative")
+	require.NotNil(t, store.Warnf, "charts is silent unless the embedder wires this")
+}
+
+func TestOutdatedReadsTheCachedIndex(t *testing.T) {
+	seedRepoCache(t, "mychart", "1.0.0", "2.1.0")
+
+	ops := &engineOps{}
+	entries, haveIndexes := ops.Outdated([]charts.Release{{
+		Name: "app", Chart: charts.ReleaseChart{Name: "mychart", Version: "1.0.0"},
+	}})
+
+	require.True(t, haveIndexes)
+	require.Len(t, entries, 1)
+	require.Equal(t, "app", entries[0].Release)
+	require.Equal(t, "1.0.0", entries[0].Installed)
+	require.Equal(t, "2.1.0", entries[0].Latest)
+}
+
+func TestOutdatedReportsNoIndexesWhenNoneAreCached(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+
+	ops := &engineOps{}
+	entries, haveIndexes := ops.Outdated([]charts.Release{{
+		Name: "app", Chart: charts.ReleaseChart{Name: "mychart", Version: "1.0.0"},
+	}})
+
+	require.False(t, haveIndexes, "no cached index is not the same answer as up to date")
+	require.Empty(t, entries)
+}
+
+// The indexes are read once per view, which is what lets the poll ask on every
+// tick without re-parsing them.
+func TestIndexesAreReadOnce(t *testing.T) {
+	base := seedRepoCache(t, "mychart", "1.0.0", "2.1.0")
+	ops := &engineOps{}
+
+	rels := []charts.Release{{Name: "app", Chart: charts.ReleaseChart{Name: "mychart", Version: "1.0.0"}}}
+	first, haveIndexes := ops.Outdated(rels)
+	require.True(t, haveIndexes)
+	require.Len(t, first, 1)
+
+	// Remove the cache entirely: a second read from disk would now find
+	// nothing, so an equal answer can only have come from what was already
+	// loaded.
+	require.NoError(t, os.RemoveAll(base))
+
+	second, haveIndexes := ops.Outdated(rels)
+	require.True(t, haveIndexes)
+	require.Equal(t, first, second)
+}

--- a/views/charts/owner.go
+++ b/views/charts/owner.go
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package chartsview
+
+import (
+	"strings"
+
+	"github.com/Eldara-Tech/swarmcli/charts"
+)
+
+// controllerOwnerPrefix is the id namespace swarmcli-cd stamps its releases
+// with, and controllerOwnerName is how it is spelled on screen.
+//
+// Display vocabulary and nothing else: the engine never reads this, and what is
+// stored on the swarm is unchanged. It is the one prefix an operator cannot
+// recognise from something they typed — "apply/" carries the `owner:` they
+// wrote in a release file, while "cd/" is a product abbreviating its own name.
+const (
+	controllerOwnerPrefix = "cd/"
+	controllerOwnerName   = "swarmcli-cd/"
+)
+
+// ownerCell renders the owner stamp of one of release's revisions.
+//
+// The stamp is "<id>:release/<name>", and on a row for that release the
+// resource half says nothing: a stamp is only evidence of ownership when it
+// names the release carrying it, so where it matches it repeats the NAME
+// column — and it is the longer half of the longest cell in the table.
+//
+// Where it does not match, or where the stamp does not parse at all, the whole
+// thing is shown verbatim. Such a stamp is not evidence of owning anything on
+// screen, so rendering it as an owner would assert something the engine itself
+// does not believe, and it is the one case where the exact bytes are what the
+// operator came to read.
+func ownerCell(stamp, release string) string {
+	if stamp == "" {
+		return "—"
+	}
+	ref, err := charts.ParseOwner(stamp)
+	if err != nil || ref.Kind != charts.OwnerKindRelease || ref.Name != release {
+		return stamp
+	}
+	if id, ok := strings.CutPrefix(ref.ID, controllerOwnerPrefix); ok && id != "" {
+		return controllerOwnerName + id
+	}
+	return ref.ID
+}

--- a/views/charts/owner_test.go
+++ b/views/charts/owner_test.go
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package chartsview
+
+import (
+	"testing"
+
+	"github.com/Eldara-Tech/swarmcli/charts"
+
+	"github.com/stretchr/testify/require"
+)
+
+// The cell drops the half of the stamp that repeats the row, and spells the
+// controller's namespace as the product that writes it.
+func TestOwnerCell(t *testing.T) {
+	for _, tc := range []struct {
+		name, stamp, release, want string
+	}{
+		{"controller", "cd/default/whoami:release/whoami", "whoami", "swarmcli-cd/default/whoami"},
+		{"controller, pre-controller-id stamp", "cd/whoami:release/whoami", "whoami", "swarmcli-cd/whoami"},
+		{"release file", "apply/prod-swarm:release/hello", "hello", "apply/prod-swarm"},
+		{"unowned", "", "hello", "—"},
+		// Not evidence of owning this release, so it is not summarised as if it
+		// were — the operator gets what is actually stored.
+		{"names another release", "cd/prod/edge:release/other", "api", "cd/prod/edge:release/other"},
+		{"another kind", "apply/prod:stack/hello", "hello", "apply/prod:stack/hello"},
+		{"unparseable", "who-knows", "hello", "who-knows"},
+		// An id naming no application is left as it is rather than dressed up
+		// as a controller id it is not.
+		{"bare prefix", "cd/:release/api", "api", "cd/"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, ownerCell(tc.stamp, tc.release))
+		})
+	}
+}
+
+// The two halves are the engine's, not this view's invention: what ownerCell
+// drops is exactly what the stamp encoding puts there, so a change to either
+// side of it fails here rather than silently rendering a different string.
+func TestOwnerCellDropsTheResourceHalfTheEngineWrote(t *testing.T) {
+	stamp := charts.OwnerRef{ID: "cd/default/whoami", Kind: charts.OwnerKindRelease, Name: "whoami"}.String()
+	require.Equal(t, "cd/default/whoami:release/whoami", stamp)
+	require.Equal(t, "swarmcli-cd/default/whoami", ownerCell(stamp, "whoami"))
+}

--- a/views/charts/readonly.go
+++ b/views/charts/readonly.go
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package chartsview
+
+import (
+	"fmt"
+	"strconv"
+)
+
+// blockedAction is a release operation this view will not perform, and the
+// command line that does.
+//
+// The keys are bound rather than left dead on purpose: `ctrl+d` deletes in the
+// configs, secrets and volumes views, so an operator arriving here will press
+// it. Answering with the exact command — release name already substituted —
+// turns that keystroke into the answer instead of into nothing happening.
+type blockedAction struct {
+	title   string
+	command string
+	// why is the one-line reason this cannot happen here, when there is more
+	// to say than "the CLI does it".
+	why string
+}
+
+// upgradeAction, rollbackAction and uninstallAction describe the three
+// mutations an operator is most likely to reach for from a release list.
+func upgradeAction(release string) blockedAction {
+	return blockedAction{
+		title:   "Upgrade a release",
+		command: fmt.Sprintf("swarmcli charts upgrade %s <repo/chart>", release),
+		why:     "An upgrade renders a chart with your values, so it needs the chart reference this view does not have.",
+	}
+}
+
+func rollbackAction(release string, revision int) blockedAction {
+	target := revision - 1
+	if target < 1 {
+		target = 1
+	}
+	return blockedAction{
+		title:   "Roll a release back",
+		command: fmt.Sprintf("swarmcli charts rollback %s %s", release, strconv.Itoa(target)),
+		why:     "Press enter on the release to see its revisions, and `d` to see what each one changed.",
+	}
+}
+
+func uninstallAction(release string) blockedAction {
+	return blockedAction{
+		title:   "Uninstall a release",
+		command: fmt.Sprintf("swarmcli charts uninstall %s", release),
+		why:     "Removing the stack by hand would leave the release's revision history behind and corrupt it.",
+	}
+}
+
+// message is what the dismiss-only dialog shows.
+func (a blockedAction) message() string {
+	msg := fmt.Sprintf("%s\n\nThis view is read-only. Run:\n\n    %s", a.title, a.command)
+	if a.why != "" {
+		msg += "\n\n" + a.why
+	}
+	return msg
+}
+
+// showBlocked opens the dismiss-only dialog for a blocked action.
+func (m *Model) showBlocked(a blockedAction) {
+	m.confirmDialog.Message = a.message()
+	m.confirmDialog.InfoMode = true
+	m.confirmDialog.Visible = true
+}

--- a/views/charts/readonly_test.go
+++ b/views/charts/readonly_test.go
@@ -1,0 +1,159 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package chartsview
+
+import (
+	"testing"
+
+	"github.com/Eldara-Tech/swarmcli/charts"
+
+	"github.com/stretchr/testify/require"
+)
+
+func upgraded(name string, revisions int) []charts.Release {
+	out := make([]charts.Release, 0, revisions)
+	for n := 1; n <= revisions; n++ {
+		status := charts.StatusSuperseded
+		if n == revisions {
+			status = charts.StatusDeployed
+		}
+		out = append(out, rev(name, n, status, "c", "1.0."+string(rune('0'+n))))
+	}
+	return out
+}
+
+// The keys are bound rather than dead: ctrl+d deletes in every other resource
+// view, so an operator will press it here. It must answer with the command.
+func TestBlockedActionsNameTheirCommand(t *testing.T) {
+	m := sized(testModel(), 120, 24)
+	loadReleases(t, m, map[string][]charts.Release{"hello": upgraded("hello", 3)}, nil)
+
+	for _, tc := range []struct{ key, want string }{
+		{"u", "swarmcli charts upgrade hello <repo/chart>"},
+		{"r", "swarmcli charts rollback hello 2"},
+		{"ctrl+d", "swarmcli charts uninstall hello"},
+	} {
+		require.Nil(t, m.Update(key(tc.key)), "a blocked action issues no command")
+		require.True(t, m.confirmDialog.Visible, "key %q must explain itself", tc.key)
+		require.True(t, m.confirmDialog.InfoMode, "dismiss-only: there is nothing to confirm")
+		require.Contains(t, m.confirmDialog.Message, tc.want)
+		require.Contains(t, m.View(), tc.want, "the dialog must actually be on screen")
+
+		m.Update(key("esc"))
+		m.Update(dismiss())
+		require.False(t, m.confirmDialog.Visible)
+	}
+}
+
+// The rollback target is the revision below the current one, which is what an
+// operator reaching for rollback almost always wants.
+func TestRollbackCommandTargetsThePreviousRevision(t *testing.T) {
+	require.Contains(t, rollbackAction("app", 5).command, "rollback app 4")
+	require.Contains(t, rollbackAction("app", 2).command, "rollback app 1")
+	require.Contains(t, rollbackAction("app", 1).command, "rollback app 1",
+		"a single-revision release has nothing below it; naming revision 0 would be a lie")
+}
+
+func TestBlockedActionsDoNothingOnAnEmptyList(t *testing.T) {
+	m := sized(testModel(), 120, 24)
+	loadReleases(t, m, nil, nil)
+	for _, k := range []string{"u", "r", "ctrl+d"} {
+		require.Nil(t, m.Update(key(k)))
+		require.False(t, m.confirmDialog.Visible, "key %q with nothing selected", k)
+	}
+}
+
+// While the dialog is up it owns the keyboard, so a stray sort or navigation
+// key does not act on the list behind it.
+func TestDialogCapturesInput(t *testing.T) {
+	m := sized(testModel(), 120, 24)
+	loadReleases(t, m, map[string][]charts.Release{
+		"a": deployed("a", "c", "1.0.0"),
+		"b": deployed("b", "c", "1.0.0"),
+	}, nil)
+
+	m.Update(key("u"))
+	require.True(t, m.CapturesInput())
+
+	m.Update(key("down"))
+	require.Equal(t, 0, m.list.Cursor, "the list must not move behind the dialog")
+
+	m.Update(key("esc"))
+	m.Update(dismiss())
+	require.False(t, m.CapturesInput())
+	m.Update(key("down"))
+	require.Equal(t, 1, m.list.Cursor)
+}
+
+// The stacks view jumps here with a release name. The view is empty when the
+// factory runs, so the selection has to survive until the first read lands.
+func TestCrossLinkSelectsAndExpandsTheRequestedRelease(t *testing.T) {
+	m := sized(testModel(), 120, 24)
+	m.pendingSelect = "wanted"
+
+	loadReleases(t, m, map[string][]charts.Release{
+		"aaa":    deployed("aaa", "c", "1.0.0"),
+		"wanted": deployed("wanted", "c", "1.0.0"),
+		"zzz":    deployed("zzz", "c", "1.0.0"),
+	}, nil)
+
+	sel, ok := m.selected()
+	require.True(t, ok)
+	require.Equal(t, "wanted", sel.Name)
+	require.True(t, m.isExpanded(), "the release the operator asked for opens on arrival")
+	require.Empty(t, m.pendingSelect, "consumed")
+	require.Len(t, m.list.Filtered, 3, "selecting is not filtering; the other releases stay visible")
+}
+
+// OnEnter runs after the factory and normally jumps to the top of the list,
+// which would undo the selection the payload asked for.
+func TestCrossLinkSurvivesOnEnter(t *testing.T) {
+	m := sized(testModel(), 120, 24)
+	m.pendingSelect = "wanted"
+	m.OnEnter()
+
+	loadReleases(t, m, map[string][]charts.Release{
+		"aaa":    deployed("aaa", "c", "1.0.0"),
+		"wanted": deployed("wanted", "c", "1.0.0"),
+	}, nil)
+
+	sel, _ := m.selected()
+	require.Equal(t, "wanted", sel.Name)
+}
+
+// A release that is not there must not leave the view fighting the cursor on
+// every poll — but an empty first read is not proof it is missing.
+func TestCrossLinkGivesUpOnlyAfterARealList(t *testing.T) {
+	m := sized(testModel(), 120, 24)
+	m.pendingSelect = "wanted"
+
+	loadReleases(t, m, nil, nil)
+	require.Equal(t, "wanted", m.pendingSelect, "an empty read proves nothing")
+
+	loadReleases(t, m, map[string][]charts.Release{"other": deployed("other", "c", "1.0.0")}, nil)
+	require.Empty(t, m.pendingSelect, "the release is genuinely not installed")
+
+	m.Update(key("down"))
+	loadReleases(t, m, map[string][]charts.Release{"other": deployed("other", "c", "1.0.0")}, nil)
+	require.Equal(t, 0, m.list.Cursor, "and the cursor is left alone from then on")
+}
+
+// Every command the help offers must be one the CLI actually has.
+func TestHelpListsTheChartOperations(t *testing.T) {
+	var found bool
+	for _, cat := range GetChartsHelpContent() {
+		if cat.Title != "Chart operations (CLI only)" {
+			continue
+		}
+		found = true
+		joined := ""
+		for _, it := range cat.Items {
+			joined += it.Keys + " " + it.Description + "\n"
+		}
+		for _, want := range []string{"upgrade", "rollback", "uninstall", "install", "apply", "repo update"} {
+			require.Contains(t, joined, want)
+		}
+	}
+	require.True(t, found, "the help must say where the mutations live")
+}

--- a/views/charts/register.go
+++ b/views/charts/register.go
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package chartsview
+
+import (
+	"github.com/Eldara-Tech/swarmcli/docker"
+	"github.com/Eldara-Tech/swarmcli/views/view"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func init() {
+	view.RegisterView(ViewName, factory)
+}
+
+// factory builds the view. It takes no docker.Deps: the release engine is this
+// view's data source, and it is reached through the releaseOps seam instead
+// (see ops.go for why that cannot live on Deps).
+func factory(_ docker.Deps, w, h int, _ any) (view.View, tea.Cmd) {
+	m := New(w, h)
+	return m, m.Init()
+}

--- a/views/charts/register.go
+++ b/views/charts/register.go
@@ -17,7 +17,16 @@ func init() {
 // factory builds the view. It takes no docker.Deps: the release engine is this
 // view's data source, and it is reached through the releaseOps seam instead
 // (see ops.go for why that cannot live on Deps).
-func factory(_ docker.Deps, w, h int, _ any) (view.View, tea.Cmd) {
+//
+// An optional {"release": name} payload arrives from a cross-link — the stacks
+// view's jump to the release that owns a stack — and selects that release once
+// the first read lands.
+func factory(_ docker.Deps, w, h int, payload any) (view.View, tea.Cmd) {
 	m := New(w, h)
+	if data, ok := payload.(map[string]any); ok {
+		if name, ok := data["release"].(string); ok && name != "" {
+			m.pendingSelect = name
+		}
+	}
 	return m, m.Init()
 }

--- a/views/charts/register_test.go
+++ b/views/charts/register_test.go
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package chartsview
+
+import (
+	"testing"
+
+	"github.com/Eldara-Tech/swarmcli/docker"
+	"github.com/Eldara-Tech/swarmcli/views/view"
+
+	"github.com/stretchr/testify/require"
+)
+
+// The payload key is a contract with the stacks view's jump. A typo on either
+// side would silently land on an unselected list.
+func TestFactoryReadsTheReleasePayload(t *testing.T) {
+	v, cmd := factory(docker.Deps{}, 100, 30, map[string]any{"release": "wanted"})
+	require.NotNil(t, cmd)
+
+	m, ok := v.(*Model)
+	require.True(t, ok)
+	require.Equal(t, "wanted", m.pendingSelect)
+	require.Equal(t, 100, m.width)
+	require.Equal(t, 30, m.height)
+}
+
+func TestFactoryToleratesAMissingOrOddPayload(t *testing.T) {
+	for name, payload := range map[string]any{
+		"nil":          nil,
+		"wrong type":   "wanted",
+		"missing key":  map[string]any{"stackName": "x"},
+		"empty string": map[string]any{"release": ""},
+		"not a string": map[string]any{"release": 7},
+	} {
+		v, _ := factory(docker.Deps{}, 80, 24, payload)
+		require.Empty(t, v.(*Model).pendingSelect, "payload %q", name)
+	}
+}
+
+func TestFactoryIsRegisteredUnderTheViewName(t *testing.T) {
+	f, ok := view.GetFactory(ViewName)
+	require.True(t, ok, "the view must be reachable by name")
+	require.NotNil(t, f)
+
+	v, _ := f(docker.Deps{}, 80, 24, nil)
+	require.Equal(t, ViewName, v.Name())
+}
+
+// A root view: esc must not pop out of it into whatever came before.
+func TestChartsIsATopLevelView(t *testing.T) {
+	require.True(t, view.IsTopLevel(ViewName))
+	require.Equal(t, view.NameCharts, ViewName)
+}
+
+// The helpbar advertises keys the view actually handles.
+func TestShortHelpItemsMatchRealKeys(t *testing.T) {
+	m := testModel()
+	keys := map[string]bool{}
+	for _, e := range m.ShortHelpItems() {
+		keys[e.Key] = true
+		require.NotEmpty(t, e.Desc, "key %q has no description", e.Key)
+	}
+	for _, want := range []string{"enter", "i", "v", "d", "s", "/", "?"} {
+		require.True(t, keys[want], "the helpbar should advertise %q", want)
+	}
+}

--- a/views/charts/update.go
+++ b/views/charts/update.go
@@ -1,0 +1,347 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package chartsview
+
+import (
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/Eldara-Tech/swarmcli/core/primitives/hash"
+	"github.com/Eldara-Tech/swarmcli/ui"
+	filterlist "github.com/Eldara-Tech/swarmcli/ui/components/filterable/list"
+	helpview "github.com/Eldara-Tech/swarmcli/views/help"
+	servicesview "github.com/Eldara-Tech/swarmcli/views/services"
+	"github.com/Eldara-Tech/swarmcli/views/view"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func formatCreated(t time.Time) string {
+	if t.IsZero() {
+		return "—"
+	}
+	return t.Format("2006-01-02 15:04")
+}
+
+// buildColumns declares the release table columns for the shared content-aware
+// layout. NAME and CHART flex; the rest size to content.
+//
+// STATUS and HEALTH are both present on purpose: the first is the record we
+// wrote when we deployed, the second is what the swarm is doing now.
+func (m *Model) buildColumns() []filterlist.Column[releaseItem] {
+	return []filterlist.Column[releaseItem]{
+		{Label: "NAME", MinWidth: 4, Flex: true, Cell: func(r releaseItem) string { return r.Name }},
+		{Label: "REV", MinWidth: 3, Cell: func(r releaseItem) string { return strconv.Itoa(r.revision()) }},
+		{Label: "STATUS", MinWidth: 6, Cell: func(r releaseItem) string { return displayOrDash(r.status()) }},
+		{Label: "HEALTH", MinWidth: 6, Cell: func(r releaseItem) string { return r.healthLabel() }},
+		{Label: "CHART", MinWidth: 5, Flex: true, Cell: func(r releaseItem) string { return r.chartRef() }},
+		{Label: "UPDATED", MinWidth: 16, Cell: func(r releaseItem) string { return formatCreated(r.Created) }},
+	}
+}
+
+// sortColumnIndex maps the active sort field to its column index for the header
+// sort arrow. Every column is sortable, so the mapping is 1:1.
+func (m *Model) sortColumnIndex() int {
+	switch m.sortField {
+	case SortByName:
+		return 0
+	case SortByRevision:
+		return 1
+	case SortByStatus:
+		return 2
+	case SortByHealth:
+		return 3
+	case SortByChart:
+		return 4
+	case SortByUpdated:
+		return 5
+	}
+	return 0
+}
+
+func (m *Model) Update(msg tea.Msg) tea.Cmd {
+	switch msg := msg.(type) {
+	case SpinnerTickMsg:
+		m.spinner++
+		if m.state == stateLoading {
+			m.list.Viewport.SetContent(m.list.View())
+		}
+		return spinnerTickCmd()
+
+	case tea.WindowSizeMsg:
+		m.width = msg.Width
+		m.height = msg.Height
+		m.list.Viewport.Width = msg.Width
+		m.list.Viewport.Height = msg.Height
+		m.list.SetOuterSize(msg.Width, msg.Height)
+		if m.firstResize {
+			m.list.Viewport.YOffset = 0
+			m.firstResize = false
+		} else if m.list.Cursor == 0 {
+			m.list.Viewport.YOffset = 0
+		}
+		return nil
+
+	case ReleasesLoadedMsg:
+		return m.handleReleasesLoaded(msg)
+
+	case TickMsg:
+		if m.visible && m.state == stateReady && !m.errorDialogActive {
+			return tea.Batch(m.checkReleasesCmd(m.lastSnapshot), tickCmd())
+		}
+		return tickCmd()
+
+	case PollRetryMsg:
+		return tickCmd()
+
+	case tea.KeyMsg:
+		if m.errorDialogActive {
+			if msg.String() == "enter" || msg.String() == "esc" {
+				m.errorDialogActive = false
+			}
+			return nil
+		}
+		return m.handleNormalKeys(msg)
+	}
+	return nil
+}
+
+func (m *Model) handleReleasesLoaded(msg ReleasesLoadedMsg) tea.Cmd {
+	if msg.Err != nil {
+		// A single unreadable release record fails the whole listing, so a
+		// transient or one-off decode failure must not empty a view that
+		// already has good data — keep it and say the refresh failed.
+		if m.state == stateReady && len(m.list.Items) > 0 {
+			l().Warnf("ChartsView: background refresh failed: %v", msg.Err)
+			m.showToast("Refresh failed (will retry)")
+			return nil
+		}
+		m.state = stateError
+		m.err = msg.Err
+		m.errorDialogActive = true
+		return nil
+	}
+
+	selectedName := ""
+	if !m.resetCursorOnNextLoad {
+		if sel, ok := m.selected(); ok {
+			selectedName = sel.Name
+		}
+	}
+
+	if h, err := hash.Compute(stableReleases(msg.Releases)); err == nil {
+		m.lastSnapshot = h
+	} else {
+		l().Errorf("ChartsView: Error computing hash: %v", err)
+	}
+
+	m.list.Items = msg.Releases
+	m.list.ApplyFilter()
+	m.applySorting()
+
+	if m.resetCursorOnNextLoad {
+		m.list.Cursor = 0
+		m.list.Viewport.YOffset = 0
+		m.resetCursorOnNextLoad = false
+	} else if selectedName != "" {
+		for i, r := range m.list.Filtered {
+			if r.Name == selectedName {
+				m.list.Cursor = i
+				break
+			}
+		}
+	}
+
+	m.state = stateReady
+	m.list.Viewport.SetContent(m.list.View())
+	return nil
+}
+
+func (m *Model) handleNormalKeys(msg tea.KeyMsg) tea.Cmd {
+	switch msg.String() {
+	case "?":
+		return func() tea.Msg {
+			return view.NavigateToMsg{ViewName: helpview.ViewName, Payload: GetChartsHelpContent()}
+		}
+	case "N":
+		m.toggleSort(SortByName)
+	case "R":
+		m.toggleSort(SortByRevision)
+	case "S":
+		m.toggleSort(SortByStatus)
+	case "H":
+		m.toggleSort(SortByHealth)
+	case "C":
+		m.toggleSort(SortByChart)
+	case "U":
+		m.toggleSort(SortByUpdated)
+	case "left":
+		m.list.ScrollLeft()
+		m.list.Viewport.SetContent(m.list.View())
+	case "right":
+		m.list.ScrollRight()
+		m.list.Viewport.SetContent(m.list.View())
+	case "up", "k":
+		if m.list.Cursor > 0 {
+			m.list.Cursor--
+			m.list.ResetColumnScroll()
+			m.list.Viewport.SetContent(m.list.View())
+		}
+	case "down", "j":
+		if m.list.Cursor < len(m.list.Filtered)-1 {
+			m.list.Cursor++
+			m.list.ResetColumnScroll()
+			m.list.Viewport.SetContent(m.list.View())
+		}
+	case "pgup":
+		m.movePage(-1)
+	case "pgdown":
+		m.movePage(1)
+	case "i":
+		if sel, ok := m.selected(); ok {
+			return m.inspectRevisionCmd(sel.Name, sel.current())
+		}
+	case "v":
+		if sel, ok := m.selected(); ok {
+			return m.inspectValuesCmd(sel.Name, sel.current())
+		}
+	case "s":
+		if sel, ok := m.selected(); ok {
+			// A release deploys a stack named after itself, so the services
+			// view's existing stack scope is the right drill-down.
+			name := sel.Name
+			return func() tea.Msg {
+				return view.NavigateToMsg{
+					ViewName: servicesview.ViewName,
+					Payload:  map[string]any{"stackName": name},
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func (m *Model) movePage(dir int) {
+	page := m.list.Viewport.Height
+	if page < 1 {
+		page = 10
+	}
+	m.list.Cursor += dir * page
+	if m.list.Cursor < 0 {
+		m.list.Cursor = 0
+	}
+	if m.list.Cursor >= len(m.list.Filtered) {
+		m.list.Cursor = len(m.list.Filtered) - 1
+	}
+	if m.list.Cursor < 0 {
+		m.list.Cursor = 0
+	}
+	m.list.ResetColumnScroll()
+	m.list.Viewport.SetContent(m.list.View())
+}
+
+func (m *Model) toggleSort(field SortField) {
+	if m.sortField == field {
+		m.sortAscending = !m.sortAscending
+	} else {
+		m.sortField = field
+		m.sortAscending = true
+	}
+	m.applySorting()
+}
+
+func cmpStr(a, b string, asc bool) bool {
+	if asc {
+		return a < b
+	}
+	return a > b
+}
+
+func cmpInt(a, b int, asc bool) bool {
+	if asc {
+		return a < b
+	}
+	return a > b
+}
+
+func (m *Model) applySorting() {
+	if len(m.list.Filtered) == 0 {
+		return
+	}
+	cursorName := ""
+	if sel, ok := m.selected(); ok {
+		cursorName = sel.Name
+	}
+
+	f := m.list.Filtered
+	asc := m.sortAscending
+	byName := func(i, j int) bool { return strings.ToLower(f[i].Name) < strings.ToLower(f[j].Name) }
+	switch m.sortField {
+	case SortByName:
+		sort.SliceStable(f, func(i, j int) bool {
+			return cmpStr(strings.ToLower(f[i].Name), strings.ToLower(f[j].Name), asc)
+		})
+	case SortByRevision:
+		sort.SliceStable(f, func(i, j int) bool {
+			if f[i].revision() == f[j].revision() {
+				return byName(i, j)
+			}
+			return cmpInt(f[i].revision(), f[j].revision(), asc)
+		})
+	case SortByStatus:
+		sort.SliceStable(f, func(i, j int) bool {
+			if f[i].status() == f[j].status() {
+				return byName(i, j)
+			}
+			return cmpStr(f[i].status(), f[j].status(), asc)
+		})
+	case SortByHealth:
+		sort.SliceStable(f, func(i, j int) bool {
+			if f[i].healthRank() == f[j].healthRank() {
+				return byName(i, j)
+			}
+			return cmpInt(f[i].healthRank(), f[j].healthRank(), asc)
+		})
+	case SortByChart:
+		sort.SliceStable(f, func(i, j int) bool {
+			if f[i].chartRef() == f[j].chartRef() {
+				return byName(i, j)
+			}
+			return cmpStr(strings.ToLower(f[i].chartRef()), strings.ToLower(f[j].chartRef()), asc)
+		})
+	case SortByUpdated:
+		sort.SliceStable(f, func(i, j int) bool {
+			if f[i].Created.Equal(f[j].Created) {
+				return byName(i, j)
+			}
+			if asc {
+				return f[i].Created.Before(f[j].Created)
+			}
+			return f[i].Created.After(f[j].Created)
+		})
+	}
+
+	if cursorName != "" {
+		for i, r := range f {
+			if r.Name == cursorName {
+				m.list.Cursor = i
+				break
+			}
+		}
+	}
+	m.list.Viewport.SetContent(m.list.View())
+}
+
+func (m *Model) setRenderItem() {
+	m.list.RenderItem = func(item releaseItem, selected bool, _ int) string {
+		row := m.list.RenderRow(item, selected)
+		if selected {
+			return ui.ListSelectedStyle.Render(row)
+		}
+		return ui.ListItemStyle.Render(row)
+	}
+	m.list.Viewport.SetContent(m.list.View())
+}

--- a/views/charts/update.go
+++ b/views/charts/update.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Eldara-Tech/swarmcli/charts"
 	"github.com/Eldara-Tech/swarmcli/core/primitives/hash"
 	"github.com/Eldara-Tech/swarmcli/ui"
 	filterlist "github.com/Eldara-Tech/swarmcli/ui/components/filterable/list"
@@ -155,9 +156,27 @@ func (m *Model) handleReleasesLoaded(msg ReleasesLoadedMsg) tea.Cmd {
 		}
 	}
 
+	m.clampChild()
 	m.state = stateReady
 	m.list.Viewport.SetContent(m.list.View())
 	return nil
+}
+
+// clampChild keeps the child selection inside the release under the cursor. A
+// reload can land on a release with fewer revisions than the last one had, and
+// a filter or sort can move the cursor to a different release entirely.
+func (m *Model) clampChild() {
+	if m.childIndex == noChild {
+		return
+	}
+	sel, ok := m.selected()
+	if !ok || !m.expanded[sel.Name] {
+		m.childIndex = noChild
+		return
+	}
+	if n := len(sel.children()); m.childIndex >= n {
+		m.childIndex = n - 1
+	}
 }
 
 func (m *Model) handleNormalKeys(msg tea.KeyMsg) tea.Cmd {
@@ -185,43 +204,140 @@ func (m *Model) handleNormalKeys(msg tea.KeyMsg) tea.Cmd {
 		m.list.ScrollRight()
 		m.list.Viewport.SetContent(m.list.View())
 	case "up", "k":
-		if m.list.Cursor > 0 {
-			m.list.Cursor--
-			m.list.ResetColumnScroll()
-			m.list.Viewport.SetContent(m.list.View())
-		}
+		m.moveUp()
 	case "down", "j":
-		if m.list.Cursor < len(m.list.Filtered)-1 {
-			m.list.Cursor++
-			m.list.ResetColumnScroll()
-			m.list.Viewport.SetContent(m.list.View())
-		}
+		m.moveDown()
 	case "pgup":
 		m.movePage(-1)
 	case "pgdown":
 		m.movePage(1)
+	case "esc":
+		// Only reached because IsRowExpanded told the app to forward it.
+		m.collapseOneLevel()
+	case "enter":
+		return m.handleEnter()
 	case "i":
-		if sel, ok := m.selected(); ok {
-			return m.inspectRevisionCmd(sel.Name, sel.current())
+		if rev, ok := m.selectedRevision(); ok {
+			sel, _ := m.selected()
+			return m.inspectRevisionCmd(sel.Name, rev)
 		}
 	case "v":
-		if sel, ok := m.selected(); ok {
-			return m.inspectValuesCmd(sel.Name, sel.current())
+		if rev, ok := m.selectedRevision(); ok {
+			sel, _ := m.selected()
+			return m.inspectValuesCmd(sel.Name, rev)
+		}
+	case "d":
+		if child, ok := m.selectedChild(); ok && child.kind == childRevision {
+			sel, _ := m.selected()
+			return m.diffRevisionCmd(sel.Name, child)
 		}
 	case "s":
 		if sel, ok := m.selected(); ok {
-			// A release deploys a stack named after itself, so the services
-			// view's existing stack scope is the right drill-down.
-			name := sel.Name
-			return func() tea.Msg {
-				return view.NavigateToMsg{
-					ViewName: servicesview.ViewName,
-					Payload:  map[string]any{"stackName": name},
-				}
-			}
+			return servicesForStackCmd(sel.Name, "")
 		}
 	}
 	return nil
+}
+
+// selectedRevision is the revision `i` and `v` act on: the one under the cursor
+// when a revision child is selected, otherwise the release's current revision.
+func (m *Model) selectedRevision() (charts.Release, bool) {
+	sel, ok := m.selected()
+	if !ok {
+		return charts.Release{}, false
+	}
+	if child, isChild := m.selectedChild(); isChild {
+		if child.kind != childRevision {
+			return charts.Release{}, false
+		}
+		return child.rev, true
+	}
+	return sel.current(), true
+}
+
+// handleEnter expands or collapses the release, unless a service child is
+// selected — from there it drills into that service.
+func (m *Model) handleEnter() tea.Cmd {
+	sel, ok := m.selected()
+	if !ok {
+		return nil
+	}
+	if child, isChild := m.selectedChild(); isChild {
+		if child.kind == childService {
+			return servicesForStackCmd(sel.Name, child.svc.Name)
+		}
+		return nil
+	}
+	m.expanded[sel.Name] = !m.expanded[sel.Name]
+	m.childIndex = noChild
+	m.list.Viewport.SetContent(m.list.View())
+	return nil
+}
+
+// servicesForStackCmd opens the services view scoped to the release's stack. A
+// release deploys a stack named after itself, so the services view's existing
+// stack scope is the right drill-down, and scale, restart and logs stay in the
+// view that owns them.
+func servicesForStackCmd(release, selectService string) tea.Cmd {
+	payload := map[string]any{"stackName": release}
+	if selectService != "" {
+		payload["selectServiceName"] = selectService
+	}
+	return func() tea.Msg {
+		return view.NavigateToMsg{ViewName: servicesview.ViewName, Payload: payload}
+	}
+}
+
+// collapseOneLevel walks esc back out: from a child to the release row, then
+// from an expanded release to a collapsed one.
+func (m *Model) collapseOneLevel() {
+	if m.childIndex != noChild {
+		m.childIndex = noChild
+		m.list.Viewport.SetContent(m.list.View())
+		return
+	}
+	if sel, ok := m.selected(); ok {
+		delete(m.expanded, sel.Name)
+		m.list.Viewport.SetContent(m.list.View())
+	}
+}
+
+// moveDown steps into an expanded release's children before moving on to the
+// next release.
+func (m *Model) moveDown() {
+	if sel, ok := m.selected(); ok && m.expanded[sel.Name] {
+		if n := len(sel.children()); m.childIndex < n-1 {
+			m.childIndex++
+			m.list.Viewport.SetContent(m.list.View())
+			return
+		}
+	}
+	if m.list.Cursor < len(m.list.Filtered)-1 {
+		m.list.Cursor++
+		m.childIndex = noChild
+		m.list.ResetColumnScroll()
+		m.list.Viewport.SetContent(m.list.View())
+	}
+}
+
+// moveUp is moveDown's mirror: out of the children to the release row, then to
+// the previous release — landing on its last child when it is expanded, so the
+// two directions traverse the same sequence of rows.
+func (m *Model) moveUp() {
+	if m.childIndex != noChild {
+		m.childIndex--
+		m.list.Viewport.SetContent(m.list.View())
+		return
+	}
+	if m.list.Cursor > 0 {
+		m.list.Cursor--
+		m.childIndex = noChild
+		if sel, ok := m.selected(); ok && m.expanded[sel.Name] {
+			m.childIndex = len(sel.children()) - 1
+		}
+		m.list.ResetColumnScroll()
+		m.list.Viewport.SetContent(m.list.View())
+	}
 }
 
 func (m *Model) movePage(dir int) {
@@ -239,6 +355,7 @@ func (m *Model) movePage(dir int) {
 	if m.list.Cursor < 0 {
 		m.list.Cursor = 0
 	}
+	m.childIndex = noChild
 	m.list.ResetColumnScroll()
 	m.list.Viewport.SetContent(m.list.View())
 }
@@ -332,16 +449,29 @@ func (m *Model) applySorting() {
 			}
 		}
 	}
+	m.clampChild()
 	m.list.Viewport.SetContent(m.list.View())
 }
 
 func (m *Model) setRenderItem() {
 	m.list.RenderItem = func(item releaseItem, selected bool, _ int) string {
 		row := m.list.RenderRow(item, selected)
-		if selected {
-			return ui.ListSelectedStyle.Render(row)
+		// The release row loses its highlight while a child is selected, so
+		// exactly one line on screen reads as the cursor.
+		if selected && m.childIndex == noChild {
+			row = ui.ListSelectedStyle.Render(row)
+		} else {
+			row = ui.ListItemStyle.Render(row)
 		}
-		return ui.ListItemStyle.Render(row)
+		if !m.expanded[item.Name] {
+			return row
+		}
+		child := noChild
+		if selected {
+			child = m.childIndex
+		}
+		lines, _ := expansionBlock(item, child)
+		return row + "\n" + strings.Join(lines, "\n")
 	}
 	m.list.Viewport.SetContent(m.list.View())
 }

--- a/views/charts/update.go
+++ b/views/charts/update.go
@@ -35,8 +35,10 @@ func formatCreated(t time.Time) string {
 const minDetailWidth = 28
 
 // minOwnerWidth is the extra surplus, on top of DETAIL's, that buys the OWNER
-// column. Owner stamps are long ("apply/prod-swarm:release/hello"), so a
-// terminal that cannot spare this much is better off without it.
+// column. Owner ids are long ("swarmcli-cd/default/hello"), so a terminal that
+// cannot spare this much is better off without it — and the margin over a
+// typical id is deliberate, since the column arrives beside DETAIL and taking
+// its width back off the explanation is what this gate exists to prevent.
 const minOwnerWidth = 32
 
 // buildColumns declares the release table for the shared content-aware layout.
@@ -61,20 +63,26 @@ func (m *Model) buildColumns() []filterlist.Column[releaseItem] {
 	}
 
 	cols := m.baseColumns(true)
-	// A second tier: with room for both, the owner stamp says whether a release
-	// is managed by `charts apply` or was installed by hand, which is the next
-	// most useful thing after why it is not converged.
+	// A second tier: with room for both, the owner says whether a release is
+	// managed by `charts apply` or by the controller, or was installed by hand,
+	// which is the next most useful thing after why it is not converged.
 	if surplus >= minDetailWidth+minOwnerWidth {
 		cols = append(cols, filterlist.Column[releaseItem]{
 			Label: "OWNER", MinWidth: 5,
-			Cell: func(r releaseItem) string { return displayOrDash(r.current().Owner) },
+			// Elastic, for two things that arrive together: an id wider than
+			// its cell can then be read with ←/→, and between OWNER and DETAIL
+			// a narrowing terminal eats into the owner and the explanation
+			// rather than into the release's identity — a long stamp used to
+			// take its width out of NAME and CHART instead.
+			Flex: true,
+			Cell: func(r releaseItem) string { return ownerCell(r.current().Owner, r.Name) },
 		})
 	}
 	return append(cols, filterlist.Column[releaseItem]{
 		Label: "DETAIL", MinWidth: 6,
-		// Both: it takes every spare cell, and it is the only column allowed to
-		// truncate, so a narrowing terminal eats into the explanation rather
-		// than into the release's name.
+		// Both: it takes every spare cell, and — with OWNER, the only other
+		// column allowed to truncate — a narrowing terminal eats into the
+		// explanation rather than into the release's name.
 		Flex: true, Grow: true,
 		Cell: func(r releaseItem) string { return r.detail() },
 	})

--- a/views/charts/update.go
+++ b/views/charts/update.go
@@ -29,7 +29,8 @@ func formatCreated(t time.Time) string {
 }
 
 // buildColumns declares the release table columns for the shared content-aware
-// layout. NAME and CHART flex; the rest size to content.
+// layout. NAME and CHART flex — they give up width first on a narrow terminal
+// and scroll when truncated — while the trailing column is the one that grows.
 //
 // STATUS and HEALTH are both present on purpose: the first is the record we
 // wrote when we deployed, the second is what the swarm is doing now.
@@ -40,16 +41,22 @@ func (m *Model) buildColumns() []filterlist.Column[releaseItem] {
 		{Label: "STATUS", MinWidth: 6, Cell: func(r releaseItem) string { return displayOrDash(r.status()) }},
 		{Label: "HEALTH", MinWidth: 6, Cell: func(r releaseItem) string { return r.healthLabel() }},
 		{Label: "CHART", MinWidth: 5, Flex: true, Cell: func(r releaseItem) string { return r.chartRef() }},
-		{Label: "UPDATED", MinWidth: 16, Cell: func(r releaseItem) string { return formatCreated(r.Created) }},
-		{Label: "UPD", MinWidth: 3, Cell: m.updCell},
+		// Next to CHART, because it is the version that chart could be at.
+		{Label: "LATEST", MinWidth: 6, Cell: m.updCell},
+		// Grow, not Flex: the leftover on a wide terminal lands after the last
+		// cell, where it reads as margin, instead of being split between NAME and
+		// CHART and opening a void in the middle of every row. Its floor equals
+		// the timestamp it renders, so it never gives width back either.
+		{Label: "UPDATED", MinWidth: 16, Grow: true, Cell: func(r releaseItem) string { return formatCreated(r.Created) }},
 	}
 }
 
-// updCell distinguishes the two reasons a release has no newer version, which
-// an empty cell would run together: nothing newer is published, versus this
-// machine has no cached index to compare against. The second is "?" rather
-// than a footer line because it is a per-row fact and the footer is already
-// carrying the counts, the convergence reason and the read-only hint.
+// updCell fills the LATEST column, distinguishing the two reasons a release has
+// no newer version, which an empty cell would run together: nothing newer is
+// published, versus this machine has no cached index to compare against. The
+// second is "?" rather than a footer line because it is a per-row fact and the
+// footer is already carrying the counts, the convergence reason and the
+// read-only hint.
 func (m *Model) updCell(r releaseItem) string {
 	if r.Latest != "" {
 		return r.Latest
@@ -75,7 +82,7 @@ func (m *Model) sortColumnIndex() int {
 	case SortByChart:
 		return 4
 	case SortByUpdated:
-		return 5
+		return 6
 	}
 	return 0
 }

--- a/views/charts/update.go
+++ b/views/charts/update.go
@@ -678,7 +678,7 @@ func (m *Model) setRenderItem() {
 		if selected {
 			child = m.childIndex
 		}
-		lines, _ := expansionBlock(item, child)
+		lines, _ := expansionBlock(item, child, m.contentWidth())
 		return row + "\n" + strings.Join(lines, "\n")
 	}
 	m.list.Viewport.SetContent(m.list.View())

--- a/views/charts/update.go
+++ b/views/charts/update.go
@@ -13,6 +13,7 @@ import (
 	"github.com/Eldara-Tech/swarmcli/core/primitives/hash"
 	"github.com/Eldara-Tech/swarmcli/ui"
 	filterlist "github.com/Eldara-Tech/swarmcli/ui/components/filterable/list"
+	"github.com/Eldara-Tech/swarmcli/views/confirmdialog"
 	helpview "github.com/Eldara-Tech/swarmcli/views/help"
 	servicesview "github.com/Eldara-Tech/swarmcli/views/services"
 	"github.com/Eldara-Tech/swarmcli/views/view"
@@ -40,8 +41,23 @@ func (m *Model) buildColumns() []filterlist.Column[releaseItem] {
 		{Label: "HEALTH", MinWidth: 6, Cell: func(r releaseItem) string { return r.healthLabel() }},
 		{Label: "CHART", MinWidth: 5, Flex: true, Cell: func(r releaseItem) string { return r.chartRef() }},
 		{Label: "UPDATED", MinWidth: 16, Cell: func(r releaseItem) string { return formatCreated(r.Created) }},
-		{Label: "UPD", MinWidth: 3, Cell: func(r releaseItem) string { return displayOrDash(r.Latest) }},
+		{Label: "UPD", MinWidth: 3, Cell: m.updCell},
 	}
+}
+
+// updCell distinguishes the two reasons a release has no newer version, which
+// an empty cell would run together: nothing newer is published, versus this
+// machine has no cached index to compare against. The second is "?" rather
+// than a footer line because it is a per-row fact and the footer is already
+// carrying the counts, the convergence reason and the read-only hint.
+func (m *Model) updCell(r releaseItem) string {
+	if r.Latest != "" {
+		return r.Latest
+	}
+	if !m.haveIndexes {
+		return "?"
+	}
+	return "—"
 }
 
 // sortColumnIndex maps the active sort field to its column index for the header
@@ -106,7 +122,15 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 			}
 			return nil
 		}
+		if m.confirmDialog.Visible {
+			return m.confirmDialog.Update(msg)
+		}
 		return m.handleNormalKeys(msg)
+
+	case confirmdialog.ResultMsg:
+		m.confirmDialog.Visible = false
+		m.confirmDialog.InfoMode = false
+		return nil
 	}
 	return nil
 }
@@ -159,10 +183,38 @@ func (m *Model) handleReleasesLoaded(msg ReleasesLoadedMsg) tea.Cmd {
 		}
 	}
 
+	m.applyPendingSelect()
 	m.clampChild()
 	m.state = stateReady
 	m.list.Viewport.SetContent(m.list.View())
 	return nil
+}
+
+// applyPendingSelect honours a cross-link's requested release once there is a
+// list to select it in.
+//
+// It selects and expands rather than filtering: the "/" filter belongs to the
+// app's search bar, and setting a query the operator never typed would leave
+// the list narrowed with nothing on screen saying why.
+func (m *Model) applyPendingSelect() {
+	if m.pendingSelect == "" {
+		return
+	}
+	for i, r := range m.list.Filtered {
+		if r.Name == m.pendingSelect {
+			m.list.Cursor = i
+			m.expanded[r.Name] = true
+			m.childIndex = noChild
+			m.pendingSelect = ""
+			return
+		}
+	}
+	// Not found. Give up only once there was a real list to look in — the
+	// first read can land empty — because retrying forever would fight the
+	// operator's cursor on every poll.
+	if len(m.list.Filtered) > 0 {
+		m.pendingSelect = ""
+	}
 }
 
 // clampChild keeps the child selection inside the release under the cursor. A
@@ -237,6 +289,18 @@ func (m *Model) handleNormalKeys(msg tea.KeyMsg) tea.Cmd {
 	case "s":
 		if sel, ok := m.selected(); ok {
 			return servicesForStackCmd(sel.Name, "")
+		}
+	case "u":
+		if sel, ok := m.selected(); ok {
+			m.showBlocked(upgradeAction(sel.Name))
+		}
+	case "r":
+		if sel, ok := m.selected(); ok {
+			m.showBlocked(rollbackAction(sel.Name, sel.revision()))
+		}
+	case "ctrl+d":
+		if sel, ok := m.selected(); ok {
+			m.showBlocked(uninstallAction(sel.Name))
 		}
 	}
 	return nil

--- a/views/charts/update.go
+++ b/views/charts/update.go
@@ -40,6 +40,7 @@ func (m *Model) buildColumns() []filterlist.Column[releaseItem] {
 		{Label: "HEALTH", MinWidth: 6, Cell: func(r releaseItem) string { return r.healthLabel() }},
 		{Label: "CHART", MinWidth: 5, Flex: true, Cell: func(r releaseItem) string { return r.chartRef() }},
 		{Label: "UPDATED", MinWidth: 16, Cell: func(r releaseItem) string { return formatCreated(r.Created) }},
+		{Label: "UPD", MinWidth: 3, Cell: func(r releaseItem) string { return displayOrDash(r.Latest) }},
 	}
 }
 
@@ -132,6 +133,8 @@ func (m *Model) handleReleasesLoaded(msg ReleasesLoadedMsg) tea.Cmd {
 			selectedName = sel.Name
 		}
 	}
+
+	m.haveIndexes = msg.HaveIndexes
 
 	if h, err := hash.Compute(stableReleases(msg.Releases)); err == nil {
 		m.lastSnapshot = h

--- a/views/charts/update.go
+++ b/views/charts/update.go
@@ -83,10 +83,15 @@ func (m *Model) sortColumnIndex() int {
 func (m *Model) Update(msg tea.Msg) tea.Cmd {
 	switch msg := msg.(type) {
 	case SpinnerTickMsg:
-		m.spinner++
-		if m.state == stateLoading {
-			m.list.Viewport.SetContent(m.list.View())
+		// Only while there is a spinner to animate. An unconditional re-arm
+		// keeps an 80ms wakeup chain alive for the life of the process, and
+		// the app builds a fresh model on every navigation here, so each
+		// visit would leave another one running.
+		if m.state != stateLoading {
+			return nil
 		}
+		m.spinner++
+		m.list.Viewport.SetContent(m.list.View())
 		return spinnerTickCmd()
 
 	case tea.WindowSizeMsg:
@@ -107,13 +112,21 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 		return m.handleReleasesLoaded(msg)
 
 	case TickMsg:
-		if m.visible && m.state == stateReady && !m.errorDialogActive {
-			return tea.Batch(m.checkReleasesCmd(m.lastSnapshot), tickCmd())
+		m.tickScheduled = false
+		// stateError is deliberately allowed through: one unreadable release
+		// record fails the whole listing, so a view that stopped polling on
+		// the first failure would stay blank until the operator navigated out
+		// and back in. stateLoading is not, because a load is already in
+		// flight.
+		if m.visible && !m.errorDialogActive && m.state != stateLoading {
+			// No re-arm here — the poll's result does it, so two polls can
+			// never be in flight at once.
+			return m.checkReleasesCmd(m.lastSnapshot)
 		}
-		return tickCmd()
+		return m.armTick()
 
 	case PollRetryMsg:
-		return tickCmd()
+		return m.armTick()
 
 	case tea.KeyMsg:
 		if m.errorDialogActive {
@@ -143,12 +156,17 @@ func (m *Model) handleReleasesLoaded(msg ReleasesLoadedMsg) tea.Cmd {
 		if m.state == stateReady && len(m.list.Items) > 0 {
 			l().Warnf("ChartsView: background refresh failed: %v", msg.Err)
 			m.showToast("Refresh failed (will retry)")
-			return nil
+			// Cleared here too: a failed load consumes the request just as a
+			// successful one does, and leaving it set would snap the cursor to
+			// the top on some later, unrelated poll.
+			m.resetCursorOnNextLoad = false
+			return m.armTick()
 		}
 		m.state = stateError
 		m.err = msg.Err
 		m.errorDialogActive = true
-		return nil
+		m.resetCursorOnNextLoad = false
+		return m.armTick()
 	}
 
 	selectedName := ""
@@ -185,9 +203,29 @@ func (m *Model) handleReleasesLoaded(msg ReleasesLoadedMsg) tea.Cmd {
 
 	m.applyPendingSelect()
 	m.clampChild()
+	m.pruneExpanded()
 	m.state = stateReady
+	m.err = nil
 	m.list.Viewport.SetContent(m.list.View())
-	return nil
+	return m.armTick()
+}
+
+// pruneExpanded drops expansion state for releases that are no longer listed,
+// so an uninstalled release that is later reinstalled does not come back
+// already open, and the map does not grow for the life of the view.
+func (m *Model) pruneExpanded() {
+	if len(m.expanded) == 0 {
+		return
+	}
+	live := make(map[string]struct{}, len(m.list.Items))
+	for _, it := range m.list.Items {
+		live[it.Name] = struct{}{}
+	}
+	for name := range m.expanded {
+		if _, ok := live[name]; !ok {
+			delete(m.expanded, name)
+		}
+	}
 }
 
 // applyPendingSelect honours a cross-link's requested release once there is a
@@ -407,21 +445,48 @@ func (m *Model) moveUp() {
 	}
 }
 
+// movePage advances the cursor by one screenful of RENDERED LINES.
+//
+// Counting items instead would page past several screens whenever a release is
+// expanded — one item can be twenty lines — and counting the viewport height
+// instead of the content region would overshoot by the frame, header and
+// footer rows on every press.
 func (m *Model) movePage(dir int) {
-	page := m.list.Viewport.Height
-	if page < 1 {
-		page = 10
+	if len(m.list.Filtered) == 0 {
+		return
 	}
-	m.list.Cursor += dir * page
-	if m.list.Cursor < 0 {
-		m.list.Cursor = 0
+	budget := m.contentLines()
+	i := m.list.Cursor
+	// The row the cursor is on occupies the screen too, so an expanded release
+	// under the cursor shortens the page rather than being travelled over for
+	// free.
+	used := m.itemLineCount(m.list.Filtered[i])
+	for {
+		next := i + dir
+		if next < 0 || next >= len(m.list.Filtered) {
+			break
+		}
+		used += m.itemLineCount(m.list.Filtered[next])
+		if used > budget {
+			break
+		}
+		i = next
 	}
-	if m.list.Cursor >= len(m.list.Filtered) {
-		m.list.Cursor = len(m.list.Filtered) - 1
+	// Always move at least one row, so a release taller than the screen does
+	// not make the key do nothing at all.
+	if i == m.list.Cursor {
+		i = m.list.Cursor + dir
 	}
-	if m.list.Cursor < 0 {
-		m.list.Cursor = 0
+	if i < 0 {
+		i = 0
 	}
+	if i >= len(m.list.Filtered) {
+		i = len(m.list.Filtered) - 1
+	}
+	if i < 0 {
+		i = 0
+	}
+	m.list.Cursor = i
 	m.childIndex = noChild
 	m.list.ResetColumnScroll()
 	m.list.Viewport.SetContent(m.list.View())

--- a/views/charts/update.go
+++ b/views/charts/update.go
@@ -28,26 +28,91 @@ func formatCreated(t time.Time) string {
 	return t.Format("2006-01-02 15:04")
 }
 
-// buildColumns declares the release table columns for the shared content-aware
-// layout. NAME and CHART flex — they give up width first on a narrow terminal
-// and scroll when truncated — while the trailing column is the one that grows.
+// minDetailWidth is the surplus, over what the other columns need, below which
+// DETAIL is not worth showing: narrower than this it would win its width by
+// truncating NAME and CHART, and a truncated explanation next to a truncated
+// name is worse than no explanation.
+const minDetailWidth = 28
+
+// minOwnerWidth is the extra surplus, on top of DETAIL's, that buys the OWNER
+// column. Owner stamps are long ("apply/prod-swarm:release/hello"), so a
+// terminal that cannot spare this much is better off without it.
+const minOwnerWidth = 32
+
+// buildColumns declares the release table for the shared content-aware layout.
 //
-// STATUS and HEALTH are both present on purpose: the first is the record we
-// wrote when we deployed, the second is what the swarm is doing now.
+// The set is responsive. A terminal with surplus width gets a DETAIL column,
+// which carries the one genuinely long, variable-length thing a release has to
+// say, and which absorbs all the leftover — so the table fills the width with
+// information rather than with air, and no column is stretched away from its
+// neighbour. A terminal without that surplus gets the compact set instead.
 func (m *Model) buildColumns() []filterlist.Column[releaseItem] {
+	base := m.baseColumns(false)
+	width := m.list.Viewport.Width
+	if width <= 0 {
+		width = m.width
+	}
+	if width <= 0 {
+		return base
+	}
+	surplus := width - filterlist.NaturalWidth(base, m.list.Items, m.sortColumnIndex())
+	if surplus < minDetailWidth {
+		return base
+	}
+
+	cols := m.baseColumns(true)
+	// A second tier: with room for both, the owner stamp says whether a release
+	// is managed by `charts apply` or was installed by hand, which is the next
+	// most useful thing after why it is not converged.
+	if surplus >= minDetailWidth+minOwnerWidth {
+		cols = append(cols, filterlist.Column[releaseItem]{
+			Label: "OWNER", MinWidth: 5,
+			Cell: func(r releaseItem) string { return displayOrDash(r.current().Owner) },
+		})
+	}
+	return append(cols, filterlist.Column[releaseItem]{
+		Label: "DETAIL", MinWidth: 6,
+		// Both: it takes every spare cell, and it is the only column allowed to
+		// truncate, so a narrowing terminal eats into the explanation rather
+		// than into the release's name.
+		Flex: true, Grow: true,
+		Cell: func(r releaseItem) string { return r.detail() },
+	})
+}
+
+// baseColumns is the set every width shows. withDetail moves the elasticity to
+// the DETAIL column that follows: without it, NAME and CHART give up width
+// first and scroll when truncated, and UPDATED soaks up any small surplus.
+func (m *Model) baseColumns(withDetail bool) []filterlist.Column[releaseItem] {
+	flex := !withDetail
 	return []filterlist.Column[releaseItem]{
-		{Label: "NAME", MinWidth: 4, Flex: true, Cell: func(r releaseItem) string { return r.Name }},
+		{Label: "NAME", MinWidth: 4, Flex: flex, Cell: func(r releaseItem) string { return r.Name }},
 		{Label: "REV", MinWidth: 3, Cell: func(r releaseItem) string { return strconv.Itoa(r.revision()) }},
 		{Label: "STATUS", MinWidth: 6, Cell: func(r releaseItem) string { return displayOrDash(r.status()) }},
 		{Label: "HEALTH", MinWidth: 6, Cell: func(r releaseItem) string { return r.healthLabel() }},
-		{Label: "CHART", MinWidth: 5, Flex: true, Cell: func(r releaseItem) string { return r.chartRef() }},
+		{Label: "CHART", MinWidth: 5, Flex: flex, Cell: func(r releaseItem) string { return r.chartRef() }},
 		// Next to CHART, because it is the version that chart could be at.
 		{Label: "LATEST", MinWidth: 6, Cell: m.updCell},
-		// Grow, not Flex: the leftover on a wide terminal lands after the last
-		// cell, where it reads as margin, instead of being split between NAME and
-		// CHART and opening a void in the middle of every row. Its floor equals
-		// the timestamp it renders, so it never gives width back either.
-		{Label: "UPDATED", MinWidth: 16, Grow: true, Cell: func(r releaseItem) string { return formatCreated(r.Created) }},
+		{Label: "UPDATED", MinWidth: 16, Grow: flex, Cell: func(r releaseItem) string { return formatCreated(r.Created) }},
+	}
+}
+
+// hasDetailColumn reports whether the current width earned the DETAIL column.
+// The footer carries the convergence reason only when it does not, so the same
+// sentence is never on screen twice.
+func (m *Model) hasDetailColumn() bool {
+	cols := m.list.Columns
+	return len(cols) > 0 && cols[len(cols)-1].Label == "DETAIL"
+}
+
+// refreshColumns rebuilds the column set and the header from it. Both the
+// terminal width and the widest cell decide whether DETAIL fits, so this runs
+// on a resize and on every load, not once at construction.
+func (m *Model) refreshColumns() {
+	cols := m.buildColumns()
+	m.list.Columns = cols
+	if m.list.Header != nil {
+		m.list.Header.Columns = filterlist.ColumnDefs(cols)
 	}
 }
 
@@ -107,6 +172,7 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 		m.list.Viewport.Width = msg.Width
 		m.list.Viewport.Height = msg.Height
 		m.list.SetOuterSize(msg.Width, msg.Height)
+		m.refreshColumns()
 		if m.firstResize {
 			m.list.Viewport.YOffset = 0
 			m.firstResize = false
@@ -193,6 +259,9 @@ func (m *Model) handleReleasesLoaded(msg ReleasesLoadedMsg) tea.Cmd {
 
 	m.list.Items = msg.Releases
 	m.list.ApplyFilter()
+	// The widest cell decides whether DETAIL fits, so the column set is
+	// reconsidered whenever the data changes, not only on a resize.
+	m.refreshColumns()
 	m.applySorting()
 
 	if m.resetCursorOnNextLoad {

--- a/views/charts/view.go
+++ b/views/charts/view.go
@@ -143,7 +143,22 @@ func (m *Model) renderFooter() string {
 	if reason := m.selectedReason(); reason != "" {
 		base += "\n" + ui.StatusBarStyle.Render(reason)
 	}
+	if note := m.indexNote(); note != "" {
+		base += "\n" + ui.StatusBarStyle.Render(note)
+	}
 	return base
+}
+
+// noIndexNote explains an empty UPD column, which otherwise reads as "nothing
+// is outdated" when the real answer is "this machine has nothing to compare
+// against".
+const noIndexNote = "⚠ No cached repository indexes — run `swarmcli charts repo update` to populate UPD"
+
+func (m *Model) indexNote() string {
+	if m.state != stateReady || m.haveIndexes || len(m.list.Items) == 0 {
+		return ""
+	}
+	return noIndexNote
 }
 
 // selectedReason is why the selected release is not converged. Convergence

--- a/views/charts/view.go
+++ b/views/charts/view.go
@@ -64,6 +64,15 @@ func (m *Model) buildMainContent() string {
 	return content
 }
 
+// contentWidth is the horizontal room a row has, which the child blocks size
+// themselves to. Zero when the view has not been sized yet.
+func (m *Model) contentWidth() int {
+	if m.list.Viewport.Width > 0 {
+		return m.list.Viewport.Width
+	}
+	return m.width
+}
+
 // contentLines is how many rows the list itself gets, once the frame, the
 // column header and the footer have taken theirs. Both the renderer and
 // paging read it, so a page is exactly what a screen shows.
@@ -95,7 +104,7 @@ func (m *Model) adjustOffsetForChild(visibleLines int) {
 		m.list.SkipOffsetAdjustment = false
 		return
 	}
-	_, childLine := expansionBlock(sel, m.childIndex)
+	_, childLine := expansionBlock(sel, m.childIndex, m.contentWidth())
 	if m.childIndex >= len(childLine) {
 		m.list.SkipOffsetAdjustment = false
 		return
@@ -130,7 +139,7 @@ func (m *Model) itemLineCount(it releaseItem) int {
 	if !m.expanded[it.Name] {
 		return 1
 	}
-	lines, _ := expansionBlock(it, noChild)
+	lines, _ := expansionBlock(it, noChild, m.contentWidth())
 	return 1 + len(lines)
 }
 

--- a/views/charts/view.go
+++ b/views/charts/view.go
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package chartsview
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/Eldara-Tech/swarmcli/ui"
+	"github.com/Eldara-Tech/swarmcli/ui/components/errordialog"
+)
+
+// emptyStateLines is what an operator sees when nothing is installed. Charts
+// are an opt-in feature, so a bare empty box reads as a broken view rather
+// than as "you have no releases".
+var emptyStateLines = []string{
+	"No chart releases found.",
+	"",
+	"Install one with:  swarmcli charts install <release> <repo/chart>",
+}
+
+func (m *Model) FrameTitle() string {
+	return fmt.Sprintf("Chart Releases (%d)", len(m.list.Filtered))
+}
+
+func (m *Model) FrameHeader() string { return m.list.RenderHeader() }
+
+func (m *Model) FrameFooter() string { return m.list.RenderFooter() }
+
+func (m *Model) FrameContent() string { return m.buildMainContent() }
+
+func (m *Model) View() string {
+	return ui.RenderViewFrame(m.FrameTitle(), m.FrameHeader(), m.FrameContent(), m.FrameFooter(),
+		m.list.Viewport.Width, m.list.Viewport.Height, false)
+}
+
+func (m *Model) buildMainContent() string {
+	width := 80
+	if m.list.Viewport.Width > 0 {
+		width = m.list.Viewport.Width
+	} else if m.width > 0 {
+		width = m.width
+	}
+
+	frame := ui.ComputeFrameDimensions(
+		m.list.Viewport.Width, m.list.Viewport.Height,
+		m.width, m.height, m.FrameHeader(), m.FrameFooter(),
+	)
+
+	content := m.list.VisibleContent(frame.DesiredContentLines)
+	switch {
+	case m.state == stateLoading && len(m.list.Items) == 0:
+		content = padTo([]string{"Loading..."}, frame.DesiredContentLines)
+	case m.state == stateReady && len(m.list.Items) == 0:
+		content = padTo(emptyStateLines, frame.DesiredContentLines)
+	}
+
+	if m.errorDialogActive {
+		errorDialog := errordialog.Render(fmt.Sprintf("%v", m.err))
+		content = ui.OverlayCentered(content, errorDialog, width, 0)
+	}
+	return content
+}
+
+// padTo renders lines into exactly n rows, so the frame does not collapse.
+func padTo(lines []string, n int) string {
+	if n < 1 {
+		n = 1
+	}
+	parts := make([]string, n)
+	for i := range parts {
+		if i < len(lines) {
+			parts[i] = lines[i]
+		}
+	}
+	return strings.Join(parts, "\n")
+}
+
+// renderFooter is the status area: counts or a transient toast, then the
+// convergence reason for the selected release.
+func (m *Model) renderFooter() string {
+	base := m.baseFooter()
+	if reason := m.selectedReason(); reason != "" {
+		base += "\n" + ui.StatusBarStyle.Render(reason)
+	}
+	return base
+}
+
+// selectedReason is why the selected release is not converged. Convergence
+// writes that sentence for display, and it is the whole value of the HEALTH
+// column — the column says something is wrong, this says what.
+func (m *Model) selectedReason() string {
+	sel, ok := m.selected()
+	if !ok || !sel.HasHealth || sel.Health.Reason == "" {
+		return ""
+	}
+	return sel.Health.Reason
+}
+
+func (m *Model) baseFooter() string {
+	if m.toastMessage != "" && time.Now().Before(m.toastUntil) {
+		return ui.StatusBarStyle.Render(m.toastMessage)
+	}
+	if m.toastMessage != "" && time.Now().After(m.toastUntil) {
+		m.toastMessage = ""
+	}
+
+	if m.state == stateLoading {
+		return ui.StatusBarStyle.Render(fmt.Sprintf("Loading chart releases… %s", ui.SpinnerCharAt(m.spinner)))
+	}
+
+	total := len(m.list.Items)
+	filtered := len(m.list.Filtered)
+	cursor := m.list.Cursor + 1
+
+	if filtered == 0 {
+		return ui.StatusBarStyle.Render("No releases")
+	}
+	if m.HasActiveFilter() {
+		return ui.StatusBarStyle.Render(fmt.Sprintf("%d/%d (filtered from %d)", cursor, filtered, total))
+	}
+	return ui.StatusBarStyle.Render(fmt.Sprintf("%d/%d", cursor, total))
+}

--- a/views/charts/view.go
+++ b/views/charts/view.go
@@ -49,6 +49,8 @@ func (m *Model) buildMainContent() string {
 		m.width, m.height, m.FrameHeader(), m.FrameFooter(),
 	)
 
+	m.adjustOffsetForChild(frame.DesiredContentLines)
+
 	content := m.list.VisibleContent(frame.DesiredContentLines)
 	switch {
 	case m.state == stateLoading && len(m.list.Items) == 0:
@@ -62,6 +64,62 @@ func (m *Model) buildMainContent() string {
 		content = ui.OverlayCentered(content, errorDialog, width, 0)
 	}
 	return content
+}
+
+// adjustOffsetForChild keeps the selected child on screen.
+//
+// VisibleContent's own scrolling treats an expanded release as a single cursor
+// unit, so a release taller than the viewport is shown from its first line and
+// a child further down falls off the bottom. While a child is selected the
+// view therefore takes the offset over itself, exactly as the services view
+// does for its inline task rows.
+func (m *Model) adjustOffsetForChild(visibleLines int) {
+	if m.childIndex == noChild {
+		m.list.SkipOffsetAdjustment = false
+		return
+	}
+	sel, ok := m.selected()
+	if !ok || !m.expanded[sel.Name] {
+		m.list.SkipOffsetAdjustment = false
+		return
+	}
+	_, childLine := expansionBlock(sel, m.childIndex)
+	if m.childIndex >= len(childLine) {
+		m.list.SkipOffsetAdjustment = false
+		return
+	}
+	m.list.SkipOffsetAdjustment = true
+
+	// Lines above the selected release, then its own row, then the child's
+	// line within the expansion block.
+	offset := 0
+	for i := 0; i < m.list.Cursor && i < len(m.list.Filtered); i++ {
+		offset += m.itemLineCount(m.list.Filtered[i])
+	}
+	offset += 1 + childLine[m.childIndex]
+
+	if visibleLines < 1 {
+		visibleLines = 1
+	}
+	if offset < m.list.Viewport.YOffset {
+		m.list.Viewport.YOffset = offset
+	} else if offset >= m.list.Viewport.YOffset+visibleLines {
+		m.list.Viewport.YOffset = offset - visibleLines + 1
+		if m.list.Viewport.YOffset < 0 {
+			m.list.Viewport.YOffset = 0
+		}
+	}
+}
+
+// itemLineCount is how many rendered lines an item occupies. It counts the
+// expansion through the same function that renders it, so the two cannot
+// disagree about how tall a release is.
+func (m *Model) itemLineCount(it releaseItem) int {
+	if !m.expanded[it.Name] {
+		return 1
+	}
+	lines, _ := expansionBlock(it, noChild)
+	return 1 + len(lines)
 }
 
 // padTo renders lines into exactly n rows, so the frame does not collapse.

--- a/views/charts/view.go
+++ b/views/charts/view.go
@@ -62,6 +62,8 @@ func (m *Model) buildMainContent() string {
 	if m.errorDialogActive {
 		errorDialog := errordialog.Render(fmt.Sprintf("%v", m.err))
 		content = ui.OverlayCentered(content, errorDialog, width, 0)
+	} else if m.confirmDialog.Visible {
+		content = ui.OverlayCentered(content, m.confirmDialog.View(), width, 0)
 	}
 	return content
 }
@@ -143,22 +145,7 @@ func (m *Model) renderFooter() string {
 	if reason := m.selectedReason(); reason != "" {
 		base += "\n" + ui.StatusBarStyle.Render(reason)
 	}
-	if note := m.indexNote(); note != "" {
-		base += "\n" + ui.StatusBarStyle.Render(note)
-	}
-	return base
-}
-
-// noIndexNote explains an empty UPD column, which otherwise reads as "nothing
-// is outdated" when the real answer is "this machine has nothing to compare
-// against".
-const noIndexNote = "⚠ No cached repository indexes — run `swarmcli charts repo update` to populate UPD"
-
-func (m *Model) indexNote() string {
-	if m.state != stateReady || m.haveIndexes || len(m.list.Items) == 0 {
-		return ""
-	}
-	return noIndexNote
+	return base + "\n" + ui.StatusBarStyle.Render(readOnlyHint)
 }
 
 // selectedReason is why the selected release is not converged. Convergence

--- a/views/charts/view.go
+++ b/views/charts/view.go
@@ -44,19 +44,15 @@ func (m *Model) buildMainContent() string {
 		width = m.width
 	}
 
-	frame := ui.ComputeFrameDimensions(
-		m.list.Viewport.Width, m.list.Viewport.Height,
-		m.width, m.height, m.FrameHeader(), m.FrameFooter(),
-	)
+	lines := m.contentLines()
+	m.adjustOffsetForChild(lines)
 
-	m.adjustOffsetForChild(frame.DesiredContentLines)
-
-	content := m.list.VisibleContent(frame.DesiredContentLines)
+	content := m.list.VisibleContent(lines)
 	switch {
 	case m.state == stateLoading && len(m.list.Items) == 0:
-		content = padTo([]string{"Loading..."}, frame.DesiredContentLines)
+		content = padTo([]string{"Loading..."}, lines)
 	case m.state == stateReady && len(m.list.Items) == 0:
-		content = padTo(emptyStateLines, frame.DesiredContentLines)
+		content = padTo(emptyStateLines, lines)
 	}
 
 	if m.errorDialogActive {
@@ -66,6 +62,20 @@ func (m *Model) buildMainContent() string {
 		content = ui.OverlayCentered(content, m.confirmDialog.View(), width, 0)
 	}
 	return content
+}
+
+// contentLines is how many rows the list itself gets, once the frame, the
+// column header and the footer have taken theirs. Both the renderer and
+// paging read it, so a page is exactly what a screen shows.
+func (m *Model) contentLines() int {
+	frame := ui.ComputeFrameDimensions(
+		m.list.Viewport.Width, m.list.Viewport.Height,
+		m.width, m.height, m.FrameHeader(), m.FrameFooter(),
+	)
+	if frame.DesiredContentLines < 1 {
+		return 1
+	}
+	return frame.DesiredContentLines
 }
 
 // adjustOffsetForChild keeps the selected child on screen.

--- a/views/charts/view.go
+++ b/views/charts/view.go
@@ -162,6 +162,12 @@ func (m *Model) renderFooter() string {
 // writes that sentence for display, and it is the whole value of the HEALTH
 // column — the column says something is wrong, this says what.
 func (m *Model) selectedReason() string {
+	// The DETAIL column carries it for every row when the terminal is wide
+	// enough; repeating the selected row's copy in the footer would be the same
+	// sentence twice on the same screen.
+	if m.hasDetailColumn() {
+		return ""
+	}
 	sel, ok := m.selected()
 	if !ok || !sel.HasHealth || sel.Health.Reason == "" {
 		return ""

--- a/views/charts/view_test.go
+++ b/views/charts/view_test.go
@@ -87,7 +87,8 @@ func TestFilteredToNothingIsNotTheEmptyState(t *testing.T) {
 	m.ApplySearchQuery("nothing-matches-this")
 
 	out := m.View()
-	require.NotContains(t, out, "swarmcli charts install")
+	require.NotContains(t, out, "No chart releases found",
+		"there are releases; the filter simply matched none of them")
 	require.Contains(t, out, "No releases")
 }
 
@@ -127,33 +128,59 @@ func TestFooterHasNoReasonWhenConverged(t *testing.T) {
 		map[string]string{"c": "1.0.0"})
 
 	require.Empty(t, m.selectedReason())
-	require.Equal(t, 1, strings.Count(m.renderFooter(), "\n")+1,
-		"a converged release with nothing to report adds no further footer lines")
+	footer := m.renderFooter()
+	require.Equal(t, 2, strings.Count(footer, "\n")+1,
+		"counts plus the read-only hint, and nothing else to report")
+	require.Contains(t, footer, readOnlyHint)
 }
 
-// An empty UPD column has two very different causes, and the footer must
-// distinguish them: nothing newer exists, versus nothing to compare against.
-func TestNoCachedIndexesIsSaidOutLoud(t *testing.T) {
+// The boundary is stated before an operator presses a key and is told no.
+func TestReadOnlyHintIsAlwaysOnScreen(t *testing.T) {
 	m := sized(testModel(), 140, 24)
-	loadReleases(t, m, map[string][]charts.Release{"app": deployed("app", "c", "1.0.0")}, nil)
+	require.Contains(t, m.View(), "Read-only", "even while loading")
 
+	loadReleases(t, m, map[string][]charts.Release{"app": deployed("app", "c", "1.0.0")}, nil)
+	require.Contains(t, m.View(), "Read-only")
+
+	loadReleases(t, m, nil, nil)
+	require.Contains(t, m.View(), "Read-only", "even with nothing installed")
+}
+
+// "nothing newer" and "nothing to compare against" are different answers, and
+// one empty cell for both would let the second read as the first.
+func TestUpdCellDistinguishesUnknownFromCurrent(t *testing.T) {
+	m := sized(testModel(), 150, 24)
+
+	loadReleases(t, m, map[string][]charts.Release{"app": deployed("app", "c", "1.0.0")}, nil)
 	require.False(t, m.haveIndexes)
-	require.Contains(t, m.renderFooter(), "No cached repository indexes")
-	require.Contains(t, m.renderFooter(), "charts repo update")
+	require.Equal(t, "?", m.updCell(m.list.Filtered[0]), "no index cached")
 
 	loadReleases(t, m,
 		map[string][]charts.Release{"app": deployed("app", "c", "1.0.0")}, nil,
 		map[string]string{"c": "1.0.0"})
 	require.True(t, m.haveIndexes)
-	require.NotContains(t, m.renderFooter(), "No cached repository indexes")
+	require.Equal(t, "—", m.updCell(m.list.Filtered[0]), "index cached, nothing newer")
+
+	loadReleases(t, m,
+		map[string][]charts.Release{"app": deployed("app", "c", "1.0.0")}, nil,
+		map[string]string{"c": "2.0.0"})
+	require.Equal(t, "2.0.0", m.updCell(m.list.Filtered[0]))
 }
 
-// With no releases at all the empty state already tells the whole story; a
-// missing-index warning on top of it is noise.
-func TestNoIndexNoteIsSuppressedOnAnEmptyList(t *testing.T) {
-	m := sized(testModel(), 120, 24)
-	loadReleases(t, m, nil, nil)
-	require.NotContains(t, m.renderFooter(), "No cached repository indexes")
+// The footer carries the counts, the convergence reason and the read-only
+// hint. A fourth line squeezes the content area enough to clip a dialog on a
+// short terminal, so the missing-index signal lives in the column instead.
+func TestFooterStaysWithinThreeLines(t *testing.T) {
+	m := sized(testModel(), 140, 24)
+	loadReleases(t, m,
+		map[string][]charts.Release{"app": deployed("app", "c", "1.0.0")},
+		map[string][]charts.ServiceState{"app": {{
+			Name: "app_web", Running: 2, Desired: 3, NewestTaskAge: time.Hour,
+		}}})
+
+	require.NotEmpty(t, m.selectedReason(), "the fixture must produce a reason line")
+	require.False(t, m.haveIndexes, "and have the missing-index condition too")
+	require.LessOrEqual(t, strings.Count(m.renderFooter(), "\n")+1, 3)
 }
 
 func TestUpdColumnShowsTheNewerVersion(t *testing.T) {

--- a/views/charts/view_test.go
+++ b/views/charts/view_test.go
@@ -123,9 +123,58 @@ func TestFooterHasNoReasonWhenConverged(t *testing.T) {
 	m := sized(testModel(), 120, 24)
 	loadReleases(t, m,
 		map[string][]charts.Release{"app": deployed("app", "c", "1.0.0")},
-		map[string][]charts.ServiceState{"app": {converged("app_web")}})
+		map[string][]charts.ServiceState{"app": {converged("app_web")}},
+		map[string]string{"c": "1.0.0"})
 
 	require.Empty(t, m.selectedReason())
 	require.Equal(t, 1, strings.Count(m.renderFooter(), "\n")+1,
-		"a converged release adds no second footer line")
+		"a converged release with nothing to report adds no further footer lines")
+}
+
+// An empty UPD column has two very different causes, and the footer must
+// distinguish them: nothing newer exists, versus nothing to compare against.
+func TestNoCachedIndexesIsSaidOutLoud(t *testing.T) {
+	m := sized(testModel(), 140, 24)
+	loadReleases(t, m, map[string][]charts.Release{"app": deployed("app", "c", "1.0.0")}, nil)
+
+	require.False(t, m.haveIndexes)
+	require.Contains(t, m.renderFooter(), "No cached repository indexes")
+	require.Contains(t, m.renderFooter(), "charts repo update")
+
+	loadReleases(t, m,
+		map[string][]charts.Release{"app": deployed("app", "c", "1.0.0")}, nil,
+		map[string]string{"c": "1.0.0"})
+	require.True(t, m.haveIndexes)
+	require.NotContains(t, m.renderFooter(), "No cached repository indexes")
+}
+
+// With no releases at all the empty state already tells the whole story; a
+// missing-index warning on top of it is noise.
+func TestNoIndexNoteIsSuppressedOnAnEmptyList(t *testing.T) {
+	m := sized(testModel(), 120, 24)
+	loadReleases(t, m, nil, nil)
+	require.NotContains(t, m.renderFooter(), "No cached repository indexes")
+}
+
+func TestUpdColumnShowsTheNewerVersion(t *testing.T) {
+	m := sized(testModel(), 150, 24)
+	loadReleases(t, m,
+		map[string][]charts.Release{
+			"stale":   deployed("stale", "c", "1.0.0"),
+			"current": deployed("current", "c2", "3.0.0"),
+			"local":   deployed("local", "unpublished", "0.1.0"),
+		}, nil,
+		map[string]string{"c": "2.0.0", "c2": "3.0.0"})
+
+	byName := map[string]releaseItem{}
+	for _, it := range m.list.Filtered {
+		byName[it.Name] = it
+	}
+	require.Equal(t, "2.0.0", byName["stale"].Latest)
+	require.Empty(t, byName["current"].Latest, "already newest")
+	require.Empty(t, byName["local"].Latest, "a chart in no index has nothing to be outdated against")
+
+	out := m.View()
+	require.Contains(t, out, "UPD")
+	require.Contains(t, out, "2.0.0")
 }

--- a/views/charts/view_test.go
+++ b/views/charts/view_test.go
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package chartsview
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Eldara-Tech/swarmcli/charts"
+
+	"github.com/stretchr/testify/require"
+)
+
+func sized(m *Model, w, h int) *Model {
+	m.SetSize(w, h)
+	return m
+}
+
+func TestViewLoadingState(t *testing.T) {
+	m := sized(testModel(), 120, 24)
+	require.Equal(t, stateLoading, m.state)
+	out := m.View()
+	require.Contains(t, out, "Chart Releases")
+	require.Contains(t, out, "Loading")
+}
+
+func TestViewReadyStateShowsReleases(t *testing.T) {
+	m := sized(testModel(), 120, 24)
+	loadReleases(t, m,
+		map[string][]charts.Release{
+			"edge":  deployed("edge", "traefik", "0.1.1"),
+			"hello": deployed("hello", "whoami", "0.1.8"),
+		},
+		map[string][]charts.ServiceState{"edge": {converged("edge_web")}})
+
+	out := m.View()
+	require.Contains(t, out, "Chart Releases (2)")
+	require.Contains(t, out, "edge")
+	require.Contains(t, out, "hello")
+	require.Contains(t, out, "traefik-0.1.1")
+	require.Contains(t, out, "converged")
+}
+
+func TestHeaderShowsAllColumns(t *testing.T) {
+	m := sized(testModel(), 140, 24)
+	loadReleases(t, m, map[string][]charts.Release{"app": deployed("app", "c", "1.0.0")}, nil)
+
+	header := m.FrameHeader()
+	for _, col := range []string{"NAME", "REV", "STATUS", "HEALTH", "CHART", "UPDATED"} {
+		require.Contains(t, header, col)
+	}
+}
+
+// STATUS and HEALTH are both present on purpose, and a release that reads
+// deployed while its rollout is stuck is exactly why.
+func TestBothStatusAndHealthAreRendered(t *testing.T) {
+	m := sized(testModel(), 140, 24)
+	loadReleases(t, m,
+		map[string][]charts.Release{"app": deployed("app", "c", "1.0.0")},
+		map[string][]charts.ServiceState{"app": {{
+			Name: "app_web", Running: 1, Desired: 1,
+			UpdateState: "paused", NewestTaskAge: time.Hour,
+		}}})
+
+	out := m.View()
+	require.Contains(t, out, "deployed", "the stored record")
+	require.Contains(t, out, "wedged", "what the swarm is actually doing")
+}
+
+// Charts are opt-in, so an empty list must not read as a broken view.
+func TestEmptyStateNamesTheInstallCommand(t *testing.T) {
+	m := sized(testModel(), 120, 24)
+	loadReleases(t, m, nil, nil)
+
+	out := m.View()
+	require.Contains(t, out, "No chart releases found")
+	require.Contains(t, out, "swarmcli charts install")
+}
+
+// An active filter that matches nothing is a different situation from having
+// no releases at all, and must not advertise the install command.
+func TestFilteredToNothingIsNotTheEmptyState(t *testing.T) {
+	m := sized(testModel(), 120, 24)
+	loadReleases(t, m, map[string][]charts.Release{"app": deployed("app", "c", "1.0.0")}, nil)
+	m.ApplySearchQuery("nothing-matches-this")
+
+	out := m.View()
+	require.NotContains(t, out, "swarmcli charts install")
+	require.Contains(t, out, "No releases")
+}
+
+func TestFooterShowsCountsAndFilterFragment(t *testing.T) {
+	m := sized(testModel(), 120, 24)
+	loadReleases(t, m, map[string][]charts.Release{
+		"a": deployed("a", "c", "1.0.0"),
+		"b": deployed("b", "c", "1.0.0"),
+	}, nil)
+
+	require.Contains(t, m.baseFooter(), "1/2")
+
+	m.ApplySearchQuery("a")
+	require.Contains(t, m.baseFooter(), "filtered from 2")
+}
+
+// The reason is the whole point of the health column: the column says something
+// is wrong, the footer says what.
+func TestFooterCarriesTheConvergenceReason(t *testing.T) {
+	m := sized(testModel(), 120, 24)
+	loadReleases(t, m,
+		map[string][]charts.Release{"app": deployed("app", "c", "1.0.0")},
+		map[string][]charts.ServiceState{"app": {{
+			Name: "app_web", Running: 2, Desired: 3, NewestTaskAge: time.Hour,
+		}}})
+
+	footer := m.renderFooter()
+	require.Contains(t, footer, "2/3 tasks running")
+	require.Contains(t, footer, "app_web")
+}
+
+func TestFooterHasNoReasonWhenConverged(t *testing.T) {
+	m := sized(testModel(), 120, 24)
+	loadReleases(t, m,
+		map[string][]charts.Release{"app": deployed("app", "c", "1.0.0")},
+		map[string][]charts.ServiceState{"app": {converged("app_web")}})
+
+	require.Empty(t, m.selectedReason())
+	require.Equal(t, 1, strings.Count(m.renderFooter(), "\n")+1,
+		"a converged release adds no second footer line")
+}

--- a/views/charts/view_test.go
+++ b/views/charts/view_test.go
@@ -202,6 +202,6 @@ func TestUpdColumnShowsTheNewerVersion(t *testing.T) {
 	require.Empty(t, byName["local"].Latest, "a chart in no index has nothing to be outdated against")
 
 	out := m.View()
-	require.Contains(t, out, "UPD")
+	require.Contains(t, out, "LATEST", "the header names the column")
 	require.Contains(t, out, "2.0.0")
 }

--- a/views/charts/view_test.go
+++ b/views/charts/view_test.go
@@ -106,22 +106,34 @@ func TestFooterShowsCountsAndFilterFragment(t *testing.T) {
 }
 
 // The reason is the whole point of the health column: the column says something
-// is wrong, the footer says what.
-func TestFooterCarriesTheConvergenceReason(t *testing.T) {
-	m := sized(testModel(), 120, 24)
-	loadReleases(t, m,
-		map[string][]charts.Release{"app": deployed("app", "c", "1.0.0")},
-		map[string][]charts.ServiceState{"app": {{
-			Name: "app_web", Running: 2, Desired: 3, NewestTaskAge: time.Hour,
-		}}})
+// is wrong, this says what. Where it lives depends on the width — the DETAIL
+// column when there is room, the footer when there is not — but it is always on
+// screen, and never twice.
+func TestTheConvergenceReasonIsOnScreenExactlyOnce(t *testing.T) {
+	const reason = "2/3 tasks running"
+	load := func(m *Model) {
+		loadReleases(t, m,
+			map[string][]charts.Release{"app": deployed("app", "c", "1.0.0")},
+			map[string][]charts.ServiceState{"app": {{
+				Name: "app_web", Running: 2, Desired: 3, NewestTaskAge: time.Hour,
+			}}})
+	}
 
-	footer := m.renderFooter()
-	require.Contains(t, footer, "2/3 tasks running")
-	require.Contains(t, footer, "app_web")
+	wide := sized(testModel(), 160, 24)
+	load(wide)
+	require.True(t, wide.hasDetailColumn(), "160 columns has room to spare")
+	require.Equal(t, 1, strings.Count(wide.View(), reason), "the DETAIL column carries it")
+	require.Empty(t, wide.selectedReason(), "so the footer must not repeat it")
+
+	narrow := sized(testModel(), 90, 24)
+	load(narrow)
+	require.False(t, narrow.hasDetailColumn(), "90 columns has none")
+	require.Equal(t, 1, strings.Count(narrow.View(), reason), "the footer carries it instead")
+	require.Contains(t, narrow.renderFooter(), "app_web")
 }
 
 func TestFooterHasNoReasonWhenConverged(t *testing.T) {
-	m := sized(testModel(), 120, 24)
+	m := sized(testModel(), 90, 24)
 	loadReleases(t, m,
 		map[string][]charts.Release{"app": deployed("app", "c", "1.0.0")},
 		map[string][]charts.ServiceState{"app": {converged("app_web")}},
@@ -171,7 +183,8 @@ func TestUpdCellDistinguishesUnknownFromCurrent(t *testing.T) {
 // hint. A fourth line squeezes the content area enough to clip a dialog on a
 // short terminal, so the missing-index signal lives in the column instead.
 func TestFooterStaysWithinThreeLines(t *testing.T) {
-	m := sized(testModel(), 140, 24)
+	// Narrow enough that the footer, not the DETAIL column, carries the reason.
+	m := sized(testModel(), 90, 24)
 	loadReleases(t, m,
 		map[string][]charts.Release{"app": deployed("app", "c", "1.0.0")},
 		map[string][]charts.ServiceState{"app": {{

--- a/views/stacks/messages.go
+++ b/views/stacks/messages.go
@@ -54,6 +54,14 @@ type StackDeleteIntentMsg struct {
 	ChartRelease string
 }
 
+// ChartJumpMsg carries the result of checking, when "g" is pressed, whether the
+// selected stack belongs to a chart release. ChartRelease is non-empty when it
+// does, and the view then navigates to the charts browser on that release.
+type ChartJumpMsg struct {
+	StackName    string
+	ChartRelease string
+}
+
 // editorContentMsg is sent when editor returns content
 type editorContentMsg struct {
 	Content         string

--- a/views/stacks/update.go
+++ b/views/stacks/update.go
@@ -233,6 +233,19 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 		m.confirmDialog.CheckboxChecked = true // Checked by default
 		return nil
 
+	case ChartJumpMsg:
+		if msg.ChartRelease == "" {
+			m.showToast(fmt.Sprintf("Stack %q is not managed by a chart release", msg.StackName))
+			return nil
+		}
+		release := msg.ChartRelease
+		return func() tea.Msg {
+			return view.NavigateToMsg{
+				ViewName: view.NameCharts,
+				Payload:  map[string]any{"release": release},
+			}
+		}
+
 	case editorContentMsg:
 		preview := msg.Content
 		if len(preview) > 100 {
@@ -439,6 +452,15 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 					m.selectedTaskIndex = -1
 					m.setRenderItem()
 				}
+			}
+		}
+
+		// 'g' goes to the chart release this stack belongs to, if any.
+		// Lowercase because capitals in this view are its sort keys, and 'c'
+		// is already create-stack.
+		if msg.String() == "g" {
+			if m.List.Cursor < len(m.List.Filtered) {
+				return m.chartJumpCmd(m.List.Filtered[m.List.Cursor].Name)
 			}
 		}
 
@@ -1016,13 +1038,23 @@ func (m *Model) handleSaveDialogKey(msg tea.KeyMsg) tea.Cmd {
 // the stack name) and emits a StackDeleteIntentMsg so the confirm dialog can
 // warn. The lookup runs off the main loop so the UI never blocks on it.
 func (m *Model) stackDeleteIntentCmd(name string) tea.Cmd {
+	return m.chartReleaseOfStackCmd(name, func(release string) tea.Msg {
+		return StackDeleteIntentMsg{StackName: name, ChartRelease: release}
+	})
+}
+
+// chartReleaseOfStackCmd resolves whether a stack belongs to a chart release
+// and hands the answer to mk. Two callers need it — the delete guard and the
+// jump to the charts view — and the lookup runs off the main loop either way,
+// so the UI never blocks on a config listing.
+func (m *Model) chartReleaseOfStackCmd(name string, mk func(release string) tea.Msg) tea.Cmd {
 	configOps := m.deps.Configs
 	return func() tea.Msg {
 		ctx, cancel := context.WithTimeout(context.Background(), userActionTimeout)
 		defer cancel()
 		release := ""
 		if cfgs, err := configOps.ListConfigs(ctx); err != nil {
-			l().Warnf("stackDeleteIntentCmd: ListConfigs failed: %v", err)
+			l().Warnf("chartReleaseOfStackCmd: ListConfigs failed: %v", err)
 		} else {
 			for _, c := range cfgs {
 				lbl := c.Spec.Labels
@@ -1034,8 +1066,16 @@ func (m *Model) stackDeleteIntentCmd(name string) tea.Cmd {
 				}
 			}
 		}
-		return StackDeleteIntentMsg{StackName: name, ChartRelease: release}
+		return mk(release)
 	}
+}
+
+// chartJumpCmd opens the charts view on the release that owns this stack, or
+// reports that nothing owns it.
+func (m *Model) chartJumpCmd(name string) tea.Cmd {
+	return m.chartReleaseOfStackCmd(name, func(release string) tea.Msg {
+		return ChartJumpMsg{StackName: name, ChartRelease: release}
+	})
 }
 
 func (m *Model) saveStackToFileCmd(stackName, filePath string) tea.Cmd {
@@ -1619,6 +1659,7 @@ func GetStacksHelpContent() []helpview.HelpCategory {
 				{Keys: "<s>", Description: "Save stack YAML to file"},
 				{Keys: "<p>", Description: "Show tasks for Stack"},
 				{Keys: "<n>", Description: "Create new stack"},
+				{Keys: "<g>", Description: "Go to the chart release this stack belongs to"},
 				{Keys: "<ctrl+d>", Description: "Delete stack"},
 				{Keys: "</>", Description: "Filter"},
 			},

--- a/views/stacks/update_test.go
+++ b/views/stacks/update_test.go
@@ -243,6 +243,32 @@ func TestKey_CtrlD_StackDeleteIntent(t *testing.T) {
 	require.Contains(t, m.confirmDialog.Message, "charts uninstall")
 }
 
+// "g" is the way into the charts browser from a stack the operator is already
+// looking at. It reuses the same ownership lookup the delete guard makes.
+func TestKey_G_JumpsToTheOwningChartRelease(t *testing.T) {
+	m := testModel()
+	loadStacks(m, fakeStacks("whoami"))
+
+	// The lookup is async: nothing navigates until the result arrives.
+	require.NotNil(t, m.Update(key("g")))
+
+	msg := runCmd(m.Update(ChartJumpMsg{StackName: "whoami", ChartRelease: "whoami"}))
+	nav, ok := msg.(view.NavigateToMsg)
+	require.True(t, ok, "expected navigation, got %T", msg)
+	require.Equal(t, view.NameCharts, nav.ViewName)
+	require.Equal(t, map[string]any{"release": "whoami"}, nav.Payload)
+}
+
+// A stack nothing owns must say so rather than opening an empty browser.
+func TestKey_G_SaysWhenAStackIsNotChartManaged(t *testing.T) {
+	m := testModel()
+	loadStacks(m, fakeStacks("plain"))
+
+	require.Nil(t, m.Update(ChartJumpMsg{StackName: "plain"}), "no navigation")
+	require.Contains(t, m.toastMessage, "not managed by a chart release")
+	require.Contains(t, m.toastMessage, "plain")
+}
+
 func TestKey_P_TogglesExpand(t *testing.T) {
 	m := testModel()
 	loadStacks(m, fakeStacks("s1"))

--- a/views/view/constants.go
+++ b/views/view/constants.go
@@ -18,12 +18,14 @@ const (
 	NameLoading  = "loading"
 	NameNetworks = "networks"
 	NameVolumes  = "volumes"
+	NameCharts   = "charts"
 )
 
 var topLevelViews = map[string]bool{
 	NameStacks: true, NameNodes: true, NameConfigs: true,
 	NameSecrets: true, NameNetworks: true, NameVolumes: true,
 	NameContexts: true, NameLoading: true, NameHelp: true,
+	NameCharts: true,
 }
 
 // RegisterTopLevel marks a view name as top-level. Called from init() by

--- a/views/view/constants_test.go
+++ b/views/view/constants_test.go
@@ -13,6 +13,7 @@ func TestIsTopLevel(t *testing.T) {
 	topLevel := []string{
 		NameStacks, NameNodes, NameConfigs, NameSecrets,
 		NameNetworks, NameVolumes, NameContexts, NameLoading, NameHelp,
+		NameCharts,
 	}
 	for _, name := range topLevel {
 		require.True(t, IsTopLevel(name), "expected %q to be top-level", name)


### PR DESCRIPTION
Closes #466.

A read-only `:charts` view (alias `:chart`) for browsing installed chart releases, built on the existing `charts/` engine.

```
┌───────────────────────── Chart Releases (2) ─────────────────────────┐
│  NAME ▲          REV STATUS   HEALTH      CHART          UPDATED  UPD│
│  edge            1   deployed converged   traefik-0.1.1  …       —   │
│  hello           2   deployed progressing whoami-0.1.8   …       0.2.0│
│     REV  STATUS      CHART         UPDATED           OWNER           │
│     1    superseded  whoami-0.1.7  2026-08-11 12:00  —               │
│     2    deployed    whoami-0.1.8  2026-08-12 12:00  apply/prod-swarm│
│     SERVICE       MODE         REPLICAS   STATUS                     │
│     hello_web     replicated   1/2        preparing                  │
│  2/2                                                                 │
│  service 'hello_web': 1/2 tasks running                              │
│  Read-only · manage releases with `swarmcli charts install|upgrade…` │
└──────────────────────────────────────────────────────────────────────┘
```

`enter` expands a release in place to its revisions and services; `i`/`v` show a
revision's manifest and values, `d` diffs it against the one below it, `s` opens
the release's services. `/` filters, every column sorts, `?` explains the rest.

## What the TUI adds over `charts list`

**Live convergence health.** `charts status` already receives `[]ServiceState`
carrying `Running/Desired/Completed/Job/UpdateState/Monitor/NewestTaskAge` and
prints four display fields from it. The rules that interpret them —
`ServiceState.Convergence()` and `Rollup()` — are written, tested, carry the
scars of #443, #473, #480 and #526, and had **no presenter anywhere in the
repo**. `HEALTH` renders them, and the reason sentence `Convergence` writes for
display lands in the footer for the selected release.

`STATUS` and `HEALTH` are both present on purpose: the first is the record we
wrote when we deployed, the second is what the swarm is doing now. They agree
until they matter — a release reading `deployed` whose rollout is
`rollback_paused`. Health is rendered only for a deployed record, because
`Rollup` on no services reports "progressing", which is right for a `--wait`
deploy and wrong on a browser row for a release that failed or never installed.

**A diff between stored revisions.** Every revision record stores its rendered
manifest, and `utils/textdiff.Lines` already exists (its package doc explicitly
anticipates a TUI caller). So `d` needs no chart, no re-render and no network —
which is exactly what `charts diff upgrade` cannot say.

## Design notes

**The data seam is view-local, not a `docker.Deps` field.** `charts` imports
`docker`, so a `docker.ChartOps` returning a `charts.Release` would close an
import cycle. The interface is declared at the consumer instead, which is the
idiomatic Go placement anyway.

**One engine change:** `Engine.AllRevisions` is exported — a thin wrapper over
the existing unexported `allRevisions`. Composing `List` with a `History` per
expanded release would gunzip and YAML-decode every stored revision twice.

**The poll gate hashes the convergence phase but not its reason.** While a
service serves out its stability window the reason counts down in milliseconds,
so hashing it would report a change on every tick and save nothing.

**`UPD` never touches the network.** The repository store is built with
`RefreshNever`: this view polls, and `RepoStore`'s methods take no context, so a
fetch started here could not even be cancelled when the view closes. The indexes
are read once per view. That makes an empty cell ambiguous, so the two causes are
separated — `—` is "nothing newer", `?` is "no cached index to compare against".

**Read-only, and it says so.** A persistent footer hint; `u`/`r`/`ctrl+d` open a
dismiss-only dialog carrying the exact command for the selected release (with
the rollback target already resolved); a "Chart operations (CLI only)" help
section. Binding those keys beats leaving them dead — `ctrl+d` deletes in the
configs, secrets and volumes views, so an operator will press it here.

**`g` in `:stacks`** jumps to the release owning that stack, reusing the
ownership lookup the delete guard already makes (extracted so both share it).

## Two deviations from the plan, both found by looking at the rendered frame

The missing-index signal moved from a footer line into the `UPD` cells. With
counts, a convergence reason, the index note and the read-only hint the footer
reached four lines and squeezed the content area enough to clip a dialog on a
short terminal.

The cross-link selects and expands rather than filtering: the `/` filter belongs
to the app's search bar, and setting a query the operator never typed would
leave the list narrowed with nothing on screen saying why.

## A pre-existing bug this surfaced — not fixed here

The last commit fixes a **branching poll loop** in this view: a tick both started
a poll and re-armed the ticker, while the poll's "nothing changed" result
re-armed it too. Driving the message loop by hand, an idle view went 1, 1, 2, 3,
5, 8, 13 ticks per round — thousands of concurrent reads within a minute.

**I copied that shape from `views/volumes`.** Measured there, one tick yields two
successors in the steady state. The same shape is in `views/configs`,
`views/secrets` and `views/networks` (configs and secrets have a `polling`
atomic that prevents overlapping *reads* but not the multiplying timers).
`views/services` is the correct one — it re-arms only from the loaded handler.

Those four are untouched here: it is a pre-existing bug and deserves its own
change. Happy to open an issue.

## Testing

`go build`, all test packages, `-race`, `gofmt` and
`golangci-lint run ./... --build-tags=integration` are clean. 86.5% statement
coverage on the new package; `AllRevisions` at 100%.

Three guards were mutation-tested rather than assumed — disabling the scroll
math, duplicating a `tickCmd`, and reverting the loop fix each make the relevant
test fail.

⚠️ **`integration-tests/charts/charts_browser_test.go` is compile-checked only** —
there is no Docker daemon in my environment, so it has never been executed. It
needs `./test-setup/testenv.sh integration`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
