### PR TITLE
refactor(ui): dialogs carry their accent, and agree on everything else

### DIFF
--- a/ui/components/errordialog/errordialog.go
+++ b/ui/components/errordialog/errordialog.go
@@ -6,48 +6,31 @@ package errordialog
 import (
 	"fmt"
 	"github.com/Eldara-Tech/swarmcli/ui"
+	"github.com/Eldara-Tech/swarmcli/ui/dialog"
 
 	"github.com/charmbracelet/lipgloss"
 )
 
 // Render renders an error dialog with the given error message
 func Render(errorMsg string) string {
-	titleStyle := lipgloss.NewStyle().
-		Bold(true).
-		Foreground(lipgloss.Color("15")).
-		Background(lipgloss.Color("196")).
-		Padding(0, 1)
-
-	borderStyle := lipgloss.NewStyle().
-		Border(lipgloss.RoundedBorder()).
-		BorderForeground(lipgloss.Color("196"))
-
-	itemStyle := lipgloss.NewStyle().
-		Padding(0, 1)
-
-	helpStyle := lipgloss.NewStyle().
-		Foreground(lipgloss.Color("240")).
-		Padding(0, 1)
-
-	keyStyle := lipgloss.NewStyle().
-		Foreground(lipgloss.Color("63")).
-		Bold(true)
+	titleStyle := dialog.TitleStyle.Background(dialog.AccentError)
+	borderStyle := dialog.BorderStyle.BorderForeground(dialog.AccentError)
 
 	var lines []string
 	lines = append(lines, titleStyle.Render(" Error "))
-	lines = append(lines, itemStyle.Render(""))
+	lines = append(lines, dialog.ItemStyle.Render(""))
 
 	maxWidth := 70
 	wrappedLines := ui.WrapText(errorMsg, maxWidth)
 	for _, line := range wrappedLines {
-		lines = append(lines, itemStyle.Render(line))
+		lines = append(lines, dialog.ItemStyle.Render(line))
 	}
 
-	lines = append(lines, itemStyle.Render(""))
+	lines = append(lines, dialog.ItemStyle.Render(""))
 	helpText := fmt.Sprintf("%s %s %s",
-		helpStyle.Render("Press"),
-		keyStyle.Render("<Enter>"),
-		helpStyle.Render("to close"))
+		dialog.HelpStyle.Render("Press"),
+		dialog.KeyStyle.Render("<Enter>"),
+		dialog.HelpStyle.Render("to close"))
 	lines = append(lines, helpText)
 
 	content := lipgloss.JoinVertical(lipgloss.Left, lines...)

--- a/ui/dialog/styles.go
+++ b/ui/dialog/styles.go
@@ -10,17 +10,18 @@ import "github.com/charmbracelet/lipgloss"
 // with a colour is readable, and there is one place to change it.
 const (
 	// An accent tints both a dialog's title bar and its border; it is what
-	// tells one kind of dialog from another at a glance.
+	// tells one kind of dialog from another at a glance, and the only thing a
+	// dialog should need to override. The view frame underneath has its own
+	// colour, ui.FrameBorderColor, which no dialog borrows — a modal that
+	// draws its frame in the frame's own colour stops reading as a layer.
 	AccentPrimary = lipgloss.Color("63")  // ordinary dialogs, selections, info
 	AccentWarning = lipgloss.Color("208") // confirmations that destroy something
 	AccentError   = lipgloss.Color("196") // errors
 	AccentEdit    = lipgloss.Color("214") // label add and remove
 
-	BorderColor = lipgloss.Color("117") // the default border, where no accent applies
-	BrightFg    = lipgloss.Color("15")  // text on an accent, and focused input
-	SelectedFg  = lipgloss.Color("230") // the brighter selection some lists use
-	MutedFg     = lipgloss.Color("250") // unselected rows
-	HelpFg      = lipgloss.Color("240") // the key hints along the bottom
+	BrightFg = lipgloss.Color("15")  // text on an accent, and focused input
+	MutedFg  = lipgloss.Color("250") // unselected rows
+	HelpFg   = lipgloss.Color("240") // the key hints along the bottom
 )
 
 // Shared dialog styles used across views for consistent dialog rendering.
@@ -33,10 +34,16 @@ var (
 
 	BorderStyle = lipgloss.NewStyle().
 			Border(lipgloss.RoundedBorder()).
-			BorderForeground(BorderColor)
+			BorderForeground(AccentPrimary)
 
 	ItemStyle = lipgloss.NewStyle().
 			Padding(0, 1)
+
+	// MessageStyle is for a block of prose rather than a row — the sentence a
+	// confirmation asks its question in. It is inset further than a row, and
+	// stands off the title above it.
+	MessageStyle = lipgloss.NewStyle().
+			Padding(1, 2)
 
 	SelectedStyle = lipgloss.NewStyle().
 			Foreground(BrightFg).

--- a/ui/dialog/styles.go
+++ b/ui/dialog/styles.go
@@ -5,31 +5,49 @@ package dialog
 
 import "github.com/charmbracelet/lipgloss"
 
+// The dialog palette. Each colour is named for the role it plays instead of
+// being repeated as a literal at every call site, so what a dialog is saying
+// with a colour is readable, and there is one place to change it.
+const (
+	// An accent tints both a dialog's title bar and its border; it is what
+	// tells one kind of dialog from another at a glance.
+	AccentPrimary = lipgloss.Color("63")  // ordinary dialogs, selections, info
+	AccentWarning = lipgloss.Color("208") // confirmations that destroy something
+	AccentError   = lipgloss.Color("196") // errors
+	AccentEdit    = lipgloss.Color("214") // label add and remove
+
+	BorderColor = lipgloss.Color("117") // the default border, where no accent applies
+	BrightFg    = lipgloss.Color("15")  // text on an accent, and focused input
+	SelectedFg  = lipgloss.Color("230") // the brighter selection some lists use
+	MutedFg     = lipgloss.Color("250") // unselected rows
+	HelpFg      = lipgloss.Color("240") // the key hints along the bottom
+)
+
 // Shared dialog styles used across views for consistent dialog rendering.
 var (
 	TitleStyle = lipgloss.NewStyle().
 			Bold(true).
-			Foreground(lipgloss.Color("15")).
-			Background(lipgloss.Color("63")).
+			Foreground(BrightFg).
+			Background(AccentPrimary).
 			Padding(0, 1)
 
 	BorderStyle = lipgloss.NewStyle().
 			Border(lipgloss.RoundedBorder()).
-			BorderForeground(lipgloss.Color("117"))
+			BorderForeground(BorderColor)
 
 	ItemStyle = lipgloss.NewStyle().
 			Padding(0, 1)
 
 	SelectedStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("15")).
-			Background(lipgloss.Color("63")).
+			Foreground(BrightFg).
+			Background(AccentPrimary).
 			Padding(0, 1)
 
 	HelpStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("240")).
+			Foreground(HelpFg).
 			Padding(0, 1)
 
 	KeyStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("63")).
+			Foreground(AccentPrimary).
 			Bold(true)
 )

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/Eldara-Tech/swarmcli/ui/dialog"
+
 	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/x/ansi"
 )
@@ -263,27 +265,6 @@ func RenderColumnHeader(labels []string, colWidths []int) string {
 func RenderConfirmDialog(message string) string {
 	contentWidth := 60
 
-	titleStyle := lipgloss.NewStyle().
-		Bold(true).
-		Foreground(lipgloss.Color("15")).
-		Background(lipgloss.Color("63")).
-		Padding(0, 1)
-
-	itemStyle := lipgloss.NewStyle().
-		Padding(0, 1)
-
-	borderStyle := lipgloss.NewStyle().
-		Border(lipgloss.RoundedBorder()).
-		BorderForeground(lipgloss.Color("117"))
-
-	helpStyle := lipgloss.NewStyle().
-		Foreground(lipgloss.Color("240")).
-		Padding(0, 1)
-
-	keyStyle := lipgloss.NewStyle().
-		Foreground(lipgloss.Color("63")).
-		Bold(true)
-
 	// Helper function to ensure exact width
 	ensureWidth := func(s string, width int) string {
 		currentWidth := lipgloss.Width(s)
@@ -294,51 +275,25 @@ func RenderConfirmDialog(message string) string {
 	}
 
 	var lines []string
-	lines = append(lines, ensureWidth(titleStyle.Render(" Confirmation "), contentWidth))
-	lines = append(lines, ensureWidth(itemStyle.Render(""), contentWidth))
-	lines = append(lines, ensureWidth(itemStyle.Render(message), contentWidth))
-	lines = append(lines, ensureWidth(itemStyle.Render(""), contentWidth))
+	lines = append(lines, ensureWidth(dialog.TitleStyle.Render(" Confirmation "), contentWidth))
+	lines = append(lines, ensureWidth(dialog.ItemStyle.Render(""), contentWidth))
+	lines = append(lines, ensureWidth(dialog.ItemStyle.Render(message), contentWidth))
+	lines = append(lines, ensureWidth(dialog.ItemStyle.Render(""), contentWidth))
 
 	helpText := fmt.Sprintf(" %s Yes • %s No",
-		keyStyle.Render("<y>"),
-		keyStyle.Render("<n>"))
-	lines = append(lines, ensureWidth(helpStyle.Render(helpText), contentWidth))
+		dialog.KeyStyle.Render("<y>"),
+		dialog.KeyStyle.Render("<n>"))
+	lines = append(lines, ensureWidth(dialog.HelpStyle.Render(helpText), contentWidth))
 
 	content := lipgloss.JoinVertical(lipgloss.Left, lines...)
-	return borderStyle.Render(content)
+	return dialog.BorderStyle.Render(content)
 }
 
 // RenderFileBrowserDialog renders a file browser dialog with common styling
 func RenderFileBrowserDialog(title, currentPath string, files []string, cursor int) string {
-	titleStyle := lipgloss.NewStyle().
-		Bold(true).
-		Foreground(lipgloss.Color("15")).
-		Background(lipgloss.Color("63")).
-		Padding(0, 1)
-
-	borderStyle := lipgloss.NewStyle().
-		Border(lipgloss.RoundedBorder()).
-		BorderForeground(lipgloss.Color("117"))
-
-	itemStyle := lipgloss.NewStyle().
-		Padding(0, 1)
-
-	selectedStyle := lipgloss.NewStyle().
-		Foreground(lipgloss.Color("15")).
-		Background(lipgloss.Color("63")).
-		Padding(0, 1)
-
-	helpStyle := lipgloss.NewStyle().
-		Foreground(lipgloss.Color("240")).
-		Padding(0, 1)
-
-	keyStyle := lipgloss.NewStyle().
-		Foreground(lipgloss.Color("63")).
-		Bold(true)
-
 	var lines []string
-	lines = append(lines, titleStyle.Render(fmt.Sprintf(" %s - Directory: %s ", title, currentPath)))
-	lines = append(lines, itemStyle.Render(""))
+	lines = append(lines, dialog.TitleStyle.Render(fmt.Sprintf(" %s - Directory: %s ", title, currentPath)))
+	lines = append(lines, dialog.ItemStyle.Render(""))
 
 	// Show files with cursor
 	maxVisible := 10
@@ -381,22 +336,22 @@ func RenderFileBrowserDialog(title, currentPath string, files []string, cursor i
 		}
 
 		if i == cursor {
-			lines = append(lines, selectedStyle.Render("→ "+displayName))
+			lines = append(lines, dialog.SelectedStyle.Render("→ "+displayName))
 		} else {
-			lines = append(lines, itemStyle.Render("  "+displayName))
+			lines = append(lines, dialog.ItemStyle.Render("  "+displayName))
 		}
 	}
 
-	lines = append(lines, itemStyle.Render(""))
+	lines = append(lines, dialog.ItemStyle.Render(""))
 	helpText := fmt.Sprintf(" %s Select/Navigate • %s / %s Move • %s Cancel",
-		keyStyle.Render("<Enter>"),
-		keyStyle.Render("<↑/↓>"),
-		keyStyle.Render("<PgUp/PgDn>"),
-		keyStyle.Render("<Esc>"))
-	lines = append(lines, helpStyle.Render(helpText))
+		dialog.KeyStyle.Render("<Enter>"),
+		dialog.KeyStyle.Render("<↑/↓>"),
+		dialog.KeyStyle.Render("<PgUp/PgDn>"),
+		dialog.KeyStyle.Render("<Esc>"))
+	lines = append(lines, dialog.HelpStyle.Render(helpText))
 
 	content := lipgloss.JoinVertical(lipgloss.Left, lines...)
-	return borderStyle.Render(content)
+	return dialog.BorderStyle.Render(content)
 }
 
 func OverlayCentered(base, overlay string, width, height int) string {

--- a/views/confirmdialog/confirmdialog.go
+++ b/views/confirmdialog/confirmdialog.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/Eldara-Tech/swarmcli/ui/dialog"
+
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/muesli/reflow/wordwrap"
@@ -111,38 +113,15 @@ func (m *Model) View() string {
 		contentWidth = maxWidth
 	}
 
-	// Styled title — color varies by mode
-	titleColor := lipgloss.Color("208") // Orange for warning/confirm
+	// The accent varies by mode, and tints the title and the border alike.
+	accent := dialog.AccentWarning
 	if m.InfoMode {
-		titleColor = lipgloss.Color("63") // Blue/purple for info
+		accent = dialog.AccentPrimary
 	}
-	titleStyle := lipgloss.NewStyle().
-		Bold(true).
-		Foreground(lipgloss.Color("15")).
-		Background(titleColor).
-		Padding(0, 1).
-		Width(contentWidth)
-
-	// Message style
-	messageStyle := lipgloss.NewStyle().
-		Padding(1, 2).
-		Width(contentWidth)
-
-	// Help style
-	helpStyle := lipgloss.NewStyle().
-		Foreground(lipgloss.Color("240")).
-		Padding(0, 2).
-		Width(contentWidth)
-
-	keyStyle := lipgloss.NewStyle().
-		Foreground(lipgloss.Color("63")).
-		Bold(true)
-
-	// Border style — matches title color
-	borderStyle := lipgloss.NewStyle().
-		Border(lipgloss.RoundedBorder()).
-		BorderForeground(titleColor).
-		Width(contentWidth + 2)
+	titleStyle := dialog.TitleStyle.Background(accent).Width(contentWidth)
+	messageStyle := dialog.ItemStyle.Padding(1, 2).Width(contentWidth)
+	helpStyle := dialog.HelpStyle.Padding(0, 2).Width(contentWidth)
+	borderStyle := dialog.BorderStyle.BorderForeground(accent).Width(contentWidth + 2)
 
 	// Build content
 	var lines []string
@@ -157,16 +136,14 @@ func (m *Model) View() string {
 
 	// Add checkbox if label is provided (confirm or info mode; never error mode)
 	if m.CheckboxLabel != "" && !m.ErrorMode {
-		checkboxStyle := lipgloss.NewStyle().
-			Padding(0, 2).
-			Width(contentWidth)
+		checkboxStyle := dialog.ItemStyle.Padding(0, 2).Width(contentWidth)
 
 		checkMark := "[ ]"
 		if m.CheckboxChecked {
 			checkMark = "[✓]"
 		}
 		checkboxText := fmt.Sprintf("%s %s",
-			keyStyle.Render(checkMark),
+			dialog.KeyStyle.Render(checkMark),
 			m.CheckboxLabel)
 		lines = append(lines, checkboxStyle.Render(checkboxText))
 	}
@@ -175,19 +152,19 @@ func (m *Model) View() string {
 	switch {
 	case m.InfoMode && m.CheckboxLabel != "":
 		helpText = fmt.Sprintf("%s Toggle • %s Close",
-			keyStyle.Render("<Space>"),
-			keyStyle.Render("<Enter/Esc>"))
+			dialog.KeyStyle.Render("<Space>"),
+			dialog.KeyStyle.Render("<Enter/Esc>"))
 	case m.ErrorMode || m.InfoMode:
-		helpText = fmt.Sprintf("%s Close", keyStyle.Render("<Enter/Esc>"))
+		helpText = fmt.Sprintf("%s Close", dialog.KeyStyle.Render("<Enter/Esc>"))
 	case m.CheckboxLabel != "":
 		helpText = fmt.Sprintf("%s Yes • %s No • %s Toggle",
-			keyStyle.Render("<y>"),
-			keyStyle.Render("<n/Esc>"),
-			keyStyle.Render("<Space>"))
+			dialog.KeyStyle.Render("<y>"),
+			dialog.KeyStyle.Render("<n/Esc>"),
+			dialog.KeyStyle.Render("<Space>"))
 	default:
 		helpText = fmt.Sprintf("%s Yes • %s No",
-			keyStyle.Render("<y>"),
-			keyStyle.Render("<n/Esc>"))
+			dialog.KeyStyle.Render("<y>"),
+			dialog.KeyStyle.Render("<n/Esc>"))
 	}
 	lines = append(lines, helpStyle.Render(helpText))
 

--- a/views/confirmdialog/confirmdialog.go
+++ b/views/confirmdialog/confirmdialog.go
@@ -119,8 +119,8 @@ func (m *Model) View() string {
 		accent = dialog.AccentPrimary
 	}
 	titleStyle := dialog.TitleStyle.Background(accent).Width(contentWidth)
-	messageStyle := dialog.ItemStyle.Padding(1, 2).Width(contentWidth)
-	helpStyle := dialog.HelpStyle.Padding(0, 2).Width(contentWidth)
+	messageStyle := dialog.MessageStyle.Width(contentWidth)
+	helpStyle := dialog.HelpStyle.Width(contentWidth)
 	borderStyle := dialog.BorderStyle.BorderForeground(accent).Width(contentWidth + 2)
 
 	// Build content
@@ -136,7 +136,7 @@ func (m *Model) View() string {
 
 	// Add checkbox if label is provided (confirm or info mode; never error mode)
 	if m.CheckboxLabel != "" && !m.ErrorMode {
-		checkboxStyle := dialog.ItemStyle.Padding(0, 2).Width(contentWidth)
+		checkboxStyle := dialog.ItemStyle.Width(contentWidth)
 
 		checkMark := "[ ]"
 		if m.CheckboxChecked {

--- a/views/logs/view.go
+++ b/views/logs/view.go
@@ -6,6 +6,7 @@ package logsview
 import (
 	"fmt"
 	"github.com/Eldara-Tech/swarmcli/ui"
+	"github.com/Eldara-Tech/swarmcli/ui/dialog"
 
 	"github.com/charmbracelet/lipgloss"
 )
@@ -99,8 +100,8 @@ func (m *Model) FrameContent() string {
 
 	if m.getNodeSelectVisible() && m.viewport.Height >= 5 {
 		availableHeight := m.viewport.Height
-		dialog := m.renderNodeSelectDialog(availableHeight)
-		viewportContent = ui.OverlayCentered(viewportContent, dialog, width, 0)
+		popup := m.renderNodeSelectDialog(availableHeight)
+		viewportContent = ui.OverlayCentered(viewportContent, popup, width, 0)
 	}
 
 	return viewportContent
@@ -165,37 +166,12 @@ func (m *Model) renderNodeSelectDialog(availableHeight int) string {
 		contentWidth = titleWidth
 	}
 
-	titleStyle := lipgloss.NewStyle().
-		Bold(true).
-		Foreground(lipgloss.Color("15")).
-		Background(lipgloss.Color("63")).
-		Padding(0, 1).
-		Width(contentWidth)
-
-	itemStyle := lipgloss.NewStyle().
-		Padding(0, 1).
-		Width(contentWidth)
-
-	selectedStyle := lipgloss.NewStyle().
-		Foreground(lipgloss.Color("230")).
-		Background(lipgloss.Color("63")).
-		Bold(true).
-		Padding(0, 1).
-		Width(contentWidth)
-
-	borderStyle := lipgloss.NewStyle().
-		Border(lipgloss.RoundedBorder()).
-		BorderForeground(lipgloss.Color("117")).
-		Width(contentWidth + 2)
-
-	helpStyle := lipgloss.NewStyle().
-		Foreground(lipgloss.Color("240")).
-		Padding(0, 1).
-		Width(contentWidth)
-
-	keyStyle := lipgloss.NewStyle().
-		Foreground(lipgloss.Color("63")).
-		Bold(true)
+	titleStyle := dialog.TitleStyle.Width(contentWidth)
+	itemStyle := dialog.ItemStyle.Width(contentWidth)
+	// A brighter selection than the shared one, which this dialog has always used.
+	selectedStyle := dialog.SelectedStyle.Foreground(dialog.SelectedFg).Bold(true).Width(contentWidth)
+	borderStyle := dialog.BorderStyle.Width(contentWidth + 2)
+	helpStyle := dialog.HelpStyle.Width(contentWidth)
 
 	// Build the content
 	var lines []string
@@ -275,9 +251,9 @@ func (m *Model) renderNodeSelectDialog(availableHeight int) string {
 
 	// Build help text with styled keys
 	helpText := fmt.Sprintf(" %s Navigate • %s Select • %s Cancel",
-		keyStyle.Render("<↑/↓/PgUp/PgDn>"),
-		keyStyle.Render("<Enter>"),
-		keyStyle.Render("<Esc>"))
+		dialog.KeyStyle.Render("<↑/↓/PgUp/PgDn>"),
+		dialog.KeyStyle.Render("<Enter>"),
+		dialog.KeyStyle.Render("<Esc>"))
 	lines = append(lines, helpStyle.Render(helpText))
 
 	content := lipgloss.JoinVertical(lipgloss.Left, lines...)

--- a/views/logs/view.go
+++ b/views/logs/view.go
@@ -168,8 +168,7 @@ func (m *Model) renderNodeSelectDialog(availableHeight int) string {
 
 	titleStyle := dialog.TitleStyle.Width(contentWidth)
 	itemStyle := dialog.ItemStyle.Width(contentWidth)
-	// A brighter selection than the shared one, which this dialog has always used.
-	selectedStyle := dialog.SelectedStyle.Foreground(dialog.SelectedFg).Bold(true).Width(contentWidth)
+	selectedStyle := dialog.SelectedStyle.Width(contentWidth)
 	borderStyle := dialog.BorderStyle.Width(contentWidth + 2)
 	helpStyle := dialog.HelpStyle.Width(contentWidth)
 

--- a/views/networks/view.go
+++ b/views/networks/view.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Eldara-Tech/swarmcli/ui/components/errordialog"
 	filterlist "github.com/Eldara-Tech/swarmcli/ui/components/filterable/list"
 	"github.com/Eldara-Tech/swarmcli/ui/components/sorting"
+	"github.com/Eldara-Tech/swarmcli/ui/dialog"
 	"strings"
 	"time"
 
@@ -233,7 +234,7 @@ func (m *Model) renderCreateNetworkDialog(width int) string {
 		body = append(body, focusMark(8)+" Manual container attachment: "+checkbox(m.createAttachable)+"  (space to toggle)")
 		if m.createDialogError != "" {
 			body = append(body, "")
-			body = append(body, lipgloss.NewStyle().Foreground(lipgloss.Color("196")).Render(m.createDialogError))
+			body = append(body, lipgloss.NewStyle().Foreground(dialog.AccentError).Render(m.createDialogError))
 		}
 		body = append(body, "")
 		body = append(body, "Tab: next field   Enter: review   Esc: cancel")
@@ -241,11 +242,7 @@ func (m *Model) renderCreateNetworkDialog(width int) string {
 
 	content := strings.Join(body, "\n")
 
-	boxStyle := lipgloss.NewStyle().
-		Border(lipgloss.RoundedBorder()).
-		BorderForeground(lipgloss.Color("117")).
-		Padding(1, 2).
-		Width(maxW)
+	boxStyle := dialog.BorderStyle.Padding(1, 2).Width(maxW)
 
 	return boxStyle.Render(content)
 }

--- a/views/nodes/view.go
+++ b/views/nodes/view.go
@@ -6,6 +6,7 @@ package nodesview
 import (
 	"fmt"
 	"github.com/Eldara-Tech/swarmcli/ui"
+	"github.com/Eldara-Tech/swarmcli/ui/dialog"
 	"sort"
 	"strings"
 
@@ -89,33 +90,12 @@ func (m *Model) renderAvailabilityDialog() string {
 	options := []string{"Active", "Pause", "Drain"}
 	contentWidth := 40
 
-	titleStyle := lipgloss.NewStyle().
-		Bold(true).
-		Foreground(lipgloss.Color("15")).
-		Background(lipgloss.Color("63")).
-		Padding(0, 1).
-		Width(contentWidth)
-
-	optionStyle := lipgloss.NewStyle().
-		Padding(0, 2).
-		Width(contentWidth)
-
-	selectedStyle := lipgloss.NewStyle().
-		Foreground(lipgloss.Color("230")).
-		Background(lipgloss.Color("63")).
-		Bold(true).
-		Padding(0, 2).
-		Width(contentWidth)
-
-	helpStyle := lipgloss.NewStyle().
-		Foreground(lipgloss.Color("240")).
-		Padding(0, 2).
-		Width(contentWidth)
-
-	borderStyle := lipgloss.NewStyle().
-		Border(lipgloss.RoundedBorder()).
-		BorderForeground(lipgloss.Color("63")).
-		Width(contentWidth + 2)
+	titleStyle := dialog.TitleStyle.Width(contentWidth)
+	// The wider padding and brighter selection this dialog has always used.
+	optionStyle := dialog.ItemStyle.Padding(0, 2).Width(contentWidth)
+	selectedStyle := dialog.SelectedStyle.Foreground(dialog.SelectedFg).Bold(true).Padding(0, 2).Width(contentWidth)
+	helpStyle := dialog.HelpStyle.Padding(0, 2).Width(contentWidth)
+	borderStyle := dialog.BorderStyle.BorderForeground(dialog.AccentPrimary).Width(contentWidth + 2)
 
 	var lines []string
 	lines = append(lines, titleStyle.Render(" Set Node Availability "))
@@ -139,24 +119,17 @@ func (m *Model) renderAvailabilityDialog() string {
 
 // renderLabelInputDialog renders the label input dialog
 func (m *Model) renderLabelInputDialog() string {
-	titleStyle := lipgloss.NewStyle().
-		Bold(true).
-		Foreground(lipgloss.Color("15")).
-		Background(lipgloss.Color("214")).
-		Padding(0, 1)
+	titleStyle := dialog.TitleStyle.Background(dialog.AccentEdit)
 
 	inputStyle := lipgloss.NewStyle().
-		Foreground(lipgloss.Color("15")).
+		Foreground(dialog.BrightFg).
 		Bold(true)
 
 	helpStyle := lipgloss.NewStyle().
-		Foreground(lipgloss.Color("240")).
+		Foreground(dialog.HelpFg).
 		Italic(true)
 
-	borderStyle := lipgloss.NewStyle().
-		Border(lipgloss.RoundedBorder()).
-		BorderForeground(lipgloss.Color("214")).
-		Padding(1, 2)
+	borderStyle := dialog.BorderStyle.BorderForeground(dialog.AccentEdit).Padding(1, 2)
 
 	var lines []string
 	lines = append(lines, titleStyle.Render("Add Node Label"))
@@ -171,27 +144,20 @@ func (m *Model) renderLabelInputDialog() string {
 
 // renderLabelRemoveDialog renders the label removal dialog
 func (m *Model) renderLabelRemoveDialog() string {
-	titleStyle := lipgloss.NewStyle().
-		Bold(true).
-		Foreground(lipgloss.Color("15")).
-		Background(lipgloss.Color("214")).
-		Padding(0, 1)
+	titleStyle := dialog.TitleStyle.Background(dialog.AccentEdit)
 
 	optionStyle := lipgloss.NewStyle().
-		Foreground(lipgloss.Color("250"))
+		Foreground(dialog.MutedFg)
 
 	selectedStyle := lipgloss.NewStyle().
-		Foreground(lipgloss.Color("15")).
+		Foreground(dialog.BrightFg).
 		Bold(true)
 
 	helpStyle := lipgloss.NewStyle().
-		Foreground(lipgloss.Color("240")).
+		Foreground(dialog.HelpFg).
 		Italic(true)
 
-	borderStyle := lipgloss.NewStyle().
-		Border(lipgloss.RoundedBorder()).
-		BorderForeground(lipgloss.Color("214")).
-		Padding(1, 2)
+	borderStyle := dialog.BorderStyle.BorderForeground(dialog.AccentEdit).Padding(1, 2)
 
 	var lines []string
 	lines = append(lines, titleStyle.Render("Remove Node Label"))

--- a/views/nodes/view.go
+++ b/views/nodes/view.go
@@ -91,11 +91,10 @@ func (m *Model) renderAvailabilityDialog() string {
 	contentWidth := 40
 
 	titleStyle := dialog.TitleStyle.Width(contentWidth)
-	// The wider padding and brighter selection this dialog has always used.
-	optionStyle := dialog.ItemStyle.Padding(0, 2).Width(contentWidth)
-	selectedStyle := dialog.SelectedStyle.Foreground(dialog.SelectedFg).Bold(true).Padding(0, 2).Width(contentWidth)
-	helpStyle := dialog.HelpStyle.Padding(0, 2).Width(contentWidth)
-	borderStyle := dialog.BorderStyle.BorderForeground(dialog.AccentPrimary).Width(contentWidth + 2)
+	optionStyle := dialog.ItemStyle.Width(contentWidth)
+	selectedStyle := dialog.SelectedStyle.Width(contentWidth)
+	helpStyle := dialog.HelpStyle.Width(contentWidth)
+	borderStyle := dialog.BorderStyle.Width(contentWidth + 2)
 
 	var lines []string
 	lines = append(lines, titleStyle.Render(" Set Node Availability "))

--- a/views/scaledialog/scaledialog.go
+++ b/views/scaledialog/scaledialog.go
@@ -76,7 +76,7 @@ func (m *Model) View() string {
 	}
 
 	titleStyle := dialog.TitleStyle.Width(contentWidth)
-	messageStyle := dialog.ItemStyle.Padding(1, 2).Width(contentWidth)
+	messageStyle := dialog.MessageStyle.Width(contentWidth)
 
 	// Replicas display style
 	replicasStyle := lipgloss.NewStyle().
@@ -86,8 +86,8 @@ func (m *Model) View() string {
 		Width(contentWidth).
 		Padding(1, 0)
 
-	helpStyle := dialog.HelpStyle.Padding(0, 2).Width(contentWidth)
-	borderStyle := dialog.BorderStyle.BorderForeground(dialog.AccentPrimary).Width(contentWidth + 2)
+	helpStyle := dialog.HelpStyle.Width(contentWidth)
+	borderStyle := dialog.BorderStyle.Width(contentWidth + 2)
 
 	// Build content
 	var lines []string

--- a/views/scaledialog/scaledialog.go
+++ b/views/scaledialog/scaledialog.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/Eldara-Tech/swarmcli/ui/dialog"
+
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 )
@@ -73,18 +75,8 @@ func (m *Model) View() string {
 		contentWidth = w
 	}
 
-	// Styled title
-	titleStyle := lipgloss.NewStyle().
-		Bold(true).
-		Foreground(lipgloss.Color("15")).
-		Background(lipgloss.Color("63")). // Blue for scale
-		Padding(0, 1).
-		Width(contentWidth)
-
-	// Message style
-	messageStyle := lipgloss.NewStyle().
-		Padding(1, 2).
-		Width(contentWidth)
+	titleStyle := dialog.TitleStyle.Width(contentWidth)
+	messageStyle := dialog.ItemStyle.Padding(1, 2).Width(contentWidth)
 
 	// Replicas display style
 	replicasStyle := lipgloss.NewStyle().
@@ -94,21 +86,8 @@ func (m *Model) View() string {
 		Width(contentWidth).
 		Padding(1, 0)
 
-	// Help style
-	helpStyle := lipgloss.NewStyle().
-		Foreground(lipgloss.Color("240")).
-		Padding(0, 2).
-		Width(contentWidth)
-
-	keyStyle := lipgloss.NewStyle().
-		Foreground(lipgloss.Color("63")).
-		Bold(true)
-
-	// Border style
-	borderStyle := lipgloss.NewStyle().
-		Border(lipgloss.RoundedBorder()).
-		BorderForeground(lipgloss.Color("63")).
-		Width(contentWidth + 2)
+	helpStyle := dialog.HelpStyle.Padding(0, 2).Width(contentWidth)
+	borderStyle := dialog.BorderStyle.BorderForeground(dialog.AccentPrimary).Width(contentWidth + 2)
 
 	// Build content
 	var lines []string
@@ -117,10 +96,10 @@ func (m *Model) View() string {
 	lines = append(lines, replicasStyle.Render(fmt.Sprintf("Replicas: %d", m.Replicas)))
 
 	helpText := fmt.Sprintf("%s Increase • %s Decrease • %s Apply • %s Cancel",
-		keyStyle.Render("<↑>"),
-		keyStyle.Render("<↓>"),
-		keyStyle.Render("<Enter>"),
-		keyStyle.Render("<Esc>"))
+		dialog.KeyStyle.Render("<↑>"),
+		dialog.KeyStyle.Render("<↓>"),
+		dialog.KeyStyle.Render("<Enter>"),
+		dialog.KeyStyle.Render("<Esc>"))
 	lines = append(lines, helpStyle.Render(helpText))
 
 	content := strings.Join(lines, "\n")

--- a/views/unlockdialog/unlockdialog.go
+++ b/views/unlockdialog/unlockdialog.go
@@ -8,9 +8,10 @@ package unlockdialog
 import (
 	"strings"
 
+	"github.com/Eldara-Tech/swarmcli/ui/dialog"
+
 	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
-	"github.com/charmbracelet/lipgloss"
 )
 
 // ResultMsg is emitted when the dialog is dismissed. Confirmed is true when the
@@ -66,41 +67,18 @@ func (m *Model) View() string {
 
 	contentWidth := 65
 
-	titleStyle := lipgloss.NewStyle().
-		Bold(true).
-		Foreground(lipgloss.Color("15")).
-		Background(lipgloss.Color("63")).
-		Padding(0, 1).
-		Width(contentWidth)
-
-	messageStyle := lipgloss.NewStyle().
-		Padding(1, 2).
-		Width(contentWidth)
-
-	inputStyle := lipgloss.NewStyle().
-		Padding(0, 2).
-		Width(contentWidth)
-
-	helpStyle := lipgloss.NewStyle().
-		Foreground(lipgloss.Color("240")).
-		Padding(1, 2, 0, 2).
-		Width(contentWidth)
-
-	keyStyle := lipgloss.NewStyle().
-		Foreground(lipgloss.Color("63")).
-		Bold(true)
-
-	borderStyle := lipgloss.NewStyle().
-		Border(lipgloss.RoundedBorder()).
-		BorderForeground(lipgloss.Color("63")).
-		Width(contentWidth + 2)
+	titleStyle := dialog.TitleStyle.Width(contentWidth)
+	messageStyle := dialog.ItemStyle.Padding(1, 2).Width(contentWidth)
+	inputStyle := dialog.ItemStyle.Padding(0, 2).Width(contentWidth)
+	helpStyle := dialog.HelpStyle.Padding(1, 2, 0, 2).Width(contentWidth)
+	borderStyle := dialog.BorderStyle.BorderForeground(dialog.AccentPrimary).Width(contentWidth + 2)
 
 	var lines []string
 	lines = append(lines, titleStyle.Render(" Unlock Swarm "))
 	lines = append(lines, messageStyle.Render("Enter the swarm unlock key to decrypt this cluster."))
 	lines = append(lines, inputStyle.Render(m.input.View()))
 
-	helpText := keyStyle.Render("<Enter>") + " Unlock • " + keyStyle.Render("<Esc>") + " Cancel"
+	helpText := dialog.KeyStyle.Render("<Enter>") + " Unlock • " + dialog.KeyStyle.Render("<Esc>") + " Cancel"
 	lines = append(lines, helpStyle.Render(helpText))
 
 	return borderStyle.Render(strings.Join(lines, "\n"))

--- a/views/unlockdialog/unlockdialog.go
+++ b/views/unlockdialog/unlockdialog.go
@@ -68,10 +68,10 @@ func (m *Model) View() string {
 	contentWidth := 65
 
 	titleStyle := dialog.TitleStyle.Width(contentWidth)
-	messageStyle := dialog.ItemStyle.Padding(1, 2).Width(contentWidth)
-	inputStyle := dialog.ItemStyle.Padding(0, 2).Width(contentWidth)
-	helpStyle := dialog.HelpStyle.Padding(1, 2, 0, 2).Width(contentWidth)
-	borderStyle := dialog.BorderStyle.BorderForeground(dialog.AccentPrimary).Width(contentWidth + 2)
+	messageStyle := dialog.MessageStyle.Width(contentWidth)
+	inputStyle := dialog.ItemStyle.Width(contentWidth)
+	helpStyle := dialog.HelpStyle.Width(contentWidth)
+	borderStyle := dialog.BorderStyle.Width(contentWidth + 2)
 
 	var lines []string
 	lines = append(lines, titleStyle.Render(" Unlock Swarm "))


### PR DESCRIPTION
Stacked on #582 — that PR points every dialog at `ui/dialog` while preserving exactly what each one drew; this one settles the disagreements it made visible. **Until #582 merges this PR's diff shows both commits**; review `c3c8231` on its own, or merge #582 first and this collapses to one commit.

## The border does not collapse onto the shared value

`dialog.BorderStyle` was `lipgloss.Color("117")` — and `ui.FrameBorderColor` (ui.go:26) is *also* `117`. That is the colour of the view frame a dialog is drawn on top of, so any dialog using the shared border framed itself in the same colour as the chrome beneath it and stopped reading as a layer.

The dialogs that had "drifted" to their accent were the ones getting it right, and they were in good company — the error dialog already bordered in red, confirm in orange, the label dialogs in amber. So the unification goes the other way: **every dialog borders in its own accent**, matching its title bar so the dialog reads as one object. `BorderColor` leaves the dialog palette; 117 stays in `ui` as view chrome.

## Everything else collapses onto the shared value

- **Selected rows** — `SelectedFg` (230) + bold is gone. The accent background is what signals selection; #ffffd7 versus #ffffff and a bold weight on an already-inverted row were adding nothing.
- **Item and help padding** — `(0,2)` overrides in nodes-availability, scale, unlock and confirm drop to the shared `(0,1)`.
- **The prose block** — scale, unlock and confirm each overrode the same thing for a real reason: the inset sentence a dialog asks its question in is not a row. That becomes `dialog.MessageStyle` instead of three copies.

## Three more hold-outs

Beyond the six in #582: `ui.RenderConfirmDialog` and `ui.RenderFileBrowserDialog` (ui.go:265, 297) each carried another byte-identical copy of the whole set — `ui` can import `ui/dialog` without a cycle, since `ui/dialog` imports only lipgloss. And `views/networks/view.go` renders its create-network dialog as a 117 box overlaid on the view. All three now use the shared styles.

**End state: every dialog in the tree derives from `ui/dialog` and overrides only its accent.** That is checkable — no dialog renderer constructs a style carrying its own `Background` or `BorderForeground` any more.

## What changed on screen

All twenty dialog states rendered before and after under a forced `termenv.TrueColor` profile and compared:

| | |
|---|---|
| unchanged | 4 — error short/wrapped, both nodes label dialogs |
| colour only, text byte-identical | 4 — both logs node-select branches, both `ui.go` helpers |
| shifted one column as padding converged | 12 — confirm ×5, nodes-availability ×3, scale ×2, unlock ×2 |

**No dialog changed width** — padding is inside the `Width(contentWidth)` box, so only the text inset moved. One vertical change: unlock loses a blank line, the spacer its help text had via `Padding(1, 2, 0, 2)` and no other dialog's had. It now has the same title / message / field / help rhythm as confirm:

```
╭───────────────────────────────────────────────────╮
│  Unlock Swarm                                     │
│                                                   │
│  Enter the swarm unlock key to decrypt this ...   │
│                                                   │
│ Key: ***************                              │
│ <Enter> Unlock • <Esc> Cancel                     │
╰───────────────────────────────────────────────────╯
```

`go test ./...` passes with no test changes — nothing asserted the old spacing. `golangci-lint run ./... --build-tags=integration` reports 0 issues.

Part of #147. The remaining work there is outside the dialogs: ~130 `lipgloss.Color` literals across the list views, which is what #279 (customizable themes) needs named.
