### PR TITLE
test(charts): run every charts subcommand against a real swarm

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,7 +104,7 @@ utils/log/
 go test ./cli -run TestGeneratedCommandBlocks -update
 ```
 
-`go test ./cli` fails if you forget; it also compares each row's flag list against what the handler and its callees actually read, so an allow-list cannot quietly drift from the code.
+`go test ./cli` fails if you forget; it also compares each row's flag list against what the handler and its callees actually read, so an allow-list cannot quietly drift from the code. It further requires `integration-tests/charts/charts_cli_test.go` to run the new command against the DinD swarm with every flag its row lists — a row the allow-list matches perfectly is still a row nothing has ever run.
 
 ## Environment Variables
 

--- a/cli/integrationcoverage_test.go
+++ b/cli/integrationcoverage_test.go
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package cli
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// integrationSuiteDir is the package that drives this CLI against a real swarm.
+// It is read rather than imported: its tests are behind the integration build
+// tag and need a Docker daemon, while this one needs neither.
+const integrationSuiteDir = "../integration-tests/charts"
+
+// dispatchFuncs are the two ways that suite invokes the CLI: cli.Dispatch, and
+// the dispatchOK helper wrapping it.
+var dispatchFuncs = map[string]bool{"Dispatch": true, "dispatchOK": true}
+
+// integrationInvocations reports, per charts subcommand, which flags the
+// integration suite passes it, read out of that suite's syntax tree.
+//
+// Only the literal arguments are read: a release name, a chart directory and a
+// temp path are variables, and none of them is a flag. An invocation therefore
+// counts when its "charts" and command words are literals, which every one of
+// them writes out.
+func integrationInvocations(t *testing.T) map[string]map[string]bool {
+	t.Helper()
+
+	fset := token.NewFileSet()
+	pkgs, err := parser.ParseDir(fset, integrationSuiteDir, nil, 0)
+	require.NoError(t, err, "the integration suite did not parse")
+	require.NotEmpty(t, pkgs, "%s holds no Go package", integrationSuiteDir)
+
+	used := map[string]map[string]bool{}
+	for _, pkg := range pkgs {
+		for _, file := range pkg.Files {
+			ast.Inspect(file, func(n ast.Node) bool {
+				call, ok := n.(*ast.CallExpr)
+				if !ok || !isDispatchCall(call) {
+					return true
+				}
+				record(used, literalArgs(call))
+				return true
+			})
+		}
+	}
+	return used
+}
+
+// isDispatchCall reports whether call runs the CLI.
+func isDispatchCall(call *ast.CallExpr) bool {
+	switch fn := call.Fun.(type) {
+	case *ast.Ident:
+		return dispatchFuncs[fn.Name]
+	case *ast.SelectorExpr:
+		return dispatchFuncs[fn.Sel.Name]
+	}
+	return false
+}
+
+// literalArgs returns the string literals inside call, in source order. The
+// arguments may be spread across the call (dispatchOK) or wrapped in a slice
+// literal (cli.Dispatch), so the whole subtree is walked rather than the
+// argument list.
+func literalArgs(call *ast.CallExpr) []string {
+	var out []string
+	ast.Inspect(call, func(n ast.Node) bool {
+		lit, ok := n.(*ast.BasicLit)
+		if !ok || lit.Kind != token.STRING {
+			return true
+		}
+		if s, err := strconv.Unquote(lit.Value); err == nil {
+			out = append(out, s)
+		}
+		return true
+	})
+	return out
+}
+
+// record credits the command named in argv with every flag argv passes it.
+func record(used map[string]map[string]bool, argv []string) {
+	var i int
+	for i < len(argv) && argv[i] != "charts" {
+		i++
+	}
+	if i+1 >= len(argv) {
+		return
+	}
+	c, ok := lookupCommand(argv[i+1])
+	if !ok {
+		return
+	}
+	if used[c.Name] == nil {
+		used[c.Name] = map[string]bool{}
+	}
+	for _, a := range argv[i+2:] {
+		if !strings.HasPrefix(a, "-") {
+			continue
+		}
+		name, _, _ := splitFlag(a)
+		if long, ok := canonicalFlag[name]; ok {
+			name = long
+		}
+		used[c.Name][name] = true
+	}
+}
+
+// Every command in the table must be run against a real swarm, with every flag
+// it accepts.
+//
+// The allow-lists are what this layer is for: a flag outside a row exits 2
+// instead of being parsed and dropped, so a row that is too narrow rejects an
+// invocation that used to work. TestFlagAllowListsMatchWhatHandlersRead proves
+// each row matches its handler; only running the command proves the row is
+// right. This reads the invocations out of the integration suite rather than
+// keeping a list of what is covered, because a hand-kept list of coverage is
+// the first thing to stop being true — a flag added to a row would otherwise
+// leave every test here green and nothing running it.
+func TestIntegrationSuiteExercisesEveryCommandAndFlag(t *testing.T) {
+	used := integrationInvocations(t)
+	require.NotEmpty(t, used, "no CLI invocation was found in %s — this test would pass on an empty suite", integrationSuiteDir)
+
+	for _, c := range chartsCommands {
+		t.Run(c.Name, func(t *testing.T) {
+			require.Contains(t, used, c.Name,
+				"nothing in %s runs `swarmcli charts %s` against a real swarm", integrationSuiteDir, c.Name)
+			for _, f := range c.Flags {
+				require.True(t, used[c.Name][f],
+					"`swarmcli charts %s` is never run with %s in %s — add it to an invocation there",
+					c.Name, f, integrationSuiteDir)
+			}
+		})
+	}
+}

--- a/integration-tests/charts/charts_cli_test.go
+++ b/integration-tests/charts/charts_cli_test.go
@@ -1,0 +1,290 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+//go:build integration
+
+package charts
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/Eldara-Tech/swarmcli/charts"
+	"github.com/Eldara-Tech/swarmcli/cli"
+	"github.com/Eldara-Tech/swarmcli/docker"
+	swarmlog "github.com/Eldara-Tech/swarmcli/utils/log"
+)
+
+// The rest of this package drives the charts *package*: it proves the engine
+// converges a real swarm. These two tests drive the *CLI layer* — the thing an
+// operator and a CI job actually type — because that layer now decides whether
+// an invocation is accepted at all. Each subcommand carries a flag allow-list,
+// and a flag outside it exits 2 rather than being parsed and dropped, so an
+// allow-list that is too narrow rejects an invocation that used to work.
+// cli.TestFlagAllowListsMatchWhatHandlersRead proves the lists agree with the
+// handlers; agreement is not the command running against a daemon.
+//
+// Between them every row of the command table is invoked with every flag it
+// lists, which cli.TestIntegrationSuiteExercisesEveryCommandAndFlag enforces by
+// reading the invocations below back out of the syntax tree.
+
+// dispatchOK runs one CLI invocation and fails naming the argv it ran. Exit 2
+// is the failure worth recognising: it is the layer refusing a flag, not the
+// command going wrong.
+func dispatchOK(t *testing.T, argv ...string) {
+	t.Helper()
+	require.Equal(t, 0, cli.Dispatch(argv, "test"), "swarmcli %s", strings.Join(argv, " "))
+}
+
+// isolateCLIState points the repository store at a temp dir. loadChart builds a
+// RepoStore for every command, including ones handed a local chart path, so
+// without this the CLI reads — and refreshes over the network — whatever
+// repositories the machine running the test happens to have configured.
+func isolateCLIState(t *testing.T) {
+	t.Helper()
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+}
+
+// TestChartsCLIImperativeLifecycle runs the imperative path end to end through
+// cli.Dispatch against the live swarm: template, install, get, diff, upgrade,
+// history, status, list, rollback, prune, apply and uninstall, each with the
+// flags its row lists.
+//
+// Exit 0 is necessary and not sufficient, so each mutating command is checked
+// against the engine afterwards: a command that exits 0 while deploying nothing
+// would otherwise pass. The three preview verbs (install --dry-run, upgrade
+// --dry-run, diff upgrade) are asserted to have recorded no revision at all.
+func TestChartsCLIImperativeLifecycle(t *testing.T) {
+	swarmlog.InitTestIfTestLogEnv()
+	isolateCLIState(t)
+
+	ctx := context.Background()
+	release := fmt.Sprintf("itest-cli-%d", time.Now().UnixNano())
+	applyRelease := release + "-apply"
+
+	chartDir := writeDemoChart(t)
+	dir := t.TempDir()
+
+	valuesFile := filepath.Join(dir, "values.yaml")
+	require.NoError(t, os.WriteFile(valuesFile, []byte("replicas: 1\n"), 0o600))
+
+	// notes is a values key no template reads. Its whole job is to be read back
+	// out of the recorded revision, which is how --set-file is proven to have
+	// reached the release rather than merely been accepted — and it keeps the
+	// shared demo chart, which eight other tests render, untouched.
+	notesFile := filepath.Join(dir, "notes.txt")
+	notes := fmt.Sprintf("set-file-%d", time.Now().UnixNano())
+	require.NoError(t, os.WriteFile(notesFile, []byte(notes), 0o600))
+
+	relFile := filepath.Join(dir, "swarmcli-release.yaml")
+	require.NoError(t, os.WriteFile(relFile, []byte(fmt.Sprintf(
+		"releases:\n  - name: %s\n    chart: %s\n", applyRelease, chartDir)), 0o600))
+
+	eng := charts.NewEngine()
+	defer func() {
+		_, _ = eng.Uninstall(ctx, release, true)
+		_, _ = eng.Uninstall(ctx, applyRelease, true)
+	}()
+
+	// --- template: renders to stdout, deploys nothing ---
+	dispatchOK(t, "charts", "template", release, chartDir,
+		"--values", valuesFile, "--set", "replicas=1", "--set-file", "notes="+notesFile,
+		"--skip-compat-check", "--no-repo-update")
+
+	// --requirements needs a chart that declares some; the external-network
+	// fixture is this package's only one. template deploys nothing, so the
+	// network it declares is not created.
+	dispatchOK(t, "charts", "template", release, writeExtNetChart(t, "itest-cli-requirements"),
+		"--requirements")
+
+	// --- install --dry-run: prints the prospective revision, records none ---
+	dispatchOK(t, "charts", "install", release, chartDir,
+		"--set", "replicas=1", "--dry-run", "--no-repo-update")
+	_, err := eng.History(ctx, release)
+	require.Error(t, err, "install --dry-run must not record a revision")
+
+	// --- install ---
+	dispatchOK(t, "charts", "install", release, chartDir,
+		"--values", valuesFile, "--set", "replicas=1", "--set-file", "notes="+notesFile,
+		"--wait", "--timeout", "90s", "--history-max", "5",
+		"--resolve-image", "never", "--skip-compat-check", "--no-repo-update")
+
+	cur, svcs, err := eng.Status(ctx, release)
+	require.NoError(t, err)
+	require.Equal(t, charts.StatusDeployed, cur.Status)
+	require.NotEmpty(t, svcs, "install --wait must leave a running service behind")
+
+	rev1, err := eng.GetRevision(ctx, release, 1)
+	require.NoError(t, err)
+	require.Equal(t, notes, rev1.Values["notes"], "--set-file must reach the recorded revision")
+
+	// --- the read-only verbs, against a release that exists ---
+	dispatchOK(t, "charts", "get", "values", release, "--revision", "1")
+	dispatchOK(t, "charts", "history", release)
+	dispatchOK(t, "charts", "status", release)
+	dispatchOK(t, "charts", "list")
+	dispatchOK(t, "charts", "outdated", "--no-repo-update")
+
+	// --- diff upgrade: a preview verb, it must not deploy ---
+	dispatchOK(t, "charts", "diff", "upgrade", release, chartDir,
+		"--values", valuesFile, "--set", "replicas=2", "--set-file", "notes="+notesFile,
+		"--reuse-values", "--skip-compat-check", "--no-repo-update")
+	hist, err := eng.History(ctx, release)
+	require.NoError(t, err)
+	require.Len(t, hist, 1, "diff upgrade must not deploy")
+
+	// --- upgrade --dry-run ---
+	dispatchOK(t, "charts", "upgrade", release, chartDir,
+		"--set", "replicas=2", "--dry-run", "--no-repo-update")
+	hist, err = eng.History(ctx, release)
+	require.NoError(t, err)
+	require.Len(t, hist, 1, "upgrade --dry-run must not record a revision")
+
+	// --- upgrade ---
+	dispatchOK(t, "charts", "upgrade", release, chartDir,
+		"--values", valuesFile, "--set", "replicas=2", "--set-file", "notes="+notesFile,
+		"--install", "--reuse-values", "--wait", "--timeout", "90s", "--history-max", "5",
+		"--resolve-image", "changed", "--skip-compat-check", "--no-repo-update")
+	hist, err = eng.History(ctx, release)
+	require.NoError(t, err)
+	require.Len(t, hist, 2, "upgrade must record a second revision")
+
+	// --- rollback: revision 3 carries revision 1's contents ---
+	dispatchOK(t, "charts", "rollback", release, "1",
+		"--wait", "--timeout", "90s", "--history-max", "5")
+	hist, err = eng.History(ctx, release)
+	require.NoError(t, err)
+	require.Len(t, hist, 3)
+	rev3, err := eng.GetRevision(ctx, release, 3)
+	require.NoError(t, err)
+	require.Equal(t, rev1.Manifest, rev3.Manifest, "rollback must re-deploy revision 1's manifest")
+
+	// --- prune --dry-run: reports what it would delete, deletes nothing ---
+	dispatchOK(t, "charts", "prune", release, "--history-max", "1", "--dry-run")
+	hist, err = eng.History(ctx, release)
+	require.NoError(t, err)
+	require.Len(t, hist, 3, "prune --dry-run must delete nothing")
+
+	// --- apply: its behaviour is covered by charts_apply_test.go; this is its
+	// flag row, which no other test passes in full ---
+	dispatchOK(t, "charts", "apply", "-f", relFile, "--diff", "--dry-run")
+	_, err = eng.History(ctx, applyRelease)
+	require.Error(t, err, "apply --diff --dry-run must not deploy")
+
+	dispatchOK(t, "charts", "apply", "-f", relFile,
+		"--wait", "--timeout", "90s", "--history-max", "5",
+		"--resolve-image", "never", "--skip-compat-check", "--no-repo-update")
+	applied, _, err := eng.Status(ctx, applyRelease)
+	require.NoError(t, err)
+	require.Equal(t, charts.StatusDeployed, applied.Status)
+
+	// --- uninstall ---
+	dispatchOK(t, "charts", "uninstall", release, "--purge-volumes")
+	_, err = docker.InspectConfig(ctx, fmt.Sprintf("swarmcli.release.%s.v1", release))
+	require.Error(t, err, "uninstall must remove the release configs")
+
+	dispatchOK(t, "charts", "uninstall", applyRelease)
+}
+
+// TestChartsCLIRepositoryCommands runs the repository-backed commands through
+// cli.Dispatch: the ones that resolve a <repo>/<chart> reference, and the only
+// ones that can carry --version at all (it is an error against a local chart
+// path). The chart is served by an httptest server, as the apply tests already
+// do, and installed on the live swarm from the pinned version.
+func TestChartsCLIRepositoryCommands(t *testing.T) {
+	swarmlog.InitTestIfTestLogEnv()
+	isolateCLIState(t)
+	// The CLI builds its own store, so the store's https-only default is out of
+	// reach — the env var is the documented way in, and the server below serves
+	// plain http.
+	t.Setenv("SWARMCLI_CHARTS_ALLOW_PLAINTEXT", "1")
+
+	ctx := context.Background()
+	release := fmt.Sprintf("itest-cli-repo-%d", time.Now().UnixNano())
+
+	const tgzName = "itest-0.1.0.tgz"
+	tgz := packChartTgz(t, writeDemoChart(t), "itest")
+	index := "apiVersion: v1\n" +
+		"entries:\n" +
+		"  itest:\n" +
+		"    - name: itest\n" +
+		"      version: \"0.1.0\"\n" +
+		"      description: integration test chart\n" +
+		"      urls: [\"" + tgzName + "\"]\n"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/index.yaml"):
+			_, _ = w.Write([]byte(index))
+		case strings.HasSuffix(r.URL.Path, tgzName):
+			_, _ = w.Write(tgz)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	dir := t.TempDir()
+	valuesFile := filepath.Join(dir, "values.yaml")
+	require.NoError(t, os.WriteFile(valuesFile, []byte("replicas: 1\n"), 0o600))
+
+	eng := charts.NewEngine()
+	defer func() { _, _ = eng.Uninstall(ctx, release, true) }()
+
+	// --- repo: the four sub-verbs are one dispatch target and four things an
+	// operator runs ---
+	dispatchOK(t, "charts", "repo", "add", "itest-repo", srv.URL)
+	dispatchOK(t, "charts", "repo", "list")
+	dispatchOK(t, "charts", "repo", "update", "itest-repo")
+
+	// --- discovery ---
+	dispatchOK(t, "charts", "search", "itest", "--no-repo-update")
+	dispatchOK(t, "charts", "show", "chart", "itest-repo/itest",
+		"--version", "0.1.0", "--skip-compat-check", "--no-repo-update")
+	dispatchOK(t, "charts", "show", "values", "itest-repo/itest")
+
+	// --- authoring: lint renders from the chart defaults with the overrides
+	// layered on, and --for-version asks whether some other engine version is
+	// admitted by the chart's declared floor ---
+	dispatchOK(t, "charts", "lint", "itest-repo/itest",
+		"--values", valuesFile, "--set", "replicas=1", "--version", "0.1.0",
+		"--for-version", "1.13.0", "--no-repo-update")
+
+	dispatchOK(t, "charts", "template", release, "itest-repo/itest", "--version", "0.1.0")
+
+	// --- install from the repository at the pinned version ---
+	dispatchOK(t, "charts", "install", release, "itest-repo/itest",
+		"--version", "0.1.0", "--wait", "--timeout", "90s")
+	cur, _, err := eng.Status(ctx, release)
+	require.NoError(t, err)
+	require.Equal(t, charts.StatusDeployed, cur.Status)
+	require.Equal(t, "0.1.0", cur.Chart.Version, "the pinned version must be the one installed")
+
+	dispatchOK(t, "charts", "diff", "upgrade", release, "itest-repo/itest",
+		"--version", "0.1.0", "--reuse-values")
+	hist, err := eng.History(ctx, release)
+	require.NoError(t, err)
+	require.Len(t, hist, 1, "diff upgrade must not deploy")
+
+	// No --wait: the waited deploy path is proven above, and this invocation is
+	// here for upgrade's --version.
+	dispatchOK(t, "charts", "upgrade", release, "itest-repo/itest",
+		"--version", "0.1.0", "--set", "replicas=1")
+	hist, err = eng.History(ctx, release)
+	require.NoError(t, err)
+	require.Len(t, hist, 2)
+
+	dispatchOK(t, "charts", "uninstall", release)
+	_, err = docker.InspectConfig(ctx, fmt.Sprintf("swarmcli.release.%s.v1", release))
+	require.Error(t, err, "uninstall must remove the release configs")
+
+	dispatchOK(t, "charts", "repo", "remove", "itest-repo")
+}

--- a/test-setup/testenv.sh
+++ b/test-setup/testenv.sh
@@ -174,8 +174,10 @@ cmd_test() {
   # Add JUnit file only if set
   [[ -n "$junit_file" ]] && args+=("--junitfile=$junit_file")
 
-  # Always include integration build tag
-  local go_test_cmd=("-tags=integration" "-v")
+  # Always include integration build tag. -timeout matches the locked-swarm and
+  # ssh-context CI jobs: these tests deploy several releases each, and go test's
+  # 10m default is a number nobody chose for them.
+  local go_test_cmd=("-tags=integration" "-v" "-timeout=15m")
 
   # views/stacks carries an integration-tagged test alongside its unit tests:
   # the view's internals are unexported, so covering the deploy seam against a


### PR DESCRIPTION
Follow-up to #579, closes #580.

The integration suite reached the `cli` layer through four invocations — `apply --diff`, `apply --dry-run`, `apply --wait`, `outdated`. #579 turned that layer from an argument splitter into the thing that decides whether an invocation is accepted at all: each subcommand carries a flag allow-list, and a flag outside it exits 2 rather than being parsed and dropped. `TestFlagAllowListsMatchWhatHandlersRead` proves each row agrees with its handler; it cannot prove the command runs.

### `integration-tests/charts/charts_cli_test.go`

`TestChartsCLIImperativeLifecycle` — local chart, live swarm: `template` (incl. `--requirements`), `install --dry-run`, `install`, `get values`, `history`, `status`, `list`, `outdated`, `diff upgrade`, `upgrade --dry-run`, `upgrade`, `rollback`, `prune --dry-run`, `apply` (preview and real), `uninstall`.

`TestChartsCLIRepositoryCommands` — an `httptest` repository, as the apply tests already stand up: `repo add|list|update|remove`, `search`, `show chart|values`, `lint`, and the commands that can carry `--version` at all (it is an error against a local chart path).

Every row of `chartsCommands` is invoked, with every flag it lists.

Exit 0 is necessary and not sufficient, so each mutating command is checked against the engine afterwards — revision numbers, history length, the values a `--set-file` actually reached, the manifest a `rollback` replayed, the configs an `uninstall` removed. The three preview verbs are asserted to have recorded no revision: a command that exits 0 while deploying nothing would otherwise pass.

`--set-file` targets a values key no template reads, so the shared `writeDemoChart` fixture — rendered by eight existing tests — is untouched. Both tests point `XDG_STATE_HOME` at a temp dir: `loadChart` builds a `RepoStore` for every command, including ones handed a local chart path.

### `cli/integrationcoverage_test.go`

`TestIntegrationSuiteExercisesEveryCommandAndFlag` reads the invocations back out of the integration suite's syntax tree and compares them against the table, rather than keeping a list of what is covered — that list is the first thing to stop being true, and deleting three hand-kept copies of the command list is what #579 was. A row nothing invokes, or a flag added to a row with nothing running it, fails here. It also fails if it finds no invocations at all, so it cannot pass by reading the wrong directory.

Mutation-tested in four directions: dropping a flag from an invocation, dropping a whole command's invocation, adding a flag to a row, and pointing it at a package with no invocations — each fails with the message naming what is missing.

### `test-setup/testenv.sh`

`-timeout=15m`, matching the `locked-swarm` and `ssh-context` jobs. These tests deploy several releases each and `go test`'s 10m default is a number nobody chose for them.

### Verification

`gofmt`, `go vet -tags=integration`, `golangci-lint run --build-tags=integration` (0 issues), `go test ./...` green, and the integration package compiles under its build tag. The environment this was written in has no Docker daemon — the same gap #579 could not close — so the CI `integration` job is the real signal here.

One check was possible without a daemon and is the core risk of #580: every invocation in the new suite was replayed through `cli.Dispatch` with no daemon, asserting none exits 2. Exit 2 is the allow-list refusing; exit 1 is the missing daemon. All 31 reached their handler, so no row is too narrow for what this suite runs. That replay was a throwaway, not committed — it proves the argv are accepted, and the committed tests prove the commands work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
