### PR TITLE
docs(features): the shell names its detach key in the terminal title

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -38,6 +38,17 @@ scrolls away with the output like any other line:
 <<SWC-Shell>> Service: <stack>/<service> | Host: <node>        ctrl+] exit
 ```
 
+For as long as the session is attached, your terminal's title names it and the
+key that leaves it:
+
+```
+SwarmCLI: <stack>/<service> — ctrl+] detach
+```
+
+Unlike the header, the title does not scroll away, and it stays put while a
+full-screen program is running. Your own title comes back when you detach.
+Terminals that show no title are the exception, as is `vim`, which sets its own.
+
 To leave the shell:
 
 - **`Ctrl+]`** detaches immediately and returns to the TUI. Use this when a


### PR DESCRIPTION
Documents the terminal-title hint added by Eldara-Tech/swarmcli-be#318, the follow-up to the discoverability gap noted when closing #553.

**Hold until swarmcli-be#318 merges and ships.** This page describes released behaviour; merging it first would document something no build does yet. Same hold that [swarmcli-be-releases#17](https://github.com/Eldara-Tech/swarmcli-be-releases/pull/17) was kept under until the terminal handover shipped — the difference is that the page now lives here, so it cannot be stranded by a move this time.

## Why

The header carries `ctrl+] exit` once and then scrolls away with the output, which is what makes it a header rather than the fixed frame #258 asked us to stop drawing. It is therefore gone in exactly the case where the key is hardest to recall: a full-screen program in the container has taken the alternate screen, so the header is not merely scrolled off but on the other buffer — and `exit` / `Ctrl+D`, which this section leads with, do not apply either, because that program owns the keyboard.

The new title sits outside both buffers and survives all of it. This paragraph goes next to the header it complements, immediately before "To leave the shell", which is where a reader who wants out will actually be looking.

## Boundary

Behaviour only — what the operator sees, and that their own title comes back on detach. No OSC sequences, no title stack, no mention of who writes it. That follows the note in #558 about the resize sentence describing mechanism rather than behaviour.

The honest limits are stated rather than omitted: terminals with no title bar, and `vim`, which sets its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)