### PR TITLE
refactor(ui): every dialog draws from the shared dialog styles

### DIFF
--- a/ui/components/errordialog/errordialog.go
+++ b/ui/components/errordialog/errordialog.go
@@ -6,48 +6,31 @@ package errordialog
 import (
 	"fmt"
 	"github.com/Eldara-Tech/swarmcli/ui"
+	"github.com/Eldara-Tech/swarmcli/ui/dialog"
 
 	"github.com/charmbracelet/lipgloss"
 )
 
 // Render renders an error dialog with the given error message
 func Render(errorMsg string) string {
-	titleStyle := lipgloss.NewStyle().
-		Bold(true).
-		Foreground(lipgloss.Color("15")).
-		Background(lipgloss.Color("196")).
-		Padding(0, 1)
-
-	borderStyle := lipgloss.NewStyle().
-		Border(lipgloss.RoundedBorder()).
-		BorderForeground(lipgloss.Color("196"))
-
-	itemStyle := lipgloss.NewStyle().
-		Padding(0, 1)
-
-	helpStyle := lipgloss.NewStyle().
-		Foreground(lipgloss.Color("240")).
-		Padding(0, 1)
-
-	keyStyle := lipgloss.NewStyle().
-		Foreground(lipgloss.Color("63")).
-		Bold(true)
+	titleStyle := dialog.TitleStyle.Background(dialog.AccentError)
+	borderStyle := dialog.BorderStyle.BorderForeground(dialog.AccentError)
 
 	var lines []string
 	lines = append(lines, titleStyle.Render(" Error "))
-	lines = append(lines, itemStyle.Render(""))
+	lines = append(lines, dialog.ItemStyle.Render(""))
 
 	maxWidth := 70
 	wrappedLines := ui.WrapText(errorMsg, maxWidth)
 	for _, line := range wrappedLines {
-		lines = append(lines, itemStyle.Render(line))
+		lines = append(lines, dialog.ItemStyle.Render(line))
 	}
 
-	lines = append(lines, itemStyle.Render(""))
+	lines = append(lines, dialog.ItemStyle.Render(""))
 	helpText := fmt.Sprintf("%s %s %s",
-		helpStyle.Render("Press"),
-		keyStyle.Render("<Enter>"),
-		helpStyle.Render("to close"))
+		dialog.HelpStyle.Render("Press"),
+		dialog.KeyStyle.Render("<Enter>"),
+		dialog.HelpStyle.Render("to close"))
 	lines = append(lines, helpText)
 
 	content := lipgloss.JoinVertical(lipgloss.Left, lines...)

--- a/ui/dialog/styles.go
+++ b/ui/dialog/styles.go
@@ -5,31 +5,49 @@ package dialog
 
 import "github.com/charmbracelet/lipgloss"
 
+// The dialog palette. Each colour is named for the role it plays instead of
+// being repeated as a literal at every call site, so what a dialog is saying
+// with a colour is readable, and there is one place to change it.
+const (
+	// An accent tints both a dialog's title bar and its border; it is what
+	// tells one kind of dialog from another at a glance.
+	AccentPrimary = lipgloss.Color("63")  // ordinary dialogs, selections, info
+	AccentWarning = lipgloss.Color("208") // confirmations that destroy something
+	AccentError   = lipgloss.Color("196") // errors
+	AccentEdit    = lipgloss.Color("214") // label add and remove
+
+	BorderColor = lipgloss.Color("117") // the default border, where no accent applies
+	BrightFg    = lipgloss.Color("15")  // text on an accent, and focused input
+	SelectedFg  = lipgloss.Color("230") // the brighter selection some lists use
+	MutedFg     = lipgloss.Color("250") // unselected rows
+	HelpFg      = lipgloss.Color("240") // the key hints along the bottom
+)
+
 // Shared dialog styles used across views for consistent dialog rendering.
 var (
 	TitleStyle = lipgloss.NewStyle().
 			Bold(true).
-			Foreground(lipgloss.Color("15")).
-			Background(lipgloss.Color("63")).
+			Foreground(BrightFg).
+			Background(AccentPrimary).
 			Padding(0, 1)
 
 	BorderStyle = lipgloss.NewStyle().
 			Border(lipgloss.RoundedBorder()).
-			BorderForeground(lipgloss.Color("117"))
+			BorderForeground(BorderColor)
 
 	ItemStyle = lipgloss.NewStyle().
 			Padding(0, 1)
 
 	SelectedStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("15")).
-			Background(lipgloss.Color("63")).
+			Foreground(BrightFg).
+			Background(AccentPrimary).
 			Padding(0, 1)
 
 	HelpStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("240")).
+			Foreground(HelpFg).
 			Padding(0, 1)
 
 	KeyStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("63")).
+			Foreground(AccentPrimary).
 			Bold(true)
 )

--- a/views/confirmdialog/confirmdialog.go
+++ b/views/confirmdialog/confirmdialog.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/Eldara-Tech/swarmcli/ui/dialog"
+
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/muesli/reflow/wordwrap"
@@ -111,38 +113,15 @@ func (m *Model) View() string {
 		contentWidth = maxWidth
 	}
 
-	// Styled title — color varies by mode
-	titleColor := lipgloss.Color("208") // Orange for warning/confirm
+	// The accent varies by mode, and tints the title and the border alike.
+	accent := dialog.AccentWarning
 	if m.InfoMode {
-		titleColor = lipgloss.Color("63") // Blue/purple for info
+		accent = dialog.AccentPrimary
 	}
-	titleStyle := lipgloss.NewStyle().
-		Bold(true).
-		Foreground(lipgloss.Color("15")).
-		Background(titleColor).
-		Padding(0, 1).
-		Width(contentWidth)
-
-	// Message style
-	messageStyle := lipgloss.NewStyle().
-		Padding(1, 2).
-		Width(contentWidth)
-
-	// Help style
-	helpStyle := lipgloss.NewStyle().
-		Foreground(lipgloss.Color("240")).
-		Padding(0, 2).
-		Width(contentWidth)
-
-	keyStyle := lipgloss.NewStyle().
-		Foreground(lipgloss.Color("63")).
-		Bold(true)
-
-	// Border style — matches title color
-	borderStyle := lipgloss.NewStyle().
-		Border(lipgloss.RoundedBorder()).
-		BorderForeground(titleColor).
-		Width(contentWidth + 2)
+	titleStyle := dialog.TitleStyle.Background(accent).Width(contentWidth)
+	messageStyle := dialog.ItemStyle.Padding(1, 2).Width(contentWidth)
+	helpStyle := dialog.HelpStyle.Padding(0, 2).Width(contentWidth)
+	borderStyle := dialog.BorderStyle.BorderForeground(accent).Width(contentWidth + 2)
 
 	// Build content
 	var lines []string
@@ -157,16 +136,14 @@ func (m *Model) View() string {
 
 	// Add checkbox if label is provided (confirm or info mode; never error mode)
 	if m.CheckboxLabel != "" && !m.ErrorMode {
-		checkboxStyle := lipgloss.NewStyle().
-			Padding(0, 2).
-			Width(contentWidth)
+		checkboxStyle := dialog.ItemStyle.Padding(0, 2).Width(contentWidth)
 
 		checkMark := "[ ]"
 		if m.CheckboxChecked {
 			checkMark = "[✓]"
 		}
 		checkboxText := fmt.Sprintf("%s %s",
-			keyStyle.Render(checkMark),
+			dialog.KeyStyle.Render(checkMark),
 			m.CheckboxLabel)
 		lines = append(lines, checkboxStyle.Render(checkboxText))
 	}
@@ -175,19 +152,19 @@ func (m *Model) View() string {
 	switch {
 	case m.InfoMode && m.CheckboxLabel != "":
 		helpText = fmt.Sprintf("%s Toggle • %s Close",
-			keyStyle.Render("<Space>"),
-			keyStyle.Render("<Enter/Esc>"))
+			dialog.KeyStyle.Render("<Space>"),
+			dialog.KeyStyle.Render("<Enter/Esc>"))
 	case m.ErrorMode || m.InfoMode:
-		helpText = fmt.Sprintf("%s Close", keyStyle.Render("<Enter/Esc>"))
+		helpText = fmt.Sprintf("%s Close", dialog.KeyStyle.Render("<Enter/Esc>"))
 	case m.CheckboxLabel != "":
 		helpText = fmt.Sprintf("%s Yes • %s No • %s Toggle",
-			keyStyle.Render("<y>"),
-			keyStyle.Render("<n/Esc>"),
-			keyStyle.Render("<Space>"))
+			dialog.KeyStyle.Render("<y>"),
+			dialog.KeyStyle.Render("<n/Esc>"),
+			dialog.KeyStyle.Render("<Space>"))
 	default:
 		helpText = fmt.Sprintf("%s Yes • %s No",
-			keyStyle.Render("<y>"),
-			keyStyle.Render("<n/Esc>"))
+			dialog.KeyStyle.Render("<y>"),
+			dialog.KeyStyle.Render("<n/Esc>"))
 	}
 	lines = append(lines, helpStyle.Render(helpText))
 

--- a/views/logs/view.go
+++ b/views/logs/view.go
@@ -6,6 +6,7 @@ package logsview
 import (
 	"fmt"
 	"github.com/Eldara-Tech/swarmcli/ui"
+	"github.com/Eldara-Tech/swarmcli/ui/dialog"
 
 	"github.com/charmbracelet/lipgloss"
 )
@@ -99,8 +100,8 @@ func (m *Model) FrameContent() string {
 
 	if m.getNodeSelectVisible() && m.viewport.Height >= 5 {
 		availableHeight := m.viewport.Height
-		dialog := m.renderNodeSelectDialog(availableHeight)
-		viewportContent = ui.OverlayCentered(viewportContent, dialog, width, 0)
+		popup := m.renderNodeSelectDialog(availableHeight)
+		viewportContent = ui.OverlayCentered(viewportContent, popup, width, 0)
 	}
 
 	return viewportContent
@@ -165,37 +166,12 @@ func (m *Model) renderNodeSelectDialog(availableHeight int) string {
 		contentWidth = titleWidth
 	}
 
-	titleStyle := lipgloss.NewStyle().
-		Bold(true).
-		Foreground(lipgloss.Color("15")).
-		Background(lipgloss.Color("63")).
-		Padding(0, 1).
-		Width(contentWidth)
-
-	itemStyle := lipgloss.NewStyle().
-		Padding(0, 1).
-		Width(contentWidth)
-
-	selectedStyle := lipgloss.NewStyle().
-		Foreground(lipgloss.Color("230")).
-		Background(lipgloss.Color("63")).
-		Bold(true).
-		Padding(0, 1).
-		Width(contentWidth)
-
-	borderStyle := lipgloss.NewStyle().
-		Border(lipgloss.RoundedBorder()).
-		BorderForeground(lipgloss.Color("117")).
-		Width(contentWidth + 2)
-
-	helpStyle := lipgloss.NewStyle().
-		Foreground(lipgloss.Color("240")).
-		Padding(0, 1).
-		Width(contentWidth)
-
-	keyStyle := lipgloss.NewStyle().
-		Foreground(lipgloss.Color("63")).
-		Bold(true)
+	titleStyle := dialog.TitleStyle.Width(contentWidth)
+	itemStyle := dialog.ItemStyle.Width(contentWidth)
+	// A brighter selection than the shared one, which this dialog has always used.
+	selectedStyle := dialog.SelectedStyle.Foreground(dialog.SelectedFg).Bold(true).Width(contentWidth)
+	borderStyle := dialog.BorderStyle.Width(contentWidth + 2)
+	helpStyle := dialog.HelpStyle.Width(contentWidth)
 
 	// Build the content
 	var lines []string
@@ -275,9 +251,9 @@ func (m *Model) renderNodeSelectDialog(availableHeight int) string {
 
 	// Build help text with styled keys
 	helpText := fmt.Sprintf(" %s Navigate • %s Select • %s Cancel",
-		keyStyle.Render("<↑/↓/PgUp/PgDn>"),
-		keyStyle.Render("<Enter>"),
-		keyStyle.Render("<Esc>"))
+		dialog.KeyStyle.Render("<↑/↓/PgUp/PgDn>"),
+		dialog.KeyStyle.Render("<Enter>"),
+		dialog.KeyStyle.Render("<Esc>"))
 	lines = append(lines, helpStyle.Render(helpText))
 
 	content := lipgloss.JoinVertical(lipgloss.Left, lines...)

--- a/views/nodes/view.go
+++ b/views/nodes/view.go
@@ -6,6 +6,7 @@ package nodesview
 import (
 	"fmt"
 	"github.com/Eldara-Tech/swarmcli/ui"
+	"github.com/Eldara-Tech/swarmcli/ui/dialog"
 	"sort"
 	"strings"
 
@@ -89,33 +90,12 @@ func (m *Model) renderAvailabilityDialog() string {
 	options := []string{"Active", "Pause", "Drain"}
 	contentWidth := 40
 
-	titleStyle := lipgloss.NewStyle().
-		Bold(true).
-		Foreground(lipgloss.Color("15")).
-		Background(lipgloss.Color("63")).
-		Padding(0, 1).
-		Width(contentWidth)
-
-	optionStyle := lipgloss.NewStyle().
-		Padding(0, 2).
-		Width(contentWidth)
-
-	selectedStyle := lipgloss.NewStyle().
-		Foreground(lipgloss.Color("230")).
-		Background(lipgloss.Color("63")).
-		Bold(true).
-		Padding(0, 2).
-		Width(contentWidth)
-
-	helpStyle := lipgloss.NewStyle().
-		Foreground(lipgloss.Color("240")).
-		Padding(0, 2).
-		Width(contentWidth)
-
-	borderStyle := lipgloss.NewStyle().
-		Border(lipgloss.RoundedBorder()).
-		BorderForeground(lipgloss.Color("63")).
-		Width(contentWidth + 2)
+	titleStyle := dialog.TitleStyle.Width(contentWidth)
+	// The wider padding and brighter selection this dialog has always used.
+	optionStyle := dialog.ItemStyle.Padding(0, 2).Width(contentWidth)
+	selectedStyle := dialog.SelectedStyle.Foreground(dialog.SelectedFg).Bold(true).Padding(0, 2).Width(contentWidth)
+	helpStyle := dialog.HelpStyle.Padding(0, 2).Width(contentWidth)
+	borderStyle := dialog.BorderStyle.BorderForeground(dialog.AccentPrimary).Width(contentWidth + 2)
 
 	var lines []string
 	lines = append(lines, titleStyle.Render(" Set Node Availability "))
@@ -139,24 +119,17 @@ func (m *Model) renderAvailabilityDialog() string {
 
 // renderLabelInputDialog renders the label input dialog
 func (m *Model) renderLabelInputDialog() string {
-	titleStyle := lipgloss.NewStyle().
-		Bold(true).
-		Foreground(lipgloss.Color("15")).
-		Background(lipgloss.Color("214")).
-		Padding(0, 1)
+	titleStyle := dialog.TitleStyle.Background(dialog.AccentEdit)
 
 	inputStyle := lipgloss.NewStyle().
-		Foreground(lipgloss.Color("15")).
+		Foreground(dialog.BrightFg).
 		Bold(true)
 
 	helpStyle := lipgloss.NewStyle().
-		Foreground(lipgloss.Color("240")).
+		Foreground(dialog.HelpFg).
 		Italic(true)
 
-	borderStyle := lipgloss.NewStyle().
-		Border(lipgloss.RoundedBorder()).
-		BorderForeground(lipgloss.Color("214")).
-		Padding(1, 2)
+	borderStyle := dialog.BorderStyle.BorderForeground(dialog.AccentEdit).Padding(1, 2)
 
 	var lines []string
 	lines = append(lines, titleStyle.Render("Add Node Label"))
@@ -171,27 +144,20 @@ func (m *Model) renderLabelInputDialog() string {
 
 // renderLabelRemoveDialog renders the label removal dialog
 func (m *Model) renderLabelRemoveDialog() string {
-	titleStyle := lipgloss.NewStyle().
-		Bold(true).
-		Foreground(lipgloss.Color("15")).
-		Background(lipgloss.Color("214")).
-		Padding(0, 1)
+	titleStyle := dialog.TitleStyle.Background(dialog.AccentEdit)
 
 	optionStyle := lipgloss.NewStyle().
-		Foreground(lipgloss.Color("250"))
+		Foreground(dialog.MutedFg)
 
 	selectedStyle := lipgloss.NewStyle().
-		Foreground(lipgloss.Color("15")).
+		Foreground(dialog.BrightFg).
 		Bold(true)
 
 	helpStyle := lipgloss.NewStyle().
-		Foreground(lipgloss.Color("240")).
+		Foreground(dialog.HelpFg).
 		Italic(true)
 
-	borderStyle := lipgloss.NewStyle().
-		Border(lipgloss.RoundedBorder()).
-		BorderForeground(lipgloss.Color("214")).
-		Padding(1, 2)
+	borderStyle := dialog.BorderStyle.BorderForeground(dialog.AccentEdit).Padding(1, 2)
 
 	var lines []string
 	lines = append(lines, titleStyle.Render("Remove Node Label"))

--- a/views/scaledialog/scaledialog.go
+++ b/views/scaledialog/scaledialog.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/Eldara-Tech/swarmcli/ui/dialog"
+
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 )
@@ -73,18 +75,8 @@ func (m *Model) View() string {
 		contentWidth = w
 	}
 
-	// Styled title
-	titleStyle := lipgloss.NewStyle().
-		Bold(true).
-		Foreground(lipgloss.Color("15")).
-		Background(lipgloss.Color("63")). // Blue for scale
-		Padding(0, 1).
-		Width(contentWidth)
-
-	// Message style
-	messageStyle := lipgloss.NewStyle().
-		Padding(1, 2).
-		Width(contentWidth)
+	titleStyle := dialog.TitleStyle.Width(contentWidth)
+	messageStyle := dialog.ItemStyle.Padding(1, 2).Width(contentWidth)
 
 	// Replicas display style
 	replicasStyle := lipgloss.NewStyle().
@@ -94,21 +86,8 @@ func (m *Model) View() string {
 		Width(contentWidth).
 		Padding(1, 0)
 
-	// Help style
-	helpStyle := lipgloss.NewStyle().
-		Foreground(lipgloss.Color("240")).
-		Padding(0, 2).
-		Width(contentWidth)
-
-	keyStyle := lipgloss.NewStyle().
-		Foreground(lipgloss.Color("63")).
-		Bold(true)
-
-	// Border style
-	borderStyle := lipgloss.NewStyle().
-		Border(lipgloss.RoundedBorder()).
-		BorderForeground(lipgloss.Color("63")).
-		Width(contentWidth + 2)
+	helpStyle := dialog.HelpStyle.Padding(0, 2).Width(contentWidth)
+	borderStyle := dialog.BorderStyle.BorderForeground(dialog.AccentPrimary).Width(contentWidth + 2)
 
 	// Build content
 	var lines []string
@@ -117,10 +96,10 @@ func (m *Model) View() string {
 	lines = append(lines, replicasStyle.Render(fmt.Sprintf("Replicas: %d", m.Replicas)))
 
 	helpText := fmt.Sprintf("%s Increase • %s Decrease • %s Apply • %s Cancel",
-		keyStyle.Render("<↑>"),
-		keyStyle.Render("<↓>"),
-		keyStyle.Render("<Enter>"),
-		keyStyle.Render("<Esc>"))
+		dialog.KeyStyle.Render("<↑>"),
+		dialog.KeyStyle.Render("<↓>"),
+		dialog.KeyStyle.Render("<Enter>"),
+		dialog.KeyStyle.Render("<Esc>"))
 	lines = append(lines, helpStyle.Render(helpText))
 
 	content := strings.Join(lines, "\n")

--- a/views/unlockdialog/unlockdialog.go
+++ b/views/unlockdialog/unlockdialog.go
@@ -8,9 +8,10 @@ package unlockdialog
 import (
 	"strings"
 
+	"github.com/Eldara-Tech/swarmcli/ui/dialog"
+
 	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
-	"github.com/charmbracelet/lipgloss"
 )
 
 // ResultMsg is emitted when the dialog is dismissed. Confirmed is true when the
@@ -66,41 +67,18 @@ func (m *Model) View() string {
 
 	contentWidth := 65
 
-	titleStyle := lipgloss.NewStyle().
-		Bold(true).
-		Foreground(lipgloss.Color("15")).
-		Background(lipgloss.Color("63")).
-		Padding(0, 1).
-		Width(contentWidth)
-
-	messageStyle := lipgloss.NewStyle().
-		Padding(1, 2).
-		Width(contentWidth)
-
-	inputStyle := lipgloss.NewStyle().
-		Padding(0, 2).
-		Width(contentWidth)
-
-	helpStyle := lipgloss.NewStyle().
-		Foreground(lipgloss.Color("240")).
-		Padding(1, 2, 0, 2).
-		Width(contentWidth)
-
-	keyStyle := lipgloss.NewStyle().
-		Foreground(lipgloss.Color("63")).
-		Bold(true)
-
-	borderStyle := lipgloss.NewStyle().
-		Border(lipgloss.RoundedBorder()).
-		BorderForeground(lipgloss.Color("63")).
-		Width(contentWidth + 2)
+	titleStyle := dialog.TitleStyle.Width(contentWidth)
+	messageStyle := dialog.ItemStyle.Padding(1, 2).Width(contentWidth)
+	inputStyle := dialog.ItemStyle.Padding(0, 2).Width(contentWidth)
+	helpStyle := dialog.HelpStyle.Padding(1, 2, 0, 2).Width(contentWidth)
+	borderStyle := dialog.BorderStyle.BorderForeground(dialog.AccentPrimary).Width(contentWidth + 2)
 
 	var lines []string
 	lines = append(lines, titleStyle.Render(" Unlock Swarm "))
 	lines = append(lines, messageStyle.Render("Enter the swarm unlock key to decrypt this cluster."))
 	lines = append(lines, inputStyle.Render(m.input.View()))
 
-	helpText := keyStyle.Render("<Enter>") + " Unlock • " + keyStyle.Render("<Esc>") + " Cancel"
+	helpText := dialog.KeyStyle.Render("<Enter>") + " Unlock • " + dialog.KeyStyle.Render("<Esc>") + " Cancel"
 	lines = append(lines, helpStyle.Render(helpText))
 
 	return borderStyle.Render(strings.Join(lines, "\n"))


### PR DESCRIPTION
`ui/dialog` has held the shared dialog styles since it was added, and four views adopted them — configs, contexts, secrets, stacks. Six other dialog renderers kept re-declaring the same styles inline:

| renderer | styles declared inline |
|---|---|
| `views/logs` node-select popup | title, item, selected, border, help, key |
| `views/nodes` availability | title, option, selected, help, border |
| `views/nodes` label add / label remove | title, input/option, selected, help, border (×2) |
| `views/scaledialog` | title, message, help, key, border |
| `views/unlockdialog` | title, message, input, help, key, border |
| `views/confirmdialog` | title, message, help, key, checkbox, border |
| `ui/components/errordialog` | title, border, item, help, key |

The same colour was written out sixteen times, so a change to any of them reached only the dialogs somebody remembered to edit.

## What this does

Points the six at `ui/dialog`, and names the colours they were repeating. The palette is small and role-named rather than exhaustive:

- **Accents** — `AccentPrimary`, `AccentWarning`, `AccentError`, `AccentEdit`. An accent tints a title bar and its border together; it is what tells one kind of dialog from another at a glance, and it is the one thing these dialogs genuinely vary.
- **Roles** — `BorderColor`, `BrightFg`, `SelectedFg`, `MutedFg`, `HelpFg`.

A dialog that wants something other than the shared value now says so in a single call — `dialog.TitleStyle.Background(dialog.AccentError)` — rather than restating the whole style.

## Nothing about what is drawn changes

Every one of the eighteen dialog states these six renderers can produce (both node-select branches, all three availability selections, both label dialogs, scale narrow and wide, unlock empty and filled, confirm in plain / checkbox / error / info / narrow-terminal modes, error short and wrapped) was rendered before and after against a forced `termenv.TrueColor` profile and compared byte for byte, escape sequences included. All eighteen are identical. The harness was temporary and is not in the diff.

`go test ./...` passes; `golangci-lint run ./... --build-tags=integration` reports 0 issues.

## Deliberately left alone

This preserves output exactly, which means the drift between these dialogs is now *visible* instead of removed. Worth a follow-up decision, not a silent change here:

- **Selected rows disagree.** `dialog.SelectedStyle` is `BrightFg` and not bold; the logs node-select and nodes availability dialogs use `SelectedFg` and bold. Both are preserved via an explicit override.
- **Row padding disagrees.** `dialog.ItemStyle` is `Padding(0, 1)`; nodes availability, scale, unlock and confirm use `Padding(0, 2)`.
- **Borders disagree.** `dialog.BorderStyle` is `BorderColor`; nodes availability, scale and unlock use `AccentPrimary` for theirs. The logs popup uses the shared `BorderColor`, so two dialogs opened from adjacent keys have differently coloured frames.
- **Single-use literals stay literal** — scale's replica-count green, error's 70-column wrap. Naming a colour used once buys nothing until there is a theme to name it for.

Part of #147 — this is its concrete half, the stalled migration rather than the open-ended sweep. There are still ~130 `lipgloss.Color` literals outside the dialogs, and #279 (customizable themes) needs those named too.

Part of #128 — the UI half. The node-select popup no longer carries its own style block, though its scroll-window arithmetic still duplicates `ui/components/filterable/list`, and the filtering/search half of that issue (logs and inspect each hand-roll the same incremental search) is untouched.
