### PR TITLE
refactor(cli): one table behind the charts CLI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,12 @@ jobs:
               - 'go.sum'
               - '.golangci.yml'
               - '.github/workflows/ci.yml'
+              # The charts command blocks in these two are generated from
+              # cli/commands.go and asserted by a test. Editing one by hand is
+              # exactly what that test exists to catch, so the test has to run
+              # on a PR that touches nothing else.
+              - 'README.md'
+              - 'charts/README.md'
             docker:
               - '**.go'
               - 'go.mod'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ tail -f ~/.local/state/swarmcli/app.log          # prod mode (JSON)
 
 ```
 main.go                    Entry point; version injection via ldflags. With args, dispatches non-interactive CLI subcommands via cli.Dispatch(); bare invocation launches the TUI (tea.NewProgram())
-cli/                       Arg-based CLI dispatch (cli.Dispatch): `charts`, `version`, `help`; cli/apply.go holds the GitOps subcommands (`charts apply`, `charts outdated`)
+cli/                       Arg-based CLI dispatch (cli.Dispatch): `charts`, `version`, `help`; cli/commands.go holds chartsCommands — the table dispatch, the usage text, per-command --help and the generated README blocks all read from; cli/apply.go holds the GitOps subcommands (`charts apply`, `charts outdated`)
 charts/                    Helm-like package manager (repos, chart rendering, releases) + declarative releases (releasefile.go, apply.go, outdated.go). charts.ChartSource (source.go) is the seam that resolves a chart ref — repo or local path — so release planning is testable without Docker, a network or a filesystem. charts.NewDockerBackend(ctxName) + NewEngineWith is the seam that targets a *specific* swarm: the default backend uses the ambient Docker context, the SDK client singleton and the shared snapshot cache, all three of which are process-global
 app/
   app.go                   Init(); triggers command autoload via _ "github.com/Eldara-Tech/swarmcli/commands" and view autoload via _ "github.com/Eldara-Tech/swarmcli/views" (view factory registry lives in views/view/registry.go)
@@ -98,7 +98,13 @@ utils/log/
 
 **New view**: Create `views/myview/`, implement `view.View` interface, and add a `register.go` whose `init()` calls `view.RegisterView(name, factory)`. Add its blank import to `views/autoload.go` so the package is loaded. See `views/nodes/register.go`.
 
-**New `swarmcli charts <sub>` CLI subcommand** (this is *not* the TUI `:` registry — it's the arg-based dispatcher): add a `case` to the switch in `cli/charts.go` `chartsMain`, put the logic in `charts/` and keep the `cli/` half thin (the `charts` package is where the coverage bar applies). Any new flag goes in the single **global** `flags` struct in `cli/args.go` — note that every subcommand therefore parses every flag and *silently ignores* what it does not read, so if a flag would be a lie for your subcommand, reject it explicitly (see `rejectUnsupported` in `cli/apply.go`). Then update **all three** places the command list is duplicated, or they drift: `chartsUsage` in `cli/charts.go`, `README.md`, and `charts/README.md`.
+**New `swarmcli charts <sub>` CLI subcommand** (this is *not* the TUI `:` registry — it's the arg-based dispatcher): add a row to `chartsCommands` in `cli/commands.go` — name, group, usage line(s), the flags the handler reads, the handler — and nothing else has a list to update: dispatch, `charts --help`, `charts <sub> --help` and the command blocks in `README.md` and `charts/README.md` all render from it. Put the logic in `charts/` and keep the `cli/` half thin (the `charts` package is where the coverage bar applies). A new flag goes in the single **global** `flags` struct in `cli/args.go`, is listed by every row whose handler reads it — a flag a row does not list is rejected, so an operator is told rather than silently ignored — and gets a `flagDocs` entry so both help surfaces can describe it. Then regenerate the README blocks:
+
+```bash
+go test ./cli -run TestGeneratedCommandBlocks -update
+```
+
+`go test ./cli` fails if you forget; it also compares each row's flag list against what the handler and its callees actually read, so an allow-list cannot quietly drift from the code.
 
 ## Environment Variables
 

--- a/README.md
+++ b/README.md
@@ -78,38 +78,48 @@ A bare `swarmcli` launches the TUI, but a few commands run non-interactively
 when arguments are supplied: `swarmcli version`, `swarmcli help`, and the
 Helm-like chart package manager `swarmcli charts <command>`:
 
+<!-- BEGIN generated: charts commands -->
 ```bash
-# Repositories
-swarmcli charts repo add <name> <url>     # add a repo and download its index
-swarmcli charts repo list                 # list configured repos
-swarmcli charts repo update [name]        # refresh indexes (all, or one); install
-                                          # and friends now refresh on their own
-swarmcli charts repo remove <name>        # remove a repo
+# Repository
+swarmcli charts repo add <name> <url>           # Add a chart repository and download its index
+swarmcli charts repo list                       # List configured repositories
+swarmcli charts repo update [name]              # Refresh repository indexes (all, or one)
+swarmcli charts repo remove <name>              # Remove a repository
 
 # Discovery
-swarmcli charts search [keyword]          # search charts across repos
-swarmcli charts show chart  <repo/chart>  # chart metadata (also: values, schema)
+swarmcli charts search [keyword]                # Search charts across repositories
+swarmcli charts show chart <repo/chart>         # Show chart metadata
+swarmcli charts show values <repo/chart>        # Show default values.yaml
+swarmcli charts show schema <repo/chart>        # Show values.schema.json
 
 # Authoring
-swarmcli charts lint <chart>                      # check a chart without deploying it
+swarmcli charts lint <chart>                    # Check a chart without deploying it
 
 # Releases
-swarmcli charts template <release> <repo/chart>   # render manifest (no deploy)
-swarmcli charts install  <release> <repo/chart>   # install a chart as a release
-swarmcli charts upgrade  <release> <repo/chart>   # upgrade to a new revision
-swarmcli charts diff upgrade <release> <repo/chart>  # preview upgrade changes
-swarmcli charts rollback <release> <revision>     # re-deploy a past revision
-swarmcli charts uninstall <release>               # remove a release
-swarmcli charts history <release>                 # revision history
-swarmcli charts get values|manifest <release>     # stored values or rendered manifest
-swarmcli charts prune [release]                   # delete old revisions beyond --history-max
-swarmcli charts list                              # list releases
-swarmcli charts status <release>                  # release status and services
+swarmcli charts template <release> <chart>      # Render manifest to stdout (no deploy)
+swarmcli charts install <release> <chart>       # Install a chart as a release
+swarmcli charts upgrade <release> <chart>       # Upgrade a release to a new revision
+swarmcli charts uninstall <release>             # Remove a release (keeps volumes)
+swarmcli charts rollback <release> <rev>        # Re-deploy the contents of a past revision
+swarmcli charts history <release>               # Show a release's revision history
+swarmcli charts prune [release]                 # Delete old revisions beyond --history-max
+swarmcli charts get values|manifest <release>   # Show stored values or rendered manifest
+swarmcli charts diff upgrade <release> <chart>  # Preview manifest changes before upgrading
+swarmcli charts list                            # List releases (alias: ls)
+swarmcli charts status <release>                # Show release status and services
 
-# GitOps — converge the swarm to a file you commit
-swarmcli charts apply -f swarmcli-release.yaml    # install/upgrade/skip to match the file
+# GitOps
+swarmcli charts apply -f <file>                 # Converge the swarm to a declarative release file
+swarmcli charts outdated                        # Show releases with a newer chart version available
+```
+<!-- END generated -->
+
+Every command takes `--help`, which lists that command's own options —
+anything else it does not read is rejected rather than quietly ignored:
+
+```bash
+swarmcli charts install --help
 swarmcli charts apply -f swarmcli-release.yaml --diff   # preview, never deploys
-swarmcli charts outdated                          # releases with a newer chart available
 ```
 
 `apply` reads a release file pinning each release to a chart version, so the

--- a/charts/README.md
+++ b/charts/README.md
@@ -45,6 +45,47 @@ index, so it applies only to a `repo/chart` reference** — a local chart carrie
 version in its own `Chart.yaml`, and passing `--version` with one is an error
 rather than being silently ignored.
 
+### Every command
+
+The full command set, as `swarmcli charts --help` lists it. Run
+`swarmcli charts <command> --help` for a command's own options.
+
+<!-- BEGIN generated: charts commands -->
+```bash
+# Repository
+swarmcli charts repo add <name> <url>           # Add a chart repository and download its index
+swarmcli charts repo list                       # List configured repositories
+swarmcli charts repo update [name]              # Refresh repository indexes (all, or one)
+swarmcli charts repo remove <name>              # Remove a repository
+
+# Discovery
+swarmcli charts search [keyword]                # Search charts across repositories
+swarmcli charts show chart <repo/chart>         # Show chart metadata
+swarmcli charts show values <repo/chart>        # Show default values.yaml
+swarmcli charts show schema <repo/chart>        # Show values.schema.json
+
+# Authoring
+swarmcli charts lint <chart>                    # Check a chart without deploying it
+
+# Releases
+swarmcli charts template <release> <chart>      # Render manifest to stdout (no deploy)
+swarmcli charts install <release> <chart>       # Install a chart as a release
+swarmcli charts upgrade <release> <chart>       # Upgrade a release to a new revision
+swarmcli charts uninstall <release>             # Remove a release (keeps volumes)
+swarmcli charts rollback <release> <rev>        # Re-deploy the contents of a past revision
+swarmcli charts history <release>               # Show a release's revision history
+swarmcli charts prune [release]                 # Delete old revisions beyond --history-max
+swarmcli charts get values|manifest <release>   # Show stored values or rendered manifest
+swarmcli charts diff upgrade <release> <chart>  # Preview manifest changes before upgrading
+swarmcli charts list                            # List releases (alias: ls)
+swarmcli charts status <release>                # Show release status and services
+
+# GitOps
+swarmcli charts apply -f <file>                 # Converge the swarm to a declarative release file
+swarmcli charts outdated                        # Show releases with a newer chart version available
+```
+<!-- END generated -->
+
 ## Declarative releases (GitOps)
 
 The commands above are imperative, and release state lives in the swarm — so

--- a/cli/apply.go
+++ b/cli/apply.go
@@ -5,19 +5,17 @@ package cli
 
 import (
 	"context"
-	"fmt"
 	"strconv"
-	"strings"
 
 	"github.com/Eldara-Tech/swarmcli/charts"
 	"github.com/Eldara-Tech/swarmcli/utils/textdiff"
 )
 
 // chartsApply converges the swarm to a declarative release manifest.
-func chartsApply(args []string) int {
-	pos, f, err := parseArgs(args)
-	if err != nil {
-		return usageErr(err.Error())
+func chartsApply(c chartsCmd, args []string) int {
+	pos, f, code := parse(c, args)
+	if code >= 0 {
+		return code
 	}
 	// apply's -f names the release manifest, not a values file: per-release values
 	// live inside the manifest. A bare positional works too.
@@ -25,10 +23,6 @@ func chartsApply(args []string) int {
 	if len(paths) != 1 {
 		return usageErr("charts apply -f <release-file>")
 	}
-	if err := rejectUnsupported(f); err != nil {
-		return usageErr(err.Error())
-	}
-
 	rf, err := charts.LoadReleaseFile(paths[0])
 	if err != nil {
 		return fail(err)
@@ -112,44 +106,6 @@ func chartsApply(args []string) int {
 	}
 	reportUnclaimed(plan)
 	return 0
-}
-
-// rejectUnsupported fails on flags apply does not honour. The charts flag set is
-// global, so every subcommand parses every flag and silently ignores whatever it
-// does not read. For a command whose entire contract is "the file is the only
-// source of truth", quietly discarding --set or --version would be a correctness
-// bug, not a cosmetic one.
-func rejectUnsupported(f flags) error {
-	var bad []string
-	if len(f.sets) > 0 {
-		bad = append(bad, "--set")
-	}
-	if len(f.setFiles) > 0 {
-		bad = append(bad, "--set-file")
-	}
-	if f.version != "" {
-		bad = append(bad, "--version")
-	}
-	if f.reuseValues {
-		bad = append(bad, "--reuse-values")
-	}
-	if f.install {
-		bad = append(bad, "--install")
-	}
-	if f.purge {
-		bad = append(bad, "--purge-volumes")
-	}
-	if f.requirements {
-		bad = append(bad, "--requirements")
-	}
-	if f.revision != 0 {
-		bad = append(bad, "--revision")
-	}
-	if len(bad) == 0 {
-		return nil
-	}
-	return fmt.Errorf("%s not supported by apply: the release file is the only source of truth "+
-		"(set chart versions and values there)", strings.Join(bad, ", "))
 }
 
 func printPlan(plan *charts.Plan, withDiff bool) {
@@ -253,10 +209,10 @@ func reportUnmanaged(plan *charts.Plan) {
 // chartsOutdated compares every installed release against the newest chart
 // version its repositories offer. It is the human-facing complement to an
 // automated updater watching the release file.
-func chartsOutdated(args []string) int {
-	_, f, err := parseArgs(args)
-	if err != nil {
-		return usageErr(err.Error())
+func chartsOutdated(c chartsCmd, args []string) int {
+	_, f, code := parse(c, args)
+	if code >= 0 {
+		return code
 	}
 	store, code := newStore(f)
 	if code >= 0 {

--- a/cli/args.go
+++ b/cli/args.go
@@ -4,6 +4,7 @@
 package cli
 
 import (
+	"errors"
 	"fmt"
 	"sort"
 	"strconv"
@@ -82,11 +83,20 @@ func (f flags) reject(c chartsCmd) error {
 	return nil
 }
 
+// errHelp reports that --help was passed. It travels as an error because the
+// parser is the only place that knows a "--help" token is a flag rather than
+// the value of the flag before it.
+var errHelp = errors.New("help requested")
+
 // parse is the prelude every charts subcommand shares: split the arguments,
 // reject a flag this command does not honour, and turn either failure into an
 // exit code. A returned code >= 0 is the command's result.
 func parse(c chartsCmd, args []string) ([]string, flags, int) {
 	pos, f, err := parseArgs(args)
+	if errors.Is(err, errHelp) {
+		out(commandHelp(c))
+		return nil, f, 0
+	}
 	if err != nil {
 		return nil, f, usageErr(err.Error())
 	}
@@ -135,6 +145,8 @@ func parseArgs(args []string) ([]string, flags, error) {
 		}
 
 		switch name {
+		case "-h", "--help":
+			return nil, f, errHelp
 		case "-f", "--values":
 			v, err := next()
 			if err != nil {

--- a/cli/args.go
+++ b/cli/args.go
@@ -5,6 +5,7 @@ package cli
 
 import (
 	"fmt"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -41,6 +42,58 @@ type flags struct {
 	// resolveImage (--resolve-image) selects the daemon's tag-to-digest
 	// resolution at deploy time: always | changed | never.
 	resolveImage string
+
+	// seen records the canonical long name of every flag actually passed. The
+	// values above cannot answer "was this flag given?" for a flag whose value
+	// happens to equal its zero value, and the allow-list check has to reject a
+	// flag the operator passed rather than one that merely looks set.
+	seen map[string]bool
+}
+
+// canonicalFlag maps a flag's short form to the long one the command table
+// lists. Long forms are the table's vocabulary, so a row never has to spell a
+// flag twice.
+var canonicalFlag = map[string]string{"-f": "--values"}
+
+// reject reports the first flag c does not honour. The charts flag set is
+// parsed globally — every subcommand understands every flag — so without this
+// a valid-but-irrelevant flag is accepted and silently dropped, which reads to
+// an operator as "it worked".
+func (f flags) reject(c chartsCmd) error {
+	allowed := make(map[string]bool, len(c.Flags))
+	for _, n := range c.Flags {
+		allowed[n] = true
+	}
+	// Sorted, so a command given two rejected flags always names the same one.
+	names := make([]string, 0, len(f.seen))
+	for n := range f.seen {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	for _, n := range names {
+		if allowed[n] {
+			continue
+		}
+		if c.FlagHint != "" {
+			return fmt.Errorf("charts %s does not accept '%s': %s", c.Name, n, c.FlagHint)
+		}
+		return fmt.Errorf("charts %s does not accept '%s'", c.Name, n)
+	}
+	return nil
+}
+
+// parse is the prelude every charts subcommand shares: split the arguments,
+// reject a flag this command does not honour, and turn either failure into an
+// exit code. A returned code >= 0 is the command's result.
+func parse(c chartsCmd, args []string) ([]string, flags, int) {
+	pos, f, err := parseArgs(args)
+	if err != nil {
+		return nil, f, usageErr(err.Error())
+	}
+	if err := f.reject(c); err != nil {
+		return nil, f, usageErr(err.Error())
+	}
+	return pos, f, -1
 }
 
 // parseArgs splits raw args into positionals and flags. It understands the
@@ -62,6 +115,14 @@ func parseArgs(args []string) ([]string, flags, error) {
 		}
 
 		name, inlineVal, hasInline := splitFlag(a)
+		if f.seen == nil {
+			f.seen = map[string]bool{}
+		}
+		canonical := name
+		if long, ok := canonicalFlag[name]; ok {
+			canonical = long
+		}
+		f.seen[canonical] = true
 		next := func() (string, error) {
 			if hasInline {
 				return inlineVal, nil

--- a/cli/charts.go
+++ b/cli/charts.go
@@ -60,34 +60,10 @@ failure names the version to upgrade to instead of surfacing as whatever error
 the missing feature happens to produce. install and upgrade ask first when run
 interactively; apply never does. template, diff and show only warn. Pass
 --skip-compat-check to try anyway. Charts declaring nothing are unaffected.
+`
 
-Common options:
-  -f, --values <file>   Values file (repeatable). For apply: the release file.
-      --set k=v         Override a value (repeatable)
-      --set-file k=path Set a value to a file's contents (repeatable). A chart
-                        references it as values/<k> from a config's file:, which
-                        is how an operator supplies a config the chart does not
-                        ship. See charts/README.md.
-      --version <ver>   Chart version, for a <repo>/<chart> reference (default: latest).
-                        Not valid with a local chart path — its Chart.yaml sets the version.
-      --dry-run         Render and validate without deploying
-      --requirements    template: emit rendered requirements.yaml, not the manifest
-      --wait            Wait for services to converge
-      --timeout <dur>   Wait timeout, e.g. 10m (default 5m)
-      --history-max <n> Max release revisions to retain
-      --resolve-image <mode>  always | changed | never — how the daemon resolves
-                        image tags to digests at deploy time (default: always)
-      --install         upgrade: install the release if absent
-      --reuse-values    upgrade/diff: layer overrides on previous values
-      --revision <n>    get: select a specific revision
-      --purge-volumes   uninstall: also remove the release's volumes
-      --diff            apply: show each changed release's manifest diff (implies --dry-run)
-      --no-repo-update  Resolve from the cached repository indexes and touch no
-                        network (also: SWARMCLI_CHARTS_NO_AUTO_UPDATE=1)
-      --skip-compat-check  Proceed despite a chart's unmet swarmcliVersion constraint
-      --for-version <ver>  lint: check the chart's swarmcliVersion against <ver>
-                        instead of this build's chart engine
-
+// chartsUsageTail is the prose that follows the option reference.
+const chartsUsageTail = `
 lint renders a chart and reports every problem it finds: a broken template,
 values that fail values.schema.json, a swarmcliVersion this build does not
 satisfy. It renders from the chart defaults, layering any -f/--set on top — a
@@ -97,10 +73,10 @@ other version — it cannot tell you the chart RUNS on that version, because thi
 binary carries only its own engine's behaviour. Rendering with a real binary of
 that version is the only thing that settles that.
 
-apply honours --wait, --timeout, --history-max and --resolve-image. It REJECTS --set,
---set-file, --version, --reuse-values, --install, --purge-volumes, --requirements and --revision rather
-than ignoring them: the release file is the only source of truth, so a value passed
-on the command line would be a lie.
+apply takes only the options that make sense for a file-driven converge, and
+REJECTS the rest rather than ignoring them: the release file is the only source
+of truth, so a value passed on the command line would be a lie. Run
+swarmcli charts apply --help for what it does take.
 
 Resolving a <repo>/<chart> reference refreshes that repository's index first, so
 install, upgrade, template, diff, show, lint and search see what the repository
@@ -119,6 +95,14 @@ func chartsMain(args []string) int {
 	sub, rest := args[0], args[1:]
 	switch sub {
 	case "-h", "--help", "help":
+		// `charts help <command>` is the same page as `charts <command> --help`,
+		// mirroring the TUI, where `:help <cmd>` and `:cmd --help` are one screen.
+		if len(rest) > 0 {
+			if c, ok := lookupCommand(rest[0]); ok {
+				out(commandHelp(c))
+				return 0
+			}
+		}
 		out(chartsUsage())
 		return 0
 	}

--- a/cli/charts.go
+++ b/cli/charts.go
@@ -130,7 +130,7 @@ func chartsMain(args []string) int {
 		}
 		return usageErr(fmt.Sprintf("%s\n\n%s", msg, chartsUsage()))
 	}
-	return c.Run(rest)
+	return c.Run(c, rest)
 }
 
 // newStore builds the repository store every charts subcommand resolves
@@ -180,7 +180,13 @@ func plaintextAllowed() bool {
 
 // --- repo ---
 
-func chartsRepo(args []string) int {
+func chartsRepo(c chartsCmd, args []string) int {
+	// repo takes no flags of its own, so this rejects any that turn up rather
+	// than letting them land among the sub-verb's positionals.
+	args, _, code := parse(c, args)
+	if code >= 0 {
+		return code
+	}
 	if len(args) == 0 {
 		return usageErr("charts repo requires a subcommand: add|list|update|remove")
 	}
@@ -255,10 +261,10 @@ func chartsRepo(args []string) int {
 
 // --- search ---
 
-func chartsSearch(args []string) int {
-	pos, f, err := parseArgs(args)
-	if err != nil {
-		return usageErr(err.Error())
+func chartsSearch(c chartsCmd, args []string) int {
+	pos, f, code := parse(c, args)
+	if code >= 0 {
+		return code
 	}
 	keyword := ""
 	if len(pos) > 0 {
@@ -286,14 +292,14 @@ func chartsSearch(args []string) int {
 
 // --- show ---
 
-func chartsShow(args []string) int {
+func chartsShow(c chartsCmd, args []string) int {
 	if len(args) < 2 {
 		return usageErr("charts show <chart|values|schema> <repo/chart>")
 	}
 	what, ref := args[0], args[1]
-	pos, f, err := parseArgs(args[2:])
-	if err != nil {
-		return usageErr(err.Error())
+	pos, f, code := parse(c, args[2:])
+	if code >= 0 {
+		return code
 	}
 	_ = pos
 	ch, _, code := loadChart(ref, f)
@@ -360,10 +366,10 @@ func printChartMeta(ch *charts.Chart) {
 // --for-version lints against a chart-engine version other than this build's,
 // which answers "does this chart's declared floor admit X?". It cannot answer
 // "does this chart run on X" — only a real X can (see charts.CheckCompatAgainst).
-func chartsLint(args []string) int {
-	pos, f, err := parseArgs(args)
-	if err != nil {
-		return usageErr(err.Error())
+func chartsLint(c chartsCmd, args []string) int {
+	pos, f, code := parse(c, args)
+	if code >= 0 {
+		return code
 	}
 	if len(pos) != 1 {
 		return usageErr("charts lint <chart>")
@@ -392,10 +398,10 @@ func chartsLint(args []string) int {
 	return 0
 }
 
-func chartsTemplate(args []string) int {
-	pos, f, err := parseArgs(args)
-	if err != nil {
-		return usageErr(err.Error())
+func chartsTemplate(c chartsCmd, args []string) int {
+	pos, f, code := parse(c, args)
+	if code >= 0 {
+		return code
 	}
 	if len(pos) != 2 {
 		return usageErr("charts template <release> <repo/chart>")
@@ -423,10 +429,10 @@ func chartsTemplate(args []string) int {
 	return 0
 }
 
-func chartsInstall(args []string) int {
-	pos, f, err := parseArgs(args)
-	if err != nil {
-		return usageErr(err.Error())
+func chartsInstall(c chartsCmd, args []string) int {
+	pos, f, code := parse(c, args)
+	if code >= 0 {
+		return code
 	}
 	if len(pos) != 2 {
 		return usageErr("charts install <release> <repo/chart>")
@@ -451,10 +457,10 @@ func chartsInstall(args []string) int {
 	return reportRelease(rel, manifest, f.dryRun)
 }
 
-func chartsUpgrade(args []string) int {
-	pos, f, err := parseArgs(args)
-	if err != nil {
-		return usageErr(err.Error())
+func chartsUpgrade(c chartsCmd, args []string) int {
+	pos, f, code := parse(c, args)
+	if code >= 0 {
+		return code
 	}
 	if len(pos) != 2 {
 		return usageErr("charts upgrade <release> <repo/chart>")
@@ -504,10 +510,10 @@ func reportRelease(rel *charts.Release, manifest string, dryRun bool) int {
 	return 0
 }
 
-func chartsRollback(args []string) int {
-	pos, f, err := parseArgs(args)
-	if err != nil {
-		return usageErr(err.Error())
+func chartsRollback(c chartsCmd, args []string) int {
+	pos, f, code := parse(c, args)
+	if code >= 0 {
+		return code
 	}
 	if len(pos) != 2 {
 		return usageErr("charts rollback <release> <revision>")
@@ -526,10 +532,10 @@ func chartsRollback(args []string) int {
 	return 0
 }
 
-func chartsHistory(args []string) int {
-	pos, _, err := parseArgs(args)
-	if err != nil {
-		return usageErr(err.Error())
+func chartsHistory(c chartsCmd, args []string) int {
+	pos, _, code := parse(c, args)
+	if code >= 0 {
+		return code
 	}
 	if len(pos) != 1 {
 		return usageErr("charts history <release>")
@@ -546,10 +552,10 @@ func chartsHistory(args []string) int {
 	return 0
 }
 
-func chartsPrune(args []string) int {
-	pos, f, err := parseArgs(args)
-	if err != nil {
-		return usageErr(err.Error())
+func chartsPrune(c chartsCmd, args []string) int {
+	pos, f, code := parse(c, args)
+	if code >= 0 {
+		return code
 	}
 	if len(pos) > 1 {
 		return usageErr("charts prune [release] [--history-max <n>] [--dry-run]")
@@ -558,6 +564,7 @@ func chartsPrune(args []string) int {
 	ctx := context.Background()
 
 	var results []charts.PruneResult
+	var err error
 	if len(pos) == 1 {
 		var res charts.PruneResult
 		res, err = e.Prune(ctx, pos[0], f.historyMax, f.dryRun)
@@ -599,14 +606,14 @@ func chartsPrune(args []string) int {
 	return 0
 }
 
-func chartsGet(args []string) int {
+func chartsGet(c chartsCmd, args []string) int {
 	if len(args) < 2 {
 		return usageErr("charts get <values|manifest> <release> [--revision N]")
 	}
 	what, release := args[0], args[1]
-	_, f, err := parseArgs(args[2:])
-	if err != nil {
-		return usageErr(err.Error())
+	_, f, code := parse(c, args[2:])
+	if code >= 0 {
+		return code
 	}
 	rel, err := charts.NewEngine().GetRevision(context.Background(), release, f.revision)
 	if err != nil {
@@ -627,16 +634,16 @@ func chartsGet(args []string) int {
 	return 0
 }
 
-func chartsDiff(args []string) int {
+func chartsDiff(c chartsCmd, args []string) int {
 	if len(args) < 1 {
 		return usageErr("charts diff upgrade <release> <repo/chart>")
 	}
 	if args[0] != "upgrade" {
 		return usageErr(fmt.Sprintf("unknown diff target '%s' (want upgrade)", args[0]))
 	}
-	pos, f, err := parseArgs(args[1:])
-	if err != nil {
-		return usageErr(err.Error())
+	pos, f, code := parse(c, args[1:])
+	if code >= 0 {
+		return code
 	}
 	if len(pos) != 2 {
 		return usageErr("charts diff upgrade <release> <repo/chart>")
@@ -736,10 +743,10 @@ func prepare(release, ref string, f flags, base map[string]any, pol compatPolicy
 
 // --- uninstall / list / status ---
 
-func chartsUninstall(args []string) int {
-	pos, f, err := parseArgs(args)
-	if err != nil {
-		return usageErr(err.Error())
+func chartsUninstall(c chartsCmd, args []string) int {
+	pos, f, code := parse(c, args)
+	if code >= 0 {
+		return code
 	}
 	if len(pos) != 1 {
 		return usageErr("charts uninstall <release> [--purge-volumes]")
@@ -763,9 +770,9 @@ func chartsUninstall(args []string) int {
 	return 0
 }
 
-func chartsList(args []string) int {
-	if _, _, err := parseArgs(args); err != nil {
-		return usageErr(err.Error())
+func chartsList(c chartsCmd, args []string) int {
+	if _, _, code := parse(c, args); code >= 0 {
+		return code
 	}
 	rels, err := charts.NewEngine().List(context.Background())
 	if err != nil {
@@ -783,10 +790,10 @@ func chartsList(args []string) int {
 	return 0
 }
 
-func chartsStatus(args []string) int {
-	pos, _, err := parseArgs(args)
-	if err != nil {
-		return usageErr(err.Error())
+func chartsStatus(c chartsCmd, args []string) int {
+	pos, _, code := parse(c, args)
+	if code >= 0 {
+		return code
 	}
 	if len(pos) != 1 {
 		return usageErr("charts status <release>")

--- a/cli/charts.go
+++ b/cli/charts.go
@@ -16,40 +16,11 @@ import (
 	"github.com/Eldara-Tech/swarmcli/utils/textdiff"
 )
 
-const chartsUsage = `Usage: swarmcli charts <command> [options]
-
-Repository:
-  repo add <name> <url>      Add a chart repository and download its index
-  repo list                  List configured repositories
-  repo update [name]         Refresh repository indexes (all, or one)
-  repo remove <name>         Remove a repository
-
-Discovery:
-  search [keyword]           Search charts across repositories
-  show chart  <repo/chart>   Show chart metadata
-  show values <repo/chart>   Show default values.yaml
-  show schema <repo/chart>   Show values.schema.json
-
-Authoring:
-  lint <chart>                Check a chart without deploying it
-
-Releases:
-  template <release> <chart>  Render manifest to stdout (no deploy)
-  install  <release> <chart>  Install a chart as a release
-  upgrade  <release> <chart>  Upgrade a release to a new revision
-  uninstall <release>         Remove a release (keeps volumes)
-  rollback <release> <rev>    Re-deploy the contents of a past revision
-  history <release>           Show a release's revision history
-  prune [release]             Delete old revisions beyond --history-max
-  get values|manifest <rel>   Show stored values or rendered manifest
-  diff upgrade <rel> <chart>  Preview manifest changes before upgrading
-  list                        List releases
-  status <release>            Show release status and services
-
-GitOps:
-  apply -f <file>             Converge the swarm to a declarative release file
-  outdated                    Show releases with a newer chart version available
-
+// chartsUsageProse is everything in `charts --help` that is not the command
+// list: what a release file is, how waves and compatibility behave, and the
+// option reference. The command list itself is rendered from chartsCommands —
+// see renderCommands.
+const chartsUsageProse = `
 A release file pins each release to a chart version, so it is reproducible and an
 automated updater (e.g. Renovate) has something concrete to bump. apply installs
 what is missing, upgrades what changed, and skips what already matches. It never
@@ -139,54 +110,27 @@ cached index is used. --no-repo-update skips the network entirely, for which
 outdated reports against the cached indexes and says so.
 `
 
-// chartsMain dispatches `swarmcli charts ...`.
+// chartsMain dispatches `swarmcli charts ...` through chartsCommands.
 func chartsMain(args []string) int {
 	if len(args) == 0 {
-		out(chartsUsage)
+		out(chartsUsage())
 		return 0
 	}
 	sub, rest := args[0], args[1:]
 	switch sub {
 	case "-h", "--help", "help":
-		out(chartsUsage)
+		out(chartsUsage())
 		return 0
-	case "repo":
-		return chartsRepo(rest)
-	case "search":
-		return chartsSearch(rest)
-	case "show":
-		return chartsShow(rest)
-	case "lint":
-		return chartsLint(rest)
-	case "template":
-		return chartsTemplate(rest)
-	case "install":
-		return chartsInstall(rest)
-	case "upgrade":
-		return chartsUpgrade(rest)
-	case "uninstall":
-		return chartsUninstall(rest)
-	case "rollback":
-		return chartsRollback(rest)
-	case "history":
-		return chartsHistory(rest)
-	case "prune":
-		return chartsPrune(rest)
-	case "get":
-		return chartsGet(rest)
-	case "diff":
-		return chartsDiff(rest)
-	case "list", "ls":
-		return chartsList(rest)
-	case "status":
-		return chartsStatus(rest)
-	case "apply":
-		return chartsApply(rest)
-	case "outdated":
-		return chartsOutdated(rest)
-	default:
-		return usageErr(fmt.Sprintf("unknown charts command '%s'\n\n%s", sub, chartsUsage))
 	}
+	c, ok := lookupCommand(sub)
+	if !ok {
+		msg := fmt.Sprintf("unknown charts command '%s'", sub)
+		if s := suggestCommand(sub, commandNames()); s != "" {
+			msg += fmt.Sprintf(" — did you mean '%s'?", s)
+		}
+		return usageErr(fmt.Sprintf("%s\n\n%s", msg, chartsUsage()))
+	}
+	return c.Run(rest)
 }
 
 // newStore builds the repository store every charts subcommand resolves

--- a/cli/charts_test.go
+++ b/cli/charts_test.go
@@ -337,16 +337,16 @@ func TestParseIntRejectsGarbage(t *testing.T) {
 
 func TestChartsApplyRequiresExactlyOneFile(t *testing.T) {
 	var code int
-	capture(t, func() { code = chartsApply(nil) })
+	capture(t, func() { code = chartsApply(cmd(t, "apply"), nil) })
 	require.Equal(t, 2, code, "no release file")
 
-	capture(t, func() { code = chartsApply([]string{"-f", "a.yaml", "-f", "b.yaml"}) })
+	capture(t, func() { code = chartsApply(cmd(t, "apply"), []string{"-f", "a.yaml", "-f", "b.yaml"}) })
 	require.Equal(t, 2, code, "two release files")
 }
 
 func TestChartsApplyMissingFile(t *testing.T) {
 	var code int
-	_, e := capture(t, func() { code = chartsApply([]string{"-f", filepath.Join(t.TempDir(), "nope.yaml")}) })
+	_, e := capture(t, func() { code = chartsApply(cmd(t, "apply"), []string{"-f", filepath.Join(t.TempDir(), "nope.yaml")}) })
 	require.Equal(t, 1, code)
 	require.Contains(t, e, "nope.yaml")
 }
@@ -359,7 +359,7 @@ func TestChartsApplyRejectsUnknownKey(t *testing.T) {
 	require.NoError(t, os.WriteFile(path, []byte("releases:\n  - name: a\n    chart: r/c\n    verison: \"1\"\n"), 0o600))
 
 	var code int
-	_, e := capture(t, func() { code = chartsApply([]string{"-f", path}) })
+	_, e := capture(t, func() { code = chartsApply(cmd(t, "apply"), []string{"-f", path}) })
 	require.Equal(t, 1, code)
 	require.Contains(t, e, "verison")
 }
@@ -381,7 +381,7 @@ func TestChartsApplyRejectsUnsupportedFlags(t *testing.T) {
 	} {
 		t.Run(flag[0], func(t *testing.T) {
 			var code int
-			_, e := capture(t, func() { code = chartsApply(append([]string{"-f", path}, flag...)) })
+			_, e := capture(t, func() { code = chartsApply(cmd(t, "apply"), append([]string{"-f", path}, flag...)) })
 			require.Equal(t, 2, code)
 			require.Contains(t, e, flag[0])
 			require.Contains(t, e, "only source of truth")

--- a/cli/commands.go
+++ b/cli/commands.go
@@ -350,8 +350,140 @@ func renderCommands(prefix string) string {
 	return b.String()
 }
 
+// flagDoc describes one option: the value it takes, if any, and what it does.
+// The order here is the order the option reference renders in.
+type flagDoc struct {
+	Name  string
+	Short string
+	Value string
+	Desc  string
+}
+
+// flagDocs is the option reference. Every flag a row lists has an entry, and
+// per-command help renders the subset that command accepts — so what an option
+// does is written once, not once per command that takes it.
+var flagDocs = []flagDoc{
+	{Name: "--values", Short: "-f", Value: "<file>", Desc: "Values file (repeatable). For apply: the release file."},
+	{Name: "--set", Value: "k=v", Desc: "Override a value (repeatable)"},
+	{Name: "--set-file", Value: "k=path", Desc: "Set a value to a file's contents (repeatable). A chart references it as values/<k> from a config's file:, which is how an operator supplies a config the chart does not ship. See charts/README.md."},
+	{Name: "--version", Value: "<ver>", Desc: "Chart version, for a <repo>/<chart> reference (default: latest). Not valid with a local chart path — its Chart.yaml sets the version."},
+	{Name: "--dry-run", Desc: "Render and validate without deploying"},
+	{Name: "--requirements", Desc: "Emit the rendered requirements.yaml, not the manifest"},
+	{Name: "--wait", Desc: "Wait for services to converge"},
+	{Name: "--timeout", Value: "<dur>", Desc: "Wait timeout, e.g. 10m (default 5m)"},
+	{Name: "--history-max", Value: "<n>", Desc: "Max release revisions to retain"},
+	{Name: "--resolve-image", Value: "<mode>", Desc: "always | changed | never — how the daemon resolves image tags to digests at deploy time (default: always)"},
+	{Name: "--install", Desc: "Install the release if it is absent"},
+	{Name: "--reuse-values", Desc: "Layer overrides on the previous release's values"},
+	{Name: "--revision", Value: "<n>", Desc: "Select a specific revision"},
+	{Name: "--purge-volumes", Desc: "Also remove the release's volumes"},
+	{Name: "--diff", Desc: "Show each changed release's manifest diff (implies --dry-run)"},
+	{Name: "--no-repo-update", Desc: "Resolve from the cached repository indexes and touch no network (also: SWARMCLI_CHARTS_NO_AUTO_UPDATE=1)"},
+	{Name: "--skip-compat-check", Desc: "Proceed despite a chart's unmet swarmcliVersion constraint"},
+	{Name: "--for-version", Value: "<ver>", Desc: "Check the chart's swarmcliVersion against <ver> instead of this build's chart engine"},
+}
+
+// renderOptions renders the option reference for the given flags, or all of
+// them when names is nil (the top-level usage text).
+func renderOptions(names []string) string {
+	want := map[string]bool{}
+	for _, n := range names {
+		want[n] = true
+	}
+
+	type row struct{ left, desc string }
+	var rows []row
+	width := 0
+	for _, d := range flagDocs {
+		if names != nil && !want[d.Name] {
+			continue
+		}
+		left := "    " + d.Name
+		if d.Short != "" {
+			left = d.Short + ", " + d.Name
+		}
+		if d.Value != "" {
+			left += " " + d.Value
+		}
+		rows = append(rows, row{left, d.Desc})
+		if len(left) > width {
+			width = len(left)
+		}
+	}
+
+	var b strings.Builder
+	for _, r := range rows {
+		indent := width + 4
+		for i, line := range wrapText(r.desc, 78-indent) {
+			if i == 0 {
+				b.WriteString("  " + r.left + strings.Repeat(" ", width-len(r.left)+2) + line + "\n")
+				continue
+			}
+			b.WriteString(strings.Repeat(" ", indent) + line + "\n")
+		}
+	}
+	return b.String()
+}
+
+// wrapText breaks text into lines of at most width columns, on spaces.
+func wrapText(text string, width int) []string {
+	if width < 20 {
+		width = 20
+	}
+	var lines []string
+	line := ""
+	for _, w := range strings.Fields(text) {
+		switch {
+		case line == "":
+			line = w
+		case len(line)+1+len(w) <= width:
+			line += " " + w
+		default:
+			lines = append(lines, line)
+			line = w
+		}
+	}
+	if line != "" {
+		lines = append(lines, line)
+	}
+	return lines
+}
+
+// commandHelp renders `swarmcli charts <command> --help`: what the command
+// takes, and the options it honours — which is the list that decides whether an
+// invocation is accepted, so an operator never has to infer it from a global
+// reference that covers every command at once.
+func commandHelp(c chartsCmd) string {
+	var b strings.Builder
+	b.WriteString("Usage:\n")
+	for _, u := range c.Usage {
+		b.WriteString(strings.TrimRight("  swarmcli charts "+c.Name+" "+u.Args, " ") + "\n")
+	}
+	if len(c.Aliases) > 0 {
+		b.WriteString("\nAlias: " + strings.Join(c.Aliases, ", ") + "\n")
+	}
+	b.WriteString("\n")
+	for _, u := range c.Usage {
+		b.WriteString("  " + u.Summary + "\n")
+	}
+	if len(c.Flags) == 0 {
+		b.WriteString("\nThis command takes no options.\n")
+		return b.String()
+	}
+	b.WriteString("\nOptions:\n")
+	b.WriteString(renderOptions(c.Flags))
+	return b.String()
+}
+
 // chartsUsage is the full `swarmcli charts --help` text: the generated command
 // list, then the prose that explains the parts a list cannot.
 func chartsUsage() string {
-	return "Usage: swarmcli charts <command> [options]\n\n" + renderCommands("") + chartsUsageProse
+	return "Usage: swarmcli charts <command> [options]\n\n" +
+		renderCommands("") +
+		chartsUsageProse +
+		"\nOptions:\n" + renderOptions(nil) +
+		"\nNot every option applies to every command — `swarmcli charts <command> --help`\n" +
+		"lists what that command takes, and anything else is rejected rather than\n" +
+		"quietly ignored.\n" +
+		chartsUsageTail
 }

--- a/cli/commands.go
+++ b/cli/commands.go
@@ -293,10 +293,21 @@ func suggestCommand(input string, names []string) string {
 	return best
 }
 
-// renderCommands renders the grouped command list. prefix is what each line
-// starts with — empty for the usage text, "swarmcli charts " for the README
-// blocks, which show commands as an operator would type them.
-func renderCommands(prefix string) string {
+// renderCommands renders the grouped command list for the usage text.
+func renderCommands() string {
+	return renderList("", ":", "")
+}
+
+// renderCommandsShell renders the same list as the READMEs show it: commands as
+// an operator types them, with the summary as a trailing comment, inside a
+// shell fence.
+func renderCommandsShell() string {
+	return renderList("swarmcli charts ", "", "# ")
+}
+
+// renderList is the one renderer behind both. prefix starts each command line,
+// groupSuffix follows a group heading, and comment starts each summary.
+func renderList(prefix, groupSuffix, comment string) string {
 	type line struct{ left, summary string }
 
 	// One column width across every group, so the block reads as one table
@@ -340,11 +351,19 @@ func renderCommands(prefix string) string {
 		if b.Len() > 0 {
 			b.WriteString("\n")
 		}
-		b.WriteString(g + ":\n")
+		heading := g + groupSuffix
+		if comment != "" {
+			heading = comment + heading
+		}
+		b.WriteString(heading + "\n")
 		for ; count > 0; count-- {
 			l := lines[i]
 			i++
-			b.WriteString("  " + l.left + strings.Repeat(" ", width-len(l.left)+2) + l.summary + "\n")
+			indent := "  "
+			if comment != "" {
+				indent = "" // a shell block is copy-pasteable, so it is not indented
+			}
+			b.WriteString(indent + l.left + strings.Repeat(" ", width-len(l.left)+2) + comment + l.summary + "\n")
 		}
 	}
 	return b.String()
@@ -479,7 +498,7 @@ func commandHelp(c chartsCmd) string {
 // list, then the prose that explains the parts a list cannot.
 func chartsUsage() string {
 	return "Usage: swarmcli charts <command> [options]\n\n" +
-		renderCommands("") +
+		renderCommands() +
 		chartsUsageProse +
 		"\nOptions:\n" + renderOptions(nil) +
 		"\nNot every option applies to every command — `swarmcli charts <command> --help`\n" +

--- a/cli/commands.go
+++ b/cli/commands.go
@@ -31,8 +31,18 @@ type chartsCmd struct {
 	// `show values`) lists each of them here: they are one dispatch target but
 	// several things an operator can run.
 	Usage []cmdUsage
+	// Flags is the allow-list: every flag this command actually reads, in long
+	// form. A flag outside it is rejected rather than parsed and dropped —
+	// derived by reading the handler and everything it calls (newStore reads
+	// --no-repo-update, loadChart adds --version, prepare adds the values and
+	// compat flags), because the flag struct is shared and reading the handler
+	// alone understates what it honours.
+	Flags []string
+	// FlagHint, when set, is appended to a rejection so the operator is told
+	// what to do instead of what not to do.
+	FlagHint string
 	// Run is the handler. It receives the arguments after the command name.
-	Run func([]string) int
+	Run func(chartsCmd, []string) int
 }
 
 // cmdUsage is one rendered line: the arguments as an operator types them, and
@@ -65,6 +75,7 @@ var chartsCommands = []chartsCmd{
 		Name:  "search",
 		Group: "Discovery",
 		Usage: []cmdUsage{{"[keyword]", "Search charts across repositories"}},
+		Flags: []string{"--no-repo-update"},
 		Run:   chartsSearch,
 	},
 	{
@@ -75,42 +86,83 @@ var chartsCommands = []chartsCmd{
 			{"values <repo/chart>", "Show default values.yaml"},
 			{"schema <repo/chart>", "Show values.schema.json"},
 		},
-		Run: chartsShow,
+		Flags: []string{"--version", "--skip-compat-check", "--no-repo-update"},
+		Run:   chartsShow,
 	},
 	{
 		Name:  "lint",
 		Group: "Authoring",
 		Usage: []cmdUsage{{"<chart>", "Check a chart without deploying it"}},
+		Flags: []string{"--values", "--set", "--version", "--for-version", "--no-repo-update"},
 		Run:   chartsLint,
 	},
 	{
 		Name:  "template",
 		Group: "Releases",
 		Usage: []cmdUsage{{"<release> <chart>", "Render manifest to stdout (no deploy)"}},
-		Run:   chartsTemplate,
+		Flags: []string{
+			"--values",
+			"--set",
+			"--set-file",
+			"--version",
+			"--requirements",
+			"--skip-compat-check",
+			"--no-repo-update",
+		},
+		Run: chartsTemplate,
 	},
 	{
 		Name:  "install",
 		Group: "Releases",
 		Usage: []cmdUsage{{"<release> <chart>", "Install a chart as a release"}},
-		Run:   chartsInstall,
+		Flags: []string{
+			"--values",
+			"--set",
+			"--set-file",
+			"--version",
+			"--dry-run",
+			"--wait",
+			"--timeout",
+			"--history-max",
+			"--resolve-image",
+			"--skip-compat-check",
+			"--no-repo-update",
+		},
+		Run: chartsInstall,
 	},
 	{
 		Name:  "upgrade",
 		Group: "Releases",
 		Usage: []cmdUsage{{"<release> <chart>", "Upgrade a release to a new revision"}},
-		Run:   chartsUpgrade,
+		Flags: []string{
+			"--values",
+			"--set",
+			"--set-file",
+			"--version",
+			"--install",
+			"--reuse-values",
+			"--dry-run",
+			"--wait",
+			"--timeout",
+			"--history-max",
+			"--resolve-image",
+			"--skip-compat-check",
+			"--no-repo-update",
+		},
+		Run: chartsUpgrade,
 	},
 	{
 		Name:  "uninstall",
 		Group: "Releases",
 		Usage: []cmdUsage{{"<release>", "Remove a release (keeps volumes)"}},
+		Flags: []string{"--purge-volumes"},
 		Run:   chartsUninstall,
 	},
 	{
 		Name:  "rollback",
 		Group: "Releases",
 		Usage: []cmdUsage{{"<release> <rev>", "Re-deploy the contents of a past revision"}},
+		Flags: []string{"--wait", "--timeout", "--history-max"},
 		Run:   chartsRollback,
 	},
 	{
@@ -123,19 +175,30 @@ var chartsCommands = []chartsCmd{
 		Name:  "prune",
 		Group: "Releases",
 		Usage: []cmdUsage{{"[release]", "Delete old revisions beyond --history-max"}},
+		Flags: []string{"--history-max", "--dry-run"},
 		Run:   chartsPrune,
 	},
 	{
 		Name:  "get",
 		Group: "Releases",
 		Usage: []cmdUsage{{"values|manifest <release>", "Show stored values or rendered manifest"}},
+		Flags: []string{"--revision"},
 		Run:   chartsGet,
 	},
 	{
 		Name:  "diff",
 		Group: "Releases",
 		Usage: []cmdUsage{{"upgrade <release> <chart>", "Preview manifest changes before upgrading"}},
-		Run:   chartsDiff,
+		Flags: []string{
+			"--values",
+			"--set",
+			"--set-file",
+			"--version",
+			"--reuse-values",
+			"--skip-compat-check",
+			"--no-repo-update",
+		},
+		Run: chartsDiff,
 	},
 	{
 		Name:    "list",
@@ -154,12 +217,29 @@ var chartsCommands = []chartsCmd{
 		Name:  "apply",
 		Group: "GitOps",
 		Usage: []cmdUsage{{"-f <file>", "Converge the swarm to a declarative release file"}},
-		Run:   chartsApply,
+		// apply refuses what it does not honour rather than ignoring it. For a
+		// command whose entire contract is "the file is the only source of
+		// truth", quietly discarding --set or --version would be a correctness
+		// bug, not a cosmetic one.
+		FlagHint: "the release file is the only source of truth (set chart versions and values there)",
+		Flags: []string{
+			"--values",
+			"--dry-run",
+			"--diff",
+			"--wait",
+			"--timeout",
+			"--history-max",
+			"--resolve-image",
+			"--skip-compat-check",
+			"--no-repo-update",
+		},
+		Run: chartsApply,
 	},
 	{
 		Name:  "outdated",
 		Group: "GitOps",
 		Usage: []cmdUsage{{"", "Show releases with a newer chart version available"}},
+		Flags: []string{"--no-repo-update"},
 		Run:   chartsOutdated,
 	},
 }

--- a/cli/commands.go
+++ b/cli/commands.go
@@ -1,0 +1,277 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package cli
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/Eldara-Tech/swarmcli/registry"
+)
+
+// chartsCmd describes one `swarmcli charts` subcommand: what it is called, what
+// it takes, and what it does. The table below is the single source of truth
+// behind dispatch, the usage text and the generated command blocks in
+// README.md and charts/README.md — three places that each used to carry their
+// own hand-maintained copy of the same list, and drifted.
+//
+// Adding a subcommand means adding a row here. Nothing else has a list to
+// update.
+type chartsCmd struct {
+	// Name is the word after `swarmcli charts`, and the key dispatch looks up.
+	Name string
+	// Aliases are alternative spellings dispatch accepts. They are reported in
+	// the rendered summary rather than given lines of their own.
+	Aliases []string
+	// Group is the heading this command is listed under. Rendering follows
+	// chartGroups order, not declaration order.
+	Group string
+	// Usage is one or more display lines. A command with sub-verbs (`repo add`,
+	// `show values`) lists each of them here: they are one dispatch target but
+	// several things an operator can run.
+	Usage []cmdUsage
+	// Run is the handler. It receives the arguments after the command name.
+	Run func([]string) int
+}
+
+// cmdUsage is one rendered line: the arguments as an operator types them, and
+// what that invocation does.
+type cmdUsage struct {
+	Args    string
+	Summary string
+}
+
+// chartGroups is the order the groups appear in, which is roughly the order an
+// operator meets them: configure a repository, find a chart, write one, deploy
+// it, then automate the deployment.
+var chartGroups = []string{"Repository", "Discovery", "Authoring", "Releases", "GitOps"}
+
+// chartsCommands is the command set. Ordering within a group is the order rows
+// appear here.
+var chartsCommands = []chartsCmd{
+	{
+		Name:  "repo",
+		Group: "Repository",
+		Usage: []cmdUsage{
+			{"add <name> <url>", "Add a chart repository and download its index"},
+			{"list", "List configured repositories"},
+			{"update [name]", "Refresh repository indexes (all, or one)"},
+			{"remove <name>", "Remove a repository"},
+		},
+		Run: chartsRepo,
+	},
+	{
+		Name:  "search",
+		Group: "Discovery",
+		Usage: []cmdUsage{{"[keyword]", "Search charts across repositories"}},
+		Run:   chartsSearch,
+	},
+	{
+		Name:  "show",
+		Group: "Discovery",
+		Usage: []cmdUsage{
+			{"chart <repo/chart>", "Show chart metadata"},
+			{"values <repo/chart>", "Show default values.yaml"},
+			{"schema <repo/chart>", "Show values.schema.json"},
+		},
+		Run: chartsShow,
+	},
+	{
+		Name:  "lint",
+		Group: "Authoring",
+		Usage: []cmdUsage{{"<chart>", "Check a chart without deploying it"}},
+		Run:   chartsLint,
+	},
+	{
+		Name:  "template",
+		Group: "Releases",
+		Usage: []cmdUsage{{"<release> <chart>", "Render manifest to stdout (no deploy)"}},
+		Run:   chartsTemplate,
+	},
+	{
+		Name:  "install",
+		Group: "Releases",
+		Usage: []cmdUsage{{"<release> <chart>", "Install a chart as a release"}},
+		Run:   chartsInstall,
+	},
+	{
+		Name:  "upgrade",
+		Group: "Releases",
+		Usage: []cmdUsage{{"<release> <chart>", "Upgrade a release to a new revision"}},
+		Run:   chartsUpgrade,
+	},
+	{
+		Name:  "uninstall",
+		Group: "Releases",
+		Usage: []cmdUsage{{"<release>", "Remove a release (keeps volumes)"}},
+		Run:   chartsUninstall,
+	},
+	{
+		Name:  "rollback",
+		Group: "Releases",
+		Usage: []cmdUsage{{"<release> <rev>", "Re-deploy the contents of a past revision"}},
+		Run:   chartsRollback,
+	},
+	{
+		Name:  "history",
+		Group: "Releases",
+		Usage: []cmdUsage{{"<release>", "Show a release's revision history"}},
+		Run:   chartsHistory,
+	},
+	{
+		Name:  "prune",
+		Group: "Releases",
+		Usage: []cmdUsage{{"[release]", "Delete old revisions beyond --history-max"}},
+		Run:   chartsPrune,
+	},
+	{
+		Name:  "get",
+		Group: "Releases",
+		Usage: []cmdUsage{{"values|manifest <release>", "Show stored values or rendered manifest"}},
+		Run:   chartsGet,
+	},
+	{
+		Name:  "diff",
+		Group: "Releases",
+		Usage: []cmdUsage{{"upgrade <release> <chart>", "Preview manifest changes before upgrading"}},
+		Run:   chartsDiff,
+	},
+	{
+		Name:    "list",
+		Aliases: []string{"ls"},
+		Group:   "Releases",
+		Usage:   []cmdUsage{{"", "List releases"}},
+		Run:     chartsList,
+	},
+	{
+		Name:  "status",
+		Group: "Releases",
+		Usage: []cmdUsage{{"<release>", "Show release status and services"}},
+		Run:   chartsStatus,
+	},
+	{
+		Name:  "apply",
+		Group: "GitOps",
+		Usage: []cmdUsage{{"-f <file>", "Converge the swarm to a declarative release file"}},
+		Run:   chartsApply,
+	},
+	{
+		Name:  "outdated",
+		Group: "GitOps",
+		Usage: []cmdUsage{{"", "Show releases with a newer chart version available"}},
+		Run:   chartsOutdated,
+	},
+}
+
+// lookupCommand resolves a name or alias to its row.
+func lookupCommand(name string) (chartsCmd, bool) {
+	for _, c := range chartsCommands {
+		if c.Name == name {
+			return c, true
+		}
+		for _, a := range c.Aliases {
+			if a == name {
+				return c, true
+			}
+		}
+	}
+	return chartsCmd{}, false
+}
+
+// commandNames lists every name and alias, sorted so a suggestion breaks ties
+// deterministically.
+func commandNames() []string {
+	var names []string
+	for _, c := range chartsCommands {
+		names = append(names, c.Name)
+		names = append(names, c.Aliases...)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// suggestCommand returns the closest command name to input within an edit
+// distance threshold, or "" if nothing is close enough. Same shape as the
+// TUI's unknown-flag suggestion (commands/api.suggestFlag), including the
+// threshold, so a typo is answered the same way on both surfaces.
+func suggestCommand(input string, names []string) string {
+	threshold := len(input) / 3
+	if threshold < 2 {
+		threshold = 2
+	}
+	best := ""
+	bestDist := threshold + 1
+	for _, n := range names {
+		if d := registry.Distance(input, n); d < bestDist {
+			best, bestDist = n, d
+		}
+	}
+	if bestDist > threshold {
+		return ""
+	}
+	return best
+}
+
+// renderCommands renders the grouped command list. prefix is what each line
+// starts with — empty for the usage text, "swarmcli charts " for the README
+// blocks, which show commands as an operator would type them.
+func renderCommands(prefix string) string {
+	type line struct{ left, summary string }
+
+	// One column width across every group, so the block reads as one table
+	// rather than a stack of independently aligned ones.
+	var lines []line
+	width := 0
+	for _, g := range chartGroups {
+		for _, c := range chartsCommands {
+			if c.Group != g {
+				continue
+			}
+			for i, u := range c.Usage {
+				left := strings.TrimRight(prefix+c.Name+" "+u.Args, " ")
+				summary := u.Summary
+				// The alias is reported on the command's first line rather than
+				// given a line of its own: it is the same command, and a second
+				// entry would read as a second thing to learn.
+				if i == 0 && len(c.Aliases) > 0 {
+					summary += " (alias: " + strings.Join(c.Aliases, ", ") + ")"
+				}
+				lines = append(lines, line{left, summary})
+				if len(left) > width {
+					width = len(left)
+				}
+			}
+		}
+	}
+
+	var b strings.Builder
+	i := 0
+	for _, g := range chartGroups {
+		count := 0
+		for _, c := range chartsCommands {
+			if c.Group == g {
+				count += len(c.Usage)
+			}
+		}
+		if count == 0 {
+			continue
+		}
+		if b.Len() > 0 {
+			b.WriteString("\n")
+		}
+		b.WriteString(g + ":\n")
+		for ; count > 0; count-- {
+			l := lines[i]
+			i++
+			b.WriteString("  " + l.left + strings.Repeat(" ", width-len(l.left)+2) + l.summary + "\n")
+		}
+	}
+	return b.String()
+}
+
+// chartsUsage is the full `swarmcli charts --help` text: the generated command
+// list, then the prose that explains the parts a list cannot.
+func chartsUsage() string {
+	return "Usage: swarmcli charts <command> [options]\n\n" + renderCommands("") + chartsUsageProse
+}

--- a/cli/commands_test.go
+++ b/cli/commands_test.go
@@ -103,19 +103,25 @@ func TestChartsMain_HelpPrintsUsage(t *testing.T) {
 	}
 }
 
-// The README blocks show commands as an operator types them; the usage text
-// shows them bare. Both come from the same rows.
-func TestRenderCommands_PrefixIsApplied(t *testing.T) {
-	block := renderCommands("swarmcli charts ")
-	require.Contains(t, block, "  swarmcli charts install <release> <chart>")
-	require.NotContains(t, renderCommands(""), "swarmcli charts install")
+// The README blocks show commands as an operator types them, commented and
+// copy-pasteable; the usage text shows them bare and indented. Both come from
+// the same rows.
+func TestRenderCommands_TwoStyles(t *testing.T) {
+	shell := renderCommandsShell()
+	require.Contains(t, shell, "swarmcli charts install <release> <chart>")
+	require.Contains(t, shell, "# Install a chart as a release")
+	require.Contains(t, shell, "# Releases")
+
+	usage := renderCommands()
+	require.NotContains(t, usage, "swarmcli charts install")
+	require.Contains(t, usage, "Releases:")
 }
 
 // A command with no arguments must not render trailing whitespace before its
 // summary column, and every line must align on one column across all groups.
 func TestRenderCommands_AlignsOneColumn(t *testing.T) {
 	var col int
-	for _, l := range strings.Split(strings.TrimRight(renderCommands(""), "\n"), "\n") {
+	for _, l := range strings.Split(strings.TrimRight(renderCommands(), "\n"), "\n") {
 		if !strings.HasPrefix(l, "  ") {
 			continue // group heading
 		}

--- a/cli/commands_test.go
+++ b/cli/commands_test.go
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package cli
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// The table is the source of truth for dispatch, the usage text and the
+// generated README blocks, so a malformed row degrades all three at once.
+func TestChartsCommands_RowsAreWellFormed(t *testing.T) {
+	groups := make(map[string]bool, len(chartGroups))
+	for _, g := range chartGroups {
+		groups[g] = true
+	}
+
+	seen := map[string]string{}
+	for _, c := range chartsCommands {
+		require.NotEmpty(t, c.Name, "every row needs a name")
+		require.NotNil(t, c.Run, "%s has no handler", c.Name)
+		require.True(t, groups[c.Group], "%s is in unknown group %q", c.Name, c.Group)
+		require.NotEmpty(t, c.Usage, "%s renders no usage line", c.Name)
+
+		for _, n := range append([]string{c.Name}, c.Aliases...) {
+			require.Empty(t, seen[n], "%q is claimed by both %s and %s", n, seen[n], c.Name)
+			seen[n] = c.Name
+		}
+		for _, u := range c.Usage {
+			require.NotEmpty(t, u.Summary, "%s has a usage line with no summary", c.Name)
+			require.NotContains(t, u.Summary, "\n", "%s: a summary is one line", c.Name)
+		}
+	}
+}
+
+// Every command reachable by dispatch must be listed, and everything listed
+// must dispatch. This is the invariant the old switch/usage-string pair had no
+// way to state.
+func TestChartsCommands_LookupCoversEveryNameAndAlias(t *testing.T) {
+	for _, n := range commandNames() {
+		c, ok := lookupCommand(n)
+		require.True(t, ok, "%q is listed but does not dispatch", n)
+		require.NotNil(t, c.Run)
+	}
+	_, ok := lookupCommand("nope")
+	require.False(t, ok)
+}
+
+func TestChartsUsage_ListsEveryCommand(t *testing.T) {
+	usage := chartsUsage()
+	for _, c := range chartsCommands {
+		require.Contains(t, usage, "  "+c.Name+" ", "%s is missing from the usage text", c.Name)
+	}
+	// The groups keep their order, so the list stays the walkthrough it reads as.
+	last := -1
+	for _, g := range chartGroups {
+		i := strings.Index(usage, "\n"+g+":\n")
+		require.Greater(t, i, last, "group %s is out of order", g)
+		last = i
+	}
+}
+
+// An alias that dispatches but is documented nowhere is how `ls` went four
+// releases without a mention.
+func TestChartsUsage_ReportsAliases(t *testing.T) {
+	require.Contains(t, chartsUsage(), "(alias: ls)")
+}
+
+func TestChartsMain_UnknownCommandSuggests(t *testing.T) {
+	var code int
+	_, e := capture(t, func() { code = chartsMain([]string{"instal"}) })
+	require.Equal(t, 2, code)
+	require.Contains(t, e, "unknown charts command 'instal'")
+	require.Contains(t, e, "did you mean 'install'?")
+}
+
+func TestChartsMain_UnknownCommandWithNothingCloseJustReports(t *testing.T) {
+	var code int
+	_, e := capture(t, func() { code = chartsMain([]string{"xyzzy"}) })
+	require.Equal(t, 2, code)
+	require.Contains(t, e, "unknown charts command 'xyzzy'")
+	require.NotContains(t, e, "did you mean")
+}
+
+func TestChartsMain_HelpPrintsUsage(t *testing.T) {
+	for _, arg := range [][]string{{}, {"help"}, {"--help"}, {"-h"}} {
+		var code int
+		o, _ := capture(t, func() { code = chartsMain(arg) })
+		require.Equal(t, 0, code)
+		require.Contains(t, o, "Usage: swarmcli charts <command> [options]")
+	}
+}
+
+// The README blocks show commands as an operator types them; the usage text
+// shows them bare. Both come from the same rows.
+func TestRenderCommands_PrefixIsApplied(t *testing.T) {
+	block := renderCommands("swarmcli charts ")
+	require.Contains(t, block, "  swarmcli charts install <release> <chart>")
+	require.NotContains(t, renderCommands(""), "swarmcli charts install")
+}
+
+// A command with no arguments must not render trailing whitespace before its
+// summary column, and every line must align on one column across all groups.
+func TestRenderCommands_AlignsOneColumn(t *testing.T) {
+	var col int
+	for _, l := range strings.Split(strings.TrimRight(renderCommands(""), "\n"), "\n") {
+		if !strings.HasPrefix(l, "  ") {
+			continue // group heading
+		}
+		require.NotContains(t, l, "  \n")
+		i := strings.Index(l[2:], "  ")
+		require.Greater(t, i, 0, "no summary column in %q", l)
+		i += 2
+		for l[i] == ' ' {
+			i++
+		}
+		if col == 0 {
+			col = i
+		}
+		require.Equal(t, col, i, "summary column moves at %q", l)
+	}
+	require.NotZero(t, col)
+}

--- a/cli/commands_test.go
+++ b/cli/commands_test.go
@@ -10,6 +10,15 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// cmd returns a command's row so a test can drive its handler exactly as
+// dispatch does, allow-list included.
+func cmd(t *testing.T, name string) chartsCmd {
+	t.Helper()
+	c, ok := lookupCommand(name)
+	require.True(t, ok, "no such command: %s", name)
+	return c
+}
+
 // The table is the source of truth for dispatch, the usage text and the
 // generated README blocks, so a malformed row degrades all three at once.
 func TestChartsCommands_RowsAreWellFormed(t *testing.T) {

--- a/cli/docs_test.go
+++ b/cli/docs_test.go
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package cli
+
+import (
+	"flag"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// updateDocs rewrites the generated blocks instead of asserting on them:
+//
+//	go test ./cli -run TestGeneratedCommandBlocks -update
+//
+// It is how a new row reaches the READMEs. Without it this test only reads.
+var updateDocs = flag.Bool("update", false, "rewrite the generated README command blocks")
+
+const (
+	blockBegin = "<!-- BEGIN generated: charts commands -->"
+	blockEnd   = "<!-- END generated -->"
+)
+
+// generatedDocs are the files carrying a generated command block. They are the
+// two places the command list used to be maintained by hand, and drifted.
+var generatedDocs = []string{"../README.md", "../charts/README.md"}
+
+// The command list in README.md and charts/README.md is rendered from
+// chartsCommands. Editing either by hand, or adding a row without
+// regenerating, fails here — which is the whole point: before this, three
+// copies of the list drifted and nothing noticed.
+func TestGeneratedCommandBlocks(t *testing.T) {
+	want := "```bash\n" + renderCommandsShell() + "```"
+
+	for _, path := range generatedDocs {
+		t.Run(path, func(t *testing.T) {
+			raw, err := os.ReadFile(path)
+			require.NoError(t, err)
+			doc := string(raw)
+
+			before, after := split(t, path, doc)
+			if *updateDocs {
+				require.NoError(t, os.WriteFile(path, []byte(before+want+after), 0o644)) //nolint:gosec // documentation, tracked in git
+				return
+			}
+
+			got := strings.TrimSuffix(strings.TrimPrefix(doc, before), after)
+			require.Equal(t, want, got,
+				"%s is stale — regenerate with: go test ./cli -run TestGeneratedCommandBlocks -update", path)
+		})
+	}
+}
+
+// split returns everything up to and including the begin marker, and everything
+// from the end marker on, so the block between them can be compared or replaced.
+func split(t *testing.T, path, doc string) (before, after string) {
+	t.Helper()
+	i := strings.Index(doc, blockBegin)
+	require.GreaterOrEqual(t, i, 0, "%s has no %s marker", path, blockBegin)
+	j := strings.Index(doc, blockEnd)
+	require.Greater(t, j, i, "%s has no %s marker after the begin marker", path, blockEnd)
+	return doc[:i+len(blockBegin)] + "\n", "\n" + doc[j:]
+}

--- a/cli/flagreads_test.go
+++ b/cli/flagreads_test.go
@@ -1,0 +1,167 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package cli
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// fieldFlag maps a field of the flags struct to the flag that sets it. The
+// struct is the parser's output and the table is the CLI's contract; this is
+// the only place the two vocabularies meet.
+var fieldFlag = map[string]string{
+	"values":          "--values",
+	"sets":            "--set",
+	"setFiles":        "--set-file",
+	"version":         "--version",
+	"dryRun":          "--dry-run",
+	"wait":            "--wait",
+	"requirements":    "--requirements",
+	"purge":           "--purge-volumes",
+	"install":         "--install",
+	"reuseValues":     "--reuse-values",
+	"diff":            "--diff",
+	"revision":        "--revision",
+	"timeout":         "--timeout",
+	"historyMax":      "--history-max",
+	"skipCompatCheck": "--skip-compat-check",
+	"noRepoUpdate":    "--no-repo-update",
+	"forVersion":      "--for-version",
+	"resolveImage":    "--resolve-image",
+}
+
+// flagPlumbing are the functions that inspect the whole flags value rather than
+// reading it as a command does. Following them would credit every command with
+// every flag.
+var flagPlumbing = map[string]bool{"parse": true, "parseArgs": true, "reject": true}
+
+// flagReads reports, per function in this package, which flags it honours: the
+// f.<field> reads in its own body plus those of every helper it hands its own f
+// to (newStore, loadChart, prepare — the reason a handler's body understates
+// what it reads).
+func flagReads(t *testing.T) map[string]map[string]bool {
+	t.Helper()
+
+	fset := token.NewFileSet()
+	files, err := parser.ParseDir(fset, ".", nil, 0)
+	require.NoError(t, err)
+	pkg, ok := files["cli"]
+	require.True(t, ok, "cli package did not parse")
+
+	direct := map[string]map[string]bool{}  // func -> flags read in its own body
+	callees := map[string]map[string]bool{} // func -> funcs it passes its own f to
+
+	for _, file := range pkg.Files {
+		for _, decl := range file.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok || flagPlumbing[fn.Name.Name] {
+				continue
+			}
+			name := fn.Name.Name
+			direct[name] = map[string]bool{}
+			callees[name] = map[string]bool{}
+
+			ast.Inspect(fn, func(n ast.Node) bool {
+				switch v := n.(type) {
+				case *ast.SelectorExpr:
+					// f.dryRun — a read of the parsed flag value.
+					if id, ok := v.X.(*ast.Ident); ok && id.Name == "f" {
+						if flag, ok := fieldFlag[v.Sel.Name]; ok {
+							direct[name][flag] = true
+						}
+					}
+				case *ast.CallExpr:
+					// helper(…, f, …) — the helper reads on this command's behalf.
+					// A call passing a fresh flags literal instead (chartsRepo's
+					// newStore(flags{…})) is deliberately not followed: those
+					// values come from the code, not from the command line.
+					id, ok := v.Fun.(*ast.Ident)
+					if !ok {
+						return true
+					}
+					for _, a := range v.Args {
+						if ai, ok := a.(*ast.Ident); ok && ai.Name == "f" {
+							callees[name][id.Name] = true
+						}
+					}
+				}
+				return true
+			})
+		}
+	}
+
+	// Close over the helper chain: prepare calls loadChart calls newStore.
+	out := map[string]map[string]bool{}
+	for name := range direct {
+		seen := map[string]bool{}
+		var walk func(string)
+		walk = func(n string) {
+			if seen[n] {
+				return
+			}
+			seen[n] = true
+			for f := range direct[n] {
+				if out[name] == nil {
+					out[name] = map[string]bool{}
+				}
+				out[name][f] = true
+			}
+			for c := range callees[n] {
+				walk(c)
+			}
+		}
+		walk(name)
+		if out[name] == nil {
+			out[name] = map[string]bool{}
+		}
+	}
+	return out
+}
+
+// The allow-lists were written by reading the handlers; this reads them back
+// out of the syntax tree and compares. Without it, a row that lists too few
+// flags rejects an invocation that used to work — and every table-driven test
+// in this package would agree with the wrong table, because they all iterate
+// it.
+func TestFlagAllowListsMatchWhatHandlersRead(t *testing.T) {
+	reads := flagReads(t)
+
+	for _, c := range chartsCommands {
+		t.Run(c.Name, func(t *testing.T) {
+			fn := handlerName(t, c)
+			got, ok := reads[fn]
+			require.True(t, ok, "handler %s not found in the syntax tree", fn)
+
+			want := map[string]bool{}
+			for _, f := range c.Flags {
+				want[f] = true
+			}
+			require.Equal(t, sortedKeys(want), sortedKeys(got),
+				"%s's allow-list and what %s reads have diverged", c.Name, fn)
+		})
+	}
+}
+
+// handlerName recovers the function name behind a row's Run, which is what
+// links the table to the syntax tree.
+func handlerName(t *testing.T, c chartsCmd) string {
+	t.Helper()
+	return "charts" + strings.ToUpper(c.Name[:1]) + c.Name[1:]
+}
+
+func sortedKeys(m map[string]bool) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/cli/flagspec_test.go
+++ b/cli/flagspec_test.go
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package cli
+
+import (
+	"os"
+	"regexp"
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// sampleValue is what a flag needing one is given, so a rejection test exercises
+// the rejection rather than "flag requires a value".
+var sampleValue = map[string]string{
+	"--values":        "values.yaml",
+	"--set":           "a=1",
+	"--set-file":      "a=/dev/null",
+	"--version":       "1.0.0",
+	"--timeout":       "5m",
+	"--history-max":   "3",
+	"--revision":      "2",
+	"--resolve-image": "always",
+	"--for-version":   "1.13.0",
+}
+
+// argsFor renders a flag as an operator would pass it.
+func argsFor(flag string) []string {
+	if v, ok := sampleValue[flag]; ok {
+		return []string{flag, v}
+	}
+	return []string{flag}
+}
+
+// parserFlags reads the long flags parseArgs accepts straight out of its
+// source. Hard-coding them here would make this file agree with itself rather
+// than with the parser, and the gap it exists to catch — a flag the parser
+// learns and no command lists — would be invisible.
+func parserFlags(t *testing.T) []string {
+	t.Helper()
+	src, err := os.ReadFile("args.go")
+	require.NoError(t, err)
+
+	seen := map[string]bool{}
+	for _, m := range regexp.MustCompile(`case "(--[a-z-]+)"`).FindAllStringSubmatch(string(src), -1) {
+		seen[m[1]] = true
+	}
+	// The switch pairs "-f" with "--values" on one case line, which the pattern
+	// above catches by its long half.
+	var out []string
+	for f := range seen {
+		out = append(out, f)
+	}
+	sort.Strings(out)
+	require.NotEmpty(t, out)
+	return out
+}
+
+// A flag the parser accepts but no command lists is unreachable: every
+// invocation of it is rejected, whichever command an operator tries. That is a
+// flag shipped by accident, and this is where it surfaces.
+func TestEveryParserFlagIsReachable(t *testing.T) {
+	listed := map[string]bool{}
+	for _, c := range chartsCommands {
+		for _, f := range c.Flags {
+			listed[f] = true
+		}
+	}
+	for _, f := range parserFlags(t) {
+		require.True(t, listed[f], "%s is parsed but no command accepts it", f)
+	}
+}
+
+// Every flag a row lists must survive that row's allow-list. A typo in the
+// table would otherwise reject a flag the handler goes on to read.
+func TestAllowedFlagsAreAccepted(t *testing.T) {
+	for _, c := range chartsCommands {
+		for _, f := range c.Flags {
+			t.Run(c.Name+f, func(t *testing.T) {
+				_, _, code := parse(c, argsFor(f))
+				require.Equal(t, -1, code, "%s should accept %s", c.Name, f)
+			})
+		}
+	}
+}
+
+// The defect #451 reports: the flag struct is global, so every subcommand
+// parses every flag and silently drops what it does not read — which reads to
+// an operator as "it worked".
+func TestUnlistedFlagsAreRejected(t *testing.T) {
+	all := parserFlags(t)
+	for _, c := range chartsCommands {
+		allowed := map[string]bool{}
+		for _, f := range c.Flags {
+			allowed[f] = true
+		}
+		for _, f := range all {
+			if allowed[f] {
+				continue
+			}
+			t.Run(c.Name+f, func(t *testing.T) {
+				var code int
+				_, e := capture(t, func() { _, _, code = parse(c, argsFor(f)) })
+				require.Equal(t, 2, code, "%s should reject %s", c.Name, f)
+				require.Contains(t, e, "charts "+c.Name+" does not accept '"+f+"'")
+			})
+		}
+	}
+}
+
+// -f is the one short form, and the table lists only long names — so it has to
+// be canonicalised before the allow-list sees it, or `-f` is rejected by every
+// command that accepts `--values`.
+func TestShortFormIsCanonicalised(t *testing.T) {
+	c := cmd(t, "install")
+	_, _, code := parse(c, []string{"-f", "values.yaml"})
+	require.Equal(t, -1, code)
+
+	var rejected int
+	_, e := capture(t, func() { _, _, rejected = parse(cmd(t, "list"), []string{"-f", "values.yaml"}) })
+	require.Equal(t, 2, rejected)
+	require.Contains(t, e, "does not accept '--values'")
+}
+
+// A rejection that names only what is wrong leaves an operator guessing. apply
+// is the one command with somewhere else to point them.
+func TestApplyRejectionNamesTheReleaseFile(t *testing.T) {
+	var code int
+	_, e := capture(t, func() { _, _, code = parse(cmd(t, "apply"), []string{"--set", "a=1"}) })
+	require.Equal(t, 2, code)
+	require.Contains(t, e, "only source of truth")
+}
+
+// End to end through dispatch, on the two invocations #451 opens with. Neither
+// reaches Docker: the allow-list is checked before the handler does anything.
+func TestDispatchRejectsIrrelevantFlags(t *testing.T) {
+	for _, tc := range []struct {
+		args []string
+		want string
+	}{
+		{[]string{"list", "--purge-volumes"}, "charts list does not accept '--purge-volumes'"},
+		{[]string{"status", "x", "--history-max", "5"}, "charts status does not accept '--history-max'"},
+	} {
+		var code int
+		_, e := capture(t, func() { code = chartsMain(tc.args) })
+		require.Equal(t, 2, code)
+		require.Contains(t, e, tc.want)
+	}
+}

--- a/cli/help_test.go
+++ b/cli/help_test.go
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package cli
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Per-command help renders from flagDocs, so a flag with no entry there prints
+// as a bare name with no explanation — and the option reference silently stops
+// covering it.
+func TestFlagDocsCoverEveryListedFlag(t *testing.T) {
+	documented := map[string]bool{}
+	for _, d := range flagDocs {
+		require.NotEmpty(t, d.Desc, "%s has no description", d.Name)
+		require.False(t, documented[d.Name], "%s is documented twice", d.Name)
+		documented[d.Name] = true
+	}
+
+	listed := map[string]bool{}
+	for _, c := range chartsCommands {
+		for _, f := range c.Flags {
+			listed[f] = true
+			require.True(t, documented[f], "%s takes %s, which the option reference does not describe", c.Name, f)
+		}
+	}
+	for _, d := range flagDocs {
+		require.True(t, listed[d.Name], "%s is documented but no command takes it", d.Name)
+	}
+}
+
+// `charts install --help` printed "Error: unknown flag '--help'" before the
+// table existed: only the top-level help was intercepted.
+func TestCommandHelpIsInterceptedPerCommand(t *testing.T) {
+	var code int
+	o, e := capture(t, func() { code = chartsMain([]string{"install", "--help"}) })
+	require.Equal(t, 0, code)
+	require.Empty(t, e)
+	require.Contains(t, o, "swarmcli charts install <release> <chart>")
+	require.Contains(t, o, "--set-file")
+	// install does not take these, so its help must not offer them.
+	require.NotContains(t, o, "--purge-volumes")
+	require.NotContains(t, o, "--revision")
+}
+
+// Help must survive being asked for after the arguments, which is how anyone
+// who started typing the command asks for it.
+func TestCommandHelpAfterPositionals(t *testing.T) {
+	var code int
+	o, _ := capture(t, func() { code = chartsMain([]string{"upgrade", "rel", "repo/chart", "-h"}) })
+	require.Equal(t, 0, code)
+	require.Contains(t, o, "swarmcli charts upgrade")
+}
+
+// A command with no options says so, rather than printing an empty heading.
+func TestCommandHelpWithNoOptions(t *testing.T) {
+	o, _ := capture(t, func() { chartsMain([]string{"list", "--help"}) })
+	require.Contains(t, o, "This command takes no options.")
+	require.Contains(t, o, "Alias: ls")
+	require.NotContains(t, o, "Options:")
+}
+
+// `charts help <command>` and `charts <command> --help` are one page, as
+// `:help <cmd>` and `:cmd --help` are in the TUI.
+func TestHelpSubcommandMatchesFlag(t *testing.T) {
+	viaVerb, _ := capture(t, func() { chartsMain([]string{"help", "status"}) })
+	viaFlag, _ := capture(t, func() { chartsMain([]string{"status", "--help"}) })
+	require.Equal(t, viaVerb, viaFlag)
+	require.Contains(t, viaVerb, "swarmcli charts status <release>")
+}
+
+// An unknown name after help falls back to the full usage rather than claiming
+// a command exists.
+func TestHelpSubcommandUnknownFallsBack(t *testing.T) {
+	var code int
+	o, _ := capture(t, func() { code = chartsMain([]string{"help", "nonsense"}) })
+	require.Equal(t, 0, code)
+	require.Contains(t, o, "Usage: swarmcli charts <command> [options]")
+}
+
+// "--help" as the VALUE of another flag is a value, not a request for help.
+// Only the parser knows the difference, which is why the interception lives
+// there rather than in a scan of the arguments.
+func TestHelpIsNotConfusedWithAFlagValue(t *testing.T) {
+	pos, f, code := parse(cmd(t, "install"), []string{"rel", "repo/chart", "--set", "--help"})
+	require.Equal(t, -1, code)
+	require.Equal(t, []string{"rel", "repo/chart"}, pos)
+	require.Equal(t, []string{"--help"}, f.sets)
+}
+
+// The top-level usage keeps the full reference; a command's help shows only its
+// own flags. Both come from flagDocs.
+func TestOptionReferenceSubsets(t *testing.T) {
+	all := renderOptions(nil)
+	for _, d := range flagDocs {
+		require.Contains(t, all, d.Name)
+	}
+
+	only := renderOptions([]string{"--wait", "--timeout"})
+	require.Contains(t, only, "--wait")
+	require.Contains(t, only, "--timeout")
+	require.NotContains(t, only, "--set")
+
+	// Every rendered line wraps rather than running off the terminal.
+	for _, l := range strings.Split(strings.TrimRight(all, "\n"), "\n") {
+		require.LessOrEqual(t, len([]rune(l)), 80, "option line is too wide: %q", l)
+	}
+}


### PR DESCRIPTION
Closes #452, closes #451.

Both issues are the same missing artefact: there was no machine-readable list of what `swarmcli charts` accepts, so the command list lived in three hand-maintained places and the flag set in none. `cli/commands.go` now holds one table — name, aliases, group, usage lines, allowed flags, handler — and four things read from it.

**Dispatch and the usage text** (#452). `chartsMain`'s switch is a lookup; the usage block is rendered. The rendered block aligns every group on one column instead of three hand-spaced ones, spells `<rel>` as `<release>` throughout, and reports the `ls` alias — which dispatch has accepted since `list` existed while no text anywhere mentioned it. An unknown command now suggests the nearest name, using the same edit distance and threshold as the TUI's unknown-flag suggestion.

**The two README blocks** (#452). Generated between markers and asserted by a test; `go test ./cli -run TestGeneratedCommandBlocks -update` regenerates them. `README.md` and `charts/README.md` join ci.yml's `code` paths-filter — without that, a PR hand-editing a block would skip the job that runs the test that catches it. `charts/README.md` keeps its Invocation walkthrough and gains the full list after it as a reference.

**Per-subcommand flag rejection** (#451). `charts list --purge-volumes` and `charts status x --history-max 5` used to parse cleanly and drop the flag, which reads as "it worked". Each row lists what its handler honours and one prelude checks it; `apply`'s `rejectUnsupported` collapses into that, keeping its message as the row's `FlagHint`. #451's other half — `--debug` as dead code — was already fixed; nothing to remove.

**`charts <command> --help`**, which answered `Error: unknown flag '--help'` before. The parser reports it (as an error, because it is the only place that knows a `--help` token is a flag and not the value of the flag before it) and the prelude prints that command's page. `charts help <command>` is the same page, mirroring `:help <cmd>` / `:cmd --help` in the TUI.

### On the allow-lists

They were derived by reading each handler *and everything it hands its flags to* — `newStore` reads `--no-repo-update`, `loadChart` adds `--version`, `prepare` adds the values and compat flags — so a handler's own body understates what it reads, and a grep would have been wrong in both directions.

A list that is too narrow rejects an invocation that used to work, and every table-driven test here iterates the same table it would be wrong in. So `TestFlagAllowListsMatchWhatHandlersRead` reads the flag reads back out of the syntax tree, follows the helper chain, and compares. Verified by mutation: dropping `--dry-run` from `install` and adding `--purge-volumes` to `list` each fail it.

Two more guards fall out: every flag the parser accepts must be listed by some command (a flag no row lists is unreachable), and every listed flag must have a `flagDocs` entry (or help renders a bare name).

### Removed rather than updated

Three hand-kept lists that were correct today and had no way to stay that way: the per-flag scope annotations in the option reference (`--install  upgrade: …`), the paragraph enumerating what `apply` rejects, and CLAUDE.md's "update all three places" instruction — replaced by "add a row; run `-update`".

### Verification

`go test ./...`, `go vet ./...`, `golangci-lint run ./... --build-tags=integration` all clean. Both generated blocks and the flag cross-check mutation-tested. Smoke-tested through the built binary: `charts ls` still dispatches, allowed flags pass through, rejected ones report with the command named. **Not run: the live-swarm sweep** — this environment has no Docker daemon, so the install/upgrade/template/diff/apply paths were exercised only up to the point where they reach the daemon.
