### PR TITLE
feat(charts): lint warns when a manifest inlines a credential

### DIFF
--- a/charts/README.md
+++ b/charts/README.md
@@ -486,6 +486,19 @@ it with the values a real install would supply. A chart that declares no
 `swarmcliVersion` gets a warning, not an error: the field is optional, but a
 chart naming no floor leaves an operator on an old build nothing to act on.
 
+It also warns when a service's `environment:` block holds a credential inline —
+a key named like a password, secret, token, API key or credential, or a value
+carrying a PEM private key. Such a value is stored verbatim in both the release
+record and the service spec, and both are readable by anyone with Docker access,
+so the credential is disclosed to every operator who can run `docker service
+inspect`. Reference an external Docker secret instead and read it from
+`/run/secrets/<name>`, through the image's `*_FILE` variable or in the service's
+own command — a value that already does either is not flagged, nor is a `${VAR}`
+the deploy substitutes. It is a warning rather than a refusal because the engine
+cannot tell a credential from a value that merely reads like one, and it fires on
+the key even when the rendered value is empty: the key is what will carry the
+credential once an operator supplies one.
+
 `--for-version` asks **whether the chart's declared floor admits that version**.
 It cannot tell you the chart *runs* on it: this binary carries one engine's
 behaviour and cannot emulate another's, so it checks the claim's shape, not its
@@ -660,10 +673,12 @@ window are the protections.
   which is readable by anyone with Docker access — as are `charts get manifest`
   and the TUI config viewer, which read it back. Do **not** inline secret
   material in templates: reference Docker secrets as separate objects instead.
-  Nothing currently enforces that. A redaction pass is
-  [issue #465](https://github.com/Eldara-Tech/swarmcli/issues/465); treat this
-  as a limitation to design around rather than something the engine will catch
-  for you.
+  `charts lint` warns about the common shape of getting this wrong (see
+  [Linting a chart](#linting-a-chart)), but it is advice at authoring time, not a gate:
+  nothing refuses a deploy over it, and no read path redacts. The same material
+  is equally visible in the service spec to anyone who can run `docker service
+  inspect`, so treat the release record as no more secret than the stack it
+  records.
 - **Chart integrity** is only as good as the index: a repository that publishes
   no `digest` gets a warning, not a refusal (see [Integrity](#integrity)). Chart
   archives are capped at 20 MiB on the wire.

--- a/charts/lint.go
+++ b/charts/lint.go
@@ -5,7 +5,9 @@ package charts
 
 import (
 	"fmt"
+	"regexp"
 	"sort"
+	"strings"
 	"time"
 
 	"gopkg.in/yaml.v3"
@@ -103,6 +105,7 @@ func Lint(ch *Chart, engine string, files [][]byte, sets []string) []LintFinding
 		return out
 	}
 	lintHealthcheckMonitor(manifest, add)
+	lintInlineSecrets(manifest, add)
 	if _, err := RenderRequirements(ch, ctx); err != nil {
 		add(LintError, "requirements.yaml: %v", err)
 	}
@@ -248,4 +251,147 @@ func isHealthcheckNone(test any) bool {
 		return len(v) > 0 && v[0] == "NONE"
 	}
 	return false
+}
+
+// secretishKey matches an environment variable name that names a credential.
+//
+// It is deliberately a rule about the key rather than the value: what makes
+// DB_PASSWORD: hunter2 wrong is the key, and no amount of looking at "hunter2"
+// establishes that. Value-shaped detection — entropy, token prefixes — fires on
+// image digests and generated identifiers and would make the rule noise. The one
+// value-shaped exception is a PEM private key, which is unambiguous wherever it
+// turns up.
+var secretishKey = regexp.MustCompile(`(?i)(password|passwd|secret|token|api[_-]?key|access[_-]?key|private[_-]?key|credential)`)
+
+// pemPrivateKey is the opening line of any PEM-armoured private key. A
+// CERTIFICATE block is deliberately not matched: it is public material and
+// inlining one is legitimate.
+var pemPrivateKey = regexp.MustCompile(`-----BEGIN (?:[A-Z0-9 ]+ )?PRIVATE KEY-----`)
+
+// runtimeRef is a value the deploy resolves rather than one the manifest
+// carries: a ${VAR}/$VAR interpolation substituted at deploy time.
+var runtimeRef = regexp.MustCompile(`^\$+\{?[A-Za-z_][A-Za-z0-9_]*\}?$`)
+
+// envPair is one entry of a service's environment: block.
+type envPair struct{ key, value string }
+
+// lintInlineSecrets warns when a service's environment: block carries credential
+// material as a literal.
+//
+// Such a value is stored verbatim twice over — in the release record Config and
+// in the swarm service spec — and both are readable by anyone with Docker
+// access, so the credential is disclosed to every operator who can run `docker
+// service inspect`. The convention charts are expected to follow instead is an
+// external Docker secret read from /run/secrets/<name>, either through an image's
+// *_FILE variable or in the service's own command.
+//
+// A warning, not an error, and deliberately so. The engine cannot tell a
+// credential from a value that merely reads like one, and refusing the deploy on
+// a name-matching heuristic would break third-party charts over a guess. It also
+// fires on the *shape* rather than the rendered value: a chart whose
+// DB_PASSWORD defaults to "" still warns, because the key is what will carry the
+// credential once an operator supplies one, and that is precisely the chart worth
+// warning its author about.
+//
+// Scope is environment: alone. command:, entrypoint: and healthcheck.test: are
+// not scanned, because the sanctioned pattern — reading /run/secrets/<name> in a
+// command wrapper — lives there, and a rule that flagged it would fire on every
+// chart that does the right thing.
+func lintInlineSecrets(manifest string, add func(LintSeverity, string, ...any)) {
+	var top map[string]yaml.Node
+	if err := yaml.Unmarshal([]byte(manifest), &top); err != nil {
+		return // the manifest already rendered; shape problems are not lint's business here
+	}
+	services, ok := top["services"]
+	if !ok {
+		return
+	}
+	for name, svc := range entries(services) {
+		var s struct {
+			Environment yaml.Node `yaml:"environment"`
+		}
+		if err := svc.Decode(&s); err != nil {
+			continue
+		}
+		for _, kv := range envPairs(s.Environment) {
+			reason, bad := inlineSecret(kv.key, kv.value)
+			if !bad {
+				continue
+			}
+			// The PEM rule fires before the _FILE exemption, so the key named
+			// here may already end in _FILE and appending another would name a
+			// variable no image reads.
+			fileVar := kv.key
+			if !strings.HasSuffix(strings.ToUpper(fileVar), "_FILE") {
+				fileVar += "_FILE"
+			}
+			add(LintWarning,
+				"services.%s.environment.%s %s. The manifest is stored verbatim in the release record and in the service spec, both readable by anyone with Docker access — reference an external Docker secret instead and read it from /run/secrets/<name>, through the image's %s variable or in the service's command",
+				name, kv.key, reason, fileVar)
+		}
+	}
+}
+
+// inlineSecret reports whether an environment entry carries credential material,
+// and why.
+//
+// The value is examined but never named in the finding it returns. A lint
+// warning is printed to a terminal and scraped into CI logs, so a rule that
+// quoted the secret it found would disclose it further than the manifest that
+// prompted the warning did.
+func inlineSecret(key, value string) (string, bool) {
+	// A value resolved elsewhere is not material, whatever the key is called:
+	// ${VAR} is substituted at deploy time, and /run/secrets/... is already the
+	// convention this rule exists to ask for.
+	if runtimeRef.MatchString(value) || strings.HasPrefix(value, "/run/secrets/") {
+		return "", false
+	}
+	// Checked before the _FILE exemption below, because a *_FILE variable
+	// holding a PEM block is not naming a path — it is the key material itself,
+	// under a name chosen to suggest otherwise.
+	if pemPrivateKey.MatchString(value) {
+		return "inlines a PEM private key", true
+	}
+	if strings.HasSuffix(strings.ToUpper(key), "_FILE") {
+		return "", false
+	}
+	if secretishKey.MatchString(key) {
+		return "names a credential", true
+	}
+	return "", false
+}
+
+// envPairs flattens an environment: block into key/value pairs. Compose accepts
+// both a mapping and a KEY=value sequence and a chart may render either, so both
+// are read.
+//
+// It walks yaml.Nodes rather than decoding into a map because an environment
+// block legitimately mixes scalar types — PORT: 8080 next to HOST: db — and
+// decoding into map[string]string fails on the whole block at the first integer,
+// taking every sibling with it. A node's raw .Value is the scalar text whatever
+// the type, and works for a non-string key too.
+func envPairs(node yaml.Node) []envPair {
+	var out []envPair
+	switch node.Kind {
+	case yaml.MappingNode:
+		for i := 0; i+1 < len(node.Content); i += 2 {
+			k, v := node.Content[i], node.Content[i+1]
+			if v.Kind != yaml.ScalarNode {
+				continue
+			}
+			out = append(out, envPair{key: k.Value, value: v.Value})
+		}
+	case yaml.SequenceNode:
+		for _, item := range node.Content {
+			if item.Kind != yaml.ScalarNode {
+				continue
+			}
+			// "KEY" with no "=" passes the host's own value through at deploy
+			// time; there is no literal in the manifest to warn about.
+			if k, v, ok := strings.Cut(item.Value, "="); ok {
+				out = append(out, envPair{key: k, value: v})
+			}
+		}
+	}
+	return out
 }

--- a/charts/lint_test.go
+++ b/charts/lint_test.go
@@ -5,6 +5,7 @@ package charts
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -308,4 +309,132 @@ services:
 		require.Contains(t, got[0].Message, `"alpha"`)
 		require.Contains(t, got[1].Message, `"zebra"`)
 	}
+}
+
+// envChart returns the demo chart with one service whose environment: block is
+// env, so a finding can only have come from the entry under test.
+func envChart(t *testing.T, env string) *Chart {
+	t.Helper()
+	return lintChart(t, func(c *Chart) {
+		c.Metadata.SwarmcliVersion = ">= 1.0.0"
+		c.Templates = map[string]string{
+			"templates/stack.yaml": "services:\n  web:\n    image: nginx\n    environment:\n" + env,
+		}
+	})
+}
+
+// inlineFindings is every finding the inline-secret rule produced, which is
+// every finding naming an environment key.
+func inlineFindings(findings []LintFinding) []string {
+	var out []string
+	for _, f := range findings {
+		if strings.Contains(f.Message, ".environment.") {
+			out = append(out, f.Message)
+		}
+	}
+	return out
+}
+
+// The rule fires on the key, so it must fire on every spelling of a key that
+// names a credential, in both shapes compose accepts for the block. Covering
+// the mapping shape proves nothing about the sequence shape: they are read by
+// different branches of envPairs.
+func TestLintWarnsOnInlineSecrets(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		env  string
+		key  string
+	}{
+		{"password", "      DB_PASSWORD: hunter2\n", "DB_PASSWORD"},
+		{"passwd", "      MYSQL_PASSWD: hunter2\n", "MYSQL_PASSWD"},
+		{"secret", "      APP_SECRET: s3kr3t\n", "APP_SECRET"},
+		{"token", "      GITHUB_TOKEN: ghp_aaaa\n", "GITHUB_TOKEN"},
+		{"api key, underscored", "      API_KEY: abc\n", "API_KEY"},
+		{"api key, run together", "      APIKEY: abc\n", "APIKEY"},
+		{"credential", "      AWS_CREDENTIALS: abc\n", "AWS_CREDENTIALS"},
+		{"lowercase key", "      db_password: hunter2\n", "db_password"},
+		{"sequence shape", "      - DB_PASSWORD=hunter2\n", "DB_PASSWORD"},
+		// An undefaulted value is the shape worth warning about, not an
+		// exemption from it: the key is what carries the credential once an
+		// operator supplies one, which is the chart its author should hear about.
+		{"empty value", "      DB_PASSWORD: \"\"\n", "DB_PASSWORD"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			findings := inlineFindings(Lint(envChart(t, tc.env), "1.13.0", nil, nil))
+			require.Len(t, findings, 1)
+			require.Contains(t, findings[0], "services.web.environment."+tc.key)
+			require.Contains(t, findings[0], "names a credential")
+			// The finding must never quote the value it matched on: a warning is
+			// printed to a terminal and scraped into CI logs.
+			require.NotContains(t, findings[0], "hunter2")
+		})
+	}
+}
+
+// The sanctioned patterns must lint silently, or the rule punishes exactly the
+// charts that got it right — all fifteen published charts rely on these.
+func TestLintAcceptsTheSecretConventions(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		env  string
+	}{
+		{"file variable naming a mounted secret", "      DB_PASSWORD_FILE: /run/secrets/db-password\n"},
+		{"file variable naming any path", "      DB_PASSWORD_FILE: /etc/creds/db\n"},
+		{"secret path under an ordinary key", "      DB_PASSWORD: /run/secrets/db-password\n"},
+		{"braced interpolation", "      DB_PASSWORD: ${DB_PASSWORD}\n"},
+		{"bare interpolation", "      DB_PASSWORD: $DB_PASSWORD\n"},
+		{"compose-escaped interpolation", "      DB_PASSWORD: $$DB_PASSWORD\n"},
+		{"innocuous key and value", "      LOG_LEVEL: debug\n"},
+		{"integer value", "      PORT: 8080\n"},
+		{"public certificate", "      TLS_CERT: \"-----BEGIN CERTIFICATE-----\\nMIIB\\n\"\n"},
+		{"sequence passthrough without a value", "      - DB_PASSWORD\n"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			findings := Lint(envChart(t, tc.env), "1.13.0", nil, nil)
+			// Before the silence assertion: a chart that failed to render
+			// produces no environment findings either, and would pass this test
+			// without the rule having read a single key.
+			require.False(t, HasErrors(findings),
+				"the chart must render for the silence below to mean anything, got:\n%s", messages(findings))
+			require.Empty(t, inlineFindings(findings),
+				"a chart following the convention must lint silently, got:\n%s", messages(findings))
+		})
+	}
+}
+
+// A PEM private key is material wherever it appears, so it is caught on a key
+// name the rule would otherwise pass — including a *_FILE name, which claims to
+// be a path and is not. That case must not then advise a DB_KEY_FILE_FILE.
+func TestLintWarnsOnAnInlinedPrivateKey(t *testing.T) {
+	const pem = "-----BEGIN RSA PRIVATE KEY-----\\nMIIEow\\n-----END RSA PRIVATE KEY-----"
+	for _, tc := range []struct{ name, env, key string }{
+		{"innocuous key", "      SIGNING_MATERIAL: \"" + pem + "\"\n", "SIGNING_MATERIAL"},
+		{"file key holding the key itself", "      TLS_KEY_FILE: \"" + pem + "\"\n", "TLS_KEY_FILE"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			findings := inlineFindings(Lint(envChart(t, tc.env), "1.13.0", nil, nil))
+			require.Len(t, findings, 1)
+			require.Contains(t, findings[0], "services.web.environment."+tc.key)
+			require.Contains(t, findings[0], "inlines a PEM private key")
+			require.NotContains(t, findings[0], "MIIEow")
+			require.NotContains(t, findings[0], "_FILE_FILE")
+		})
+	}
+}
+
+// An integer sibling must not hide a credential: decoding the block into
+// map[string]string fails on PORT and would take DB_PASSWORD with it.
+func TestLintReadsAnEnvBlockOfMixedTypes(t *testing.T) {
+	findings := inlineFindings(Lint(envChart(t,
+		"      PORT: 8080\n      DB_PASSWORD: hunter2\n      REPLICAS: 3\n"), "1.13.0", nil, nil))
+	require.Len(t, findings, 1)
+	require.Contains(t, findings[0], "services.web.environment.DB_PASSWORD")
+}
+
+// The rule is a warning, never an error: the engine cannot tell a credential
+// from a value that reads like one, so it must not fail a chart over a guess.
+func TestLintInlineSecretIsAWarning(t *testing.T) {
+	findings := Lint(envChart(t, "      DB_PASSWORD: hunter2\n"), "1.13.0", nil, nil)
+	require.NotEmpty(t, inlineFindings(findings))
+	require.False(t, HasErrors(findings))
 }


### PR DESCRIPTION
## What

`charts/README.md` told chart authors not to inline secret material and noted that nothing enforced it. This adds the authoring-time half: `charts lint` now warns when a service's `environment:` block holds a credential — under a key named like one (password, passwd, secret, token, api key, access key, private key, credential), or in a value carrying a PEM private key.

```
warning: services.web.environment.DB_PASSWORD names a credential. The manifest is
stored verbatim in the release record and in the service spec, both readable by
anyone with Docker access — reference an external Docker secret instead and read
it from /run/secrets/<name>, through the image's DB_PASSWORD_FILE variable or in
the service's command
```

## Key design decisions

**A rule about the key, not the value.** What makes `DB_PASSWORD: hunter2` wrong is the key; no amount of looking at `hunter2` establishes it. Value-shaped detection — entropy scoring, token prefixes — fires on image digests and generated identifiers and would make the rule noise. The one exception is a PEM private key, unambiguous wherever it appears, and therefore checked **before** the `*_FILE` exemption: a `*_FILE` variable holding key material is not naming a path, it is the material under a name chosen to suggest otherwise.

**A warning, not a refusal.** The engine cannot distinguish a credential from a value that merely reads like one, and refusing a deploy on a name-matching heuristic would break third-party charts over a guess.

**Redaction was considered and rejected on the way here.** `Rollback` replays the stored manifest verbatim (`charts/release.go:258`) and `apply` decides "unchanged" by canonicalising the stored values (`charts/apply.go:455-495`), so redacting either breaks both. Redacting the read paths is bypassed by `docker config inspect`. And the same material is equally visible in the service spec to anyone who can `docker service inspect`, which no amount of redaction reaches — so the honest control is to tell the author, not to obscure the record.

**Fires on the shape, not the rendered value.** A chart whose `DB_PASSWORD` defaults to `""` still warns: the key is what carries the credential once an operator supplies one, and that is exactly the chart worth telling its author about.

**`environment:` alone is scanned.** `command:`/`entrypoint:` are where the *sanctioned* `/run/secrets` read lives, so a rule covering them would fire on every chart that does the right thing.

**Exempted:** `*_FILE` keys, values under `/run/secrets/`, and `${VAR}`/`$VAR`/`$$VAR` interpolations the deploy substitutes.

## Validation against the real corpus

All fifteen published `swarmcli-charts` lint silently under the rule.

That number alone proves nothing — a rule that never executed reports zero too — so the manifests were forced to render and the inspected entries counted: **195 environment entries across 14 charts, no findings**. (Renovate cannot render from bare defaults by design; it has a `{{ fail }}` guard demanding input, which is the documented reason `Lint` accepts `-f`/`--set`.)

Disabling the exemptions then makes the rule fire on **mariadb, postgres, swarmcli-cd and keycloak** — so the exemptions are load-bearing on charts that do the right thing, not decoration. That run also caught a wording bug that would otherwise have shipped: the remediation appended `_FILE` unconditionally, yielding `MARIADB_PASSWORD_FILE_FILE`. Unreachable via the key-name branch, reachable via the PEM branch. Fixed, with an assertion that `_FILE_FILE` never appears.

## Testing

Four test functions in the refuse/accept-pair convention of `files_test.go`: ten warn cases across both compose shapes for `environment:` (mapping and `KEY=value` sequence), ten accept cases covering every exemption, the two PEM cases, a mixed-type block (an integer sibling must not hide a credential — decoding into `map[string]string` would fail on `PORT` and take `DB_PASSWORD` with it), and one asserting the finding is never an error.

Findings assert the matched value is **never quoted** — a lint warning is printed to a terminal and scraped into CI logs, so a rule that echoed the secret it found would disclose it further than the manifest did.

The accept tests assert the chart rendered (`HasErrors` is false) before asserting silence, or a render failure would pass them vacuously. Verified by mutation: removing the `_FILE` exemption fails them.

`go build ./...`, `go test ./...`, `gofmt` and `golangci-lint run` are clean.

## Docs

`charts/README.md` gains the rule under [Linting a chart](#linting-a-chart), and the "Notes & limitations" secrets entry is rewritten: it no longer says nothing enforces this, and it now states the service-spec parity that makes the release record no more secret than the stack it records.

## Relationship to #465

This does **not** close #465, which asks for a redaction pass. It delivers the authoring-time warning instead, for the reasons above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
