### PR TITLE
fix(secrets): never write a secret's payload to the log

### DIFF
--- a/views/secrets/actions.go
+++ b/views/secrets/actions.go
@@ -231,17 +231,13 @@ func (m *Model) createSecretFromFileCmd(name, filePath string, labels map[string
 			return errorMsg(fmt.Errorf("failed to read file: %w", err))
 		}
 
-		// Base64 encode if requested
+		// Base64 encode if requested. The payload is never logged, at any level:
+		// it is the secret, and a debug log is the file an operator attaches to
+		// a bug report — one lumberjack keeps as five compressed rotations for
+		// fourteen days, long after the terminal it was typed into is gone.
+		// CreateSecret already logs its size, which is the part worth having.
 		if encode {
-			encoded := base64.StdEncoding.EncodeToString(data)
-			// Debug: show encoded payload (may be large)
-			const maxLogged = 4096
-			if len(encoded) > maxLogged {
-				l().Debugf("Secret %s base64 payload (%d chars, truncated to %d): %s…", name, len(encoded), maxLogged, encoded[:maxLogged])
-			} else {
-				l().Debugf("Secret %s base64 payload (%d chars): %s", name, len(encoded), encoded)
-			}
-			data = []byte(encoded)
+			data = []byte(base64.StdEncoding.EncodeToString(data))
 		}
 
 		// Create the secret
@@ -266,17 +262,9 @@ func (m *Model) createSecretFromContentCmd(name string, content []byte, labels m
 	return func() tea.Msg {
 		l().Infof("Creating secret %s from inline content (encode=%v, labels=%v)", name, encode, labels)
 
-		// Base64 encode if requested
+		// Never logged — see createSecretFromFileCmd.
 		if encode {
-			encoded := base64.StdEncoding.EncodeToString(content)
-			// Debug: show encoded payload
-			const maxLogged = 4096
-			if len(encoded) > maxLogged {
-				l().Debugf("Secret %s base64 payload (%d chars, truncated to %d): %s…", name, len(encoded), maxLogged, encoded[:maxLogged])
-			} else {
-				l().Debugf("Secret %s base64 payload (%d chars): %s", name, len(encoded), encoded)
-			}
-			content = []byte(encoded)
+			content = []byte(base64.StdEncoding.EncodeToString(content))
 		}
 
 		// Create the secret

--- a/views/secrets/actions_test.go
+++ b/views/secrets/actions_test.go
@@ -4,13 +4,21 @@
 package secretsview
 
 import (
+	"bytes"
 	"context"
+	"encoding/base64"
 	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/Eldara-Tech/swarmcli/docker"
+	swarmlog "github.com/Eldara-Tech/swarmcli/utils/log"
 	"github.com/Eldara-Tech/swarmcli/views/view"
 
+	tea "github.com/charmbracelet/bubbletea"
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/stretchr/testify/require"
 )
@@ -244,4 +252,71 @@ func TestCheckSecretsCmd_HashMatchesAfterLoad(t *testing.T) {
 	msg := runCmd(cmd)
 	_, isLoaded := msg.(secretsLoadedMsg)
 	require.False(t, isLoaded, "hash from secretsLoadedMsg must match hash from checkSecretsCmd for identical data")
+}
+
+// captureLog bridges the package logger into a buffer at debug level, so a test
+// can assert on everything the code under test writes. utils/log keeps the
+// previous logger in package-private state, so cleanup installs a discarding
+// bridge rather than restoring one; no other test here reads the log.
+func captureLog(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	var buf bytes.Buffer
+	swarmlog.InitSlog(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	t.Cleanup(func() {
+		swarmlog.InitSlog(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelError}))
+	})
+	return &buf
+}
+
+// A secret's own bytes must never reach the log at any level. The debug log is
+// the file an operator attaches to a bug report, and lumberjack keeps five
+// compressed rotations of it for fourteen days, so a line written here outlives
+// the terminal the secret was typed into by a fortnight.
+//
+// Both creation paths are covered because each encodes its payload itself, and
+// each carried its own copy of the line that printed it — fixing one proved
+// nothing about the other. The unencoded cases are here to catch a log added to
+// the branch that does no encoding, which is the obvious place for the next one
+// to appear.
+//
+// The Contains assertion is not decoration. Without it, a bridge that captured
+// nothing at all would satisfy every NotContains below and the test would pass
+// while asserting nothing.
+func TestCreateSecretNeverLogsThePayload(t *testing.T) {
+	const payload = "hunter2-correct-horse-battery-staple"
+	encoded := base64.StdEncoding.EncodeToString([]byte(payload))
+
+	file := filepath.Join(t.TempDir(), "secret.txt")
+	require.NoError(t, os.WriteFile(file, []byte(payload), 0o600))
+
+	for _, tc := range []struct {
+		name string
+		cmd  func(*Model) tea.Cmd
+	}{
+		{"from file", func(m *Model) tea.Cmd {
+			return m.createSecretFromFileCmd("s-file", file, nil, true)
+		}},
+		{"from file, not encoded", func(m *Model) tea.Cmd {
+			return m.createSecretFromFileCmd("s-file", file, nil, false)
+		}},
+		{"from content", func(m *Model) tea.Cmd {
+			return m.createSecretFromContentCmd("s-content", []byte(payload), nil, true)
+		}},
+		{"from content, not encoded", func(m *Model) tea.Cmd {
+			return m.createSecretFromContentCmd("s-content", []byte(payload), nil, false)
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			buf := captureLog(t)
+			m := testModel(func(m *Model) { m.deps.Secrets = noopSecretOps() })
+
+			require.IsType(t, secretCreatedMsg{}, runCmd(tc.cmd(m)))
+
+			logged := buf.String()
+			require.Contains(t, logged, "Creating secret",
+				"the bridge captured none of this command's own lines, so the assertions below prove nothing")
+			require.NotContains(t, logged, payload, "the secret's plaintext reached the log")
+			require.NotContains(t, logged, encoded, "the secret's base64 reached the log")
+		})
+	}
 }


### PR DESCRIPTION
## What

Both secret-creation paths in the secrets view logged the **full base64 of the secret** at `Debug` level, truncated at 4096 characters:

```go
l().Debugf("Secret %s base64 payload (%d chars): %s", name, len(encoded), encoded)
```

`LOG_LEVEL=debug` is enough to turn this on in a release build — no dev mode, no build tag — and the line lands in `~/.local/state/swarmcli/app-debug.log`, which lumberjack keeps as five compressed rotations for fourteen days. So a secret outlived the terminal it was typed into by a fortnight, in precisely the file an operator gets asked to attach to a bug report.

## The fix

The payload is dropped rather than shortened. A prefix of a credential is still a credential, and `docker.CreateSecret` already logs the size, which was the only part of the line worth having. That also restores consistency with every other write on this path — `docker/secret.go:148` and `views/secrets/update.go:201` both log a length and nothing else.

Only the two `Debugf` calls change; the encoding behaviour is identical.

## Testing

`TestCreateSecretNeverLogsThePayload` bridges the package logger into a buffer at debug level and asserts the plaintext and its base64 are both absent, across four cases: from-file and from-content, encoded and not.

It also asserts a line that *should* be present is present. Without that half, a bridge that captured nothing at all would satisfy every `NotContains` and the test would pass while checking nothing.

Verified by mutation rather than by observing green: re-introducing the payload line in each function makes the corresponding subtest fail on the base64, and the unencoded subtests correctly stay green.

`go build ./...`, `go test ./...`, `gofmt` and `golangci-lint run` are clean.

## Not in scope

Found while researching #465, which is unrelated and stays open pending a separate decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
