### PR TITLE
refactor(ui): one frame budget, and name what a frame spends on itself

### DIFF
--- a/app/update.go
+++ b/app/update.go
@@ -431,9 +431,9 @@ func (m *Model) updateForResize(msg tea.WindowSizeMsg) tea.Cmd {
 		usableHeight = msg.Height
 	} else {
 		// Normal mode:
-		// - Width: subtract 4 for frame borders/padding
+		// - Width: subtract what the frame spends on itself
 		// - Height: pass full height, handleViewResize will subtract systeminfo header
-		usableWidth = msg.Width - 4
+		usableWidth = msg.Width - ui.FrameChromeColumns
 		usableHeight = msg.Height
 	}
 	// If an input bar is visible, reserve its lines so the main view is reduced

--- a/ui/dialog/styles.go
+++ b/ui/dialog/styles.go
@@ -24,6 +24,13 @@ const (
 	HelpFg   = lipgloss.Color("240") // the key hints along the bottom
 )
 
+// BoxInsetColumns is how much wider a dialog's box is than the rows inside it.
+// Rows are rendered at the dialog's content width; the box is built as
+// BorderStyle.Width(contentWidth + BoxInsetColumns), which leaves a column of
+// space between each row and the border. lipgloss draws the border outside the
+// width it is given, so this is slack inside the frame, not the frame itself.
+const BoxInsetColumns = 2
+
 // Shared dialog styles used across views for consistent dialog rendering.
 var (
 	TitleStyle = lipgloss.NewStyle().

--- a/ui/framecalc.go
+++ b/ui/framecalc.go
@@ -6,7 +6,16 @@ package ui
 import "strings"
 
 const (
-	horizontalPadding = 4
+	// FrameChromeColumns is what a frame spends on itself horizontally: the two
+	// border columns, plus a column of padding inside each of them. Turning a
+	// content or viewport width into the width of the frame around it means
+	// adding this, and going the other way means subtracting it.
+	FrameChromeColumns = 4
+
+	// BorderColumns is the two vertical border glyphs alone, without the
+	// padding — the span between the corners of a frame of a given width is
+	// that width less this.
+	BorderColumns = 2
 
 	// FramedChromeRows is what RenderViewFrame's bordered layout spends on the
 	// frame itself: the top border, which carries the title, and the bottom one.
@@ -41,7 +50,7 @@ func ComputeFrameDimensions(viewportWidth, viewportHeight, fallbackWidth, fallba
 	if frameWidth <= 0 {
 		frameWidth = 80
 	}
-	frameWidth += horizontalPadding
+	frameWidth += FrameChromeColumns
 
 	frameHeight := viewportHeight
 	if frameHeight <= 0 {

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -75,13 +75,13 @@ func RenderFramedBox(title, header, content, footer string, width int) string {
 		}
 	}
 	if width <= 0 {
-		width = contentWidth + 4 // padding left/right
+		width = contentWidth + FrameChromeColumns
 	}
 
 	titleStyled := styleFrameTitle(" " + title + " ")
 	headerStyled := FrameHeaderStyle.Render(header)
 
-	borderWidth := width - 2 // left/right borders
+	borderWidth := width - BorderColumns
 
 	// Border style
 	borderStyle := lipgloss.NewStyle().Foreground(FrameBorderColor)
@@ -121,12 +121,17 @@ func RenderFramedBox(title, header, content, footer string, width int) string {
 	// Box lines start with top border
 	boxLines := []string{topLine}
 
-	// Optional header
+	// Optional header. Bordered a line at a time, like the content below it:
+	// framing a multi-line header as one line put the opening border on its
+	// first row and the closing one on its last, and measured the whole string
+	// for padding.
 	if header != "" {
-		boxLines = append(boxLines, fmt.Sprintf("%s%s%s",
-			borderStyle.Render("│"),
-			padLine(headerStyled, borderWidth),
-			borderStyle.Render("│")))
+		for _, l := range strings.Split(headerStyled, "\n") {
+			boxLines = append(boxLines, fmt.Sprintf("%s%s%s",
+				borderStyle.Render("│"),
+				padLine(l, borderWidth),
+				borderStyle.Render("│")))
+		}
 	}
 
 	// Content
@@ -164,24 +169,11 @@ func RenderFramedBoxHeight(title, header, content, footer string, width, frameHe
 		return RenderFramedBox(title, header, content, footer, width)
 	}
 
-	// Count footer lines
-	footerLines := []string{}
-	if footer != "" {
-		footerLines = strings.Split(footer, "\n")
-	}
-
-	// Header occupies one line if present
-	headerLines := 0
-	if header != "" {
-		headerLines = 1
-	}
-
-	// Desired content lines inside the box (not counting borders/top/bottom)
-	// total box lines = 2 (top+bottom) + headerLines + contentLines + len(footerLines)
-	desiredContentLines := frameHeight - 2 - headerLines - len(footerLines)
-	if desiredContentLines < 0 {
-		desiredContentLines = 0
-	}
+	// The rows left for content once the frame, header and footer have taken
+	// theirs. ContentRows is the one place that budget is worked out; counting
+	// it again here is how the two came to disagree about a header of more
+	// than one line.
+	desiredContentLines := ContentRows(frameHeight, FramedChromeRows, header, footer)
 
 	// Current content lines
 	contentLines := strings.Split(content, "\n")
@@ -190,17 +182,15 @@ func RenderFramedBoxHeight(title, header, content, footer string, width, frameHe
 		contentLines = contentLines[:len(contentLines)-1]
 	}
 
-	// Pad or trim content lines to desired length
-	if len(contentLines) < desiredContentLines {
-		// Append empty lines
-		for i := 0; i < desiredContentLines-len(contentLines); i++ {
-			contentLines = append(contentLines, "")
-		}
-	} else if len(contentLines) > desiredContentLines {
+	// Pad or trim content lines to desired length. The bound is re-read each
+	// pass, so it has to be the length itself rather than a gap computed from
+	// it — a gap shrinks as the appends land, and the loop stops half way.
+	for len(contentLines) < desiredContentLines {
+		contentLines = append(contentLines, "")
+	}
+	if len(contentLines) > desiredContentLines {
 		contentLines = contentLines[:desiredContentLines]
 	}
-
-	// No debug logging
 
 	paddedContent := strings.Join(contentLines, "\n")
 	return RenderFramedBox(title, header, paddedContent, footer, width)

--- a/ui/ui_test.go
+++ b/ui/ui_test.go
@@ -101,3 +101,48 @@ func TestOverlayCentered_AlignsWithWideChars(t *testing.T) {
 		require.Equal(t, leftCols[0], c, "dialog left border must be column-aligned on every row")
 	}
 }
+
+// TestRenderFramedBoxBordersEveryHeaderLine — the header was appended as a
+// single box line however many lines it had, so a two-line header put the
+// opening border on its first row and the closing one on its last.
+func TestRenderFramedBoxBordersEveryHeaderLine(t *testing.T) {
+	out := RenderFramedBox("Title", "NAME      STATE\nfiltered: web", "alpha\nbravo", "1-5 of 5", 40)
+
+	rows := strings.Split(out, "\n")
+	require.Greater(t, len(rows), 2)
+	for i, row := range rows[1 : len(rows)-1] {
+		require.Truef(t, strings.HasPrefix(row, "│"), "row %d does not open with a border: %q", i, row)
+		require.Truef(t, strings.HasSuffix(row, "│"), "row %d does not close with a border: %q", i, row)
+		require.Equalf(t, 40, lipgloss.Width(row), "row %d is not the frame's width: %q", i, row)
+	}
+}
+
+// TestRenderFramedBoxHeightFillsRequestedHeight — the pad loop recomputed the
+// gap it was closing while closing it, so it stopped around half way and the
+// box came out short of the height it was asked for.
+func TestRenderFramedBoxHeightFillsRequestedHeight(t *testing.T) {
+	for _, tc := range []struct {
+		name           string
+		header, footer string
+		frameHeight    int
+	}{
+		{"no header or footer", "", "", 12},
+		{"header", "NAME      STATE", "", 12},
+		{"header and footer", "NAME      STATE", "1-5 of 5", 12},
+		{"two-line header", "NAME      STATE\nfiltered: web", "1-5 of 5", 12},
+		{"two-line header, tall frame", "NAME      STATE\nfiltered: web", "1-5 of 5", 24},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			out := RenderFramedBoxHeight("Title", tc.header, "alpha\nbravo", tc.footer, 40, tc.frameHeight)
+			require.Len(t, strings.Split(out, "\n"), tc.frameHeight)
+		})
+	}
+}
+
+// TestRenderFramedBoxHeightCannotShrinkBelowItsChrome — when the borders,
+// header and footer already fill the requested height there is nothing left to
+// give, and the box is as short as it can be rather than the height asked for.
+func TestRenderFramedBoxHeightCannotShrinkBelowItsChrome(t *testing.T) {
+	out := RenderFramedBoxHeight("Title", "one\ntwo\nthree", "footer\nsecond", "x", 40, 6)
+	require.Greater(t, len(strings.Split(out, "\n")), 6)
+}

--- a/views/confirmdialog/confirmdialog.go
+++ b/views/confirmdialog/confirmdialog.go
@@ -121,7 +121,7 @@ func (m *Model) View() string {
 	titleStyle := dialog.TitleStyle.Background(accent).Width(contentWidth)
 	messageStyle := dialog.MessageStyle.Width(contentWidth)
 	helpStyle := dialog.HelpStyle.Width(contentWidth)
-	borderStyle := dialog.BorderStyle.BorderForeground(accent).Width(contentWidth + 2)
+	borderStyle := dialog.BorderStyle.BorderForeground(accent).Width(contentWidth + dialog.BoxInsetColumns)
 
 	// Build content
 	var lines []string

--- a/views/contexts/view.go
+++ b/views/contexts/view.go
@@ -210,7 +210,7 @@ func (m *Model) renderImportDialog() string {
 
 	titleStyleWithWidth := dialog.TitleStyle.Width(contentWidth)
 	itemStyleWithWidth := dialog.ItemStyle.Width(contentWidth)
-	borderStyleWithWidth := dialog.BorderStyle.Width(contentWidth + 2)
+	borderStyleWithWidth := dialog.BorderStyle.Width(contentWidth + dialog.BoxInsetColumns)
 	helpStyleWithWidth := dialog.HelpStyle.Width(contentWidth)
 
 	var lines []string

--- a/views/inspect/view.go
+++ b/views/inspect/view.go
@@ -47,5 +47,5 @@ func (m *Model) FrameContent() string { return m.viewport.View() }
 // the viewport is already sized to the rows it should fill.
 func (m *Model) View() string {
 	return ui.RenderFramedBox(m.FrameTitle(), m.FrameHeader(), m.FrameContent(), m.FrameFooter(),
-		m.viewport.Width+4)
+		m.viewport.Width+ui.FrameChromeColumns)
 }

--- a/views/loading/loading.go
+++ b/views/loading/loading.go
@@ -82,10 +82,10 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 		m.spinner++
 		return m.spinnerTickCmd()
 	case tea.WindowSizeMsg:
-		// WindowSizeMsg here is already adjusted by the app (height minus systeminfo header and footer)
-		// But we need to add back the 4 pixels that were subtracted for viewport padding
-		// because the loading view renders its own frame
-		m.width = msg.Width + 4
+		// WindowSizeMsg here is already adjusted by the app (height minus systeminfo
+		// header and footer), including the columns the app took off for the frame.
+		// This view renders its own frame, so it adds them back.
+		m.width = msg.Width + ui.FrameChromeColumns
 		m.height = msg.Height
 		return nil
 	}

--- a/views/logs/view.go
+++ b/views/logs/view.go
@@ -115,7 +115,7 @@ func (m *Model) View() string {
 		return ""
 	}
 	return ui.RenderFramedBox(m.FrameTitle(), m.FrameHeader(), m.FrameContent(), m.FrameFooter(),
-		m.viewport.Width+4)
+		m.viewport.Width+ui.FrameChromeColumns)
 }
 
 // renderNodeSelectDialog renders the node selection popup
@@ -169,7 +169,7 @@ func (m *Model) renderNodeSelectDialog(availableHeight int) string {
 	titleStyle := dialog.TitleStyle.Width(contentWidth)
 	itemStyle := dialog.ItemStyle.Width(contentWidth)
 	selectedStyle := dialog.SelectedStyle.Width(contentWidth)
-	borderStyle := dialog.BorderStyle.Width(contentWidth + 2)
+	borderStyle := dialog.BorderStyle.Width(contentWidth + dialog.BoxInsetColumns)
 	helpStyle := dialog.HelpStyle.Width(contentWidth)
 
 	// Build the content

--- a/views/nodes/view.go
+++ b/views/nodes/view.go
@@ -94,7 +94,7 @@ func (m *Model) renderAvailabilityDialog() string {
 	optionStyle := dialog.ItemStyle.Width(contentWidth)
 	selectedStyle := dialog.SelectedStyle.Width(contentWidth)
 	helpStyle := dialog.HelpStyle.Width(contentWidth)
-	borderStyle := dialog.BorderStyle.Width(contentWidth + 2)
+	borderStyle := dialog.BorderStyle.Width(contentWidth + dialog.BoxInsetColumns)
 
 	var lines []string
 	lines = append(lines, titleStyle.Render(" Set Node Availability "))

--- a/views/scaledialog/scaledialog.go
+++ b/views/scaledialog/scaledialog.go
@@ -87,7 +87,7 @@ func (m *Model) View() string {
 		Padding(1, 0)
 
 	helpStyle := dialog.HelpStyle.Width(contentWidth)
-	borderStyle := dialog.BorderStyle.Width(contentWidth + 2)
+	borderStyle := dialog.BorderStyle.Width(contentWidth + dialog.BoxInsetColumns)
 
 	// Build content
 	var lines []string

--- a/views/unlockdialog/unlockdialog.go
+++ b/views/unlockdialog/unlockdialog.go
@@ -71,7 +71,7 @@ func (m *Model) View() string {
 	messageStyle := dialog.MessageStyle.Width(contentWidth)
 	inputStyle := dialog.ItemStyle.Width(contentWidth)
 	helpStyle := dialog.HelpStyle.Width(contentWidth)
-	borderStyle := dialog.BorderStyle.Width(contentWidth + 2)
+	borderStyle := dialog.BorderStyle.Width(contentWidth + dialog.BoxInsetColumns)
 
 	var lines []string
 	lines = append(lines, titleStyle.Render(" Unlock Swarm "))


### PR DESCRIPTION
Closes #588. The issue asked for one implementation of the frame budget and names for the repeated columns. Getting the first turned up two defects underneath it, both of which had to be fixed before one budget could be correct — so this is more than the rename the issue described, and the extra is explained below.

## The divergence was a symptom

`ui.ContentRows` works out the rows a frame leaves for content; `RenderFramedBoxHeight` worked it out again and subtracted `1` for the header however many lines it had. The reason the two could disagree and both look defensible:

**A multi-line header did not render.** `RenderFramedBox` appended the header as a single box line (`ui.go:126`), so the opening `│` landed on its first physical row and the closing `│` on its last, with `padLine` measuring the whole string:

```
┌─────────────── Title ────────────────┐
│NAME      STATE                          ← no closing border
filtered: web                         │   ← no opening border
│alpha                                 │
```

Counting the header as one row matched what was *drawn*; counting its real rows matched what logs and inspect size their **viewport** to. Neither was wrong given the other. The header is now bordered a line at a time, exactly as the content beside it already was, and the budget question has one answer.

**The padding never reached its target.** The loop closing the gap recomputed the gap on each pass while appending to the slice it measured:

```go
for i := 0; i < desiredContentLines-len(contentLines); i++ {
    contentLines = append(contentLines, "")   // len grows, bound shrinks
}
```

It converges on the midpoint and stops — a box asked for 20 rows with 5 lines of content came out at 15. Of the 72 box shapes exercised here, **54 missed the height they asked for; now 6 do**, all of them frames whose borders, header and footer already fill the requested height, which is what "when possible" in the doc comment covers. `TrimOrPadContentToLines` immediately below had the same loop written correctly; they match now.

Neither defect is reachable from today's UI — every `FrameHeader()` in the tree is single-line, and the height shortfall is invisible because the views that care size their own viewport. Both are one multi-line header away from being visible, in the frame-calculation code #287 is about.

## The columns

Turning a content width into the width of the frame around it costs **4** — two borders plus a column of padding inside each. It was written at seven call sites across `ui`, `app` and three views, and already named in `ui/framecalc.go` as `horizontalPadding`, unexported, where none of them could reach it. It is now `ui.FrameChromeColumns`, sitting beside the `FramedChromeRows` it is the horizontal twin of, with `ui.BorderColumns` for the two glyphs alone.

**Correction to the issue:** I wrote there that the dialogs' `contentWidth + 2` was a sixth copy of "make the box wide enough for its own frame". It is not. lipgloss draws a border *outside* the width it is given — `BorderStyle.Width(40)` renders 42 columns — so that `2` is slack between the rows and the border, a different quantity that happens to share the value. It is named separately as `dialog.BoxInsetColumns` rather than folded into `BorderColumns`.

## Verification

149 rendered shapes captured before and after — `RenderFramedBox`, `RenderFramedBoxHeight` and `RenderViewFrame` across headers of 0–3 lines, footers of 0–2, two widths, three frame heights, plus `ComputeFrameDimensions` and both `ui` dialogs:

| | |
|---|---|
| byte-identical | the frame spec, both dialogs, and every single-line/no-header case — what a rename should look like |
| changed | multi-line-header shapes (the border fix) and `boxheight` shapes (the padding fix) — nothing else |

Three regression tests are permanent, and they bite: against the unfixed `ui.go` all of `TestRenderFramedBoxBordersEveryHeaderLine` and every subtest of `TestRenderFramedBoxHeightFillsRequestedHeight` fail, including the single-line-header ones.

`go test ./...` passes, `golangci-lint run ./... --build-tags=integration` reports 0 issues.

## Left alone

`views/tasks/update.go` has its own `frameOverhead := 5`, a `contentWidth` computed as `msg.Width - frame.FrameWidth + msg.Width`, and a `- 4`. I could not convince myself the `- 4` there means the same quantity, so I did not touch it — that view's sizing looks like it wants its own look, not a constant swap.
