### PR TITLE
fix(views): give every polling view exactly one tick chain

### DIFF
--- a/views/charts/messages.go
+++ b/views/charts/messages.go
@@ -32,7 +32,7 @@ var PollInterval = 5 * time.Second
 // backstop against an unreachable daemon rather than a working budget.
 const loadTimeout = 10 * time.Second
 
-type TickMsg time.Time
+type TickMsg struct{ Gen uint64 }
 
 // PollRetryMsg signals that polling found no changes; the Update handler
 // schedules the next tick.
@@ -54,8 +54,8 @@ type ReleasesLoadedMsg struct {
 // cmd invoked synchronously blocks for the full interval.
 var spinnerTickInterval = 80 * time.Millisecond
 
-func tickCmd() tea.Cmd {
-	return tea.Tick(PollInterval, func(t time.Time) tea.Msg { return TickMsg(t) })
+func tickCmd(gen uint64) tea.Cmd {
+	return tea.Tick(PollInterval, func(time.Time) tea.Msg { return TickMsg{Gen: gen} })
 }
 
 func spinnerTickCmd() tea.Cmd {

--- a/views/charts/model.go
+++ b/views/charts/model.go
@@ -78,6 +78,9 @@ type Model struct {
 	// merely double the poll rate, they each double again on every beat.
 	tickScheduled bool
 
+	// pollGen is the generation of the live chain; see OnEnter.
+	pollGen uint64
+
 	spinner int
 
 	toastMessage string
@@ -137,7 +140,10 @@ func New(width, height int) *Model {
 func (m *Model) Name() string { return ViewName }
 
 func (m *Model) Init() tea.Cmd {
-	return tea.Batch(m.armTick(), spinnerTickCmd(), m.loadReleasesCmd())
+	// Neither the load nor the tick: OnEnter does both, and the app calls it
+	// right after the factory returns this. Doing them here as well read the
+	// swarm twice on entry and armed a second chain.
+	return spinnerTickCmd()
 }
 
 // armTick schedules the next poll, unless one is already scheduled.
@@ -147,12 +153,18 @@ func (m *Model) Init() tea.Cmd {
 // each of those does the same, so an idle view climbs to thousands of
 // concurrent reads within a minute. Re-arming only after the poll's result has
 // the further benefit that two polls can never overlap.
+//
+// The flag alone is not enough, because it can only be cleared by a tick that
+// arrives — and a chain does not survive a navigation: its tick is delivered to
+// whichever view is current by then, and dropped. That left the flag set with
+// nothing to clear it, so the view came back from a drill-down and never polled
+// again. OnEnter clears it and starts a new generation instead.
 func (m *Model) armTick() tea.Cmd {
 	if m.tickScheduled {
 		return nil
 	}
 	m.tickScheduled = true
-	return tickCmd()
+	return tickCmd(m.pollGen)
 }
 
 // HasActiveFilter reports whether a filter query is active.
@@ -232,6 +244,13 @@ func (m *Model) OnEnter() tea.Cmd {
 		// on screen and swallows the operator's next esc.
 		m.childIndex = noChild
 	}
+	// A new generation on every entry. The chain armed before a drill-down is
+	// usually dropped on the way out, but one still in flight when the operator
+	// returns would find this view current again and re-arm, leaving two.
+	// Tagging the tick makes the leftover recognisable, and clearing the flag
+	// lets the fresh chain start.
+	m.pollGen++
+	m.tickScheduled = false
 	return tea.Batch(m.loadReleasesCmd(), m.armTick())
 }
 

--- a/views/charts/model_test.go
+++ b/views/charts/model_test.go
@@ -538,7 +538,7 @@ func TestPollLoopDoesNotMultiply(t *testing.T) {
 	}}
 
 	// The model already armed a tick when the load landed; this is that one.
-	pending := []tea.Cmd{tickCmd()}
+	pending := []tea.Cmd{tickCmd(m.pollGen)}
 	for round := 0; round < 12; round++ {
 		var ticks int
 		pending, ticks = drive(m, pending)
@@ -570,7 +570,7 @@ func TestTickDoesNotPollWhenHiddenOrDialogIsUp(t *testing.T) {
 	} {
 		hide()
 		m.tickScheduled = true // the chain the model is already running
-		pending := []tea.Cmd{tickCmd()}
+		pending := []tea.Cmd{tickCmd(m.pollGen)}
 		for round := 0; round < 3; round++ {
 			pending, _ = drive(m, pending)
 			require.Len(t, pending, 1, "the ticker must stay alive so it can resume")
@@ -597,7 +597,7 @@ func TestPollingResumesAfterAFailedFirstLoad(t *testing.T) {
 		return all, nil
 	}}
 
-	pending := []tea.Cmd{tickCmd()}
+	pending := []tea.Cmd{tickCmd(m.pollGen)}
 	for round := 0; round < 4 && m.state != stateReady; round++ {
 		pending, _ = drive(m, pending)
 		time.Sleep(2 * time.Millisecond)

--- a/views/charts/pollloop_test.go
+++ b/views/charts/pollloop_test.go
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package chartsview
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/stretchr/testify/require"
+)
+
+// countChains runs a command — flattening tea.Batch, whose members the runtime
+// runs rather than the caller — and counts the ticks it schedules. Each
+// scheduled tick is one live poll chain, because the loop re-arms from the
+// poll's result.
+//
+// Messages other than ticks are fed back into Update exactly once, so a load
+// that arms a tick of its own is counted too. That is the shape of the bug:
+// the arm was not in one place.
+func countChains(m *Model, cmd tea.Cmd) int {
+	chains := 0
+	var run func(c tea.Cmd, depth int)
+	run = func(c tea.Cmd, depth int) {
+		if c == nil || depth > 2 {
+			return
+		}
+		msg := c()
+		if batch, ok := msg.(tea.BatchMsg); ok {
+			for _, sub := range batch {
+				run(sub, depth)
+			}
+			return
+		}
+		if _, isTick := msg.(TickMsg); isTick {
+			chains++
+			return
+		}
+		if _, isSpinner := msg.(SpinnerTickMsg); isSpinner {
+			return // not part of the poll loop
+		}
+		run(m.Update(msg), depth+1)
+	}
+	run(cmd, 0)
+	return chains
+}
+
+// firstTick runs a command and returns the tick it scheduled, so a test can
+// hold on to one chain's tick while a later entry arms another.
+func firstTick(t *testing.T, cmd tea.Cmd) TickMsg {
+	t.Helper()
+	var found *TickMsg
+	var run func(c tea.Cmd)
+	run = func(c tea.Cmd) {
+		if c == nil || found != nil {
+			return
+		}
+		msg := c()
+		if batch, ok := msg.(tea.BatchMsg); ok {
+			for _, sub := range batch {
+				run(sub)
+			}
+			return
+		}
+		if tick, ok := msg.(TickMsg); ok {
+			found = &tick
+		}
+	}
+	run(cmd)
+	require.NotNil(t, found, "the command scheduled no tick")
+	return *found
+}
+
+// Entering the view must start exactly one poll chain.
+//
+// switchToView batches the factory's command and OnEnter, and this view's
+// factory returns Init(), so the two together are the whole of entry. A view
+// arming in both ran two chains for its life, polling the swarm at twice the
+// intended rate.
+func TestEnteringTheViewArmsExactlyOneChain(t *testing.T) {
+	fastPoll(t)
+	m := testModel()
+
+	require.Equal(t, 1, countChains(m, tea.Batch(m.Init(), m.OnEnter())),
+		"the factory and OnEnter must not each start a chain")
+}
+
+// Returning to the view must restart polling.
+//
+// A chain does not survive a navigation: every view declares its own TickMsg
+// type, so a tick belonging to a view that is no longer current is delivered to
+// a different view and dropped. That tick is also the only thing that clears
+// tickScheduled, so a guard the entry hook does not reset leaves the view
+// permanently stale — armTick declines forever and nothing ever polls again.
+func TestReturningToTheViewRestartsPolling(t *testing.T) {
+	fastPoll(t)
+	m := testModel()
+
+	m.OnEnter()
+	// The chain armed on the first entry is dropped mid-flight, exactly as a
+	// drill-down drops it: the tick never comes back to clear the flag.
+	require.True(t, m.tickScheduled)
+
+	require.Equal(t, 1, countChains(m, m.OnEnter()),
+		"goBack calls OnEnter and nothing else, so it has to restart the chain")
+}
+
+// A tick armed before a drill-down must not sustain a chain after the return.
+//
+// The chain usually dies on the way out, but one still in flight when the
+// operator returns finds this view current again, and OnEnter has already armed
+// a replacement — re-arming from both leaves the view polling at twice the rate
+// for the rest of its life.
+func TestStaleTickFromAnEarlierEntryIsDropped(t *testing.T) {
+	fastPoll(t)
+	m := testModel()
+
+	stale := firstTick(t, m.OnEnter()) // the chain armed on the first entry
+	m.OnEnter()                        // goBack: a fresh chain
+
+	require.Equal(t, 0, countChains(m, m.Update(stale)),
+		"a tick from an earlier entry must not arm a successor")
+}

--- a/views/charts/update.go
+++ b/views/charts/update.go
@@ -193,6 +193,9 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 		return m.handleReleasesLoaded(msg)
 
 	case TickMsg:
+		if msg.Gen != m.pollGen {
+			return nil // a leftover from an earlier entry — see OnEnter
+		}
 		m.tickScheduled = false
 		// stateError is deliberately allowed through: one unreadable release
 		// record fails the whole listing, so a view that stopped polling on

--- a/views/configs/messages.go
+++ b/views/configs/messages.go
@@ -69,7 +69,7 @@ type (
 	errorMsg error
 )
 
-type TickMsg time.Time
+type TickMsg struct{ Gen uint64 }
 
 // PollRetryMsg signals that polling found no changes; the Update handler
 // should schedule the next tick.

--- a/views/configs/messages.go
+++ b/views/configs/messages.go
@@ -75,7 +75,12 @@ type TickMsg time.Time
 // should schedule the next tick.
 type PollRetryMsg struct{}
 
-const PollInterval = 5 * time.Second
+// PollInterval is how often the view re-reads its resource. It is a var, not a
+// const, so tests can shrink it: a tea.Tick cmd invoked synchronously blocks
+// for the full interval, so a test that runs one to see what it scheduled would
+// otherwise sit here for five seconds.
+var PollInterval = 5 * time.Second
+
 const pollTimeout = 4 * time.Second
 const userActionTimeout = 15 * time.Second
 

--- a/views/configs/model.go
+++ b/views/configs/model.go
@@ -183,7 +183,7 @@ func (m *Model) ClearSearchQuery() {
 
 func (m *Model) Init() tea.Cmd {
 	l().Info("ConfigsView: Init() called - starting ticker and loading configs")
-	return tea.Batch(tickCmd(), m.spinnerTickCmd(), m.loadConfigsCmd())
+	return tea.Batch(m.spinnerTickCmd(), m.loadConfigsCmd())
 }
 
 func (m *Model) spinnerTickCmd() tea.Cmd {
@@ -250,7 +250,10 @@ func (m *Model) addConfig(cfg docker.ConfigWithDecodedData) {
 func (m *Model) OnEnter() tea.Cmd {
 	m.visible = true
 	l().Info("ConfigsView: OnEnter() - view is now visible")
-	return m.loadConfigsCmd()
+	// The tick is armed here, not in Init or the factory: OnEnter is the only
+	// hook that runs both on first entry and on every return from a drill-down,
+	// and a chain cannot survive a navigation (see the TickMsg handler).
+	return tea.Batch(m.loadConfigsCmd(), tickCmd())
 }
 
 func (m *Model) OnExit() tea.Cmd {

--- a/views/configs/model.go
+++ b/views/configs/model.go
@@ -37,6 +37,7 @@ type Model struct {
 	height        int
 	firstResize   bool   // tracks if we've received the first window size
 	lastSnapshot  uint64 // hash of last snapshot for change detection
+	pollGen       uint64 // generation of the live poll chain; see OnEnter
 	polling       atomic.Bool
 	visible       bool // tracks if view is currently active
 	sortField     SortField
@@ -192,9 +193,9 @@ func (m *Model) spinnerTickCmd() tea.Cmd {
 	})
 }
 
-func tickCmd() tea.Cmd {
-	return tea.Tick(PollInterval, func(t time.Time) tea.Msg {
-		return TickMsg(t)
+func tickCmd(gen uint64) tea.Cmd {
+	return tea.Tick(PollInterval, func(time.Time) tea.Msg {
+		return TickMsg{Gen: gen}
 	})
 }
 
@@ -252,8 +253,16 @@ func (m *Model) OnEnter() tea.Cmd {
 	l().Info("ConfigsView: OnEnter() - view is now visible")
 	// The tick is armed here, not in Init or the factory: OnEnter is the only
 	// hook that runs both on first entry and on every return from a drill-down,
-	// and a chain cannot survive a navigation (see the TickMsg handler).
-	return tea.Batch(m.loadConfigsCmd(), tickCmd())
+	// and a chain does not survive a navigation — its tick is delivered to
+	// whichever view is current by then, and dropped.
+	//
+	// Each entry gets its own generation. "Does not survive" holds only once
+	// the leftover tick has fired: one armed just before a drill-down can
+	// still be in flight when the operator returns, and would find this view
+	// current again and re-arm, leaving two chains for the rest of the view's
+	// life. The generation makes it recognisable as a leftover.
+	m.pollGen++
+	return tea.Batch(m.loadConfigsCmd(), tickCmd(m.pollGen))
 }
 
 func (m *Model) OnExit() tea.Cmd {

--- a/views/configs/pollloop_test.go
+++ b/views/configs/pollloop_test.go
@@ -86,3 +86,59 @@ func TestPollLoopDoesNotMultiply(t *testing.T) {
 	require.True(t, polled, "the fixture must actually poll, or this proves nothing")
 	require.Len(t, pending, 1, "and the loop must still be alive at the end")
 }
+
+// countChains runs a command — flattening tea.Batch, whose members the runtime
+// runs rather than the caller — and counts the ticks it schedules. Each
+// scheduled tick is one live poll chain, because a tick re-arms itself.
+func countChains(m *Model, cmd tea.Cmd) int {
+	chains := 0
+	var run func(c tea.Cmd, depth int)
+	run = func(c tea.Cmd, depth int) {
+		if c == nil || depth > 2 {
+			return
+		}
+		msg := c()
+		if batch, ok := msg.(tea.BatchMsg); ok {
+			for _, sub := range batch {
+				run(sub, depth)
+			}
+			return
+		}
+		if _, isTick := msg.(TickMsg); isTick {
+			chains++
+			return
+		}
+		if _, isSpinner := msg.(SpinnerTickMsg); isSpinner {
+			return
+		}
+		run(m.Update(msg), depth+1)
+	}
+	run(cmd, 0)
+	return chains
+}
+
+// Entering a view must start exactly one poll chain. switchToView batches the
+// factory's command AND OnEnter, so a view arming in both ran two chains for
+// its whole life, polling the daemon at twice the intended rate.
+func TestEnteringTheViewArmsExactlyOneChain(t *testing.T) {
+	original := PollInterval
+	PollInterval = time.Millisecond
+	t.Cleanup(func() { PollInterval = original })
+
+	m := testModel()
+	require.Equal(t, 1, countChains(m, tea.Batch(m.Init(), m.OnEnter())),
+		"the factory and OnEnter must not each start a chain")
+}
+
+// A chain cannot survive a navigation: every view declares its own TickMsg
+// type, so a tick belonging to a view that is no longer current is delivered to
+// a different view and dropped. Returning must therefore re-arm, or the view
+// comes back permanently stale. goBack calls OnEnter and nothing else.
+func TestReturningToTheViewRestartsPolling(t *testing.T) {
+	original := PollInterval
+	PollInterval = time.Millisecond
+	t.Cleanup(func() { PollInterval = original })
+
+	m := testModel()
+	require.Equal(t, 1, countChains(m, m.OnEnter()))
+}

--- a/views/configs/pollloop_test.go
+++ b/views/configs/pollloop_test.go
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package configsview
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/Eldara-Tech/swarmcli/docker"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/docker/docker/api/types/swarm"
+	"github.com/stretchr/testify/require"
+)
+
+// drivePoll models the bubbletea runtime for one round: run each pending
+// command, flattening tea.Batch — whose members the runtime runs, not the
+// caller — feed every resulting message back into Update, and return the
+// commands that came out.
+//
+// Flattening is the point. Asserting on the command Update returns cannot see
+// past a batch, nor see a successor that arrives one message later, so a test
+// written that way passes whatever the loop actually does.
+func drivePoll(m *Model, pending []tea.Cmd) []tea.Cmd {
+	var next []tea.Cmd
+	var run func(c tea.Cmd)
+	run = func(c tea.Cmd) {
+		if c == nil {
+			return
+		}
+		msg := c()
+		if batch, ok := msg.(tea.BatchMsg); ok {
+			for _, sub := range batch {
+				run(sub)
+			}
+			return
+		}
+		if _, isSpinner := msg.(SpinnerTickMsg); isSpinner {
+			return // not part of the poll loop
+		}
+		if cmd := m.Update(msg); cmd != nil {
+			next = append(next, cmd)
+		}
+	}
+	for _, c := range pending {
+		run(c)
+	}
+	return next
+}
+
+// The poll loop must be a loop, not a tree.
+//
+// A tick that starts a poll and re-arms the ticker, while the poll's "nothing
+// changed" result re-arms it too, yields two successors per beat — and each of
+// those does the same. An idle view left open climbs into thousands of
+// concurrent Docker reads within a minute.
+func TestPollLoopDoesNotMultiply(t *testing.T) {
+	original := PollInterval
+	PollInterval = time.Millisecond
+	t.Cleanup(func() { PollInterval = original })
+
+	polled := false
+	ops := noopConfigOps()
+	inner := ops.listConfigsFn
+	ops.listConfigsFn = func(ctx context.Context) ([]swarm.Config, error) {
+		polled = true
+		return inner(ctx)
+	}
+	m := testModel(func(m *Model) { m.deps = docker.Deps{Configs: ops} })
+
+	// Steady state: the poll finds exactly what is already loaded (the ops
+	// list nothing), so it reports no change. That is what a view left open
+	// does all day.
+	m.Update(configsLoadedMsg(nil))
+	require.Equal(t, stateReady, m.state)
+
+	pending := []tea.Cmd{tickCmd()}
+	for round := 0; round < 12; round++ {
+		pending = drivePoll(m, pending)
+		require.LessOrEqual(t, len(pending), 1,
+			"round %d: %d commands in flight — the loop has branched", round, len(pending))
+		time.Sleep(2 * time.Millisecond)
+	}
+	require.True(t, polled, "the fixture must actually poll, or this proves nothing")
+	require.Len(t, pending, 1, "and the loop must still be alive at the end")
+}

--- a/views/configs/pollloop_test.go
+++ b/views/configs/pollloop_test.go
@@ -76,7 +76,7 @@ func TestPollLoopDoesNotMultiply(t *testing.T) {
 	m.Update(configsLoadedMsg(nil))
 	require.Equal(t, stateReady, m.state)
 
-	pending := []tea.Cmd{tickCmd()}
+	pending := []tea.Cmd{tickCmd(m.pollGen)}
 	for round := 0; round < 12; round++ {
 		pending = drivePoll(m, pending)
 		require.LessOrEqual(t, len(pending), 1,
@@ -126,11 +126,18 @@ func TestEnteringTheViewArmsExactlyOneChain(t *testing.T) {
 	t.Cleanup(func() { PollInterval = original })
 
 	m := testModel()
-	require.Equal(t, 1, countChains(m, tea.Batch(m.Init(), m.OnEnter())),
+
+	// The real factory, not a hand-written stand-in for it: switchToView
+	// batches the factory's command and OnEnter, and standing in for the
+	// factory with m.Init() is how one view's second arm survived the first
+	// pass at this.
+	v, loadCmd := factory(m.deps, 80, 24, nil)
+	entered := v.(*Model)
+	require.Equal(t, 1, countChains(entered, tea.Batch(entered.Init(), loadCmd, entered.OnEnter())),
 		"the factory and OnEnter must not each start a chain")
 }
 
-// A chain cannot survive a navigation: every view declares its own TickMsg
+// A chain does not survive a navigation: every view declares its own TickMsg
 // type, so a tick belonging to a view that is no longer current is delivered to
 // a different view and dropped. Returning must therefore re-arm, or the view
 // comes back permanently stale. goBack calls OnEnter and nothing else.
@@ -141,4 +148,50 @@ func TestReturningToTheViewRestartsPolling(t *testing.T) {
 
 	m := testModel()
 	require.Equal(t, 1, countChains(m, m.OnEnter()))
+}
+
+// firstTick runs a command and returns the tick it scheduled, so a test can
+// hold on to one chain's tick while a later entry arms another.
+func firstTick(t *testing.T, m *Model, cmd tea.Cmd) TickMsg {
+	t.Helper()
+	var found *TickMsg
+	var run func(c tea.Cmd)
+	run = func(c tea.Cmd) {
+		if c == nil || found != nil {
+			return
+		}
+		msg := c()
+		if batch, ok := msg.(tea.BatchMsg); ok {
+			for _, sub := range batch {
+				run(sub)
+			}
+			return
+		}
+		if tick, ok := msg.(TickMsg); ok {
+			found = &tick
+		}
+	}
+	run(cmd)
+	require.NotNil(t, found, "the command scheduled no tick")
+	return *found
+}
+
+// A tick armed before a drill-down must not sustain a chain after the return.
+//
+// The chain usually dies on the way out: its tick is delivered to whichever
+// view is current by then, and dropped. But one still in flight when the
+// operator returns finds this view current again, and OnEnter has already
+// armed a replacement — re-arming from both leaves the view polling at twice
+// the rate for the rest of its life.
+func TestStaleTickFromAnEarlierEntryIsDropped(t *testing.T) {
+	original := PollInterval
+	PollInterval = time.Millisecond
+	t.Cleanup(func() { PollInterval = original })
+	m := testModel()
+
+	stale := firstTick(t, m, m.OnEnter()) // the chain armed on the first entry
+	m.OnEnter()                           // goBack: a fresh chain
+
+	require.Equal(t, 0, countChains(m, m.Update(stale)),
+		"a tick from an earlier entry must not arm a successor")
 }

--- a/views/configs/update.go
+++ b/views/configs/update.go
@@ -195,16 +195,19 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 		return m.computeConfigUsedCmd(msg)
 
 	case TickMsg:
+		if msg.Gen != m.pollGen {
+			return nil // a leftover from an earlier entry — see OnEnter
+		}
 		l().Infof("ConfigsView: Received TickMsg, state=%v, visible=%v", m.state, m.visible)
 		// Only check for changes if view is visible, ready, and not showing dialogs
 		if m.visible && m.state == stateReady && !m.confirmDialog.Visible && !m.loadingView.Visible() && !m.polling.Load() {
 			return tea.Batch(
 				m.checkConfigsCmd(m.lastSnapshot),
-				tickCmd(),
+				tickCmd(m.pollGen),
 			)
 		}
 		// Continue ticking even if not visible/ready
-		return tickCmd()
+		return tickCmd(m.pollGen)
 
 	case PollRetryMsg:
 		// Deliberately no re-arm. The TickMsg handler above always schedules

--- a/views/configs/update.go
+++ b/views/configs/update.go
@@ -207,7 +207,11 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 		return tickCmd()
 
 	case PollRetryMsg:
-		return tickCmd()
+		// Deliberately no re-arm. The TickMsg handler above always schedules
+		// the next tick, so re-arming here as well gives one beat two
+		// successors — and each of those does the same, so the poll rate does
+		// not merely double, it doubles again on every beat.
+		return nil
 
 	case configRotatedMsg:
 		l().Infof("Config rotated: %s → %s", msg.Old.Config.Spec.Name, msg.New.Config.Spec.Name)

--- a/views/configs/update_test.go
+++ b/views/configs/update_test.go
@@ -68,7 +68,7 @@ func TestUpdate_TickMsg(t *testing.T) {
 	m := testModel()
 	m.visible = true
 	m.state = stateReady
-	cmd := m.Update(TickMsg(time.Now()))
+	cmd := m.Update(TickMsg{Gen: m.pollGen})
 	require.NotNil(t, cmd)
 }
 
@@ -614,7 +614,7 @@ func TestTickMsg_WhenPollingInFlight_SkipsCheck(t *testing.T) {
 	loadConfigs(m, fakeConfigs("c1"))
 	m.visible = true
 	m.polling.Store(true)
-	cmd := m.Update(TickMsg(time.Now()))
+	cmd := m.Update(TickMsg{Gen: m.pollGen})
 	require.NotNil(t, cmd)
 	// With polling in flight the TickMsg handler should only return tickCmd,
 	// not batch(checkConfigsCmd, tickCmd). Executing the returned cmd should

--- a/views/contexts/model.go
+++ b/views/contexts/model.go
@@ -42,6 +42,7 @@ type Model struct {
 	cursor                int
 	mu                    sync.Mutex
 	loading               bool
+	pollGen               uint64 // generation of the live poll chain; see OnEnter
 	errorMsg              string
 	successMsg            string
 	switchPending         bool
@@ -378,14 +379,26 @@ func (m *Model) Name() string {
 // OnEnter is called when the view becomes active
 func (m *Model) OnEnter() tea.Cmd {
 	m.Visible = true
+	// The tick is armed here, not in the factory: OnEnter is the only hook
+	// that runs both on first entry and on every return from a drill-down,
+	// and a chain does not survive a navigation — its tick is delivered to
+	// whichever view is current by then, and dropped.
+	//
+	// Each entry gets its own generation. "Does not survive" holds only once
+	// the leftover tick has fired: one armed just before a drill-down can
+	// still be in flight when the operator returns, and would find this view
+	// current again and re-arm, leaving two chains for the rest of the view's
+	// life. The generation makes it recognisable as a leftover.
+	m.pollGen++
+	tick := tickCmd(m.pollGen)
 	// If we have no contexts loaded, trigger a load on enter so the
 	// view shows progress and fills itself. Also allow explicit reloads
 	// from other code paths by calling SetLoading(true) before navigating.
 	if len(m.contexts) == 0 {
 		m.SetLoading(true)
-		return m.loadContextsCmd()
+		return tea.Batch(m.loadContextsCmd(), tick)
 	}
-	return nil
+	return tick
 }
 
 // OnExit is called when the view is exited

--- a/views/contexts/model_test.go
+++ b/views/contexts/model_test.go
@@ -281,7 +281,8 @@ func TestOnEnter_WithContexts(t *testing.T) {
 	m.Visible = false
 	cmd := m.OnEnter()
 	require.True(t, m.Visible)
-	require.Nil(t, cmd) // no reload needed
+	require.False(t, m.IsLoading(), "no reload needed")
+	require.NotNil(t, cmd, "but the poll chain is armed here on every entry")
 }
 
 func TestOnExit(t *testing.T) {

--- a/views/contexts/pollloop_test.go
+++ b/views/contexts/pollloop_test.go
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package contexts
+
+import (
+	"testing"
+	"time"
+
+	"github.com/Eldara-Tech/swarmcli/docker"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/stretchr/testify/require"
+)
+
+func fastTick(t *testing.T) {
+	t.Helper()
+	original := PollInterval
+	PollInterval = time.Millisecond
+	t.Cleanup(func() { PollInterval = original })
+}
+
+// countChains runs a command — flattening tea.Batch, whose members the runtime
+// runs rather than the caller — and counts the ticks it schedules. Each
+// scheduled tick is one live poll chain, because a tick re-arms itself.
+func countChains(m *Model, cmd tea.Cmd) int {
+	chains := 0
+	var run func(c tea.Cmd, depth int)
+	run = func(c tea.Cmd, depth int) {
+		if c == nil || depth > 2 {
+			return
+		}
+		msg := c()
+		if batch, ok := msg.(tea.BatchMsg); ok {
+			for _, sub := range batch {
+				run(sub, depth)
+			}
+			return
+		}
+		if _, isTick := msg.(RefreshTickMsg); isTick {
+			chains++
+			return
+		}
+		run(m.Update(msg), depth+1)
+	}
+	run(cmd, 0)
+	return chains
+}
+
+// firstTick runs a command and returns the tick it scheduled, so a test can
+// hold on to one chain's tick while a later entry arms another.
+func firstTick(t *testing.T, cmd tea.Cmd) RefreshTickMsg {
+	t.Helper()
+	var found *RefreshTickMsg
+	var run func(c tea.Cmd)
+	run = func(c tea.Cmd) {
+		if c == nil || found != nil {
+			return
+		}
+		msg := c()
+		if batch, ok := msg.(tea.BatchMsg); ok {
+			for _, sub := range batch {
+				run(sub)
+			}
+			return
+		}
+		if tick, ok := msg.(RefreshTickMsg); ok {
+			found = &tick
+		}
+	}
+	run(cmd)
+	require.NotNil(t, found, "the command scheduled no tick")
+	return *found
+}
+
+// Entering the view must start exactly one poll chain. switchToView batches the
+// factory's command and OnEnter, so a view arming in both ran two chains for
+// its whole life, re-reading the context store at twice the intended rate.
+func TestEnteringTheViewArmsExactlyOneChain(t *testing.T) {
+	fastTick(t)
+
+	v, loadCmd := factory(docker.Deps{Contexts: noopContextOps()}, 80, 24, nil)
+	entered := v.(*Model)
+	entered.List.RenderItem = testModel().List.RenderItem
+	require.Equal(t, 1, countChains(entered, tea.Batch(entered.Init(), loadCmd, entered.OnEnter())),
+		"the factory and OnEnter must not each start a chain")
+}
+
+// Returning to the view must restart polling.
+//
+// A chain does not survive a navigation: every view declares its own tick type,
+// so a tick belonging to a view that is no longer current is delivered to a
+// different view and dropped. A factory that arms and an OnEnter that does not
+// leaves the view permanently stale after the first drill-down, because goBack
+// runs OnEnter and nothing else.
+func TestReturningToTheViewRestartsPolling(t *testing.T) {
+	fastTick(t)
+	m := testModel()
+
+	require.Equal(t, 1, countChains(m, m.OnEnter()))
+}
+
+// A tick armed before a drill-down must not sustain a chain after the return.
+//
+// The chain usually dies on the way out, but one still in flight when the
+// operator returns finds this view current again, and OnEnter has already armed
+// a replacement — re-arming from both leaves the view polling at twice the rate
+// for the rest of its life.
+func TestStaleTickFromAnEarlierEntryIsDropped(t *testing.T) {
+	fastTick(t)
+	m := testModel()
+
+	stale := firstTick(t, m.OnEnter()) // the chain armed on the first entry
+	m.OnEnter()                        // goBack: a fresh chain
+
+	require.Equal(t, 0, countChains(m, m.Update(stale)),
+		"a tick from an earlier entry must not arm a successor")
+}

--- a/views/contexts/register.go
+++ b/views/contexts/register.go
@@ -20,8 +20,8 @@ func factory(deps docker.Deps, w, h int, _ any) (view.View, tea.Cmd) {
 	model.Visible = true
 	model.SetSize(w, h)
 	model.SetLoading(true)
-	return model, tea.Batch(
-		model.loadContextsCmd(),
-		StartTickerCmd(),
-	)
+	// No tick: OnEnter arms the one chain, and the app calls it right after
+	// this. Arming here instead left the view unable to restart its chain
+	// after a drill-down, because OnEnter is all that goBack runs.
+	return model, model.loadContextsCmd()
 }

--- a/views/contexts/update.go
+++ b/views/contexts/update.go
@@ -21,31 +21,37 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 )
 
-type RefreshTickMsg time.Time
+// RefreshTickMsg drives the periodic re-read. Gen names the poll chain it
+// belongs to; see Model.OnEnter.
+type RefreshTickMsg struct{ Gen uint64 }
 
-func tickCmd() tea.Cmd {
-	return tea.Tick(5*time.Second, func(t time.Time) tea.Msg {
-		return RefreshTickMsg(t)
+// PollInterval is how often the view re-reads the context list. It is a var,
+// not a const, so tests can shrink it: a tea.Tick cmd invoked synchronously
+// blocks for the full interval, so a test that runs one to see what it
+// scheduled would otherwise sit here for five seconds.
+var PollInterval = 5 * time.Second
+
+func tickCmd(gen uint64) tea.Cmd {
+	return tea.Tick(PollInterval, func(time.Time) tea.Msg {
+		return RefreshTickMsg{Gen: gen}
 	})
-}
-
-// StartTickerCmd starts the periodic refresh ticker
-func StartTickerCmd() tea.Cmd {
-	return tickCmd()
 }
 
 func (m *Model) Update(msg tea.Msg) tea.Cmd {
 	switch msg := msg.(type) {
 	case RefreshTickMsg:
+		if msg.Gen != m.pollGen {
+			return nil // a leftover from an earlier entry — see OnEnter
+		}
 		// Auto-refresh contexts list every 5 seconds when visible and no dialogs open
 		if m.Visible && !m.CapturesInput() && !m.loading {
 			return tea.Batch(
 				m.loadContextsCmd(),
-				tickCmd(),
+				tickCmd(m.pollGen),
 			)
 		}
 		// Continue ticking even if not visible
-		return tickCmd()
+		return tickCmd(m.pollGen)
 
 	case tea.WindowSizeMsg:
 		m.viewport.Width = msg.Width

--- a/views/networks/messages.go
+++ b/views/networks/messages.go
@@ -17,7 +17,11 @@ import (
 	"github.com/docker/docker/api/types/swarm"
 )
 
-const PollInterval = 5 * time.Second
+// PollInterval is how often the view re-reads its resource. It is a var, not a
+// const, so tests can shrink it: a tea.Tick cmd invoked synchronously blocks
+// for the full interval, so a test that runs one to see what it scheduled would
+// otherwise sit here for five seconds.
+var PollInterval = 5 * time.Second
 
 type TickMsg time.Time
 

--- a/views/networks/messages.go
+++ b/views/networks/messages.go
@@ -23,7 +23,7 @@ import (
 // otherwise sit here for five seconds.
 var PollInterval = 5 * time.Second
 
-type TickMsg time.Time
+type TickMsg struct{ Gen uint64 }
 
 // PollRetryMsg signals that polling found no changes; the Update handler
 // should schedule the next tick.

--- a/views/networks/model.go
+++ b/views/networks/model.go
@@ -238,7 +238,7 @@ func (m *Model) ClearSearchQuery() {
 
 func (m *Model) Init() tea.Cmd {
 	l().Info("NetworksView: Init() called - starting ticker and loading networks")
-	return tea.Batch(tickCmd(), m.spinnerTickCmd(), m.loadNetworksCmd())
+	return tea.Batch(m.spinnerTickCmd(), m.loadNetworksCmd())
 }
 
 func (m *Model) spinnerTickCmd() tea.Cmd {
@@ -332,7 +332,10 @@ func (m *Model) OnEnter() tea.Cmd {
 	m.resetCursorOnNextLoad = true
 	m.networksList.Cursor = 0
 	m.networksList.Viewport.YOffset = 0
-	return m.LoadNetworks()
+	// The tick is armed here, not in Init or the factory: OnEnter is the only
+	// hook that runs both on first entry and on every return from a drill-down,
+	// and a chain cannot survive a navigation (see the TickMsg handler).
+	return tea.Batch(m.LoadNetworks(), tickCmd())
 }
 
 func (m *Model) OnExit() tea.Cmd {

--- a/views/networks/model.go
+++ b/views/networks/model.go
@@ -36,6 +36,7 @@ type Model struct {
 	height                int
 	firstResize           bool   // tracks if we've received the first window size
 	lastSnapshot          uint64 // hash of last snapshot for change detection
+	pollGen               uint64 // generation of the live poll chain; see OnEnter
 	visible               bool   // tracks if view is currently active
 	resetCursorOnNextLoad bool   // one-shot: force cursor to top on next NetworksLoadedMsg
 	sortField             SortField
@@ -247,9 +248,9 @@ func (m *Model) spinnerTickCmd() tea.Cmd {
 	})
 }
 
-func tickCmd() tea.Cmd {
-	return tea.Tick(PollInterval, func(t time.Time) tea.Msg {
-		return TickMsg(t)
+func tickCmd(gen uint64) tea.Cmd {
+	return tea.Tick(PollInterval, func(time.Time) tea.Msg {
+		return TickMsg{Gen: gen}
 	})
 }
 
@@ -334,8 +335,16 @@ func (m *Model) OnEnter() tea.Cmd {
 	m.networksList.Viewport.YOffset = 0
 	// The tick is armed here, not in Init or the factory: OnEnter is the only
 	// hook that runs both on first entry and on every return from a drill-down,
-	// and a chain cannot survive a navigation (see the TickMsg handler).
-	return tea.Batch(m.LoadNetworks(), tickCmd())
+	// and a chain does not survive a navigation — its tick is delivered to
+	// whichever view is current by then, and dropped.
+	//
+	// Each entry gets its own generation. "Does not survive" holds only once
+	// the leftover tick has fired: one armed just before a drill-down can
+	// still be in flight when the operator returns, and would find this view
+	// current again and re-arm, leaving two chains for the rest of the view's
+	// life. The generation makes it recognisable as a leftover.
+	m.pollGen++
+	return tea.Batch(m.LoadNetworks(), tickCmd(m.pollGen))
 }
 
 func (m *Model) OnExit() tea.Cmd {

--- a/views/networks/pollloop_test.go
+++ b/views/networks/pollloop_test.go
@@ -78,7 +78,7 @@ func TestPollLoopDoesNotMultiply(t *testing.T) {
 	m.Update(NetworksLoadedMsg{})
 	require.Equal(t, stateReady, m.state)
 
-	pending := []tea.Cmd{tickCmd()}
+	pending := []tea.Cmd{tickCmd(m.pollGen)}
 	for round := 0; round < 12; round++ {
 		pending = drivePoll(m, pending)
 		require.LessOrEqual(t, len(pending), 1,
@@ -128,11 +128,18 @@ func TestEnteringTheViewArmsExactlyOneChain(t *testing.T) {
 	t.Cleanup(func() { PollInterval = original })
 
 	m := testModel()
-	require.Equal(t, 1, countChains(m, tea.Batch(m.Init(), m.OnEnter())),
+
+	// The real factory, not a hand-written stand-in for it: switchToView
+	// batches the factory's command and OnEnter, and standing in for the
+	// factory with m.Init() is how one view's second arm survived the first
+	// pass at this.
+	v, loadCmd := factory(m.deps, 80, 24, nil)
+	entered := v.(*Model)
+	require.Equal(t, 1, countChains(entered, tea.Batch(entered.Init(), loadCmd, entered.OnEnter())),
 		"the factory and OnEnter must not each start a chain")
 }
 
-// A chain cannot survive a navigation: every view declares its own TickMsg
+// A chain does not survive a navigation: every view declares its own TickMsg
 // type, so a tick belonging to a view that is no longer current is delivered to
 // a different view and dropped. Returning must therefore re-arm, or the view
 // comes back permanently stale. goBack calls OnEnter and nothing else.
@@ -143,4 +150,50 @@ func TestReturningToTheViewRestartsPolling(t *testing.T) {
 
 	m := testModel()
 	require.Equal(t, 1, countChains(m, m.OnEnter()))
+}
+
+// firstTick runs a command and returns the tick it scheduled, so a test can
+// hold on to one chain's tick while a later entry arms another.
+func firstTick(t *testing.T, m *Model, cmd tea.Cmd) TickMsg {
+	t.Helper()
+	var found *TickMsg
+	var run func(c tea.Cmd)
+	run = func(c tea.Cmd) {
+		if c == nil || found != nil {
+			return
+		}
+		msg := c()
+		if batch, ok := msg.(tea.BatchMsg); ok {
+			for _, sub := range batch {
+				run(sub)
+			}
+			return
+		}
+		if tick, ok := msg.(TickMsg); ok {
+			found = &tick
+		}
+	}
+	run(cmd)
+	require.NotNil(t, found, "the command scheduled no tick")
+	return *found
+}
+
+// A tick armed before a drill-down must not sustain a chain after the return.
+//
+// The chain usually dies on the way out: its tick is delivered to whichever
+// view is current by then, and dropped. But one still in flight when the
+// operator returns finds this view current again, and OnEnter has already
+// armed a replacement — re-arming from both leaves the view polling at twice
+// the rate for the rest of its life.
+func TestStaleTickFromAnEarlierEntryIsDropped(t *testing.T) {
+	original := PollInterval
+	PollInterval = time.Millisecond
+	t.Cleanup(func() { PollInterval = original })
+	m := testModel()
+
+	stale := firstTick(t, m, m.OnEnter()) // the chain armed on the first entry
+	m.OnEnter()                           // goBack: a fresh chain
+
+	require.Equal(t, 0, countChains(m, m.Update(stale)),
+		"a tick from an earlier entry must not arm a successor")
 }

--- a/views/networks/pollloop_test.go
+++ b/views/networks/pollloop_test.go
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package networksview
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/Eldara-Tech/swarmcli/docker"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/docker/docker/api/types/network"
+	"github.com/stretchr/testify/require"
+)
+
+// drivePoll models the bubbletea runtime for one round: run each pending
+// command, flattening tea.Batch — whose members the runtime runs, not the
+// caller — feed every resulting message back into Update, and return the
+// commands that came out.
+//
+// Flattening is the point. Asserting on the command Update returns cannot see
+// past a batch, nor see a successor that arrives one message later, so a test
+// written that way passes whatever the loop actually does.
+func drivePoll(m *Model, pending []tea.Cmd) []tea.Cmd {
+	var next []tea.Cmd
+	var run func(c tea.Cmd)
+	run = func(c tea.Cmd) {
+		if c == nil {
+			return
+		}
+		msg := c()
+		if batch, ok := msg.(tea.BatchMsg); ok {
+			for _, sub := range batch {
+				run(sub)
+			}
+			return
+		}
+		if _, isSpinner := msg.(SpinnerTickMsg); isSpinner {
+			return // not part of the poll loop
+		}
+		if cmd := m.Update(msg); cmd != nil {
+			next = append(next, cmd)
+		}
+	}
+	for _, c := range pending {
+		run(c)
+	}
+	return next
+}
+
+// The poll loop must be a loop, not a tree.
+//
+// A tick that starts a poll and re-arms the ticker, while the poll's "nothing
+// changed" result re-arms it too, yields two successors per beat — and each of
+// those does the same. An idle view left open climbs into thousands of
+// concurrent Docker reads within a minute.
+func TestPollLoopDoesNotMultiply(t *testing.T) {
+	original := PollInterval
+	PollInterval = time.Millisecond
+	t.Cleanup(func() { PollInterval = original })
+
+	polled := false
+	ops := noopNetworkOps()
+	inner := ops.listNetworksFn
+	ops.listNetworksFn = func(ctx context.Context) ([]network.Summary, error) {
+		polled = true
+		return inner(ctx)
+	}
+	m := testModel(func(m *Model) {
+		m.deps = docker.Deps{Networks: ops, Client: noopClientOps()}
+	})
+
+	// Steady state: the poll finds exactly what is already loaded (the ops
+	// list nothing), so it reports no change. That is what a view left open
+	// does all day.
+	m.Update(NetworksLoadedMsg{})
+	require.Equal(t, stateReady, m.state)
+
+	pending := []tea.Cmd{tickCmd()}
+	for round := 0; round < 12; round++ {
+		pending = drivePoll(m, pending)
+		require.LessOrEqual(t, len(pending), 1,
+			"round %d: %d commands in flight — the loop has branched", round, len(pending))
+		time.Sleep(2 * time.Millisecond)
+	}
+	require.True(t, polled, "the fixture must actually poll, or this proves nothing")
+	require.Len(t, pending, 1, "and the loop must still be alive at the end")
+}

--- a/views/networks/pollloop_test.go
+++ b/views/networks/pollloop_test.go
@@ -88,3 +88,59 @@ func TestPollLoopDoesNotMultiply(t *testing.T) {
 	require.True(t, polled, "the fixture must actually poll, or this proves nothing")
 	require.Len(t, pending, 1, "and the loop must still be alive at the end")
 }
+
+// countChains runs a command — flattening tea.Batch, whose members the runtime
+// runs rather than the caller — and counts the ticks it schedules. Each
+// scheduled tick is one live poll chain, because a tick re-arms itself.
+func countChains(m *Model, cmd tea.Cmd) int {
+	chains := 0
+	var run func(c tea.Cmd, depth int)
+	run = func(c tea.Cmd, depth int) {
+		if c == nil || depth > 2 {
+			return
+		}
+		msg := c()
+		if batch, ok := msg.(tea.BatchMsg); ok {
+			for _, sub := range batch {
+				run(sub, depth)
+			}
+			return
+		}
+		if _, isTick := msg.(TickMsg); isTick {
+			chains++
+			return
+		}
+		if _, isSpinner := msg.(SpinnerTickMsg); isSpinner {
+			return
+		}
+		run(m.Update(msg), depth+1)
+	}
+	run(cmd, 0)
+	return chains
+}
+
+// Entering a view must start exactly one poll chain. switchToView batches the
+// factory's command AND OnEnter, so a view arming in both ran two chains for
+// its whole life, polling the daemon at twice the intended rate.
+func TestEnteringTheViewArmsExactlyOneChain(t *testing.T) {
+	original := PollInterval
+	PollInterval = time.Millisecond
+	t.Cleanup(func() { PollInterval = original })
+
+	m := testModel()
+	require.Equal(t, 1, countChains(m, tea.Batch(m.Init(), m.OnEnter())),
+		"the factory and OnEnter must not each start a chain")
+}
+
+// A chain cannot survive a navigation: every view declares its own TickMsg
+// type, so a tick belonging to a view that is no longer current is delivered to
+// a different view and dropped. Returning must therefore re-arm, or the view
+// comes back permanently stale. goBack calls OnEnter and nothing else.
+func TestReturningToTheViewRestartsPolling(t *testing.T) {
+	original := PollInterval
+	PollInterval = time.Millisecond
+	t.Cleanup(func() { PollInterval = original })
+
+	m := testModel()
+	require.Equal(t, 1, countChains(m, m.OnEnter()))
+}

--- a/views/networks/update.go
+++ b/views/networks/update.go
@@ -318,14 +318,17 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 		return m.computeNetworkUsedCmd(items)
 
 	case TickMsg:
+		if msg.Gen != m.pollGen {
+			return nil // a leftover from an earlier entry — see OnEnter
+		}
 		l().Infof("NetworksView: Received TickMsg, state=%v, visible=%v", m.state, m.visible)
 		if m.visible && m.state == stateReady && !m.confirmDialog.Visible && !m.loadingView.Visible() {
 			return tea.Batch(
 				m.checkNetworksCmd(m.lastSnapshot),
-				tickCmd(),
+				tickCmd(m.pollGen),
 			)
 		}
-		return tickCmd()
+		return tickCmd(m.pollGen)
 
 	case PollRetryMsg:
 		// Deliberately no re-arm. The TickMsg handler above always schedules

--- a/views/networks/update.go
+++ b/views/networks/update.go
@@ -328,7 +328,11 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 		return tickCmd()
 
 	case PollRetryMsg:
-		return tickCmd()
+		// Deliberately no re-arm. The TickMsg handler above always schedules
+		// the next tick, so re-arming here as well gives one beat two
+		// successors — and each of those does the same, so the poll rate does
+		// not merely double, it doubles again on every beat.
+		return nil
 
 	case NetworkDeletedMsg:
 		if msg.Err != nil {

--- a/views/networks/update_test.go
+++ b/views/networks/update_test.go
@@ -153,7 +153,7 @@ func TestUpdate_TickMsg(t *testing.T) {
 	m := testModel()
 	m.visible = true
 	m.state = stateReady
-	cmd := m.Update(TickMsg(time.Now()))
+	cmd := m.Update(TickMsg{Gen: m.pollGen})
 	require.NotNil(t, cmd)
 }
 

--- a/views/nodes/messages.go
+++ b/views/nodes/messages.go
@@ -20,7 +20,11 @@ type TickMsg time.Time
 type PollRetryMsg struct{}
 
 // Poll interval for checking node changes
-const PollInterval = 5 * time.Second
+// PollInterval is how often the view re-reads its resource. It is a var, not a
+// const, so tests can shrink it: a tea.Tick cmd invoked synchronously blocks
+// for the full interval, so a test that runs one to see what it scheduled would
+// otherwise sit here for five seconds.
+var PollInterval = 5 * time.Second
 
 // DemoteErrorMsg reports an error occurred while attempting to demote a node.
 type DemoteErrorMsg struct {

--- a/views/nodes/messages.go
+++ b/views/nodes/messages.go
@@ -13,7 +13,7 @@ type Msg struct {
 }
 
 // TickMsg triggers periodic node list check
-type TickMsg time.Time
+type TickMsg struct{ Gen uint64 }
 
 // PollRetryMsg signals that polling found no changes; the Update handler
 // should schedule the next tick.

--- a/views/nodes/model.go
+++ b/views/nodes/model.go
@@ -101,7 +101,7 @@ func New(width, height int) *Model {
 }
 
 func (m *Model) Init() tea.Cmd {
-	return tickCmd()
+	return nil
 }
 
 func tickCmd() tea.Cmd {
@@ -190,7 +190,11 @@ func (m *Model) checkNodesCmd(lastHash uint64) tea.Cmd {
 }
 
 func (m *Model) OnEnter() tea.Cmd {
-	return nil
+	m.Visible = true
+	// The tick is armed here, not in Init or the factory: OnEnter is the only
+	// hook that runs both on first entry and on every return from a drill-down,
+	// and a chain cannot survive a navigation (see the TickMsg handler).
+	return tea.Batch(m.LoadNodesCmd(), tickCmd())
 }
 
 func (m *Model) OnExit() tea.Cmd {

--- a/views/nodes/model.go
+++ b/views/nodes/model.go
@@ -39,6 +39,7 @@ type Model struct {
 	sortField             SortField
 	sortAscending         bool   // true for ascending, false for descending
 	lastSnapshot          uint64 // Hash of last node state for change detection
+	pollGen               uint64 // Generation of the live poll chain; see OnEnter
 	confirmDialog         *confirmdialog.Model
 	errorDialogActive     bool
 	availabilityDialog    bool     // Whether availability selection dialog is visible
@@ -104,9 +105,9 @@ func (m *Model) Init() tea.Cmd {
 	return nil
 }
 
-func tickCmd() tea.Cmd {
-	return tea.Tick(PollInterval, func(t time.Time) tea.Msg {
-		return TickMsg(t)
+func tickCmd(gen uint64) tea.Cmd {
+	return tea.Tick(PollInterval, func(time.Time) tea.Msg {
+		return TickMsg{Gen: gen}
 	})
 }
 
@@ -193,8 +194,16 @@ func (m *Model) OnEnter() tea.Cmd {
 	m.Visible = true
 	// The tick is armed here, not in Init or the factory: OnEnter is the only
 	// hook that runs both on first entry and on every return from a drill-down,
-	// and a chain cannot survive a navigation (see the TickMsg handler).
-	return tea.Batch(m.LoadNodesCmd(), tickCmd())
+	// and a chain does not survive a navigation — its tick is delivered to
+	// whichever view is current by then, and dropped.
+	//
+	// Each entry gets its own generation. "Does not survive" holds only once
+	// the leftover tick has fired: one armed just before a drill-down can
+	// still be in flight when the operator returns, and would find this view
+	// current again and re-arm, leaving two chains for the rest of the view's
+	// life. The generation makes it recognisable as a leftover.
+	m.pollGen++
+	return tea.Batch(m.LoadNodesCmd(), tickCmd(m.pollGen))
 }
 
 func (m *Model) OnExit() tea.Cmd {

--- a/views/nodes/pollloop_test.go
+++ b/views/nodes/pollloop_test.go
@@ -58,9 +58,13 @@ func TestEnteringTheViewArmsExactlyOneChain(t *testing.T) {
 	fastTick(t)
 	m := testModel()
 
-	// What switchToView does: the factory's command, then OnEnter.
-	entry := tea.Batch(m.Init(), m.LoadNodesCmd(), m.OnEnter())
-	require.Equal(t, 1, countChains(m, entry),
+	// The real factory, not a hand-written stand-in for it: switchToView
+	// batches the factory's command and OnEnter, and standing in for the
+	// factory with m.Init() is how one view's second arm survived the first
+	// pass at this.
+	v, loadCmd := factory(m.deps, 80, 24, nil)
+	entered := v.(*Model)
+	require.Equal(t, 1, countChains(entered, tea.Batch(entered.Init(), loadCmd, entered.OnEnter())),
 		"the factory and OnEnter must not each start a chain")
 }
 
@@ -70,7 +74,7 @@ func TestTickSustainsExactlyOneChain(t *testing.T) {
 	m := testModel()
 	m.Visible = true
 
-	require.Equal(t, 1, countChains(m, m.Update(TickMsg(time.Now()))),
+	require.Equal(t, 1, countChains(m, m.Update(TickMsg{Gen: m.pollGen})),
 		"a tick must schedule exactly one successor")
 
 	// The poll reporting no change must not schedule another on top of it.
@@ -78,7 +82,7 @@ func TestTickSustainsExactlyOneChain(t *testing.T) {
 		"PollRetryMsg must not re-arm; the tick already did")
 }
 
-// A chain cannot survive a navigation: every view declares its own TickMsg
+// A chain does not survive a navigation: every view declares its own TickMsg
 // type, so a tick belonging to a view that is no longer current is delivered to
 // a different view and dropped. Returning must therefore re-arm, or the view
 // comes back permanently stale.
@@ -88,4 +92,48 @@ func TestReturningToTheViewRestartsPolling(t *testing.T) {
 
 	require.Equal(t, 1, countChains(m, m.OnEnter()),
 		"goBack calls OnEnter and nothing else, so it has to restart the chain")
+}
+
+// firstTick runs a command and returns the tick it scheduled, so a test can
+// hold on to one chain's tick while a later entry arms another.
+func firstTick(t *testing.T, m *Model, cmd tea.Cmd) TickMsg {
+	t.Helper()
+	var found *TickMsg
+	var run func(c tea.Cmd)
+	run = func(c tea.Cmd) {
+		if c == nil || found != nil {
+			return
+		}
+		msg := c()
+		if batch, ok := msg.(tea.BatchMsg); ok {
+			for _, sub := range batch {
+				run(sub)
+			}
+			return
+		}
+		if tick, ok := msg.(TickMsg); ok {
+			found = &tick
+		}
+	}
+	run(cmd)
+	require.NotNil(t, found, "the command scheduled no tick")
+	return *found
+}
+
+// A tick armed before a drill-down must not sustain a chain after the return.
+//
+// The chain usually dies on the way out: its tick is delivered to whichever
+// view is current by then, and dropped. But one still in flight when the
+// operator returns finds this view current again, and OnEnter has already
+// armed a replacement — re-arming from both leaves the view polling at twice
+// the rate for the rest of its life.
+func TestStaleTickFromAnEarlierEntryIsDropped(t *testing.T) {
+	fastTick(t)
+	m := testModel()
+
+	stale := firstTick(t, m, m.OnEnter()) // the chain armed on the first entry
+	m.OnEnter()                           // goBack: a fresh chain
+
+	require.Equal(t, 0, countChains(m, m.Update(stale)),
+		"a tick from an earlier entry must not arm a successor")
 }

--- a/views/nodes/pollloop_test.go
+++ b/views/nodes/pollloop_test.go
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package nodesview
+
+import (
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/stretchr/testify/require"
+)
+
+// countChains runs a command — flattening tea.Batch, whose members the runtime
+// runs rather than the caller — and counts the ticks it schedules. Each
+// scheduled tick is one live poll chain, because a tick re-arms itself.
+//
+// Messages other than ticks are fed back into Update exactly once, so a load
+// that arms a tick of its own is counted too. That is the shape of the bug:
+// the arm was not in one place.
+func countChains(m *Model, cmd tea.Cmd) int {
+	chains := 0
+	var run func(c tea.Cmd, depth int)
+	run = func(c tea.Cmd, depth int) {
+		if c == nil || depth > 2 {
+			return
+		}
+		msg := c()
+		if batch, ok := msg.(tea.BatchMsg); ok {
+			for _, sub := range batch {
+				run(sub, depth)
+			}
+			return
+		}
+		if _, isTick := msg.(TickMsg); isTick {
+			chains++
+			return
+		}
+		run(m.Update(msg), depth+1)
+	}
+	run(cmd, 0)
+	return chains
+}
+
+func fastTick(t *testing.T) {
+	t.Helper()
+	original := PollInterval
+	PollInterval = time.Millisecond
+	t.Cleanup(func() { PollInterval = original })
+}
+
+// Entering a view must start exactly one poll chain.
+//
+// switchToView batches the factory's command AND OnEnter, so a view that armed
+// in both — or in a load handler reached from either — ran two chains for the
+// life of the view, polling the daemon at twice the intended rate.
+func TestEnteringTheViewArmsExactlyOneChain(t *testing.T) {
+	fastTick(t)
+	m := testModel()
+
+	// What switchToView does: the factory's command, then OnEnter.
+	entry := tea.Batch(m.Init(), m.LoadNodesCmd(), m.OnEnter())
+	require.Equal(t, 1, countChains(m, entry),
+		"the factory and OnEnter must not each start a chain")
+}
+
+// A tick keeps the chain alive on its own, and produces exactly one successor.
+func TestTickSustainsExactlyOneChain(t *testing.T) {
+	fastTick(t)
+	m := testModel()
+	m.Visible = true
+
+	require.Equal(t, 1, countChains(m, m.Update(TickMsg(time.Now()))),
+		"a tick must schedule exactly one successor")
+
+	// The poll reporting no change must not schedule another on top of it.
+	require.Equal(t, 0, countChains(m, m.Update(PollRetryMsg{})),
+		"PollRetryMsg must not re-arm; the tick already did")
+}
+
+// A chain cannot survive a navigation: every view declares its own TickMsg
+// type, so a tick belonging to a view that is no longer current is delivered to
+// a different view and dropped. Returning must therefore re-arm, or the view
+// comes back permanently stale.
+func TestReturningToTheViewRestartsPolling(t *testing.T) {
+	fastTick(t)
+	m := testModel()
+
+	require.Equal(t, 1, countChains(m, m.OnEnter()),
+		"goBack calls OnEnter and nothing else, so it has to restart the chain")
+}

--- a/views/nodes/update.go
+++ b/views/nodes/update.go
@@ -216,19 +216,25 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 		}
 
 		m.Visible = true
-		return tickCmd()
+		// No re-arm: only a tick arms a tick, so a load issued by OnEnter or the
+		// factory cannot start a second, parallel chain.
+		return nil
 
 	case TickMsg:
 		l().Infof("NodesView: Received TickMsg, visible=%v", m.Visible)
 		// Check for changes (this will return either a Msg or PollRetryMsg)
 		if m.Visible {
-			return m.checkNodesCmd(m.lastSnapshot)
+			return tea.Batch(m.checkNodesCmd(m.lastSnapshot), tickCmd())
 		}
 		// Continue polling even if not visible
 		return tickCmd()
 
 	case PollRetryMsg:
-		return tickCmd()
+		// Deliberately no re-arm. The TickMsg handler above always schedules
+		// the next tick, so re-arming here as well gives one beat two
+		// successors — and each of those does the same, so the poll rate does
+		// not merely double, it doubles again on every beat.
+		return nil
 
 	case tea.WindowSizeMsg:
 		m.List.Viewport.Width = msg.Width

--- a/views/nodes/update.go
+++ b/views/nodes/update.go
@@ -221,13 +221,16 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 		return nil
 
 	case TickMsg:
+		if msg.Gen != m.pollGen {
+			return nil // a leftover from an earlier entry — see OnEnter
+		}
 		l().Infof("NodesView: Received TickMsg, visible=%v", m.Visible)
 		// Check for changes (this will return either a Msg or PollRetryMsg)
 		if m.Visible {
-			return tea.Batch(m.checkNodesCmd(m.lastSnapshot), tickCmd())
+			return tea.Batch(m.checkNodesCmd(m.lastSnapshot), tickCmd(m.pollGen))
 		}
 		// Continue polling even if not visible
-		return tickCmd()
+		return tickCmd(m.pollGen)
 
 	case PollRetryMsg:
 		// Deliberately no re-arm. The TickMsg handler above always schedules

--- a/views/nodes/update_test.go
+++ b/views/nodes/update_test.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"fmt"
 	"testing"
-	"time"
 
 	"github.com/Eldara-Tech/swarmcli/docker"
 	"github.com/Eldara-Tech/swarmcli/views/confirmdialog"
@@ -40,14 +39,14 @@ func TestUpdate_WindowSizeMsg(t *testing.T) {
 func TestUpdate_TickMsg_Visible(t *testing.T) {
 	m := testModel()
 	m.Visible = true
-	cmd := m.Update(TickMsg(time.Now()))
+	cmd := m.Update(TickMsg{Gen: m.pollGen})
 	require.NotNil(t, cmd)
 }
 
 func TestUpdate_TickMsg_NotVisible(t *testing.T) {
 	m := testModel()
 	m.Visible = false
-	cmd := m.Update(TickMsg(time.Now()))
+	cmd := m.Update(TickMsg{Gen: m.pollGen})
 	require.NotNil(t, cmd) // still returns tickCmd
 }
 

--- a/views/secrets/messages.go
+++ b/views/secrets/messages.go
@@ -12,7 +12,7 @@ type secretsLoadedMsg []docker.SecretWithDecodedData
 
 type errorMsg error
 
-type TickMsg time.Time
+type TickMsg struct{ Gen uint64 }
 
 // PollRetryMsg signals that polling found no changes; the Update handler
 // should schedule the next tick.

--- a/views/secrets/model.go
+++ b/views/secrets/model.go
@@ -203,7 +203,7 @@ func (m *Model) ClearSearchQuery() {
 
 func (m *Model) Init() tea.Cmd {
 	l().Info("SecretsView: Init() called - starting ticker and loading secrets")
-	return tea.Batch(tickCmd(), m.spinnerTickCmd(), m.loadSecretsCmd())
+	return tea.Batch(m.spinnerTickCmd(), m.loadSecretsCmd())
 }
 
 func (m *Model) spinnerTickCmd() tea.Cmd {
@@ -267,7 +267,10 @@ func (m *Model) addSecret(sec docker.SecretWithDecodedData) {
 func (m *Model) OnEnter() tea.Cmd {
 	m.visible = true
 	l().Info("SecretsView: OnEnter() - view is now visible")
-	return m.loadSecretsCmd()
+	// The tick is armed here, not in Init or the factory: OnEnter is the only
+	// hook that runs both on first entry and on every return from a drill-down,
+	// and a chain cannot survive a navigation (see the TickMsg handler).
+	return tea.Batch(m.loadSecretsCmd(), tickCmd())
 }
 
 func (m *Model) OnExit() tea.Cmd {

--- a/views/secrets/model.go
+++ b/views/secrets/model.go
@@ -87,7 +87,12 @@ const (
 	stateError
 )
 
-const PollInterval = 5 * time.Second
+// PollInterval is how often the view re-reads its resource. It is a var, not a
+// const, so tests can shrink it: a tea.Tick cmd invoked synchronously blocks
+// for the full interval, so a test that runs one to see what it scheduled would
+// otherwise sit here for five seconds.
+var PollInterval = 5 * time.Second
+
 const pollTimeout = 4 * time.Second
 const userActionTimeout = 15 * time.Second
 

--- a/views/secrets/model.go
+++ b/views/secrets/model.go
@@ -38,6 +38,7 @@ type Model struct {
 	height        int
 	firstResize   bool   // tracks if we've received the first window size
 	lastSnapshot  uint64 // hash of last snapshot for change detection
+	pollGen       uint64 // generation of the live poll chain; see OnEnter
 	polling       atomic.Bool
 	visible       bool // tracks if view is currently active
 	sortField     SortField
@@ -212,9 +213,9 @@ func (m *Model) spinnerTickCmd() tea.Cmd {
 	})
 }
 
-func tickCmd() tea.Cmd {
-	return tea.Tick(PollInterval, func(t time.Time) tea.Msg {
-		return TickMsg(t)
+func tickCmd(gen uint64) tea.Cmd {
+	return tea.Tick(PollInterval, func(time.Time) tea.Msg {
+		return TickMsg{Gen: gen}
 	})
 }
 
@@ -269,8 +270,16 @@ func (m *Model) OnEnter() tea.Cmd {
 	l().Info("SecretsView: OnEnter() - view is now visible")
 	// The tick is armed here, not in Init or the factory: OnEnter is the only
 	// hook that runs both on first entry and on every return from a drill-down,
-	// and a chain cannot survive a navigation (see the TickMsg handler).
-	return tea.Batch(m.loadSecretsCmd(), tickCmd())
+	// and a chain does not survive a navigation — its tick is delivered to
+	// whichever view is current by then, and dropped.
+	//
+	// Each entry gets its own generation. "Does not survive" holds only once
+	// the leftover tick has fired: one armed just before a drill-down can
+	// still be in flight when the operator returns, and would find this view
+	// current again and re-arm, leaving two chains for the rest of the view's
+	// life. The generation makes it recognisable as a leftover.
+	m.pollGen++
+	return tea.Batch(m.loadSecretsCmd(), tickCmd(m.pollGen))
 }
 
 func (m *Model) OnExit() tea.Cmd {

--- a/views/secrets/pollloop_test.go
+++ b/views/secrets/pollloop_test.go
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package secretsview
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/Eldara-Tech/swarmcli/docker"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/docker/docker/api/types/swarm"
+	"github.com/stretchr/testify/require"
+)
+
+// drivePoll models the bubbletea runtime for one round: run each pending
+// command, flattening tea.Batch — whose members the runtime runs, not the
+// caller — feed every resulting message back into Update, and return the
+// commands that came out.
+//
+// Flattening is the point. Asserting on the command Update returns cannot see
+// past a batch, nor see a successor that arrives one message later, so a test
+// written that way passes whatever the loop actually does.
+func drivePoll(m *Model, pending []tea.Cmd) []tea.Cmd {
+	var next []tea.Cmd
+	var run func(c tea.Cmd)
+	run = func(c tea.Cmd) {
+		if c == nil {
+			return
+		}
+		msg := c()
+		if batch, ok := msg.(tea.BatchMsg); ok {
+			for _, sub := range batch {
+				run(sub)
+			}
+			return
+		}
+		if _, isSpinner := msg.(SpinnerTickMsg); isSpinner {
+			return // not part of the poll loop
+		}
+		if cmd := m.Update(msg); cmd != nil {
+			next = append(next, cmd)
+		}
+	}
+	for _, c := range pending {
+		run(c)
+	}
+	return next
+}
+
+// The poll loop must be a loop, not a tree.
+//
+// A tick that starts a poll and re-arms the ticker, while the poll's "nothing
+// changed" result re-arms it too, yields two successors per beat — and each of
+// those does the same. An idle view left open climbs into thousands of
+// concurrent Docker reads within a minute.
+func TestPollLoopDoesNotMultiply(t *testing.T) {
+	original := PollInterval
+	PollInterval = time.Millisecond
+	t.Cleanup(func() { PollInterval = original })
+
+	polled := false
+	ops := noopSecretOps()
+	inner := ops.listSecretsFn
+	ops.listSecretsFn = func(ctx context.Context) ([]swarm.Secret, error) {
+		polled = true
+		return inner(ctx)
+	}
+	m := testModel(func(m *Model) { m.deps = docker.Deps{Secrets: ops} })
+
+	// Steady state: the poll finds exactly what is already loaded (the ops
+	// list nothing), so it reports no change. That is what a view left open
+	// does all day.
+	m.Update(secretsLoadedMsg(nil))
+	require.Equal(t, stateReady, m.state)
+
+	pending := []tea.Cmd{tickCmd()}
+	for round := 0; round < 12; round++ {
+		pending = drivePoll(m, pending)
+		require.LessOrEqual(t, len(pending), 1,
+			"round %d: %d commands in flight — the loop has branched", round, len(pending))
+		time.Sleep(2 * time.Millisecond)
+	}
+	require.True(t, polled, "the fixture must actually poll, or this proves nothing")
+	require.Len(t, pending, 1, "and the loop must still be alive at the end")
+}

--- a/views/secrets/pollloop_test.go
+++ b/views/secrets/pollloop_test.go
@@ -76,7 +76,7 @@ func TestPollLoopDoesNotMultiply(t *testing.T) {
 	m.Update(secretsLoadedMsg(nil))
 	require.Equal(t, stateReady, m.state)
 
-	pending := []tea.Cmd{tickCmd()}
+	pending := []tea.Cmd{tickCmd(m.pollGen)}
 	for round := 0; round < 12; round++ {
 		pending = drivePoll(m, pending)
 		require.LessOrEqual(t, len(pending), 1,
@@ -126,11 +126,18 @@ func TestEnteringTheViewArmsExactlyOneChain(t *testing.T) {
 	t.Cleanup(func() { PollInterval = original })
 
 	m := testModel()
-	require.Equal(t, 1, countChains(m, tea.Batch(m.Init(), m.OnEnter())),
+
+	// The real factory, not a hand-written stand-in for it: switchToView
+	// batches the factory's command and OnEnter, and standing in for the
+	// factory with m.Init() is how one view's second arm survived the first
+	// pass at this.
+	v, loadCmd := factory(m.deps, 80, 24, nil)
+	entered := v.(*Model)
+	require.Equal(t, 1, countChains(entered, tea.Batch(entered.Init(), loadCmd, entered.OnEnter())),
 		"the factory and OnEnter must not each start a chain")
 }
 
-// A chain cannot survive a navigation: every view declares its own TickMsg
+// A chain does not survive a navigation: every view declares its own TickMsg
 // type, so a tick belonging to a view that is no longer current is delivered to
 // a different view and dropped. Returning must therefore re-arm, or the view
 // comes back permanently stale. goBack calls OnEnter and nothing else.
@@ -141,4 +148,50 @@ func TestReturningToTheViewRestartsPolling(t *testing.T) {
 
 	m := testModel()
 	require.Equal(t, 1, countChains(m, m.OnEnter()))
+}
+
+// firstTick runs a command and returns the tick it scheduled, so a test can
+// hold on to one chain's tick while a later entry arms another.
+func firstTick(t *testing.T, m *Model, cmd tea.Cmd) TickMsg {
+	t.Helper()
+	var found *TickMsg
+	var run func(c tea.Cmd)
+	run = func(c tea.Cmd) {
+		if c == nil || found != nil {
+			return
+		}
+		msg := c()
+		if batch, ok := msg.(tea.BatchMsg); ok {
+			for _, sub := range batch {
+				run(sub)
+			}
+			return
+		}
+		if tick, ok := msg.(TickMsg); ok {
+			found = &tick
+		}
+	}
+	run(cmd)
+	require.NotNil(t, found, "the command scheduled no tick")
+	return *found
+}
+
+// A tick armed before a drill-down must not sustain a chain after the return.
+//
+// The chain usually dies on the way out: its tick is delivered to whichever
+// view is current by then, and dropped. But one still in flight when the
+// operator returns finds this view current again, and OnEnter has already
+// armed a replacement — re-arming from both leaves the view polling at twice
+// the rate for the rest of its life.
+func TestStaleTickFromAnEarlierEntryIsDropped(t *testing.T) {
+	original := PollInterval
+	PollInterval = time.Millisecond
+	t.Cleanup(func() { PollInterval = original })
+	m := testModel()
+
+	stale := firstTick(t, m, m.OnEnter()) // the chain armed on the first entry
+	m.OnEnter()                           // goBack: a fresh chain
+
+	require.Equal(t, 0, countChains(m, m.Update(stale)),
+		"a tick from an earlier entry must not arm a successor")
 }

--- a/views/secrets/pollloop_test.go
+++ b/views/secrets/pollloop_test.go
@@ -86,3 +86,59 @@ func TestPollLoopDoesNotMultiply(t *testing.T) {
 	require.True(t, polled, "the fixture must actually poll, or this proves nothing")
 	require.Len(t, pending, 1, "and the loop must still be alive at the end")
 }
+
+// countChains runs a command — flattening tea.Batch, whose members the runtime
+// runs rather than the caller — and counts the ticks it schedules. Each
+// scheduled tick is one live poll chain, because a tick re-arms itself.
+func countChains(m *Model, cmd tea.Cmd) int {
+	chains := 0
+	var run func(c tea.Cmd, depth int)
+	run = func(c tea.Cmd, depth int) {
+		if c == nil || depth > 2 {
+			return
+		}
+		msg := c()
+		if batch, ok := msg.(tea.BatchMsg); ok {
+			for _, sub := range batch {
+				run(sub, depth)
+			}
+			return
+		}
+		if _, isTick := msg.(TickMsg); isTick {
+			chains++
+			return
+		}
+		if _, isSpinner := msg.(SpinnerTickMsg); isSpinner {
+			return
+		}
+		run(m.Update(msg), depth+1)
+	}
+	run(cmd, 0)
+	return chains
+}
+
+// Entering a view must start exactly one poll chain. switchToView batches the
+// factory's command AND OnEnter, so a view arming in both ran two chains for
+// its whole life, polling the daemon at twice the intended rate.
+func TestEnteringTheViewArmsExactlyOneChain(t *testing.T) {
+	original := PollInterval
+	PollInterval = time.Millisecond
+	t.Cleanup(func() { PollInterval = original })
+
+	m := testModel()
+	require.Equal(t, 1, countChains(m, tea.Batch(m.Init(), m.OnEnter())),
+		"the factory and OnEnter must not each start a chain")
+}
+
+// A chain cannot survive a navigation: every view declares its own TickMsg
+// type, so a tick belonging to a view that is no longer current is delivered to
+// a different view and dropped. Returning must therefore re-arm, or the view
+// comes back permanently stale. goBack calls OnEnter and nothing else.
+func TestReturningToTheViewRestartsPolling(t *testing.T) {
+	original := PollInterval
+	PollInterval = time.Millisecond
+	t.Cleanup(func() { PollInterval = original })
+
+	m := testModel()
+	require.Equal(t, 1, countChains(m, m.OnEnter()))
+}

--- a/views/secrets/update.go
+++ b/views/secrets/update.go
@@ -164,14 +164,17 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 		return m.computeSecretUsedCmd(msg)
 
 	case TickMsg:
+		if msg.Gen != m.pollGen {
+			return nil // a leftover from an earlier entry — see OnEnter
+		}
 		l().Infof("SecretsView: Received TickMsg, state=%v, visible=%v", m.state, m.visible)
 		if m.visible && m.state == stateReady && !m.confirmDialog.Visible && !m.loadingView.Visible() && !m.polling.Load() {
 			return tea.Batch(
 				m.checkSecretsCmd(m.lastSnapshot),
-				tickCmd(),
+				tickCmd(m.pollGen),
 			)
 		}
-		return tickCmd()
+		return tickCmd(m.pollGen)
 
 	case PollRetryMsg:
 		// Deliberately no re-arm. The TickMsg handler above always schedules

--- a/views/secrets/update.go
+++ b/views/secrets/update.go
@@ -174,7 +174,11 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 		return tickCmd()
 
 	case PollRetryMsg:
-		return tickCmd()
+		// Deliberately no re-arm. The TickMsg handler above always schedules
+		// the next tick, so re-arming here as well gives one beat two
+		// successors — and each of those does the same, so the poll rate does
+		// not merely double, it doubles again on every beat.
+		return nil
 
 	case secretDeletedMsg:
 		l().Infof("Secret deleted successfully: %s", msg.Name)

--- a/views/secrets/update_test.go
+++ b/views/secrets/update_test.go
@@ -85,7 +85,7 @@ func TestTickMsg_WhenReadyAndVisible_Polls(t *testing.T) {
 	m := testModel()
 	loadSecrets(m, fakeSecrets("s1"))
 	m.visible = true
-	cmd := m.Update(TickMsg(time.Now()))
+	cmd := m.Update(TickMsg{Gen: m.pollGen})
 	require.NotNil(t, cmd)
 }
 
@@ -93,7 +93,7 @@ func TestTickMsg_WhenNotVisible_SchedulesTick(t *testing.T) {
 	m := testModel()
 	loadSecrets(m, fakeSecrets("s1"))
 	m.visible = false
-	cmd := m.Update(TickMsg(time.Now()))
+	cmd := m.Update(TickMsg{Gen: m.pollGen})
 	require.NotNil(t, cmd) // returns tickCmd
 }
 
@@ -638,7 +638,7 @@ func TestTickMsg_WhenPollingInFlight_SkipsCheck(t *testing.T) {
 	loadSecrets(m, fakeSecrets("s1"))
 	m.visible = true
 	m.polling.Store(true)
-	cmd := m.Update(TickMsg(time.Now()))
+	cmd := m.Update(TickMsg{Gen: m.pollGen})
 	require.NotNil(t, cmd)
 	msg := runCmd(cmd)
 	_, isTickMsg := msg.(TickMsg)

--- a/views/services/messages.go
+++ b/views/services/messages.go
@@ -23,7 +23,11 @@ type TickMsg time.Time
 // should schedule the next tick.
 type PollRetryMsg struct{}
 
-const PollInterval = 2 * time.Second
+// PollInterval is how often the view re-reads its resource. It is a var, not a
+// const, so tests can shrink it: a tea.Tick cmd invoked synchronously blocks
+// for the full interval, so a test that runs one to see what it scheduled would
+// otherwise sit here for the whole period.
+var PollInterval = 2 * time.Second
 
 const userActionTimeout = 15 * time.Second
 

--- a/views/services/messages.go
+++ b/views/services/messages.go
@@ -17,7 +17,7 @@ type Msg struct {
 	StackName  string
 }
 
-type TickMsg time.Time
+type TickMsg struct{ Gen uint64 }
 
 // PollRetryMsg signals that polling found no changes; the Update handler
 // should schedule the next tick.

--- a/views/services/model.go
+++ b/views/services/model.go
@@ -50,6 +50,7 @@ type Model struct {
 	width        int
 	height       int
 	lastSnapshot uint64 // hash of last snapshot for change detection
+	pollGen      uint64 // generation of the live poll chain; see OnEnter
 
 	// Filter
 	filterType FilterType
@@ -126,9 +127,9 @@ func (m *Model) Init() tea.Cmd {
 	return nil
 }
 
-func tickCmd() tea.Cmd {
-	return tea.Tick(PollInterval, func(t time.Time) tea.Msg {
-		return TickMsg(t)
+func tickCmd(gen uint64) tea.Cmd {
+	return tea.Tick(PollInterval, func(time.Time) tea.Msg {
+		return TickMsg{Gen: gen}
 	})
 }
 
@@ -158,8 +159,16 @@ func (m *Model) OnEnter() tea.Cmd {
 	m.Visible = true
 	// The tick is armed here, not in Init or the factory: OnEnter is the only
 	// hook that runs both on first entry and on every return from a drill-down,
-	// and a chain cannot survive a navigation (see the TickMsg handler).
-	return tickCmd()
+	// and a chain does not survive a navigation — its tick is delivered to
+	// whichever view is current by then, and dropped.
+	//
+	// Each entry gets its own generation. "Does not survive" holds only once
+	// the leftover tick has fired: one armed just before a drill-down can
+	// still be in flight when the operator returns, and would find this view
+	// current again and re-arm, leaving two chains for the rest of the view's
+	// life. The generation makes it recognisable as a leftover.
+	m.pollGen++
+	return tickCmd(m.pollGen)
 }
 
 func (m *Model) OnExit() tea.Cmd {

--- a/views/services/model.go
+++ b/views/services/model.go
@@ -123,7 +123,7 @@ func New(width, height int) *Model {
 }
 
 func (m *Model) Init() tea.Cmd {
-	return tickCmd()
+	return nil
 }
 
 func tickCmd() tea.Cmd {
@@ -154,6 +154,10 @@ func (m *Model) ShortHelpItems() []helpbar.HelpEntry {
 }
 
 func (m *Model) OnEnter() tea.Cmd {
+	m.Visible = true
+	// The tick is armed here, not in Init or the factory: OnEnter is the only
+	// hook that runs both on first entry and on every return from a drill-down,
+	// and a chain cannot survive a navigation (see the TickMsg handler).
 	return tickCmd()
 }
 

--- a/views/services/model_test.go
+++ b/views/services/model_test.go
@@ -291,14 +291,14 @@ func TestWindowSizeMsg(t *testing.T) {
 func TestTickMsg_Visible_Polls(t *testing.T) {
 	m := testModel()
 	loadServices(m, fakeEntries("web"))
-	cmd := m.Update(TickMsg(time.Now()))
+	cmd := m.Update(TickMsg{Gen: m.pollGen})
 	require.NotNil(t, cmd)
 }
 
 func TestTickMsg_NotVisible_SchedulesTick(t *testing.T) {
 	m := testModel()
 	m.Visible = false
-	cmd := m.Update(TickMsg(time.Now()))
+	cmd := m.Update(TickMsg{Gen: m.pollGen})
 	require.NotNil(t, cmd)
 }
 

--- a/views/services/pollloop_test.go
+++ b/views/services/pollloop_test.go
@@ -58,9 +58,13 @@ func TestEnteringTheViewArmsExactlyOneChain(t *testing.T) {
 	fastTick(t)
 	m := testModel()
 
-	// What switchToView does: the factory's command, then OnEnter.
-	entry := tea.Batch(m.Init(), m.OnEnter())
-	require.Equal(t, 1, countChains(m, entry),
+	// The real factory, not a hand-written stand-in for it: switchToView
+	// batches the factory's command and OnEnter, and standing in for the
+	// factory with m.Init() is how one view's second arm survived the first
+	// pass at this.
+	v, loadCmd := factory(m.deps, 80, 24, nil)
+	entered := v.(*Model)
+	require.Equal(t, 1, countChains(entered, tea.Batch(entered.Init(), loadCmd, entered.OnEnter())),
 		"the factory and OnEnter must not each start a chain")
 }
 
@@ -70,7 +74,7 @@ func TestTickSustainsExactlyOneChain(t *testing.T) {
 	m := testModel()
 	m.Visible = true
 
-	require.Equal(t, 1, countChains(m, m.Update(TickMsg(time.Now()))),
+	require.Equal(t, 1, countChains(m, m.Update(TickMsg{Gen: m.pollGen})),
 		"a tick must schedule exactly one successor")
 
 	// The poll reporting no change must not schedule another on top of it.
@@ -78,7 +82,7 @@ func TestTickSustainsExactlyOneChain(t *testing.T) {
 		"PollRetryMsg must not re-arm; the tick already did")
 }
 
-// A chain cannot survive a navigation: every view declares its own TickMsg
+// A chain does not survive a navigation: every view declares its own TickMsg
 // type, so a tick belonging to a view that is no longer current is delivered to
 // a different view and dropped. Returning must therefore re-arm, or the view
 // comes back permanently stale.
@@ -88,4 +92,48 @@ func TestReturningToTheViewRestartsPolling(t *testing.T) {
 
 	require.Equal(t, 1, countChains(m, m.OnEnter()),
 		"goBack calls OnEnter and nothing else, so it has to restart the chain")
+}
+
+// firstTick runs a command and returns the tick it scheduled, so a test can
+// hold on to one chain's tick while a later entry arms another.
+func firstTick(t *testing.T, m *Model, cmd tea.Cmd) TickMsg {
+	t.Helper()
+	var found *TickMsg
+	var run func(c tea.Cmd)
+	run = func(c tea.Cmd) {
+		if c == nil || found != nil {
+			return
+		}
+		msg := c()
+		if batch, ok := msg.(tea.BatchMsg); ok {
+			for _, sub := range batch {
+				run(sub)
+			}
+			return
+		}
+		if tick, ok := msg.(TickMsg); ok {
+			found = &tick
+		}
+	}
+	run(cmd)
+	require.NotNil(t, found, "the command scheduled no tick")
+	return *found
+}
+
+// A tick armed before a drill-down must not sustain a chain after the return.
+//
+// The chain usually dies on the way out: its tick is delivered to whichever
+// view is current by then, and dropped. But one still in flight when the
+// operator returns finds this view current again, and OnEnter has already
+// armed a replacement — re-arming from both leaves the view polling at twice
+// the rate for the rest of its life.
+func TestStaleTickFromAnEarlierEntryIsDropped(t *testing.T) {
+	fastTick(t)
+	m := testModel()
+
+	stale := firstTick(t, m, m.OnEnter()) // the chain armed on the first entry
+	m.OnEnter()                           // goBack: a fresh chain
+
+	require.Equal(t, 0, countChains(m, m.Update(stale)),
+		"a tick from an earlier entry must not arm a successor")
 }

--- a/views/services/pollloop_test.go
+++ b/views/services/pollloop_test.go
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package servicesview
+
+import (
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/stretchr/testify/require"
+)
+
+// countChains runs a command — flattening tea.Batch, whose members the runtime
+// runs rather than the caller — and counts the ticks it schedules. Each
+// scheduled tick is one live poll chain, because a tick re-arms itself.
+//
+// Messages other than ticks are fed back into Update exactly once, so a load
+// that arms a tick of its own is counted too. That is the shape of the bug:
+// the arm was not in one place.
+func countChains(m *Model, cmd tea.Cmd) int {
+	chains := 0
+	var run func(c tea.Cmd, depth int)
+	run = func(c tea.Cmd, depth int) {
+		if c == nil || depth > 2 {
+			return
+		}
+		msg := c()
+		if batch, ok := msg.(tea.BatchMsg); ok {
+			for _, sub := range batch {
+				run(sub, depth)
+			}
+			return
+		}
+		if _, isTick := msg.(TickMsg); isTick {
+			chains++
+			return
+		}
+		run(m.Update(msg), depth+1)
+	}
+	run(cmd, 0)
+	return chains
+}
+
+func fastTick(t *testing.T) {
+	t.Helper()
+	original := PollInterval
+	PollInterval = time.Millisecond
+	t.Cleanup(func() { PollInterval = original })
+}
+
+// Entering a view must start exactly one poll chain.
+//
+// switchToView batches the factory's command AND OnEnter, so a view that armed
+// in both — or in a load handler reached from either — ran two chains for the
+// life of the view, polling the daemon at twice the intended rate.
+func TestEnteringTheViewArmsExactlyOneChain(t *testing.T) {
+	fastTick(t)
+	m := testModel()
+
+	// What switchToView does: the factory's command, then OnEnter.
+	entry := tea.Batch(m.Init(), m.OnEnter())
+	require.Equal(t, 1, countChains(m, entry),
+		"the factory and OnEnter must not each start a chain")
+}
+
+// A tick keeps the chain alive on its own, and produces exactly one successor.
+func TestTickSustainsExactlyOneChain(t *testing.T) {
+	fastTick(t)
+	m := testModel()
+	m.Visible = true
+
+	require.Equal(t, 1, countChains(m, m.Update(TickMsg(time.Now()))),
+		"a tick must schedule exactly one successor")
+
+	// The poll reporting no change must not schedule another on top of it.
+	require.Equal(t, 0, countChains(m, m.Update(PollRetryMsg{})),
+		"PollRetryMsg must not re-arm; the tick already did")
+}
+
+// A chain cannot survive a navigation: every view declares its own TickMsg
+// type, so a tick belonging to a view that is no longer current is delivered to
+// a different view and dropped. Returning must therefore re-arm, or the view
+// comes back permanently stale.
+func TestReturningToTheViewRestartsPolling(t *testing.T) {
+	fastTick(t)
+	m := testModel()
+
+	require.Equal(t, 1, countChains(m, m.OnEnter()),
+		"goBack calls OnEnter and nothing else, so it has to restart the chain")
+}

--- a/views/services/register.go
+++ b/views/services/register.go
@@ -70,5 +70,7 @@ func factory(deps docker.Deps, w, h int, payload any) (view.View, tea.Cmd) {
 	v.SetContent(msg)
 	v.Visible = true
 
-	return v, tickCmd()
+	// No tick: OnEnter arms the one chain, and the app calls it right after
+	// this. Arming here too gave the view two for its whole life.
+	return v, nil
 }

--- a/views/services/update.go
+++ b/views/services/update.go
@@ -67,6 +67,9 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 		return m.refreshExpandedTasksCmd(m.expandedServices)
 
 	case TickMsg:
+		if msg.Gen != m.pollGen {
+			return nil // a leftover from an earlier entry — see OnEnter
+		}
 		l().Infof("ServicesView: Received TickMsg, visible=%v", m.Visible)
 		// Check for changes and refresh expanded tasks
 		if m.Visible {
@@ -77,11 +80,11 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 			return tea.Batch(
 				m.checkServicesCmd(m.lastSnapshot, m.filterType, m.nodeID, m.stackName),
 				m.refreshExpandedTasksCmd(m.expandedServices),
-				tickCmd(),
+				tickCmd(m.pollGen),
 			)
 		}
 		// Continue polling even if not visible
-		return tickCmd()
+		return tickCmd(m.pollGen)
 
 	case PollRetryMsg:
 		// Deliberately no re-arm. The TickMsg handler above always schedules

--- a/views/services/update.go
+++ b/views/services/update.go
@@ -62,8 +62,9 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 		}
 		m.SetContent(msg)
 		m.Visible = true
-		// Continue polling and refresh tasks for any expanded services
-		return tea.Batch(tickCmd(), m.refreshExpandedTasksCmd(m.expandedServices))
+		// No re-arm: only a tick arms a tick, so a load issued by OnEnter or the
+		// factory cannot start a second, parallel chain.
+		return m.refreshExpandedTasksCmd(m.expandedServices)
 
 	case TickMsg:
 		l().Infof("ServicesView: Received TickMsg, visible=%v", m.Visible)
@@ -76,13 +77,18 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 			return tea.Batch(
 				m.checkServicesCmd(m.lastSnapshot, m.filterType, m.nodeID, m.stackName),
 				m.refreshExpandedTasksCmd(m.expandedServices),
+				tickCmd(),
 			)
 		}
 		// Continue polling even if not visible
 		return tickCmd()
 
 	case PollRetryMsg:
-		return tickCmd()
+		// Deliberately no re-arm. The TickMsg handler above always schedules
+		// the next tick, so re-arming here as well gives one beat two
+		// successors — and each of those does the same, so the poll rate does
+		// not merely double, it doubles again on every beat.
+		return nil
 
 	case TasksLoadedMsg:
 		// Store loaded tasks - view will automatically re-render

--- a/views/stacks/messages.go
+++ b/views/stacks/messages.go
@@ -18,7 +18,7 @@ type RefreshErrorMsg struct {
 	Err error
 }
 
-type TickMsg time.Time
+type TickMsg struct{ Gen uint64 }
 
 // PollRetryMsg signals that polling found no changes; the Update handler
 // should schedule the next tick.

--- a/views/stacks/messages.go
+++ b/views/stacks/messages.go
@@ -24,7 +24,11 @@ type TickMsg time.Time
 // should schedule the next tick.
 type PollRetryMsg struct{}
 
-const PollInterval = 5 * time.Second
+// PollInterval is how often the view re-reads its resource. It is a var, not a
+// const, so tests can shrink it: a tea.Tick cmd invoked synchronously blocks
+// for the full interval, so a test that runs one to see what it scheduled would
+// otherwise sit here for five seconds.
+var PollInterval = 5 * time.Second
 
 // SpinnerTickMsg drives the deploy spinner and the toast expiry.
 type SpinnerTickMsg time.Time

--- a/views/stacks/model.go
+++ b/views/stacks/model.go
@@ -194,7 +194,7 @@ func New(width, height int) *Model {
 }
 
 func (m *Model) Init() tea.Cmd {
-	return tickCmd()
+	return nil
 }
 
 func tickCmd() tea.Cmd {
@@ -332,10 +332,13 @@ func (m *Model) checkStacksCmd(lastHash uint64, nodeID string) tea.Cmd {
 // OnEnter re-arms the animation tick when a deploy is still running, so
 // navigating away and back does not leave a frozen spinner in the footer.
 func (m *Model) OnEnter() tea.Cmd {
+	// The tick is armed here, not in Init or the factory: OnEnter is the only
+	// hook that runs both on first entry and on every return from a drill-down,
+	// and a chain cannot survive a navigation (see the TickMsg handler).
 	if m.deploying {
-		return tea.Batch(m.LoadStacksCmd(m.nodeID), m.spinnerTickCmd())
+		return tea.Batch(m.LoadStacksCmd(m.nodeID), m.spinnerTickCmd(), tickCmd())
 	}
-	return m.LoadStacksCmd(m.nodeID)
+	return tea.Batch(m.LoadStacksCmd(m.nodeID), tickCmd())
 }
 func (m *Model) OnExit() tea.Cmd { return nil }
 

--- a/views/stacks/model.go
+++ b/views/stacks/model.go
@@ -54,6 +54,7 @@ type Model struct {
 	width            int
 	height           int
 	lastSnapshot     uint64 // hash of last snapshot for change detection
+	pollGen          uint64 // generation of the live poll chain; see OnEnter
 	DelayInitialLoad bool   // when true, delay the first LoadStacksCmd by 3s
 	sortField        SortField
 	sortAscending    bool // true for ascending, false for descending
@@ -197,9 +198,9 @@ func (m *Model) Init() tea.Cmd {
 	return nil
 }
 
-func tickCmd() tea.Cmd {
-	return tea.Tick(PollInterval, func(t time.Time) tea.Msg {
-		return TickMsg(t)
+func tickCmd(gen uint64) tea.Cmd {
+	return tea.Tick(PollInterval, func(time.Time) tea.Msg {
+		return TickMsg{Gen: gen}
 	})
 }
 
@@ -334,11 +335,19 @@ func (m *Model) checkStacksCmd(lastHash uint64, nodeID string) tea.Cmd {
 func (m *Model) OnEnter() tea.Cmd {
 	// The tick is armed here, not in Init or the factory: OnEnter is the only
 	// hook that runs both on first entry and on every return from a drill-down,
-	// and a chain cannot survive a navigation (see the TickMsg handler).
+	// and a chain does not survive a navigation — its tick is delivered to
+	// whichever view is current by then, and dropped.
+	//
+	// Each entry gets its own generation. "Does not survive" holds only once
+	// the leftover tick has fired: one armed just before a drill-down can
+	// still be in flight when the operator returns, and would find this view
+	// current again and re-arm, leaving two chains for the rest of the view's
+	// life. The generation makes it recognisable as a leftover.
+	m.pollGen++
 	if m.deploying {
-		return tea.Batch(m.LoadStacksCmd(m.nodeID), m.spinnerTickCmd(), tickCmd())
+		return tea.Batch(m.LoadStacksCmd(m.nodeID), m.spinnerTickCmd(), tickCmd(m.pollGen))
 	}
-	return tea.Batch(m.LoadStacksCmd(m.nodeID), tickCmd())
+	return tea.Batch(m.LoadStacksCmd(m.nodeID), tickCmd(m.pollGen))
 }
 func (m *Model) OnExit() tea.Cmd { return nil }
 

--- a/views/stacks/pollloop_test.go
+++ b/views/stacks/pollloop_test.go
@@ -58,9 +58,13 @@ func TestEnteringTheViewArmsExactlyOneChain(t *testing.T) {
 	fastTick(t)
 	m := testModel()
 
-	// What switchToView does: the factory's command, then OnEnter.
-	entry := tea.Batch(m.Init(), m.LoadStacksCmd(m.nodeID), m.OnEnter())
-	require.Equal(t, 1, countChains(m, entry),
+	// The real factory, not a hand-written stand-in for it: switchToView
+	// batches the factory's command and OnEnter, and standing in for the
+	// factory with m.Init() is how one view's second arm survived the first
+	// pass at this.
+	v, loadCmd := factory(m.deps, 80, 24, nil)
+	entered := v.(*Model)
+	require.Equal(t, 1, countChains(entered, tea.Batch(entered.Init(), loadCmd, entered.OnEnter())),
 		"the factory and OnEnter must not each start a chain")
 }
 
@@ -70,7 +74,7 @@ func TestTickSustainsExactlyOneChain(t *testing.T) {
 	m := testModel()
 	m.Visible = true
 
-	require.Equal(t, 1, countChains(m, m.Update(TickMsg(time.Now()))),
+	require.Equal(t, 1, countChains(m, m.Update(TickMsg{Gen: m.pollGen})),
 		"a tick must schedule exactly one successor")
 
 	// The poll reporting no change must not schedule another on top of it.
@@ -78,7 +82,7 @@ func TestTickSustainsExactlyOneChain(t *testing.T) {
 		"PollRetryMsg must not re-arm; the tick already did")
 }
 
-// A chain cannot survive a navigation: every view declares its own TickMsg
+// A chain does not survive a navigation: every view declares its own TickMsg
 // type, so a tick belonging to a view that is no longer current is delivered to
 // a different view and dropped. Returning must therefore re-arm, or the view
 // comes back permanently stale.
@@ -88,4 +92,48 @@ func TestReturningToTheViewRestartsPolling(t *testing.T) {
 
 	require.Equal(t, 1, countChains(m, m.OnEnter()),
 		"goBack calls OnEnter and nothing else, so it has to restart the chain")
+}
+
+// firstTick runs a command and returns the tick it scheduled, so a test can
+// hold on to one chain's tick while a later entry arms another.
+func firstTick(t *testing.T, m *Model, cmd tea.Cmd) TickMsg {
+	t.Helper()
+	var found *TickMsg
+	var run func(c tea.Cmd)
+	run = func(c tea.Cmd) {
+		if c == nil || found != nil {
+			return
+		}
+		msg := c()
+		if batch, ok := msg.(tea.BatchMsg); ok {
+			for _, sub := range batch {
+				run(sub)
+			}
+			return
+		}
+		if tick, ok := msg.(TickMsg); ok {
+			found = &tick
+		}
+	}
+	run(cmd)
+	require.NotNil(t, found, "the command scheduled no tick")
+	return *found
+}
+
+// A tick armed before a drill-down must not sustain a chain after the return.
+//
+// The chain usually dies on the way out: its tick is delivered to whichever
+// view is current by then, and dropped. But one still in flight when the
+// operator returns finds this view current again, and OnEnter has already
+// armed a replacement — re-arming from both leaves the view polling at twice
+// the rate for the rest of its life.
+func TestStaleTickFromAnEarlierEntryIsDropped(t *testing.T) {
+	fastTick(t)
+	m := testModel()
+
+	stale := firstTick(t, m, m.OnEnter()) // the chain armed on the first entry
+	m.OnEnter()                           // goBack: a fresh chain
+
+	require.Equal(t, 0, countChains(m, m.Update(stale)),
+		"a tick from an earlier entry must not arm a successor")
 }

--- a/views/stacks/pollloop_test.go
+++ b/views/stacks/pollloop_test.go
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package stacksview
+
+import (
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/stretchr/testify/require"
+)
+
+// countChains runs a command — flattening tea.Batch, whose members the runtime
+// runs rather than the caller — and counts the ticks it schedules. Each
+// scheduled tick is one live poll chain, because a tick re-arms itself.
+//
+// Messages other than ticks are fed back into Update exactly once, so a load
+// that arms a tick of its own is counted too. That is the shape of the bug:
+// the arm was not in one place.
+func countChains(m *Model, cmd tea.Cmd) int {
+	chains := 0
+	var run func(c tea.Cmd, depth int)
+	run = func(c tea.Cmd, depth int) {
+		if c == nil || depth > 2 {
+			return
+		}
+		msg := c()
+		if batch, ok := msg.(tea.BatchMsg); ok {
+			for _, sub := range batch {
+				run(sub, depth)
+			}
+			return
+		}
+		if _, isTick := msg.(TickMsg); isTick {
+			chains++
+			return
+		}
+		run(m.Update(msg), depth+1)
+	}
+	run(cmd, 0)
+	return chains
+}
+
+func fastTick(t *testing.T) {
+	t.Helper()
+	original := PollInterval
+	PollInterval = time.Millisecond
+	t.Cleanup(func() { PollInterval = original })
+}
+
+// Entering a view must start exactly one poll chain.
+//
+// switchToView batches the factory's command AND OnEnter, so a view that armed
+// in both — or in a load handler reached from either — ran two chains for the
+// life of the view, polling the daemon at twice the intended rate.
+func TestEnteringTheViewArmsExactlyOneChain(t *testing.T) {
+	fastTick(t)
+	m := testModel()
+
+	// What switchToView does: the factory's command, then OnEnter.
+	entry := tea.Batch(m.Init(), m.LoadStacksCmd(m.nodeID), m.OnEnter())
+	require.Equal(t, 1, countChains(m, entry),
+		"the factory and OnEnter must not each start a chain")
+}
+
+// A tick keeps the chain alive on its own, and produces exactly one successor.
+func TestTickSustainsExactlyOneChain(t *testing.T) {
+	fastTick(t)
+	m := testModel()
+	m.Visible = true
+
+	require.Equal(t, 1, countChains(m, m.Update(TickMsg(time.Now()))),
+		"a tick must schedule exactly one successor")
+
+	// The poll reporting no change must not schedule another on top of it.
+	require.Equal(t, 0, countChains(m, m.Update(PollRetryMsg{})),
+		"PollRetryMsg must not re-arm; the tick already did")
+}
+
+// A chain cannot survive a navigation: every view declares its own TickMsg
+// type, so a tick belonging to a view that is no longer current is delivered to
+// a different view and dropped. Returning must therefore re-arm, or the view
+// comes back permanently stale.
+func TestReturningToTheViewRestartsPolling(t *testing.T) {
+	fastTick(t)
+	m := testModel()
+
+	require.Equal(t, 1, countChains(m, m.OnEnter()),
+		"goBack calls OnEnter and nothing else, so it has to restart the chain")
+}

--- a/views/stacks/update.go
+++ b/views/stacks/update.go
@@ -75,17 +75,20 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 		return tea.Batch(cmds...)
 
 	case TickMsg:
+		if msg.Gen != m.pollGen {
+			return nil // a leftover from an earlier entry — see OnEnter
+		}
 		l().Infof("StacksView: Received TickMsg, visible=%v", m.Visible)
 		// Check for changes (this will return either a Msg or PollRetryMsg)
 		if m.Visible {
 			return tea.Batch(
 				m.checkStacksCmd(m.lastSnapshot, m.nodeID),
 				m.refreshExpandedStackTasksCmd(m.expandedStacks),
-				tickCmd(),
+				tickCmd(m.pollGen),
 			)
 		}
 		// Continue polling even if not visible
-		return tickCmd()
+		return tickCmd(m.pollGen)
 
 	case PollRetryMsg:
 		// Deliberately no re-arm. The TickMsg handler above always schedules

--- a/views/stacks/update.go
+++ b/views/stacks/update.go
@@ -55,8 +55,9 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 		// Create commands that will load tasks for each stack asynchronously.
 		taskOps := m.deps.Tasks
 		var cmds []tea.Cmd
-		// Always keep the tick running
-		cmds = append(cmds, tickCmd())
+		// No re-arm: only a tick arms a tick, so a load issued by OnEnter or the
+		// factory cannot start a second, parallel chain.
+
 		for _, s := range msg.Stacks {
 			stackName := s.Name
 			// If we already have tasks cached, skip
@@ -80,13 +81,18 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 			return tea.Batch(
 				m.checkStacksCmd(m.lastSnapshot, m.nodeID),
 				m.refreshExpandedStackTasksCmd(m.expandedStacks),
+				tickCmd(),
 			)
 		}
 		// Continue polling even if not visible
 		return tickCmd()
 
 	case PollRetryMsg:
-		return tickCmd()
+		// Deliberately no re-arm. The TickMsg handler above always schedules
+		// the next tick, so re-arming here as well gives one beat two
+		// successors — and each of those does the same, so the poll rate does
+		// not merely double, it doubles again on every beat.
+		return nil
 
 	case SpinnerTickMsg:
 		m.spinner++

--- a/views/stacks/update_test.go
+++ b/views/stacks/update_test.go
@@ -70,14 +70,14 @@ func TestUpdate_Msg_LaunchesTaskFetches(t *testing.T) {
 func TestUpdate_TickMsg_WhenVisible(t *testing.T) {
 	m := testModel()
 	m.Visible = true
-	cmd := m.Update(TickMsg(time.Now()))
+	cmd := m.Update(TickMsg{Gen: m.pollGen})
 	require.NotNil(t, cmd)
 }
 
 func TestUpdate_TickMsg_WhenNotVisible(t *testing.T) {
 	m := testModel()
 	m.Visible = false
-	cmd := m.Update(TickMsg(time.Now()))
+	cmd := m.Update(TickMsg{Gen: m.pollGen})
 	// Should still return tick cmd for polling
 	require.NotNil(t, cmd)
 }

--- a/views/tasks/messages.go
+++ b/views/tasks/messages.go
@@ -16,7 +16,7 @@ type TasksLoadedMsg struct {
 	Error error
 }
 
-type TickMsg time.Time
+type TickMsg struct{ Gen uint64 }
 
 // PollRetryMsg signals that polling found no changes; the Update handler
 // should schedule the next tick.
@@ -38,9 +38,9 @@ func LoadTasksCmd(stackName string) tea.Cmd {
 	}
 }
 
-func tickCmd() tea.Cmd {
-	return tea.Tick(PollInterval, func(t time.Time) tea.Msg {
-		return TickMsg(t)
+func tickCmd(gen uint64) tea.Cmd {
+	return tea.Tick(PollInterval, func(time.Time) tea.Msg {
+		return TickMsg{Gen: gen}
 	})
 }
 

--- a/views/tasks/messages.go
+++ b/views/tasks/messages.go
@@ -22,7 +22,11 @@ type TickMsg time.Time
 // should schedule the next tick.
 type PollRetryMsg struct{}
 
-const PollInterval = 2 * time.Second
+// PollInterval is how often the view re-reads its resource. It is a var, not a
+// const, so tests can shrink it: a tea.Tick cmd invoked synchronously blocks
+// for the full interval, so a test that runs one to see what it scheduled would
+// otherwise sit here for the whole period.
+var PollInterval = 2 * time.Second
 
 func LoadTasksCmd(stackName string) tea.Cmd {
 	return func() tea.Msg {

--- a/views/tasks/model.go
+++ b/views/tasks/model.go
@@ -30,6 +30,7 @@ type Model struct {
 	sortField     SortField
 	sortAscending bool   // true for ascending, false for descending
 	lastSnapshot  uint64 // hash of last snapshot for change detection
+	pollGen       uint64 // generation of the live poll chain; see OnEnter
 }
 
 func New(width, height int, stackName string) *Model {
@@ -61,8 +62,16 @@ func (m *Model) OnEnter() tea.Cmd {
 	m.visible = true
 	// The tick is armed here, not in Init or the factory: OnEnter is the only
 	// hook that runs both on first entry and on every return from a drill-down,
-	// and a chain cannot survive a navigation (see the TickMsg handler).
-	return tea.Batch(LoadTasksCmd(m.stackName), tickCmd())
+	// and a chain does not survive a navigation — its tick is delivered to
+	// whichever view is current by then, and dropped.
+	//
+	// Each entry gets its own generation. "Does not survive" holds only once
+	// the leftover tick has fired: one armed just before a drill-down can
+	// still be in flight when the operator returns, and would find this view
+	// current again and re-arm, leaving two chains for the rest of the view's
+	// life. The generation makes it recognisable as a leftover.
+	m.pollGen++
+	return tea.Batch(LoadTasksCmd(m.stackName), tickCmd(m.pollGen))
 }
 
 func (m *Model) OnExit() tea.Cmd {

--- a/views/tasks/model.go
+++ b/views/tasks/model.go
@@ -59,7 +59,10 @@ func (m *Model) Name() string {
 
 func (m *Model) OnEnter() tea.Cmd {
 	m.visible = true
-	return LoadTasksCmd(m.stackName)
+	// The tick is armed here, not in Init or the factory: OnEnter is the only
+	// hook that runs both on first entry and on every return from a drill-down,
+	// and a chain cannot survive a navigation (see the TickMsg handler).
+	return tea.Batch(LoadTasksCmd(m.stackName), tickCmd())
 }
 
 func (m *Model) OnExit() tea.Cmd {

--- a/views/tasks/pollloop_test.go
+++ b/views/tasks/pollloop_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Eldara-Tech/swarmcli/docker"
+
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/stretchr/testify/require"
 )
@@ -56,11 +58,13 @@ func fastTick(t *testing.T) {
 // life of the view, polling the daemon at twice the intended rate.
 func TestEnteringTheViewArmsExactlyOneChain(t *testing.T) {
 	fastTick(t)
-	m := testModel()
-
-	// What switchToView does: the factory's command, then OnEnter.
-	entry := tea.Batch(m.Init(), LoadTasksCmd(m.stackName), m.OnEnter())
-	require.Equal(t, 1, countChains(m, entry),
+	// The real factory, not a hand-written stand-in for it: switchToView
+	// batches the factory's command and OnEnter, and standing in for the
+	// factory with m.Init() is how one view's second arm survived the first
+	// pass at this.
+	v, loadCmd := factory(docker.Deps{}, 80, 24, nil)
+	entered := v.(*Model)
+	require.Equal(t, 1, countChains(entered, tea.Batch(entered.Init(), loadCmd, entered.OnEnter())),
 		"the factory and OnEnter must not each start a chain")
 }
 
@@ -70,7 +74,7 @@ func TestTickSustainsExactlyOneChain(t *testing.T) {
 	m := testModel()
 	m.visible = true
 
-	require.Equal(t, 1, countChains(m, m.Update(TickMsg(time.Now()))),
+	require.Equal(t, 1, countChains(m, m.Update(TickMsg{Gen: m.pollGen})),
 		"a tick must schedule exactly one successor")
 
 	// The poll reporting no change must not schedule another on top of it.
@@ -78,7 +82,7 @@ func TestTickSustainsExactlyOneChain(t *testing.T) {
 		"PollRetryMsg must not re-arm; the tick already did")
 }
 
-// A chain cannot survive a navigation: every view declares its own TickMsg
+// A chain does not survive a navigation: every view declares its own TickMsg
 // type, so a tick belonging to a view that is no longer current is delivered to
 // a different view and dropped. Returning must therefore re-arm, or the view
 // comes back permanently stale.
@@ -88,4 +92,48 @@ func TestReturningToTheViewRestartsPolling(t *testing.T) {
 
 	require.Equal(t, 1, countChains(m, m.OnEnter()),
 		"goBack calls OnEnter and nothing else, so it has to restart the chain")
+}
+
+// firstTick runs a command and returns the tick it scheduled, so a test can
+// hold on to one chain's tick while a later entry arms another.
+func firstTick(t *testing.T, m *Model, cmd tea.Cmd) TickMsg {
+	t.Helper()
+	var found *TickMsg
+	var run func(c tea.Cmd)
+	run = func(c tea.Cmd) {
+		if c == nil || found != nil {
+			return
+		}
+		msg := c()
+		if batch, ok := msg.(tea.BatchMsg); ok {
+			for _, sub := range batch {
+				run(sub)
+			}
+			return
+		}
+		if tick, ok := msg.(TickMsg); ok {
+			found = &tick
+		}
+	}
+	run(cmd)
+	require.NotNil(t, found, "the command scheduled no tick")
+	return *found
+}
+
+// A tick armed before a drill-down must not sustain a chain after the return.
+//
+// The chain usually dies on the way out: its tick is delivered to whichever
+// view is current by then, and dropped. But one still in flight when the
+// operator returns finds this view current again, and OnEnter has already
+// armed a replacement — re-arming from both leaves the view polling at twice
+// the rate for the rest of its life.
+func TestStaleTickFromAnEarlierEntryIsDropped(t *testing.T) {
+	fastTick(t)
+	m := testModel()
+
+	stale := firstTick(t, m, m.OnEnter()) // the chain armed on the first entry
+	m.OnEnter()                           // goBack: a fresh chain
+
+	require.Equal(t, 0, countChains(m, m.Update(stale)),
+		"a tick from an earlier entry must not arm a successor")
 }

--- a/views/tasks/pollloop_test.go
+++ b/views/tasks/pollloop_test.go
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package tasksview
+
+import (
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/stretchr/testify/require"
+)
+
+// countChains runs a command — flattening tea.Batch, whose members the runtime
+// runs rather than the caller — and counts the ticks it schedules. Each
+// scheduled tick is one live poll chain, because a tick re-arms itself.
+//
+// Messages other than ticks are fed back into Update exactly once, so a load
+// that arms a tick of its own is counted too. That is the shape of the bug:
+// the arm was not in one place.
+func countChains(m *Model, cmd tea.Cmd) int {
+	chains := 0
+	var run func(c tea.Cmd, depth int)
+	run = func(c tea.Cmd, depth int) {
+		if c == nil || depth > 2 {
+			return
+		}
+		msg := c()
+		if batch, ok := msg.(tea.BatchMsg); ok {
+			for _, sub := range batch {
+				run(sub, depth)
+			}
+			return
+		}
+		if _, isTick := msg.(TickMsg); isTick {
+			chains++
+			return
+		}
+		run(m.Update(msg), depth+1)
+	}
+	run(cmd, 0)
+	return chains
+}
+
+func fastTick(t *testing.T) {
+	t.Helper()
+	original := PollInterval
+	PollInterval = time.Millisecond
+	t.Cleanup(func() { PollInterval = original })
+}
+
+// Entering a view must start exactly one poll chain.
+//
+// switchToView batches the factory's command AND OnEnter, so a view that armed
+// in both — or in a load handler reached from either — ran two chains for the
+// life of the view, polling the daemon at twice the intended rate.
+func TestEnteringTheViewArmsExactlyOneChain(t *testing.T) {
+	fastTick(t)
+	m := testModel()
+
+	// What switchToView does: the factory's command, then OnEnter.
+	entry := tea.Batch(m.Init(), LoadTasksCmd(m.stackName), m.OnEnter())
+	require.Equal(t, 1, countChains(m, entry),
+		"the factory and OnEnter must not each start a chain")
+}
+
+// A tick keeps the chain alive on its own, and produces exactly one successor.
+func TestTickSustainsExactlyOneChain(t *testing.T) {
+	fastTick(t)
+	m := testModel()
+	m.visible = true
+
+	require.Equal(t, 1, countChains(m, m.Update(TickMsg(time.Now()))),
+		"a tick must schedule exactly one successor")
+
+	// The poll reporting no change must not schedule another on top of it.
+	require.Equal(t, 0, countChains(m, m.Update(PollRetryMsg{})),
+		"PollRetryMsg must not re-arm; the tick already did")
+}
+
+// A chain cannot survive a navigation: every view declares its own TickMsg
+// type, so a tick belonging to a view that is no longer current is delivered to
+// a different view and dropped. Returning must therefore re-arm, or the view
+// comes back permanently stale.
+func TestReturningToTheViewRestartsPolling(t *testing.T) {
+	fastTick(t)
+	m := testModel()
+
+	require.Equal(t, 1, countChains(m, m.OnEnter()),
+		"goBack calls OnEnter and nothing else, so it has to restart the chain")
+}

--- a/views/tasks/register.go
+++ b/views/tasks/register.go
@@ -17,5 +17,7 @@ func init() {
 func factory(_ docker.Deps, w, h int, payload any) (view.View, tea.Cmd) {
 	stackName, _ := payload.(string)
 	model := New(w, h, stackName)
-	return model, model.OnEnter()
+	// No load and no tick: the app calls OnEnter right after this, and doing
+	// it here as well loaded twice and armed two chains.
+	return model, nil
 }

--- a/views/tasks/tasks_test.go
+++ b/views/tasks/tasks_test.go
@@ -121,7 +121,10 @@ func TestUpdate_TasksLoaded(t *testing.T) {
 	m := testModel()
 	cmd := m.Update(TasksLoadedMsg{Tasks: fakeTasks("t1", "t2")})
 	require.Len(t, m.tasks, 2)
-	require.NotNil(t, cmd) // tickCmd
+	// A load does not arm the ticker. Only OnEnter and a tick itself do, so a
+	// load issued by OnEnter or the factory cannot start a second chain
+	// alongside the one OnEnter already started.
+	require.Nil(t, cmd)
 }
 
 func TestUpdate_TasksLoaded_Error(t *testing.T) {

--- a/views/tasks/update.go
+++ b/views/tasks/update.go
@@ -34,20 +34,25 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 		}
 		// Reapply sorting to maintain sort order after data refresh
 		m.applySorting()
-		// Continue polling
-		return tickCmd()
+		// No re-arm: only a tick arms a tick, so a load issued by OnEnter or the
+		// factory cannot start a second, parallel chain.
+		return nil
 
 	case TickMsg:
 		l().Infof("TasksView: Received TickMsg, visible=%v", m.visible)
 		// Check for changes (this will return either a TasksLoadedMsg or PollRetryMsg)
 		if m.visible {
-			return CheckTasksCmd(m.lastSnapshot, m.stackName)
+			return tea.Batch(CheckTasksCmd(m.lastSnapshot, m.stackName), tickCmd())
 		}
 		// Continue polling even if not visible
 		return tickCmd()
 
 	case PollRetryMsg:
-		return tickCmd()
+		// Deliberately no re-arm. The TickMsg handler above always schedules
+		// the next tick, so re-arming here as well gives one beat two
+		// successors — and each of those does the same, so the poll rate does
+		// not merely double, it doubles again on every beat.
+		return nil
 
 	case tea.WindowSizeMsg:
 		m.width = msg.Width

--- a/views/tasks/update.go
+++ b/views/tasks/update.go
@@ -39,13 +39,16 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 		return nil
 
 	case TickMsg:
+		if msg.Gen != m.pollGen {
+			return nil // a leftover from an earlier entry — see OnEnter
+		}
 		l().Infof("TasksView: Received TickMsg, visible=%v", m.visible)
 		// Check for changes (this will return either a TasksLoadedMsg or PollRetryMsg)
 		if m.visible {
-			return tea.Batch(CheckTasksCmd(m.lastSnapshot, m.stackName), tickCmd())
+			return tea.Batch(CheckTasksCmd(m.lastSnapshot, m.stackName), tickCmd(m.pollGen))
 		}
 		// Continue polling even if not visible
-		return tickCmd()
+		return tickCmd(m.pollGen)
 
 	case PollRetryMsg:
 		// Deliberately no re-arm. The TickMsg handler above always schedules

--- a/views/volumes/messages.go
+++ b/views/volumes/messages.go
@@ -24,7 +24,7 @@ import (
 // otherwise sit here for five seconds.
 var PollInterval = 5 * time.Second
 
-type TickMsg time.Time
+type TickMsg struct{ Gen uint64 }
 
 // PollRetryMsg signals that polling found no changes; the Update handler
 // should schedule the next tick.

--- a/views/volumes/messages.go
+++ b/views/volumes/messages.go
@@ -18,7 +18,11 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 )
 
-const PollInterval = 5 * time.Second
+// PollInterval is how often the view re-reads its resource. It is a var, not a
+// const, so tests can shrink it: a tea.Tick cmd invoked synchronously blocks
+// for the full interval, so a test that runs one to see what it scheduled would
+// otherwise sit here for five seconds.
+var PollInterval = 5 * time.Second
 
 type TickMsg time.Time
 

--- a/views/volumes/model.go
+++ b/views/volumes/model.go
@@ -116,7 +116,7 @@ func (m *Model) Name() string { return ViewName }
 
 func (m *Model) Init() tea.Cmd {
 	l().Info("VolumesView: Init() called - starting ticker and loading volumes")
-	return tea.Batch(tickCmd(), m.spinnerTickCmd(), m.loadVolumesCmd())
+	return tea.Batch(m.spinnerTickCmd(), m.loadVolumesCmd())
 }
 
 func (m *Model) spinnerTickCmd() tea.Cmd {
@@ -202,7 +202,10 @@ func (m *Model) OnEnter() tea.Cmd {
 	m.resetCursorOnNextLoad = true
 	m.volumesList.Cursor = 0
 	m.volumesList.Viewport.YOffset = 0
-	return m.loadVolumesCmd()
+	// The tick is armed here, not in Init or the factory: OnEnter is the only
+	// hook that runs both on first entry and on every return from a drill-down,
+	// and a chain cannot survive a navigation (see the TickMsg handler).
+	return tea.Batch(m.loadVolumesCmd(), tickCmd())
 }
 
 func (m *Model) OnExit() tea.Cmd {

--- a/views/volumes/model.go
+++ b/views/volumes/model.go
@@ -42,6 +42,7 @@ type Model struct {
 	height        int
 	firstResize   bool
 	lastSnapshot  uint64
+	pollGen       uint64 // generation of the live poll chain; see OnEnter
 	visible       bool
 	sortField     SortField
 	sortAscending bool
@@ -125,9 +126,9 @@ func (m *Model) spinnerTickCmd() tea.Cmd {
 	})
 }
 
-func tickCmd() tea.Cmd {
-	return tea.Tick(PollInterval, func(t time.Time) tea.Msg {
-		return TickMsg(t)
+func tickCmd(gen uint64) tea.Cmd {
+	return tea.Tick(PollInterval, func(time.Time) tea.Msg {
+		return TickMsg{Gen: gen}
 	})
 }
 
@@ -204,8 +205,16 @@ func (m *Model) OnEnter() tea.Cmd {
 	m.volumesList.Viewport.YOffset = 0
 	// The tick is armed here, not in Init or the factory: OnEnter is the only
 	// hook that runs both on first entry and on every return from a drill-down,
-	// and a chain cannot survive a navigation (see the TickMsg handler).
-	return tea.Batch(m.loadVolumesCmd(), tickCmd())
+	// and a chain does not survive a navigation — its tick is delivered to
+	// whichever view is current by then, and dropped.
+	//
+	// Each entry gets its own generation. "Does not survive" holds only once
+	// the leftover tick has fired: one armed just before a drill-down can
+	// still be in flight when the operator returns, and would find this view
+	// current again and re-arm, leaving two chains for the rest of the view's
+	// life. The generation makes it recognisable as a leftover.
+	m.pollGen++
+	return tea.Batch(m.loadVolumesCmd(), tickCmd(m.pollGen))
 }
 
 func (m *Model) OnExit() tea.Cmd {

--- a/views/volumes/pollloop_test.go
+++ b/views/volumes/pollloop_test.go
@@ -85,3 +85,59 @@ func TestPollLoopDoesNotMultiply(t *testing.T) {
 	require.True(t, polled, "the fixture must actually poll, or this proves nothing")
 	require.Len(t, pending, 1, "and the loop must still be alive at the end")
 }
+
+// countChains runs a command — flattening tea.Batch, whose members the runtime
+// runs rather than the caller — and counts the ticks it schedules. Each
+// scheduled tick is one live poll chain, because a tick re-arms itself.
+func countChains(m *Model, cmd tea.Cmd) int {
+	chains := 0
+	var run func(c tea.Cmd, depth int)
+	run = func(c tea.Cmd, depth int) {
+		if c == nil || depth > 2 {
+			return
+		}
+		msg := c()
+		if batch, ok := msg.(tea.BatchMsg); ok {
+			for _, sub := range batch {
+				run(sub, depth)
+			}
+			return
+		}
+		if _, isTick := msg.(TickMsg); isTick {
+			chains++
+			return
+		}
+		if _, isSpinner := msg.(SpinnerTickMsg); isSpinner {
+			return
+		}
+		run(m.Update(msg), depth+1)
+	}
+	run(cmd, 0)
+	return chains
+}
+
+// Entering a view must start exactly one poll chain. switchToView batches the
+// factory's command AND OnEnter, so a view arming in both ran two chains for
+// its whole life, polling the daemon at twice the intended rate.
+func TestEnteringTheViewArmsExactlyOneChain(t *testing.T) {
+	original := PollInterval
+	PollInterval = time.Millisecond
+	t.Cleanup(func() { PollInterval = original })
+
+	m := testModel()
+	require.Equal(t, 1, countChains(m, tea.Batch(m.Init(), m.OnEnter())),
+		"the factory and OnEnter must not each start a chain")
+}
+
+// A chain cannot survive a navigation: every view declares its own TickMsg
+// type, so a tick belonging to a view that is no longer current is delivered to
+// a different view and dropped. Returning must therefore re-arm, or the view
+// comes back permanently stale. goBack calls OnEnter and nothing else.
+func TestReturningToTheViewRestartsPolling(t *testing.T) {
+	original := PollInterval
+	PollInterval = time.Millisecond
+	t.Cleanup(func() { PollInterval = original })
+
+	m := testModel()
+	require.Equal(t, 1, countChains(m, m.OnEnter()))
+}

--- a/views/volumes/pollloop_test.go
+++ b/views/volumes/pollloop_test.go
@@ -75,7 +75,7 @@ func TestPollLoopDoesNotMultiply(t *testing.T) {
 	m.Update(VolumesLoadedMsg{Volumes: toVolumeItems(vols)})
 	require.Equal(t, stateReady, m.state)
 
-	pending := []tea.Cmd{tickCmd()}
+	pending := []tea.Cmd{tickCmd(m.pollGen)}
 	for round := 0; round < 12; round++ {
 		pending = drivePoll(m, pending)
 		require.LessOrEqual(t, len(pending), 1,
@@ -125,11 +125,18 @@ func TestEnteringTheViewArmsExactlyOneChain(t *testing.T) {
 	t.Cleanup(func() { PollInterval = original })
 
 	m := testModel()
-	require.Equal(t, 1, countChains(m, tea.Batch(m.Init(), m.OnEnter())),
+
+	// The real factory, not a hand-written stand-in for it: switchToView
+	// batches the factory's command and OnEnter, and standing in for the
+	// factory with m.Init() is how one view's second arm survived the first
+	// pass at this.
+	v, loadCmd := factory(m.deps, 80, 24, nil)
+	entered := v.(*Model)
+	require.Equal(t, 1, countChains(entered, tea.Batch(entered.Init(), loadCmd, entered.OnEnter())),
 		"the factory and OnEnter must not each start a chain")
 }
 
-// A chain cannot survive a navigation: every view declares its own TickMsg
+// A chain does not survive a navigation: every view declares its own TickMsg
 // type, so a tick belonging to a view that is no longer current is delivered to
 // a different view and dropped. Returning must therefore re-arm, or the view
 // comes back permanently stale. goBack calls OnEnter and nothing else.
@@ -140,4 +147,50 @@ func TestReturningToTheViewRestartsPolling(t *testing.T) {
 
 	m := testModel()
 	require.Equal(t, 1, countChains(m, m.OnEnter()))
+}
+
+// firstTick runs a command and returns the tick it scheduled, so a test can
+// hold on to one chain's tick while a later entry arms another.
+func firstTick(t *testing.T, m *Model, cmd tea.Cmd) TickMsg {
+	t.Helper()
+	var found *TickMsg
+	var run func(c tea.Cmd)
+	run = func(c tea.Cmd) {
+		if c == nil || found != nil {
+			return
+		}
+		msg := c()
+		if batch, ok := msg.(tea.BatchMsg); ok {
+			for _, sub := range batch {
+				run(sub)
+			}
+			return
+		}
+		if tick, ok := msg.(TickMsg); ok {
+			found = &tick
+		}
+	}
+	run(cmd)
+	require.NotNil(t, found, "the command scheduled no tick")
+	return *found
+}
+
+// A tick armed before a drill-down must not sustain a chain after the return.
+//
+// The chain usually dies on the way out: its tick is delivered to whichever
+// view is current by then, and dropped. But one still in flight when the
+// operator returns finds this view current again, and OnEnter has already
+// armed a replacement — re-arming from both leaves the view polling at twice
+// the rate for the rest of its life.
+func TestStaleTickFromAnEarlierEntryIsDropped(t *testing.T) {
+	original := PollInterval
+	PollInterval = time.Millisecond
+	t.Cleanup(func() { PollInterval = original })
+	m := testModel()
+
+	stale := firstTick(t, m, m.OnEnter()) // the chain armed on the first entry
+	m.OnEnter()                           // goBack: a fresh chain
+
+	require.Equal(t, 0, countChains(m, m.Update(stale)),
+		"a tick from an earlier entry must not arm a successor")
 }

--- a/views/volumes/pollloop_test.go
+++ b/views/volumes/pollloop_test.go
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package volumesview
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/Eldara-Tech/swarmcli/docker"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/stretchr/testify/require"
+)
+
+// drivePoll models the bubbletea runtime for one round: run each pending
+// command, flattening tea.Batch — whose members the runtime runs, not the
+// caller — feed every resulting message back into Update, and return the
+// commands that came out.
+//
+// Flattening is the point. Asserting on the command Update returns cannot see
+// past a batch, nor see a successor that arrives one message later, so a test
+// written that way passes whatever the loop actually does.
+func drivePoll(m *Model, pending []tea.Cmd) []tea.Cmd {
+	var next []tea.Cmd
+	var run func(c tea.Cmd)
+	run = func(c tea.Cmd) {
+		if c == nil {
+			return
+		}
+		msg := c()
+		if batch, ok := msg.(tea.BatchMsg); ok {
+			for _, sub := range batch {
+				run(sub)
+			}
+			return
+		}
+		if _, isSpinner := msg.(SpinnerTickMsg); isSpinner {
+			return // not part of the poll loop
+		}
+		if cmd := m.Update(msg); cmd != nil {
+			next = append(next, cmd)
+		}
+	}
+	for _, c := range pending {
+		run(c)
+	}
+	return next
+}
+
+// The poll loop must be a loop, not a tree.
+//
+// A tick that starts a poll and re-arms the ticker, while the poll's "nothing
+// changed" result re-arms it too, yields two successors per beat — and each of
+// those does the same. An idle view left open climbs into thousands of
+// concurrent Docker reads within a minute.
+func TestPollLoopDoesNotMultiply(t *testing.T) {
+	original := PollInterval
+	PollInterval = time.Millisecond
+	t.Cleanup(func() { PollInterval = original })
+
+	// Steady state: the poll finds exactly what is already loaded, so it
+	// reports no change. That is what a view left open does all day.
+	vols := []docker.VolumeInfo{{Name: "v1", Driver: "local"}}
+	polled := false
+	m := testModel(func(m *Model) {
+		m.deps = docker.Deps{Volumes: &mockVolumeOps{
+			listVolumesFn: func(_ context.Context) ([]docker.VolumeInfo, error) {
+				polled = true
+				return vols, nil
+			},
+		}}
+	})
+	m.Update(VolumesLoadedMsg{Volumes: toVolumeItems(vols)})
+	require.Equal(t, stateReady, m.state)
+
+	pending := []tea.Cmd{tickCmd()}
+	for round := 0; round < 12; round++ {
+		pending = drivePoll(m, pending)
+		require.LessOrEqual(t, len(pending), 1,
+			"round %d: %d commands in flight — the loop has branched", round, len(pending))
+		time.Sleep(2 * time.Millisecond)
+	}
+	require.True(t, polled, "the fixture must actually poll, or this proves nothing")
+	require.Len(t, pending, 1, "and the loop must still be alive at the end")
+}

--- a/views/volumes/update.go
+++ b/views/volumes/update.go
@@ -90,7 +90,11 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 		return tickCmd()
 
 	case PollRetryMsg:
-		return tickCmd()
+		// Deliberately no re-arm. The TickMsg handler above always schedules
+		// the next tick, so re-arming here as well gives one beat two
+		// successors — and each of those does the same, so the poll rate does
+		// not merely double, it doubles again on every beat.
+		return nil
 
 	case tea.KeyMsg:
 		if m.errorDialogActive {

--- a/views/volumes/update.go
+++ b/views/volumes/update.go
@@ -84,10 +84,13 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 		return m.handleVolumesLoaded(msg)
 
 	case TickMsg:
-		if m.visible && m.state == stateReady && !m.errorDialogActive {
-			return tea.Batch(m.checkVolumesCmd(m.lastSnapshot), tickCmd())
+		if msg.Gen != m.pollGen {
+			return nil // a leftover from an earlier entry — see OnEnter
 		}
-		return tickCmd()
+		if m.visible && m.state == stateReady && !m.errorDialogActive {
+			return tea.Batch(m.checkVolumesCmd(m.lastSnapshot), tickCmd(m.pollGen))
+		}
+		return tickCmd(m.pollGen)
 
 	case PollRetryMsg:
 		// Deliberately no re-arm. The TickMsg handler above always schedules


### PR DESCRIPTION
Follow-up to #573, which found the first of these by inheriting it. Independent
of that PR — this branches off `main` and touches no file it touches.

Two commits, two defects, one rule.

## 1. The poll loop branched (`volumes`, `configs`, `secrets`, `networks`)

Each re-armed its ticker **twice per beat**:

```go
case TickMsg:
    if …ready… {
        return tea.Batch(m.checkXCmd(m.lastSnapshot), tickCmd())  // successor #1
    }
    return tickCmd()

case PollRetryMsg:      // ← what checkXCmd returns when nothing changed
    return tickCmd()    // successor #2
```

Nothing changing is the steady state of a browser left open, so this is the
common path. Driving the message loop by hand, an idle view goes
**1, 1, 2, 3, 5, 8, 13** ticks per round — within a minute it is thousands of
concurrent Docker reads, with no ceiling. Each read lists every
config/secret/network/volume on the daemon.

## 2. Then measuring the other four turned up the same rule broken again

- **Two chains from startup.** `switchToView` batches the factory's command
  *and* `OnEnter()`, and several views armed in both — or in a load handler
  reachable from either. `nodes` ran two chains for the life of the view
  (measured), as did `stacks` and `services`: twice the intended poll rate.

- **Polling stopped after a round trip.** Every view declares its own `TickMsg`
  type, and the app never broadcasts — it only calls `currentView.Update`. So a
  tick belonging to a view that is no longer current is delivered elsewhere and
  dropped: **a chain cannot survive a navigation.** Views arming only in `Init`
  — including the four from defect 1 — came back from a drill-down permanently
  stale, never polling again. `nodes` was the worst case, its `OnEnter`
  returning `nil`.

## The rule

**The tick is armed in `OnEnter`, and only a tick arms a tick.**

`OnEnter` is the one hook that runs on first entry (`switchToView`) and on every
return (`goBack`), exactly once each. `Init` and the factory no longer arm, so
entry cannot start two. Load handlers no longer arm, so a refresh cannot start
another. `PollRetryMsg` keeps its type — it is still the honest "no change"
signal — and simply stops re-arming.

Applied to all eight polling views: `volumes`, `configs`, `secrets`,
`networks`, `nodes`, `stacks`, `tasks`, `services`.

## Tests

Three regression tests per view, all of which **flatten `tea.Batch`**. That
flattening is the point, and is why this survived review in the first place: a
test asserting on the command `Update` returns cannot see past a batch, nor see
a successor that arrives one message later. (My own first attempt at this test
in #573 had exactly that flaw and passed against the broken code.)

- the loop does not multiply over 12 rounds, and still polls
- entering arms exactly one chain
- returning restarts one

Every one was mutation-tested — the fixes were reverted, in two separate views
for the entry test, and the tests fail. One pre-existing test in `views/tasks`
asserted that a load *does* arm a tick; it encoded the bug and is updated with
a comment saying so.

`PollInterval` becomes a `var` in each view, as `spinnerTickInterval` already
is in the tree: a `tea.Tick` cmd invoked synchronously blocks for the full
interval, so a test that runs one to see what it scheduled would otherwise sit
there for seconds.

## 3. Closing the gap: every tick carries its generation

The first pass left one hole open, and this branch now closes it rather than
documenting it.

"A chain cannot survive a navigation" only holds **once the tick has fired**. A
tick armed just before a drill-down can still be in flight when the operator
comes back, and it then finds the view current again and re-arms — alongside
the chain `OnEnter` just started. Nothing in the model could tell the two
apart, so the tick itself now says which entry armed it:

```go
type TickMsg struct{ Gen uint64 }

case TickMsg:
    if msg.Gen != m.pollGen {
        return nil // a leftover from an earlier entry
    }
```

`OnEnter` increments `pollGen` on every entry. A leftover is inert.

Measuring for that turned up three more arms the first pass had missed:

- **`services`' factory armed a tick of its own** (`register.go`), so entering
  the view started two chains — the exact defect §2 claims to have fixed. It
  survived because the entry test stood in for the factory with `m.Init()`
  instead of calling it. Every view's entry test now drives the **real
  factory**, which is what `switchToView` does.
- **`tasks`' factory called `OnEnter()` itself** and returned it as the load
  command, so entry loaded twice and armed twice.
- **`charts` and `contexts` had the inverse defect** — they never double-armed,
  they stopped polling. `charts` (from #573, on `main`) guards its ticker with
  a `tickScheduled` flag that only an *arriving* tick clears; a tick dropped on
  the way out of the view left the flag set forever, so `armTick` declined and
  the view never polled again after the first drill-down. `contexts` armed in
  its factory and not in `OnEnter`, which is all `goBack` runs. Both now arm
  per generation in `OnEnter`; `charts` keeps its flag, which still does its
  own job of collapsing the several paths that re-arm after a poll result.

That makes it ten polling views on one rule, not eight.

Two more regression tests per view, mutation-tested like the rest:

- a tick from an earlier entry arms no successor (fails with the guard removed:
  1 chain instead of 0)
- `charts` restarts polling on re-entry (fails without the flag reset: 0 chains
  instead of 1)

and the entry test now calls the real factory (fails with `services`' factory
arm restored: 2 chains instead of 1).

## Base

Merged `main` (`af7eb2e`) into the branch — no conflicts. `go build`, `go vet`,
`go test ./...` and `golangci-lint run ./... --build-tags=integration` are
clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

