### PR TITLE
feat(services): container statistics keybinding, and header memory matching docker stats

### DIFF
--- a/docker/info.go
+++ b/docker/info.go
@@ -209,6 +209,26 @@ func GetSwarmCPUUsage() (string, error) {
 	return result, nil
 }
 
+// memUsageNoCache is the memory figure `docker stats` reports: the cgroup's
+// usage less the page cache, which is reclaimable and so is not the container's
+// working set. cgroup v1 names that quantity total_inactive_file and cgroup v2
+// names it inactive_file; either is subtracted only when it is smaller than
+// Usage, which is how docker/cli guards a counter the host did not supply.
+//
+// Without the subtraction the header reads high — by the whole page cache — and
+// disagrees with `docker stats` and with every other view of the same number.
+func memUsageNoCache(mem container.MemoryStats) uint64 {
+	// cgroup v1
+	if v, isCgroup1 := mem.Stats["total_inactive_file"]; isCgroup1 && v < mem.Usage {
+		return mem.Usage - v
+	}
+	// cgroup v2
+	if v := mem.Stats["inactive_file"]; v < mem.Usage {
+		return mem.Usage - v
+	}
+	return mem.Usage
+}
+
 // GetSwarmMemUsage returns actual memory usage across running containers.
 func GetSwarmMemUsage() (string, error) {
 	c, err := GetClient()
@@ -269,7 +289,7 @@ func GetSwarmMemUsage() (string, error) {
 				return
 			}
 
-			results <- memResult{usage: int64(s.MemoryStats.Usage)}
+			results <- memResult{usage: int64(memUsageNoCache(s.MemoryStats))}
 		}(cont.ID)
 	}
 
@@ -387,7 +407,7 @@ func GetSwarmResourceUsage() (cpuPct string, memPct string, err error) {
 				cpuPct = (cpuDelta / systemDelta) * onlineCPUs * 100.0
 			}
 
-			results <- result{cpuPercent: cpuPct, memUsage: int64(s.MemoryStats.Usage)}
+			results <- result{cpuPercent: cpuPct, memUsage: int64(memUsageNoCache(s.MemoryStats))}
 		}(cont.ID)
 	}
 

--- a/docker/info_test.go
+++ b/docker/info_test.go
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package docker
+
+import (
+	"testing"
+
+	"github.com/docker/docker/api/types/container"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMemUsageNoCache(t *testing.T) {
+	const usage = 500
+
+	cases := []struct {
+		name  string
+		stats map[string]uint64
+		usage uint64
+		want  uint64
+	}{
+		{
+			name:  "cgroup v1 subtracts total_inactive_file",
+			stats: map[string]uint64{"total_inactive_file": 100, "inactive_file": 400},
+			usage: usage,
+			want:  400,
+		},
+		{
+			name:  "cgroup v2 subtracts inactive_file",
+			stats: map[string]uint64{"inactive_file": 120},
+			usage: usage,
+			want:  380,
+		},
+		{
+			// A counter at least as large as Usage is not a page-cache figure we
+			// can trust, so it is ignored rather than producing an underflow.
+			name:  "v1 counter not smaller than usage is ignored",
+			stats: map[string]uint64{"total_inactive_file": usage},
+			usage: usage,
+			want:  usage,
+		},
+		{
+			name:  "v2 counter not smaller than usage is ignored",
+			stats: map[string]uint64{"inactive_file": usage + 1},
+			usage: usage,
+			want:  usage,
+		},
+		{
+			name:  "no cache counters reported",
+			stats: map[string]uint64{},
+			usage: usage,
+			want:  usage,
+		},
+		{
+			name:  "nil stats map",
+			stats: nil,
+			usage: usage,
+			want:  usage,
+		},
+		{
+			name:  "stopped container reports nothing",
+			stats: nil,
+			usage: 0,
+			want:  0,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := memUsageNoCache(container.MemoryStats{Usage: c.usage, Stats: c.stats})
+			require.Equal(t, c.want, got)
+		})
+	}
+}
+
+// The header must report what `docker stats` reports. A raw MemoryStats.Usage
+// counts the page cache, which is reclaimable, and reads high by exactly the
+// amount this test pins.
+func TestMemUsageNoCache_DiffersFromRawUsage(t *testing.T) {
+	m := container.MemoryStats{Usage: 1 << 30, Stats: map[string]uint64{"inactive_file": 768 << 20}}
+	require.Equal(t, uint64(256<<20), memUsageNoCache(m))
+	require.NotEqual(t, m.Usage, memUsageNoCache(m))
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -30,7 +30,7 @@ features a licence unlocks. On top of the Community Edition it adds:
 - [Bootstrap](bootstrap.md) — `:bootstrap` end-to-end: what gets deployed and how.
 - [Migration](migration.md) — moving an existing stack to application-layer mTLS (`:bootstrap --migrate`).
 - [RBAC](rbac.md) — managing users, roles, onboarding, and revocation.
-- [Features](features.md) — shell and reveal-secret in detail.
+- [Features](features.md) — shell, reveal-secret, port-forward and container statistics in detail.
 - [Volumes](volumes.md) — listing across nodes, create/delete/prune, in-volume file browser.
 - [Charts](../charts/README.md) — the chart package manager both editions ship: repositories, install/upgrade, and declarative releases (`charts apply`, `charts outdated`).
 - [Configuration](configuration.md) — environment variables and on-disk paths for both editions.

--- a/docs/features.md
+++ b/docs/features.md
@@ -5,8 +5,8 @@ Copyright © 2026 Eldara Tech
 
 # Pro features
 
-Three license-gated capabilities ride on top of the standard SwarmCLI TUI.
-All three require:
+Four license-gated capabilities ride on top of the standard SwarmCLI TUI.
+All of them require:
 
 - A valid (or in-grace) Business Edition license — see [License](license.md).
 - A managed Docker context (i.e. a Swarm that has been put through
@@ -260,14 +260,79 @@ See [RBAC — Roles](rbac.md#roles).
 | `forward closed: agent disconnected` | The on-node agent is down or its network path broke. Check `:bootstrap --check`. |
 | `forward target task is no longer running` | The container restarted or moved nodes. Reopen the forward. |
 
+## Container statistics
+
+Press `t` on any row in the Services view to graph one container's CPU,
+memory, network and block I/O over time. Press `p` first to expand a
+service's tasks and the graph opens on the replica you highlighted;
+from the service row it opens on the first.
+
+The last fifteen minutes are already there when the view opens. Each
+node collects its containers' usage in the background while SwarmCLI is
+connected, so you are looking at what happened *before* you went to
+look — not at a graph that starts filling in from the moment you arrive.
+
+### Reading the view
+
+Four panes: **CPU**, **MEM**, **NET rx/tx** and **BLK r/w**. Each names
+its current, average and peak value for the span on screen.
+
+| Key | Action |
+|---|---|
+| `w` | Cycle the span: 1 minute → 5 minutes → 15 minutes |
+| `p` | Pause. The graph freezes so a spike can be read; press again to catch up |
+| `n` / `N` | Step to the next / previous replica of the same service |
+| `Esc` | Back |
+
+The memory pane is scaled to the container's **own** limit when its
+service declares one (`deploy.resources.limits.memory`), so the graph
+answers "how close is this to being killed". A container with no limit
+is scaled to its own peak instead, and the pane is titled `MEM` rather
+than `MEM / <limit>` — the daemon reports the whole host's memory as an
+unconstrained container's limit, and a percentage of that would tell you
+nothing about the container.
+
+CPU is the same figure `docker stats` reports, and is scaled by core
+count: a container fully using two cores reads 200%.
+
+Below about 90 columns the four panes stack into one column and as many
+as fit are drawn.
+
+### What is measured, and what is not
+
+A pane reads **`not reported by this host`** when the host does not
+publish that metric at all — a container on the host network has no
+per-interface counters, and some systems publish no block-I/O counters.
+That is deliberately distinct from a flat line at zero, which means the
+container really did nothing.
+
+A container that restarts inside the window leaves a short gap rather
+than a spike: its counters begin again from zero, and a rate derived
+across that reset would be fiction.
+
+The graph is a viewer, not a monitoring system. Fifteen minutes is what
+the nodes hold; if you need history beyond that, or alerting, run a
+metrics stack (cAdvisor, Prometheus) alongside.
+
+### Failure modes
+
+| What you see | Cause |
+|---|---|
+| `Stats (BE)`, greyed out | No valid license; open `:license`. |
+| `Container statistics need up-to-date infrastructure` | The deployed agent predates this feature. Re-run `:bootstrap`. |
+| `Container statistics need a bootstrapped Docker context` | The current context talks to a daemon directly. `:contexts` to switch, or `:bootstrap`. |
+| `No samples yet` | The node has just started collecting. It fills in within a few seconds. |
+| `service … has no running tasks` | Nothing is running to measure. |
+
 ## Where the gates live
 
-All three features are license-gated — each is enabled only when the
+All four features are license-gated — each is enabled only when the
 active license grants it:
 
 - Shell
 - Reveal-secret
 - Port-forward
+- Container statistics
 
 Tier-to-feature mapping is centralised: today, both `be` and `trial`
-tiers grant all three features. See [License — Model](license.md#model).
+tiers grant all four features. See [License — Model](license.md#model).

--- a/docs/features.md
+++ b/docs/features.md
@@ -301,10 +301,21 @@ as fit are drawn.
 ### What is measured, and what is not
 
 A pane reads **`not reported by this host`** when the host does not
-publish that metric at all — a container on the host network has no
-per-interface counters, and some systems publish no block-I/O counters.
-That is deliberately distinct from a flat line at zero, which means the
-container really did nothing.
+publish that metric at all. That is deliberately distinct from a flat
+line at zero, which means the container really did nothing.
+
+Common reasons:
+
+| Pane | Why it may be unavailable |
+|---|---|
+| NET | The container runs on the host network, so it has no per-interface counters of its own. |
+| MEM, BLK | Memory and block I/O both come from cgroup controllers. If the controllers are not delegated to the container's cgroup, the daemon has nothing to report. This is usual under rootless Docker and under Docker-in-Docker, and happens on any host whose cgroup hierarchy does not enable `memory` and `io` for the slice Docker runs in. |
+
+To confirm it is the host rather than SwarmCLI, run `docker stats` against
+the same container on that node: it reads the same daemon fields, so it
+shows the same gaps. `docker info` also prints a warning line per missing
+controller (`No memory limit support`, and similar) at the end of its
+output.
 
 A container that restarts inside the window leaves a short gap rather
 than a spike: its counters begin again from zero, and a rate derived

--- a/views/services/model.go
+++ b/views/services/model.go
@@ -147,6 +147,7 @@ func (m *Model) ShortHelpItems() []helpbar.HelpEntry {
 		{Key: "x", Desc: view.BEHelpDesc("shell", "Shell"), Disabled: !view.HasAction("shell")},
 		{Key: "w", Desc: view.BEHelpDesc("port-forwards", "Active Forwards"), Disabled: !view.HasAction("port-forwards")},
 		{Key: "shift+w", Desc: view.BEHelpDesc("port-forward", "Port Forward"), Disabled: !view.HasAction("port-forward")},
+		{Key: "t", Desc: view.BEHelpDesc("container-stats", "Stats"), Disabled: !view.HasAction("container-stats")},
 		{Key: "/", Desc: "Filter"},
 		{Key: "?", Desc: "Help"},
 		{Key: "esc", Desc: "Back"},

--- a/views/services/model_test.go
+++ b/views/services/model_test.go
@@ -748,6 +748,8 @@ func TestShortHelpItems_IncludesShellAndPortForward(t *testing.T) {
 	require.Contains(t, keys["x"], "(BE)")
 	require.Contains(t, keys, "w")
 	require.Contains(t, keys["w"], "(BE)")
+	require.Contains(t, keys, "t")
+	require.Contains(t, keys["t"], "(BE)")
 }
 
 func TestKey_X_NoAction_ShowsBEDialog(t *testing.T) {
@@ -836,4 +838,84 @@ func TestGetServicesHelpContent_IncludesBEActions(t *testing.T) {
 	require.True(t, found["<x>"])
 	require.True(t, found["<w>"])
 	require.True(t, found["<shift+w>"])
+	require.True(t, found["<t>"])
+}
+
+func TestKey_T_ServiceRow_PassesServiceAndNoTask(t *testing.T) {
+	got := ""
+	view.RegisterAction("container-stats", func(ref string) tea.Cmd {
+		return func() tea.Msg { got = ref; return nil }
+	})
+	defer view.UnregisterActionForTest("container-stats")
+
+	m := testModel()
+	loadServices(m, fakeEntries("web"))
+	cmd := m.Update(key("t"))
+	require.NotNil(t, cmd)
+	runCmd(cmd)
+	// Empty task field: the cursor is on the service row, so the extension
+	// picks the replica rather than this view guessing one.
+	require.Equal(t, []string{"web", ""}, view.DecodeRef(got))
+}
+
+func TestKey_T_TaskRow_PassesThatReplicasTaskID(t *testing.T) {
+	got := ""
+	view.RegisterAction("container-stats", func(ref string) tea.Cmd {
+		return func() tea.Msg { got = ref; return nil }
+	})
+	defer view.UnregisterActionForTest("container-stats")
+
+	m := testModel()
+	loadServices(m, fakeEntries("web"))
+	m.expandedServices["id-web"] = true
+	m.serviceTasks["id-web"] = []docker.TaskEntry{{ID: "task-a"}, {ID: "task-b"}}
+	m.selectedTaskIndex = 1
+
+	cmd := m.Update(key("t"))
+	require.NotNil(t, cmd)
+	runCmd(cmd)
+	require.Equal(t, []string{"web", "task-b"}, view.DecodeRef(got))
+}
+
+// The task list is refreshed on a 2s poll while a task row stays selected, so
+// the index can outlive the row it named. That must read as "no replica
+// picked", not index a slice that shrank.
+func TestKey_T_StaleTaskIndex_FallsBackToService(t *testing.T) {
+	got := ""
+	view.RegisterAction("container-stats", func(ref string) tea.Cmd {
+		return func() tea.Msg { got = ref; return nil }
+	})
+	defer view.UnregisterActionForTest("container-stats")
+
+	m := testModel()
+	loadServices(m, fakeEntries("web"))
+	m.expandedServices["id-web"] = true
+	m.serviceTasks["id-web"] = []docker.TaskEntry{{ID: "task-a"}}
+	m.selectedTaskIndex = 3
+
+	cmd := m.Update(key("t"))
+	require.NotNil(t, cmd)
+	runCmd(cmd)
+	require.Equal(t, []string{"web", ""}, view.DecodeRef(got))
+}
+
+func TestKey_T_NoAction_ShowsBEDialog(t *testing.T) {
+	m := testModel()
+	loadServices(m, fakeEntries("web"))
+	m.Update(key("t"))
+	require.True(t, m.confirmDialog.Visible)
+	require.True(t, m.confirmDialog.ErrorMode)
+	require.Contains(t, m.confirmDialog.Message, "Stats")
+	require.Contains(t, m.confirmDialog.Message, "swarmcli.io/be")
+}
+
+func TestKey_T_NoSelection_NoOp(t *testing.T) {
+	view.RegisterAction("container-stats", func(string) tea.Cmd {
+		return func() tea.Msg { return nil }
+	})
+	defer view.UnregisterActionForTest("container-stats")
+
+	m := testModel() // empty list
+	require.Nil(t, m.Update(key("t")))
+	require.False(t, m.confirmDialog.Visible)
 }

--- a/views/services/update.go
+++ b/views/services/update.go
@@ -450,49 +450,33 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 				return nil
 			}
 			entry := m.List.Filtered[m.List.Cursor]
-			action, ok := view.GetAction("shell")
-			if !ok {
-				if cmd := view.FeatureLockedCmd("Shell"); cmd != nil {
-					return cmd
-				}
-				m.confirmDialog.Visible = true
-				m.confirmDialog.ErrorMode = true
-				m.confirmDialog.Message = view.BEUnavailableErr("Shell").Error()
-				return nil
-			}
-			return action(entry.ServiceName)
+			return m.dispatchAction("shell", "Shell", entry.ServiceName)
 		case "w":
 			if m.List.Cursor >= len(m.List.Filtered) {
 				return nil
 			}
 			entry := m.List.Filtered[m.List.Cursor]
-			action, ok := view.GetAction("port-forwards")
-			if !ok {
-				if cmd := view.FeatureLockedCmd("Active Forwards"); cmd != nil {
-					return cmd
-				}
-				m.confirmDialog.Visible = true
-				m.confirmDialog.ErrorMode = true
-				m.confirmDialog.Message = view.BEUnavailableErr("Active Forwards").Error()
-				return nil
-			}
-			return action(entry.ServiceName)
+			return m.dispatchAction("port-forwards", "Active Forwards", entry.ServiceName)
 		case "W":
 			if m.List.Cursor >= len(m.List.Filtered) {
 				return nil
 			}
 			entry := m.List.Filtered[m.List.Cursor]
-			action, ok := view.GetAction("port-forward")
-			if !ok {
-				if cmd := view.FeatureLockedCmd("Port Forward"); cmd != nil {
-					return cmd
-				}
-				m.confirmDialog.Visible = true
-				m.confirmDialog.ErrorMode = true
-				m.confirmDialog.Message = view.BEUnavailableErr("Port Forward").Error()
+			return m.dispatchAction("port-forward", "Port Forward", entry.ServiceName)
+		// t opens live resource statistics for the selection. The ref carries the
+		// service name and, when a task row is highlighted, that replica's task
+		// ID; an empty second field means "the service — pick a replica". The
+		// Swarm API reports no container CPU, memory, network or block-IO at all
+		// (those counters exist only on the node running the container), so the
+		// default build supplies none and the key stays inert unless an extension
+		// that can reach per-node container state registers the action.
+		case "t":
+			if m.List.Cursor >= len(m.List.Filtered) {
 				return nil
 			}
-			return action(entry.ServiceName)
+			entry := m.List.Filtered[m.List.Cursor]
+			return m.dispatchAction("container-stats", "Stats",
+				view.EncodeRef(entry.ServiceName, m.selectedTaskID()))
 		case "esc":
 			// ESC should also go back to stacks view
 			m.Visible = false
@@ -583,6 +567,39 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 	var cmd tea.Cmd
 	m.List.Viewport, cmd = m.List.Viewport.Update(msg)
 	return cmd
+}
+
+// dispatchAction invokes a registered action, or surfaces the standard
+// "Business Edition feature" dialog when it is not available. The action
+// keybindings are inert in builds that do not register them, and an
+// unlicensed build takes this same path because the registry's guard is
+// evaluated on every lookup.
+func (m *Model) dispatchAction(actionName, label, arg string) tea.Cmd {
+	action, ok := view.GetAction(actionName)
+	if !ok {
+		if cmd := view.FeatureLockedCmd(label); cmd != nil {
+			return cmd
+		}
+		m.confirmDialog.Visible = true
+		m.confirmDialog.ErrorMode = true
+		m.confirmDialog.Message = view.BEUnavailableErr(label).Error()
+		return nil
+	}
+	return action(arg)
+}
+
+// selectedTaskID returns the ID of the highlighted task row, or "" when the
+// cursor is on the service row itself. An action that can act on either gets
+// both: the service name always, and one replica only when the user picked one.
+func (m *Model) selectedTaskID() string {
+	if m.selectedTaskIndex < 0 || m.List.Cursor >= len(m.List.Filtered) {
+		return ""
+	}
+	tasks := m.serviceTasks[m.List.Filtered[m.List.Cursor].ServiceID]
+	if m.selectedTaskIndex >= len(tasks) {
+		return ""
+	}
+	return tasks[m.selectedTaskIndex].ID
 }
 
 func (m *Model) SetContent(msg Msg) {
@@ -993,6 +1010,7 @@ func GetServicesHelpContent() []helpview.HelpCategory {
 				{Keys: "<x>", Description: view.BEHelpDesc("shell", "Open shell into service container")},
 				{Keys: "<w>", Description: view.BEHelpDesc("port-forwards", "Show active port-forwards")},
 				{Keys: "<shift+w>", Description: view.BEHelpDesc("port-forward", "Forward service ports to localhost")},
+				{Keys: "<t>", Description: view.BEHelpDesc("container-stats", "CPU, memory, network and I/O over time")},
 				{Keys: "</>", Description: "Filter"},
 			},
 		},


### PR DESCRIPTION
## What

Two things, and the second is here because the first puts a second view of the same number on screen.

**A `t` keybinding on the services view**, as an extension point for live per-container resource statistics — CPU, memory, network and block I/O over time. The Swarm API carries none of it: those counters exist only on the node running the container. So the default build registers no action, and the key renders as `Stats (BE)`, greyed, exactly like `x`, `w` and `shift+w`.

The action ref carries the service name plus, when a task row is highlighted (`p` to expand), that one replica's task ID. An empty task field means "the service — pick a replica", so an extension can offer the same ergonomics `x` already has.

**The header's MEM figure now matches `docker stats`.** `MemoryStats.Usage` includes the page cache, which is reclaimable and is not the container's working set, so the header read high by the whole cache. `memUsageNoCache` applies docker/cli's `calculateMemUsageUnixNoCache` — `total_inactive_file` on cgroup v1, `inactive_file` on v2, each subtracted only when smaller than `Usage` — at **both** call sites: `GetSwarmMemUsage` and the single-pass `GetSwarmResourceUsage`.

> **Operator-visible:** the header will report less memory than it used to, and will agree with `docker stats` for the first time. Nothing else changes.

## Scope I extended into, and why

`x`, `w` and `shift+w` each carried their own copy of the lookup-or-BE-dialog block. Four copies in one switch was three too many and the new key would have been a fifth, so all four now go through the `dispatchAction` helper the volumes view already uses. Behaviour is identical — same labels, same dialog, same `FeatureLockedCmd` precedence.

The memory fix landed at both call sites rather than only the one the header happens to call today, because they are the same defect.

## Tests

- `t` dispatches with the service name and an empty task field from a service row.
- `t` dispatches that replica's task ID from a highlighted task row.
- A **stale** `selectedTaskIndex` — the task list refreshes on a 2s poll while a row stays selected — resolves to the empty field rather than indexing a slice that shrank.
- `t` with no action registered raises the BE dialog; `t` on an empty list is a no-op.
- Help bar and `?` screen both carry the key.
- `memUsageNoCache` table test across cgroup v1, cgroup v2, a counter not smaller than `Usage`, absent counters, a nil map and a stopped container.

Both new behaviours were mutation-checked: stubbing `memUsageNoCache` to return `mem.Usage` and `selectedTaskID` to return `""` each fails the tests that claim to cover them.

`go build`, `go vet`, `gofmt -l`, `go test -race -count=1 ./...` and `golangci-lint run ./... --build-tags=integration` are all clean.
