### PR TITLE
fix(logs): count search matches in the pass that builds the visible set

### DIFF
--- a/views/logs/logs_test.go
+++ b/views/logs/logs_test.go
@@ -1032,3 +1032,85 @@ func TestResizeWithFollowOffClampsWithoutJumping(t *testing.T) {
 	require.Len(t, rows, 57)
 	require.Contains(t, rows[len(rows)-1], "line-499")
 }
+
+// search returns the matches after typing term and pressing enter, the way a
+// user reaches them.
+func search(m *Model, term string) {
+	m.mode = "search"
+	for _, r := range term {
+		HandleKey(m, key(string(r)))
+	}
+	HandleKey(m, key("enter"))
+}
+
+// TestSearchCountsLinesThatArriveLater — the incremental update was guarded on
+// "no filter is switched on", and hide-stopped is on by default, so on a live
+// stream the counter froze at whatever the search found when it was entered
+// and n/N navigated a stale set (#586).
+func TestSearchCountsLinesThatArriveLater(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		setup func(m *Model)
+	}{
+		{"hide-stopped, the default", func(*Model) {}},
+		{"node filter", func(m *Model) { m.setNodeFilter("node-a") }},
+		{"slash filter", func(m *Model) { m.ApplySearchQuery("needle") }},
+		{"no filter at all", func(m *Model) { m.setHideStopped(false) }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			m := hideStoppedModel()
+			m.Update(tea.WindowSizeMsg{Width: 120, Height: 24})
+			tc.setup(m)
+
+			m.Update(LineMsg{Line: "node-a\x00task-run\x00first needle"})
+			search(m, "needle")
+			require.Len(t, m.searchMatches, 1)
+
+			for i := 0; i < 3; i++ {
+				m.Update(LineMsg{Line: "node-a\x00task-run\x00another needle"})
+			}
+			require.Equal(t, []int{0, 1, 2, 3}, m.searchMatches,
+				"matches in lines that arrived after the search must be counted")
+		})
+	}
+}
+
+// TestSearchMatchesAreVisibleIndices — a hidden line must not advance the index
+// the matches are numbered by, or n/N scrolls to the wrong row.
+func TestSearchMatchesAreVisibleIndices(t *testing.T) {
+	m := hideStoppedModel()
+	m.Update(tea.WindowSizeMsg{Width: 120, Height: 24})
+
+	m.Update(LineMsg{Line: "node-a\x00task-run\x00needle one"})
+	m.Update(LineMsg{Line: "node-a\x00task-stop\x00needle hidden"})
+	m.Update(LineMsg{Line: "node-a\x00task-run\x00needle two"})
+	search(m, "needle")
+
+	// The shutdown task's line is filtered out, so the two visible matches are
+	// numbered 0 and 1 rather than 0 and 2.
+	require.Equal(t, []int{0, 1}, m.searchMatches)
+	require.Equal(t, 2, m.getVisibleCount())
+}
+
+// TestSearchSurvivesTheBufferWrapping — once MaxLines is reached every new line
+// drops one off the top, which used to discard the whole match set on each
+// line and leave the counter reading zero for the rest of the session.
+func TestSearchSurvivesTheBufferWrapping(t *testing.T) {
+	m := hideStoppedModel()
+	m.MaxLines = 4
+	m.Update(tea.WindowSizeMsg{Width: 120, Height: 24})
+
+	m.Update(LineMsg{Line: "node-a\x00task-run\x00needle"})
+	search(m, "needle")
+	require.Len(t, m.searchMatches, 1)
+
+	// Six more lines through a four-line buffer: the first needle is long gone
+	// and the three that remain are the last three appended.
+	for i := 0; i < 3; i++ {
+		m.Update(LineMsg{Line: "node-a\x00task-run\x00filler"})
+	}
+	for i := 0; i < 3; i++ {
+		m.Update(LineMsg{Line: "node-a\x00task-run\x00needle"})
+	}
+	require.Equal(t, []int{1, 2, 3}, m.searchMatches)
+}

--- a/views/logs/update.go
+++ b/views/logs/update.go
@@ -69,19 +69,6 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 			m.lineTasks = newTaskBuf
 		}
 
-		// update searchMatches incrementally
-		if m.searchTerm != "" {
-			if linesDropped > 0 && m.searchMatches != nil {
-				// Lines dropped from top invalidate visible indices; recompute on next n/N
-				m.searchMatches = nil
-			} else if m.nodeFilter == "" && m.filterQuery == "" && !m.hideStopped {
-				// Simple case: no filters, raw index equals visible index
-				if strings.Contains(strings.ToLower(actualLine), strings.ToLower(m.searchTerm)) {
-					m.searchMatches = append(m.searchMatches, len(m.lines)-1)
-				}
-			}
-			// When filters are active, skip incremental update; highlightContent will recompute
-		}
 		shouldFollow := m.follow
 		m.mu.Unlock()
 
@@ -314,40 +301,15 @@ func (m *Model) SetContent(content string) {
 	l().Debugf("[logsview] SetContent called: total lines=%d", len(m.lines))
 }
 
+// highlightContent rebuilds the rendered content, which is also what recomputes
+// the search matches, and re-anchors the selected match inside the new set.
 func (m *Model) highlightContent() {
-	if m.searchTerm == "" {
-		m.searchMatches = nil
-	} else {
-		m.searchMatches = []int{}
-		lower := strings.ToLower(m.searchTerm)
-		m.mu.Lock()
-		var stopped map[string]bool
-		if m.hideStopped {
-			stopped = m.stoppedTaskIDs()
-		}
-		visibleIdx := 0
-		for i, L := range m.lines {
-			// Skip lines hidden by any active filter (must match buildContent
-			// exactly so search-match indices line up with the rendered output).
-			if !m.lineVisible(i, stopped) {
-				continue
-			}
-			if strings.Contains(strings.ToLower(L), lower) {
-				m.searchMatches = append(m.searchMatches, visibleIdx)
-			}
-			visibleIdx++
-		}
-		m.mu.Unlock()
-		if len(m.searchMatches) > 0 {
-			if m.searchIndex >= len(m.searchMatches) {
-				m.searchIndex = 0
-			}
-		} else {
-			m.searchIndex = 0
-		}
+	content := m.buildContent()
+	if m.searchIndex >= len(m.searchMatches) {
+		m.searchIndex = 0
 	}
 	if m.ready {
-		m.viewport.SetContent(m.buildContent())
+		m.viewport.SetContent(content)
 	}
 }
 
@@ -362,11 +324,21 @@ func (m *Model) buildContent() string {
 	if m.hideStopped {
 		stopped = m.stoppedTaskIDs()
 	}
+	// Collect the search matches in the same pass. They are indices into the
+	// visible lines, so they can only be counted where the visible set is
+	// built — deriving them anywhere else means a second copy of this walk,
+	// and the two drifting apart is what froze the match counter (#586).
+	lower := strings.ToLower(m.searchTerm)
+	m.searchMatches = nil
 	var filteredLines []string
 	for i, line := range m.lines {
-		if m.lineVisible(i, stopped) {
-			filteredLines = append(filteredLines, line)
+		if !m.lineVisible(i, stopped) {
+			continue
 		}
+		if lower != "" && strings.Contains(strings.ToLower(line), lower) {
+			m.searchMatches = append(m.searchMatches, len(filteredLines))
+		}
+		filteredLines = append(filteredLines, line)
 	}
 	m.visibleCount = len(filteredLines)
 


### PR DESCRIPTION
Fixes #586 — a `ctrl+f` search on a live stream stopped counting matches. The header froze at whatever the search found when it was entered, and `n`/`N` navigated that stale set for the rest of the session.

## Why it was wrong in two ways

`searchMatches` holds indices into the **visible** lines, so it can only be maintained where the visible set is decided. It was instead maintained in two other places:

1. **The incremental append in `LineMsg`** ran only when `m.nodeFilter == "" && m.filterQuery == "" && !m.hideStopped`. `hideStopped` defaults to `true`, so the path was dead in normal use. The comment below it — "highlightContent will recompute" — did not hold: `highlightContent` only ever runs from a keypress, and `n`/`N` deliberately do not call it.
2. **The same block discarded the entire match set** whenever a line was dropped off the top. Once `MaxLines` is reached that is *every* line, so a long-running view reads zero matches permanently — the same symptom from a second cause.

## The fix

`buildContent` already walks every line applying `lineVisible`. Collect the matches in that walk, and delete the other two copies: the incremental block goes, and `highlightContent` becomes a rebuild plus an index clamp instead of a second copy of the same loop. Net −46 lines of logic.

There is no longer an index maintained apart from the thing it indexes, which is why this fixes the counter under the hide-stopped, node and `/` filters and across the buffer wrapping, rather than just the reported case.

## Tests

Four regression tests, and I checked they bite — against the unfixed `update.go` they fail on hide-stopped, node-filter, slash-filter and buffer-wrapping, and pass on "no filter at all", which was the one path that already worked:

```
--- FAIL: TestSearchCountsLinesThatArriveLater/hide-stopped,_the_default
--- FAIL: TestSearchCountsLinesThatArriveLater/node_filter
--- FAIL: TestSearchCountsLinesThatArriveLater/slash_filter
--- FAIL: TestSearchSurvivesTheBufferWrapping
```

`TestSearchMatchesAreVisibleIndices` passes both ways by design — it pins the invariant that a hidden line must not advance the numbering, which `highlightContent` already got right at rest and which the new single pass has to keep.

## Cost

One case-fold per visible line while a search is active. Measured: allocation-free, ~0.22 ms per 5000 lines, against a pass that already costs ~4.2 ms joining and re-wrapping those same lines — about 5%. (The 20k allocations a search adds to `buildContent` come from `utils.HighlightMatches` styling each match, which it already did.)

`go test ./...` passes, `-race` clean on `views/logs`, `golangci-lint run ./... --build-tags=integration` reports 0 issues.

## Not fixed here

Match indices can still go stale without a keypress if the *snapshot* changes — a task going terminal hides lines that were visible. That is a different trigger needing invalidation the view does not have, and it belongs with the shared search component in #128 rather than in this fix.
