### PR TITLE
fix(views): wrap the help sheet, and say ✓ when a release is up to date

### DIFF
--- a/charts/outdated.go
+++ b/charts/outdated.go
@@ -5,31 +5,36 @@ package charts
 
 import "sort"
 
-// OutdatedEntry is one installed release with a newer chart version available.
-type OutdatedEntry struct {
-	Release   string
-	Chart     string
-	Repo      string
-	Installed string
-	Latest    string
+// Availability is what the cached repository indexes know about one installed
+// release's chart. It exists because "nothing newer" and "nothing to compare
+// against" are different answers that an absent entry ran together: a local
+// chart is in no index, and a release at the newest published version is in one
+// — the second is up to date, the first is merely unknowable.
+type Availability struct {
+	// Repo is the repository that supplied Latest.
+	Repo string
+	// Latest is the newest version of this chart in any index, whether or not
+	// it is newer than what is installed.
+	Latest string
+	// Newer reports that Latest is an upgrade from the installed version. A
+	// release ahead of every index — installed from a local chart, say — is
+	// current rather than outdated, so this is false there too.
+	Newer bool
 }
 
-// Outdated joins installed releases against the newest version of their chart in
-// any configured repository index. Releases already at the newest version, and
-// those whose chart appears in no index (a local chart), are omitted.
+// Available joins installed releases against the cached repository indexes,
+// keyed by release name. A release whose chart appears in no index is absent
+// from the result, which is the one fact Outdated cannot report.
 //
 // A Release does not record which repository it came from, so a chart present in
 // two repositories resolves to the highest version across them, reporting the
 // repository that supplied it. That ambiguity is documented rather than designed
 // away: recording the source repository is a change to persisted release state,
 // which is not worth making for a case most users never hit.
-func Outdated(rels []Release, indexes map[string]*Index) []OutdatedEntry {
-	var out []OutdatedEntry
+func Available(rels []Release, indexes map[string]*Index) map[string]Availability {
+	out := make(map[string]Availability, len(rels))
 	for _, rel := range rels {
-		var (
-			bestVer  string
-			bestRepo string
-		)
+		var bestVer, bestRepo string
 		for repo, idx := range indexes {
 			versions := idx.Entries[rel.Chart.Name]
 			if len(versions) == 0 {
@@ -40,15 +45,45 @@ func Outdated(rels []Release, indexes map[string]*Index) []OutdatedEntry {
 				bestVer, bestRepo = latest.Version, repo
 			}
 		}
-		if bestVer == "" || compareVersions(bestVer, rel.Chart.Version) <= 0 {
+		if bestVer == "" {
+			continue
+		}
+		out[rel.Name] = Availability{
+			Repo:   bestRepo,
+			Latest: bestVer,
+			Newer:  compareVersions(bestVer, rel.Chart.Version) > 0,
+		}
+	}
+	return out
+}
+
+// OutdatedEntry is one installed release with a newer chart version available.
+type OutdatedEntry struct {
+	Release   string
+	Chart     string
+	Repo      string
+	Installed string
+	Latest    string
+}
+
+// Outdated is Available filtered to the releases with an upgrade waiting.
+// Releases already at the newest version, those ahead of every index, and those
+// whose chart appears in no index (a local chart) are all omitted — a caller
+// that needs to tell those apart wants Available.
+func Outdated(rels []Release, indexes map[string]*Index) []OutdatedEntry {
+	available := Available(rels, indexes)
+	var out []OutdatedEntry
+	for _, rel := range rels {
+		avail, ok := available[rel.Name]
+		if !ok || !avail.Newer {
 			continue
 		}
 		out = append(out, OutdatedEntry{
 			Release:   rel.Name,
 			Chart:     rel.Chart.Name,
-			Repo:      bestRepo,
+			Repo:      avail.Repo,
 			Installed: rel.Chart.Version,
-			Latest:    bestVer,
+			Latest:    avail.Latest,
 		})
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i].Release < out[j].Release })

--- a/charts/outdated_test.go
+++ b/charts/outdated_test.go
@@ -83,3 +83,58 @@ func TestOutdatedSortsByRelease(t *testing.T) {
 	require.Equal(t, "alpha", got[0].Release)
 	require.Equal(t, "zeta", got[1].Release)
 }
+
+// --- Available ---
+
+// Available answers the question Outdated cannot: an entry with Newer false is
+// a release on the newest published version, and no entry at all is a chart in
+// no index. Outdated omits both, which made the two indistinguishable.
+func TestAvailableSeparatesCurrentFromNotIndexed(t *testing.T) {
+	indexes := map[string]*Index{"repo": idx("mychart", "1.0.0", "2.1.0")}
+
+	got := Available([]Release{
+		rel("stale", "mychart", "1.0.0"),
+		rel("current", "mychart", "2.1.0"),
+		rel("ahead", "mychart", "3.0.0"),
+		rel("local", "unpublished", "0.1.0"),
+	}, indexes)
+
+	require.Equal(t, Availability{Repo: "repo", Latest: "2.1.0", Newer: true}, got["stale"])
+	require.Equal(t, Availability{Repo: "repo", Latest: "2.1.0", Newer: false}, got["current"])
+	require.Equal(t, Availability{Repo: "repo", Latest: "2.1.0", Newer: false}, got["ahead"],
+		"a release ahead of the index has nothing newer to install")
+	require.NotContains(t, got, "local", "a chart in no index is absent, not current")
+}
+
+func TestAvailableIsEmptyWithoutIndexes(t *testing.T) {
+	got := Available([]Release{rel("app", "mychart", "1.0.0")}, nil)
+	require.Empty(t, got)
+}
+
+// Outdated is now a filter over Available, so this pins the two together: every
+// entry Outdated reports must be one Available marked as newer, and nothing
+// else.
+func TestOutdatedIsAvailableFilteredToUpgrades(t *testing.T) {
+	indexes := map[string]*Index{"repo": idx("mychart", "1.0.0", "2.1.0")}
+	rels := []Release{
+		rel("stale", "mychart", "1.0.0"),
+		rel("current", "mychart", "2.1.0"),
+		rel("local", "unpublished", "0.1.0"),
+	}
+
+	avail := Available(rels, indexes)
+	var wantNewer []string
+	for name, a := range avail {
+		if a.Newer {
+			wantNewer = append(wantNewer, name)
+		}
+	}
+
+	got := Outdated(rels, indexes)
+	require.Len(t, got, len(wantNewer))
+	for _, e := range got {
+		require.Contains(t, wantNewer, e.Release)
+		require.Equal(t, avail[e.Release].Latest, e.Latest)
+		require.Equal(t, avail[e.Release].Repo, e.Repo)
+	}
+}

--- a/views/charts/help.go
+++ b/views/charts/help.go
@@ -40,8 +40,9 @@ func GetChartsHelpContent() []helpview.HelpCategory {
 			Title: "The LATEST column",
 			Items: []helpview.HelpItem{
 				{Keys: "0.2.0", Description: "A newer chart version is published in a cached repository index"},
-				{Keys: "—", Description: "Nothing newer, or the chart is in no index (a local chart)"},
-				{Keys: "?", Description: "No cached index to compare against — run `swarmcli charts repo update`"},
+				{Keys: "✓", Description: "Up to date: the chart is in a cached index and nothing newer is published"},
+				{Keys: "—", Description: "Nothing to compare against — the chart is in no cached index, which is what a local chart looks like"},
+				{Keys: "?", Description: "No cached index at all — run `swarmcli charts repo update`"},
 			},
 		},
 		{

--- a/views/charts/item.go
+++ b/views/charts/item.go
@@ -34,10 +34,12 @@ type releaseItem struct {
 	Services []charts.ServiceState
 
 	// Latest is the newest version of this chart in a cached repository index,
-	// when that is newer than what is installed. Empty otherwise, which covers
-	// both "already current" and "this chart is in no index" — a local chart
-	// has nothing to be outdated against.
+	// whether or not it is newer than what is installed, and Newer says which.
+	// Latest is empty only when the chart is in no index at all — a local chart
+	// has nothing to compare against, which is a different answer from being up
+	// to date and is why this is not one field.
 	Latest string
+	Newer  bool
 }
 
 func (i releaseItem) FilterValue() string { return i.Name }

--- a/views/charts/messages.go
+++ b/views/charts/messages.go
@@ -133,13 +133,10 @@ func readReleases(ops releaseOps) ([]releaseItem, bool, error) {
 	for _, it := range items {
 		currents = append(currents, it.current())
 	}
-	entries, haveIndexes := ops.Outdated(currents)
-	latest := make(map[string]string, len(entries))
-	for _, e := range entries {
-		latest[e.Release] = e.Latest
-	}
+	avail, haveIndexes := ops.Available(currents)
 	for i := range items {
-		items[i].Latest = latest[items[i].Name]
+		a := avail[items[i].Name]
+		items[i].Latest, items[i].Newer = a.Latest, a.Newer
 	}
 	return items, haveIndexes, nil
 }

--- a/views/charts/model_test.go
+++ b/views/charts/model_test.go
@@ -42,24 +42,19 @@ func (m *mockOps) ServiceStates(ctx context.Context, release string) []charts.Se
 	return m.serviceStatesFn(ctx, release)
 }
 
-// Outdated mirrors charts.Outdated's contract closely enough for the view:
-// only a strictly newer version is reported, and a chart in no index is not.
-func (m *mockOps) Outdated(rels []charts.Release) ([]charts.OutdatedEntry, bool) {
+// Available answers through the real charts.Available, over an index built
+// from the fixture. Mirroring its rules by hand is how a fake comes to disagree
+// with production — version comparison in particular is not string equality.
+func (m *mockOps) Available(rels []charts.Release) (map[string]charts.Availability, bool) {
 	if m.indexes == nil {
 		return nil, false
 	}
-	var out []charts.OutdatedEntry
-	for _, r := range rels {
-		latest, ok := m.indexes[r.Chart.Name]
-		if !ok || latest == r.Chart.Version {
-			continue
-		}
-		out = append(out, charts.OutdatedEntry{
-			Release: r.Name, Chart: r.Chart.Name,
-			Installed: r.Chart.Version, Latest: latest,
-		})
+	entries := make(map[string][]charts.IndexEntry, len(m.indexes))
+	for chart, version := range m.indexes {
+		entries[chart] = []charts.IndexEntry{{Name: chart, Version: version}}
 	}
-	return out, true
+	index := map[string]*charts.Index{"fixture": {APIVersion: "v1", Entries: entries}}
+	return charts.Available(rels, index), true
 }
 
 func noopOps() *mockOps {

--- a/views/charts/ops.go
+++ b/views/charts/ops.go
@@ -27,10 +27,13 @@ type releaseOps interface {
 	// the shared Docker snapshot cache, so calling it once per release costs
 	// one snapshot and N in-memory filters.
 	ServiceStates(ctx context.Context, release string) []charts.ServiceState
-	// Outdated joins the installed releases against the cached repository
-	// indexes. haveIndexes reports whether there was anything to compare
-	// against, so the view can say "no indexes" rather than "up to date".
-	Outdated(rels []charts.Release) (entries []charts.OutdatedEntry, haveIndexes bool)
+	// Available joins the installed releases against the cached repository
+	// indexes, one entry per release whose chart is in one. haveIndexes reports
+	// whether there was anything to compare against, so the view can say "no
+	// indexes" rather than "up to date" — and a release missing from the map
+	// while haveIndexes is true is a chart in no index, which is a third answer
+	// again.
+	Available(rels []charts.Release) (avail map[string]charts.Availability, haveIndexes bool)
 }
 
 // engineOps binds releaseOps to the ambient release engine.
@@ -63,12 +66,12 @@ func (o *engineOps) ServiceStates(ctx context.Context, release string) []charts.
 	return o.engine.Backend.StackServices(ctx, release)
 }
 
-func (o *engineOps) Outdated(rels []charts.Release) ([]charts.OutdatedEntry, bool) {
+func (o *engineOps) Available(rels []charts.Release) (map[string]charts.Availability, bool) {
 	o.once.Do(o.loadIndexes)
 	if !o.haveIndexes {
 		return nil, false
 	}
-	return charts.Outdated(rels, o.indexes), true
+	return charts.Available(rels, o.indexes), true
 }
 
 // loadIndexes reads the cached repository indexes and nothing else.

--- a/views/charts/ops_test.go
+++ b/views/charts/ops_test.go
@@ -48,31 +48,59 @@ func TestRepoStoreNeverGoesToTheNetwork(t *testing.T) {
 	require.NotNil(t, store.Warnf, "charts is silent unless the embedder wires this")
 }
 
-func TestOutdatedReadsTheCachedIndex(t *testing.T) {
+func TestAvailableReadsTheCachedIndex(t *testing.T) {
 	seedRepoCache(t, "mychart", "1.0.0", "2.1.0")
 
 	ops := &engineOps{}
-	entries, haveIndexes := ops.Outdated([]charts.Release{{
+	avail, haveIndexes := ops.Available([]charts.Release{{
 		Name: "app", Chart: charts.ReleaseChart{Name: "mychart", Version: "1.0.0"},
 	}})
 
 	require.True(t, haveIndexes)
-	require.Len(t, entries, 1)
-	require.Equal(t, "app", entries[0].Release)
-	require.Equal(t, "1.0.0", entries[0].Installed)
-	require.Equal(t, "2.1.0", entries[0].Latest)
+	require.Len(t, avail, 1)
+	require.Equal(t, "2.1.0", avail["app"].Latest)
+	require.True(t, avail["app"].Newer)
 }
 
-func TestOutdatedReportsNoIndexesWhenNoneAreCached(t *testing.T) {
+// A release already on the newest published version is in the map with Newer
+// false — present, so the view can say "up to date" rather than "unknown".
+func TestAvailableReportsACurrentReleaseRatherThanOmittingIt(t *testing.T) {
+	seedRepoCache(t, "mychart", "1.0.0", "2.1.0")
+
+	ops := &engineOps{}
+	avail, haveIndexes := ops.Available([]charts.Release{{
+		Name: "app", Chart: charts.ReleaseChart{Name: "mychart", Version: "2.1.0"},
+	}})
+
+	require.True(t, haveIndexes)
+	require.Contains(t, avail, "app")
+	require.False(t, avail["app"].Newer)
+}
+
+// A chart in no cached index is absent, which is what a local chart looks like
+// and is a different answer from being current.
+func TestAvailableOmitsAChartInNoIndex(t *testing.T) {
+	seedRepoCache(t, "mychart", "1.0.0", "2.1.0")
+
+	ops := &engineOps{}
+	avail, haveIndexes := ops.Available([]charts.Release{{
+		Name: "app", Chart: charts.ReleaseChart{Name: "local-only", Version: "0.1.0"},
+	}})
+
+	require.True(t, haveIndexes)
+	require.NotContains(t, avail, "app")
+}
+
+func TestAvailableReportsNoIndexesWhenNoneAreCached(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 
 	ops := &engineOps{}
-	entries, haveIndexes := ops.Outdated([]charts.Release{{
+	avail, haveIndexes := ops.Available([]charts.Release{{
 		Name: "app", Chart: charts.ReleaseChart{Name: "mychart", Version: "1.0.0"},
 	}})
 
 	require.False(t, haveIndexes, "no cached index is not the same answer as up to date")
-	require.Empty(t, entries)
+	require.Empty(t, avail)
 }
 
 // The indexes are read once per view, which is what lets the poll ask on every
@@ -82,7 +110,7 @@ func TestIndexesAreReadOnce(t *testing.T) {
 	ops := &engineOps{}
 
 	rels := []charts.Release{{Name: "app", Chart: charts.ReleaseChart{Name: "mychart", Version: "1.0.0"}}}
-	first, haveIndexes := ops.Outdated(rels)
+	first, haveIndexes := ops.Available(rels)
 	require.True(t, haveIndexes)
 	require.Len(t, first, 1)
 
@@ -91,7 +119,7 @@ func TestIndexesAreReadOnce(t *testing.T) {
 	// loaded.
 	require.NoError(t, os.RemoveAll(base))
 
-	second, haveIndexes := ops.Outdated(rels)
+	second, haveIndexes := ops.Available(rels)
 	require.True(t, haveIndexes)
 	require.Equal(t, first, second)
 }

--- a/views/charts/update.go
+++ b/views/charts/update.go
@@ -124,20 +124,23 @@ func (m *Model) refreshColumns() {
 	}
 }
 
-// updCell fills the LATEST column, distinguishing the two reasons a release has
-// no newer version, which an empty cell would run together: nothing newer is
-// published, versus this machine has no cached index to compare against. The
-// second is "?" rather than a footer line because it is a per-row fact and the
-// footer is already carrying the counts, the convergence reason and the
-// read-only hint.
+// updCell fills the LATEST column. Four answers, because "no newer version" is
+// three different facts and a reader acts on each differently: the release is on
+// the newest published version, or its chart is in no index to compare against,
+// or this machine has no cached index at all. The last two are "—" and "?"
+// rather than footer lines because they are per-row facts, and the footer is
+// already carrying the counts, the convergence reason and the read-only hint.
 func (m *Model) updCell(r releaseItem) string {
-	if r.Latest != "" {
-		return r.Latest
-	}
-	if !m.haveIndexes {
+	switch {
+	case !m.haveIndexes:
 		return "?"
+	case r.Latest == "":
+		return "—" // the chart is in no cached index: a local chart
+	case r.Newer:
+		return r.Latest
+	default:
+		return "✓"
 	}
-	return "—"
 }
 
 // sortColumnIndex maps the active sort field to its column index for the header

--- a/views/charts/view_test.go
+++ b/views/charts/view_test.go
@@ -160,23 +160,43 @@ func TestReadOnlyHintIsAlwaysOnScreen(t *testing.T) {
 
 // "nothing newer" and "nothing to compare against" are different answers, and
 // one empty cell for both would let the second read as the first.
-func TestUpdCellDistinguishesUnknownFromCurrent(t *testing.T) {
+// TestUpdCellTellsTheFourAnswersApart: "no newer version" is three different
+// facts, and an operator acts on each differently — upgrade, nothing to do, or
+// go and cache an index.
+func TestUpdCellTellsTheFourAnswersApart(t *testing.T) {
 	m := sized(testModel(), 150, 24)
 
 	loadReleases(t, m, map[string][]charts.Release{"app": deployed("app", "c", "1.0.0")}, nil)
 	require.False(t, m.haveIndexes)
-	require.Equal(t, "?", m.updCell(m.list.Filtered[0]), "no index cached")
+	require.Equal(t, "?", m.updCell(m.list.Filtered[0]), "no index cached at all")
 
 	loadReleases(t, m,
 		map[string][]charts.Release{"app": deployed("app", "c", "1.0.0")}, nil,
 		map[string]string{"c": "1.0.0"})
 	require.True(t, m.haveIndexes)
-	require.Equal(t, "—", m.updCell(m.list.Filtered[0]), "index cached, nothing newer")
+	require.Equal(t, "✓", m.updCell(m.list.Filtered[0]), "in the index and on its newest version")
+
+	loadReleases(t, m,
+		map[string][]charts.Release{"app": deployed("app", "c", "1.0.0")}, nil,
+		map[string]string{"other": "9.9.9"})
+	require.Equal(t, "—", m.updCell(m.list.Filtered[0]), "the chart is in no index: a local chart")
 
 	loadReleases(t, m,
 		map[string][]charts.Release{"app": deployed("app", "c", "1.0.0")}, nil,
 		map[string]string{"c": "2.0.0"})
 	require.Equal(t, "2.0.0", m.updCell(m.list.Filtered[0]))
+}
+
+// A release ahead of every cached index — installed from a local chart, say —
+// has nothing newer to install, so it reads as current rather than as an
+// upgrade back to an older version.
+func TestUpdCellTreatsAReleaseAheadOfTheIndexAsCurrent(t *testing.T) {
+	m := sized(testModel(), 150, 24)
+	loadReleases(t, m,
+		map[string][]charts.Release{"app": deployed("app", "c", "3.0.0")}, nil,
+		map[string]string{"c": "1.0.0"})
+
+	require.Equal(t, "✓", m.updCell(m.list.Filtered[0]))
 }
 
 // The footer carries the counts, the convergence reason and the read-only
@@ -211,10 +231,16 @@ func TestUpdColumnShowsTheNewerVersion(t *testing.T) {
 		byName[it.Name] = it
 	}
 	require.Equal(t, "2.0.0", byName["stale"].Latest)
-	require.Empty(t, byName["current"].Latest, "already newest")
-	require.Empty(t, byName["local"].Latest, "a chart in no index has nothing to be outdated against")
+	require.True(t, byName["stale"].Newer)
+
+	require.Equal(t, "3.0.0", byName["current"].Latest, "the newest published version, which is the installed one")
+	require.False(t, byName["current"].Newer, "already newest")
+
+	require.Empty(t, byName["local"].Latest, "a chart in no index has nothing to compare against")
 
 	out := m.View()
 	require.Contains(t, out, "LATEST", "the header names the column")
 	require.Contains(t, out, "2.0.0")
+	require.Contains(t, out, "✓", "the up-to-date release says so rather than showing a dash")
+	require.Contains(t, out, "—", "and the local chart still reads as unknowable")
 }

--- a/views/help/layout.go
+++ b/views/help/layout.go
@@ -1,0 +1,184 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package helpview
+
+import (
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+// The cheat sheet's column count is a property of the terminal, never of how
+// many categories an author wrote. Deriving it from the content — one column
+// per category — is what made every description a candidate for truncation:
+// each category added took space away from all the others, and the only
+// defence left was to cut the sentence.
+
+const (
+	// minCategoryWidth is the narrowest a category column may be. Below it a
+	// description is more wrapping than words, so the layout takes fewer,
+	// wider columns instead.
+	minCategoryWidth = 44
+
+	// categoryGutter is the blank space kept between two columns.
+	categoryGutter = 2
+
+	// keyDescGap separates a key from its description.
+	keyDescGap = 2
+
+	// minDescWidth is the narrowest a description may be beside its key.
+	// Under it the item stacks: key on its own line, description indented
+	// below. The same fallback the per-command help screen uses for usage
+	// lines, and for the same reason — a key that is really a phrase.
+	minDescWidth = 16
+
+	// stackedIndent indents a stacked item's description under its key.
+	stackedIndent = 2
+)
+
+var (
+	categoryTitleStyle = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("2"))
+	itemKeyStyle       = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("33"))
+	itemDescStyle      = lipgloss.NewStyle().Foreground(lipgloss.Color("252"))
+)
+
+// columnCount is how many category columns fit in width. At least one, never
+// more than there are categories to put in them.
+func columnCount(width, categories int) int {
+	if categories < 1 {
+		return 1
+	}
+	fit := width / minCategoryWidth
+	if fit < 1 {
+		fit = 1
+	}
+	if fit > categories {
+		fit = categories
+	}
+	return fit
+}
+
+// renderCategory lays out one category as a block width columns wide. Every
+// measurement here is display width — lipgloss wraps on it and never splits a
+// rune, which is the other half of why this no longer cuts text.
+func renderCategory(cat HelpCategory, width int) string {
+	if width < 1 {
+		width = 1
+	}
+	lines := []string{categoryTitleStyle.Render(strings.ToUpper(cat.Title))}
+
+	keyWidth := 0
+	for _, item := range cat.Items {
+		if w := lipgloss.Width(item.Keys); w > keyWidth {
+			keyWidth = w
+		}
+	}
+	// A key column may not take more than half the block. Some categories
+	// document values rather than keystrokes — a column name, a status word —
+	// and one long entry must not leave every description in the category a
+	// sliver.
+	if half := width / 2; keyWidth > half {
+		keyWidth = half
+	}
+
+	descWidth := width - keyWidth - keyDescGap
+	for _, item := range cat.Items {
+		lines = append(lines, renderItem(item, width, keyWidth, descWidth)...)
+	}
+	return strings.Join(lines, "\n")
+}
+
+// renderItem renders one key/description pair, side by side when the
+// description has room to read and stacked when it does not.
+func renderItem(item HelpItem, width, keyWidth, descWidth int) []string {
+	key := itemKeyStyle.Render(item.Keys)
+	if descWidth < minDescWidth {
+		out := []string{key}
+		if item.Description == "" {
+			return out
+		}
+		indent := strings.Repeat(" ", stackedIndent)
+		desc := itemDescStyle.Width(width - stackedIndent).Render(item.Description)
+		for _, line := range strings.Split(desc, "\n") {
+			out = append(out, indent+line)
+		}
+		return out
+	}
+
+	row := lipgloss.JoinHorizontal(lipgloss.Top,
+		itemKeyStyle.Width(keyWidth).Render(item.Keys),
+		strings.Repeat(" ", keyDescGap),
+		itemDescStyle.Width(descWidth).Render(item.Description),
+	)
+	return strings.Split(row, "\n")
+}
+
+// packColumns distributes rendered category blocks over at most cols columns,
+// keeping declaration order — a reader goes down a column and then on to the
+// next, which is how the categories were written to be read.
+//
+// The split is the one that minimises the tallest column, found by binary
+// search over the ceiling. Filling each column to an average and moving on does
+// not work: whatever is left when the last column starts has to go in it, so
+// the sheet ends with three categories stacked beside three empty ones.
+func packColumns(blocks []string, cols int) []string {
+	if cols < 1 {
+		cols = 1
+	}
+	if cols >= len(blocks) {
+		return blocks
+	}
+
+	heights := make([]int, len(blocks))
+	lo, hi := 0, 0
+	for i, b := range blocks {
+		heights[i] = lipgloss.Height(b) + 1 // the blank line under the block
+		if heights[i] > lo {
+			lo = heights[i] // no column can be shorter than its tallest block
+		}
+		hi += heights[i]
+	}
+	for lo < hi {
+		mid := (lo + hi) / 2
+		if columnsNeeded(heights, mid) <= cols {
+			hi = mid
+		} else {
+			lo = mid + 1
+		}
+	}
+	return splitAt(blocks, heights, lo)
+}
+
+// columnsNeeded is how many columns the blocks take when none may exceed
+// ceiling rows.
+func columnsNeeded(heights []int, ceiling int) int {
+	columns, current := 1, 0
+	for _, h := range heights {
+		if current > 0 && current+h > ceiling {
+			columns++
+			current = 0
+		}
+		current += h
+	}
+	return columns
+}
+
+// splitAt cuts the blocks into columns none of which exceeds ceiling rows.
+func splitAt(blocks []string, heights []int, ceiling int) []string {
+	var columns []string
+	var current []string
+	currentHeight := 0
+	for i, b := range blocks {
+		if currentHeight > 0 && currentHeight+heights[i] > ceiling {
+			columns = append(columns, strings.Join(current, "\n\n"))
+			current, currentHeight = nil, 0
+		}
+		current = append(current, b)
+		currentHeight += heights[i]
+	}
+	if len(current) > 0 {
+		columns = append(columns, strings.Join(current, "\n\n"))
+	}
+	return columns
+}

--- a/views/help/layout_internal_test.go
+++ b/views/help/layout_internal_test.go
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package helpview
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/stretchr/testify/require"
+)
+
+func TestColumnCount(t *testing.T) {
+	require.Equal(t, 1, columnCount(60, 6))
+	require.Equal(t, 1, columnCount(minCategoryWidth*2-1, 6))
+	require.Equal(t, 2, columnCount(minCategoryWidth*2, 6))
+	require.Equal(t, 4, columnCount(200, 6))
+	require.Equal(t, 3, columnCount(200, 3), "never more columns than categories")
+	require.Equal(t, 1, columnCount(0, 3), "a zero width still renders")
+	require.Equal(t, 1, columnCount(200, 0))
+}
+
+func TestPackColumns_KeepsOrderAndTheColumnBudget(t *testing.T) {
+	blocks := []string{"a", "bb\nbb", "c", "ddd\nddd\nddd", "e", "f"}
+
+	for _, cols := range []int{0, 1, 2, 3, 4, 6, 9} {
+		packed := packColumns(blocks, cols)
+		require.LessOrEqual(t, len(packed), max(cols, 1))
+		require.Equal(t, strings.Join(blocks, "\n\n"), strings.Join(packed, "\n\n"),
+			"cols=%d reordered or dropped a category", cols)
+	}
+}
+
+// TestPackColumns_IsTheBestSplitAvailable checks the claim the binary search
+// makes, against every contiguous split there is. The greedy fill it replaced
+// fails this: it meets the average and then empties the remainder into the last
+// column.
+func TestPackColumns_IsTheBestSplitAvailable(t *testing.T) {
+	blocks := []string{"a", "bb\nbb", "c\nc\nc\nc\nc", "ddd\nddd\nddd", "e", "f\nf"}
+
+	for _, cols := range []int{2, 3, 4, 5} {
+		packed := packColumns(blocks, cols)
+		require.Equal(t, bestTallest(blocks, cols), tallest(packed),
+			"cols=%d is not the most even split available", cols)
+	}
+}
+
+func TestPackColumns_ABlockTallerThanTheCeilingStillFits(t *testing.T) {
+	blocks := []string{"a", strings.Repeat("x\n", 40), "b"}
+
+	packed := packColumns(blocks, 2)
+	require.LessOrEqual(t, len(packed), 2)
+	require.Equal(t, strings.Join(blocks, "\n\n"), strings.Join(packed, "\n\n"))
+}
+
+func tallest(columns []string) int {
+	h := 0
+	for _, c := range columns {
+		if n := lipgloss.Height(c); n > h {
+			h = n
+		}
+	}
+	return h
+}
+
+// bestTallest is the smallest achievable tallest-column height over every
+// contiguous split of blocks into at most cols columns. Exhaustive, which is
+// affordable because the input is a handful of categories.
+func bestTallest(blocks []string, cols int) int {
+	best := -1
+	var walk func(start, columnsLeft int, worst int)
+	walk = func(start, columnsLeft, worst int) {
+		if start == len(blocks) {
+			if best < 0 || worst < best {
+				best = worst
+			}
+			return
+		}
+		if columnsLeft == 0 {
+			return
+		}
+		for end := start + 1; end <= len(blocks); end++ {
+			// A column's height is its blocks plus the blank line between them,
+			// which is how packColumns joins and measures them.
+			h := lipgloss.Height(strings.Join(blocks[start:end], "\n\n"))
+			walk(end, columnsLeft-1, max(worst, h))
+		}
+	}
+	walk(0, cols, 0)
+	return best
+}

--- a/views/help/layout_test.go
+++ b/views/help/layout_test.go
@@ -1,0 +1,204 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package helpview_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	chartsview "github.com/Eldara-Tech/swarmcli/views/charts"
+	configsview "github.com/Eldara-Tech/swarmcli/views/configs"
+	contextsview "github.com/Eldara-Tech/swarmcli/views/contexts"
+	helpview "github.com/Eldara-Tech/swarmcli/views/help"
+	networksview "github.com/Eldara-Tech/swarmcli/views/networks"
+	nodesview "github.com/Eldara-Tech/swarmcli/views/nodes"
+	secretsview "github.com/Eldara-Tech/swarmcli/views/secrets"
+	servicesview "github.com/Eldara-Tech/swarmcli/views/services"
+	stacksview "github.com/Eldara-Tech/swarmcli/views/stacks"
+	tasksview "github.com/Eldara-Tech/swarmcli/views/tasks"
+	volumesview "github.com/Eldara-Tech/swarmcli/views/volumes"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
+	"github.com/stretchr/testify/require"
+)
+
+// shipped is every cheat sheet in this repo. The layout is only worth as much
+// as it is worth for the content that actually reaches an operator, and the
+// content is what a table of hand-written fixtures would keep missing: charts
+// alone carries a 124-rune description, which is what broke this.
+func shipped() map[string][]helpview.HelpCategory {
+	return map[string][]helpview.HelpCategory{
+		"charts":   chartsview.GetChartsHelpContent(),
+		"configs":  configsview.GetConfigsHelpContent(),
+		"contexts": contextsview.GetContextsHelpContent(),
+		"networks": networksview.GetNetworksHelpContent(),
+		"nodes":    nodesview.GetNodesHelpContent(),
+		"secrets":  secretsview.GetSecretsHelpContent(),
+		"services": servicesview.GetServicesHelpContent(),
+		"stacks":   stacksview.GetStacksHelpContent(),
+		"tasks":    tasksview.GetTasksHelpContent(),
+		"volumes":  volumesview.GetVolumesHelpContent(),
+	}
+}
+
+// terminalWidths spans a phone-sized split pane to an ultrawide. 102 and 108
+// are here by name: the old arithmetic panicked at exactly those widths with
+// the charts content, and nothing about them is otherwise special.
+var terminalWidths = []int{60, 80, 102, 108, 120, 160, 200, 300}
+
+func render(width, height int, categories []helpview.HelpCategory) string {
+	return helpview.NewDetailed(width, height, categories).FrameContent()
+}
+
+func TestLayout_StaysInsideTheTerminal(t *testing.T) {
+	for name, categories := range shipped() {
+		for _, width := range terminalWidths {
+			t.Run(fmt.Sprintf("%s/%d", name, width), func(t *testing.T) {
+				out := render(width, 40, categories)
+				require.True(t, utf8.ValidString(out), "a cut inside a rune leaves invalid UTF-8")
+				for i, line := range strings.Split(out, "\n") {
+					require.LessOrEqual(t, lipgloss.Width(line), width,
+						"line %d overflows the terminal: %q", i, ansi.Strip(line))
+				}
+			})
+		}
+	}
+}
+
+// TestLayout_KeepsEveryWord is the assertion the screenshot on #593 was of. At
+// width 60 every content lays out in a single column, so a description that
+// survives can be found in the output with its wrapping whitespace removed.
+func TestLayout_KeepsEveryWord(t *testing.T) {
+	for name, categories := range shipped() {
+		t.Run(name, func(t *testing.T) {
+			out := squash(render(60, 400, categories))
+			for _, cat := range categories {
+				for _, item := range cat.Items {
+					require.Contains(t, out, squash(item.Description),
+						"the %s help cuts %q", name, item.Description)
+					require.Contains(t, out, squash(item.Keys))
+				}
+			}
+		})
+	}
+}
+
+// TestLayout_UsesTheWidthItIsGiven guards the other direction: wrapping every
+// description would be readable and waste an ultrawide terminal.
+func TestLayout_UsesTheWidthItIsGiven(t *testing.T) {
+	categories := chartsview.GetChartsHelpContent()
+
+	// The rendered page is always the frame's height; what a wider terminal
+	// buys is fewer rows carrying content, because the categories sit beside
+	// each other rather than under.
+	narrow := filledRows(render(60, 400, categories))
+	wide := filledRows(render(240, 400, categories))
+
+	require.Greater(t, narrow, wide,
+		"a wider terminal should take columns, not the same single column")
+	require.Positive(t, wide)
+}
+
+// TestLayout_KeyThatIsReallyAPhrase: some categories document values rather
+// than keystrokes. The key column is capped at half the block so one long
+// entry cannot leave every description in its category a sliver.
+func TestLayout_KeyThatIsReallyAPhrase(t *testing.T) {
+	categories := []helpview.HelpCategory{{
+		Title: "When a pane says something instead of drawing",
+		Items: []helpview.HelpItem{
+			{Keys: "not reported by this host", Description: "No sample in the window carried this metric"},
+			{Keys: "<w>", Description: "Cycle the window"},
+		},
+	}}
+
+	out := render(70, 40, categories)
+	squashed := squash(out)
+	for _, item := range categories[0].Items {
+		require.Contains(t, squashed, squash(item.Description))
+		require.Contains(t, squashed, squash(item.Keys))
+	}
+	for _, line := range strings.Split(out, "\n") {
+		require.LessOrEqual(t, lipgloss.Width(line), 70)
+	}
+}
+
+// TestLayout_WrapsUnderTheDescription guards the shape of a wrapped item, not
+// merely that it fits: the column is padded to its width at the end, so text
+// that was never wrapped would be folded there anyway — flush against the left
+// edge, under the key rather than under the sentence it continues.
+func TestLayout_WrapsUnderTheDescription(t *testing.T) {
+	const firstWord = "aardvark"
+	categories := []helpview.HelpCategory{{
+		Title: "General",
+		Items: []helpview.HelpItem{{
+			Keys:        "<x>",
+			Description: firstWord + " sentence long enough that it has to wrap several times over at this narrow width",
+		}},
+	}}
+
+	var body []string
+	for _, line := range strings.Split(ansi.Strip(render(40, 40, categories)), "\n") {
+		if strings.TrimSpace(line) != "" {
+			body = append(body, strings.TrimRight(line, " "))
+		}
+	}
+	require.GreaterOrEqual(t, len(body), 4, "the description must have wrapped more than once")
+
+	indent := strings.Index(body[1], firstWord) // body[0] is the category title
+	require.Greater(t, indent, 0, "the description starts after the key")
+	for i, line := range body[2:] {
+		require.True(t, strings.HasPrefix(line, strings.Repeat(" ", indent)),
+			"continuation line %d starts under the key instead of the description: %q", i, line)
+		require.NotEqual(t, byte(' '), line[indent],
+			"continuation line %d does not start at the description column: %q", i, line)
+	}
+}
+
+// TestLayout_ScrollsRatherThanLosingTheTail: wrapping makes screens taller, and
+// a frame that cannot show all of it must be able to reach the rest.
+func TestLayout_ScrollsRatherThanLosingTheTail(t *testing.T) {
+	categories := chartsview.GetChartsHelpContent()
+	m := helpview.NewDetailed(60, 12, categories)
+
+	first := m.FrameContent()
+	require.LessOrEqual(t, len(strings.Split(first, "\n")), 12)
+	require.Contains(t, m.FrameFooter(), "scroll", "the footer must offer the keys that reach the rest")
+
+	m.Viewable.GotoBottom()
+	last := m.FrameContent()
+	require.NotEqual(t, squash(first), squash(last), "the page must move")
+
+	lastCategory := categories[len(categories)-1]
+	lastItem := lastCategory.Items[len(lastCategory.Items)-1]
+	require.Contains(t, squash(last), squash(lastItem.Description),
+		"the end of the sheet must be reachable")
+}
+
+func TestLayout_ShortSheetOffersNoScrollKeys(t *testing.T) {
+	m := helpview.NewDetailed(200, 40, tasksview.GetTasksHelpContent())
+	m.FrameContent()
+	require.NotContains(t, m.FrameFooter(), "scroll")
+}
+
+// filledRows counts the rows that carry something, as opposed to the blank
+// ones the viewport pads its page out with.
+func filledRows(s string) int {
+	n := 0
+	for _, line := range strings.Split(s, "\n") {
+		if strings.TrimSpace(ansi.Strip(line)) != "" {
+			n++
+		}
+	}
+	return n
+}
+
+// squash strips styling and every space and newline, so a string that was
+// wrapped across lines and columns still matches the sentence it came from,
+// while a truncated one does not.
+func squash(s string) string {
+	return strings.Join(strings.Fields(ansi.Strip(s)), "")
+}

--- a/views/help/model.go
+++ b/views/help/model.go
@@ -46,6 +46,10 @@ type Model struct {
 	height     int
 	// app-level "/" filter query
 	query string
+	// overflows records whether the last render left content out of sight, so
+	// the footer can offer the scroll keys only when there is something to
+	// scroll to.
+	overflows bool
 	// commandHelp, when set, selects the vertical single-column
 	// per-command help layout (distinct from the columnar keybinding
 	// cheat-sheet produced by NewDetailed).

--- a/views/help/view.go
+++ b/views/help/view.go
@@ -29,6 +29,12 @@ func (m *Model) FrameHeader() string {
 var SupportContact string
 
 func (m *Model) FrameFooter() string {
+	// overflows is set by the last render, which the app runs before it asks
+	// for the footer. Both variants are one line, so the frame's row budget is
+	// the same either way and a stale flag cannot resize anything.
+	if m.overflows {
+		return ui.StatusBarStyle.Render("<↑/↓> scroll · <esc> go back")
+	}
 	return ui.StatusBarStyle.Render("Press <esc> to go back")
 }
 
@@ -53,109 +59,108 @@ func (m *Model) View() string {
 	return ui.RenderViewFrame(m.FrameTitle(), m.FrameHeader(), m.FrameContent(), m.FrameFooter(), m.Viewable.Width, m.Viewable.Height, false)
 }
 
+// buildCategorizedContent lays the cheat sheet out as category blocks packed
+// into as many columns as the terminal has room for, and hands the result to
+// the viewport so a screen taller than the frame scrolls instead of losing its
+// tail. See layout.go for why the column count is not the category count.
 func (m *Model) buildCategorizedContent() string {
-	width := m.Viewable.Width
-	if width <= 0 {
-		width = m.width
-	}
-	if width <= 0 {
-		width = 80
-	}
+	width := m.contentWidth()
+	categories := m.filteredCategories()
 
-	categoryStyle := lipgloss.NewStyle().
-		Bold(true).
-		Foreground(lipgloss.Color("2"))
-
-	keyStyle := lipgloss.NewStyle().
-		Foreground(lipgloss.Color("33")).
-		Bold(true)
-
-	descStyle := lipgloss.NewStyle().
-		Foreground(lipgloss.Color("252"))
-
-	// Apply query filter to categories
-	categories := m.categories
-	if m.query != "" {
-		lower := strings.ToLower(m.query)
-		var filtered []HelpCategory
-		for _, cat := range categories {
-			var items []HelpItem
-			for _, item := range cat.Items {
-				if strings.Contains(strings.ToLower(item.Keys), lower) ||
-					strings.Contains(strings.ToLower(item.Description), lower) {
-					items = append(items, item)
-				}
-			}
-			if len(items) > 0 {
-				filtered = append(filtered, HelpCategory{Title: cat.Title, Items: items})
-			}
-		}
-		categories = filtered
+	// Balancing can find that the sheet reads better in fewer columns than the
+	// width allows. Take that answer and lay out again in it, so the columns
+	// that remain get the whole width rather than leaving an empty one.
+	cols := columnCount(width, len(categories))
+	packed := packAt(categories, width, cols)
+	for len(packed) < cols && cols > 1 {
+		cols = len(packed)
+		packed = packAt(categories, width, cols)
 	}
 
-	numCols := len(categories)
-	if numCols == 0 {
-		numCols = 1
+	colWidth := width / max(len(packed), 1)
+	for i, col := range packed {
+		packed[i] = lipgloss.NewStyle().Width(colWidth).Render(col)
 	}
-	colWidth := width / numCols
-	maxKeyWidth := 15
 
-	maxRows := 0
+	return m.scroll(lipgloss.JoinHorizontal(lipgloss.Top, packed...))
+}
+
+// packAt renders the categories for a cols-wide layout and balances them
+// across it.
+func packAt(categories []HelpCategory, width, cols int) []string {
+	colWidth := width / cols
+	blocks := make([]string, 0, len(categories))
 	for _, cat := range categories {
-		if len(cat.Items) > maxRows {
-			maxRows = len(cat.Items)
-		}
+		blocks = append(blocks, renderCategory(cat, colWidth-categoryGutter))
 	}
+	return packColumns(blocks, cols)
+}
 
-	var headerParts []string
-	for _, cat := range categories {
-		titleText := strings.ToUpper(cat.Title)
-		paddedTitle := fmt.Sprintf("%-*s", colWidth, titleText)
-		styledTitle := categoryStyle.Render(paddedTitle)
-		headerParts = append(headerParts, styledTitle)
+// contentWidth is the width the cheat sheet has to lay out in.
+func (m *Model) contentWidth() int {
+	if m.Viewable.Width > 0 {
+		return m.Viewable.Width
 	}
-	headerRow := strings.Join(headerParts, "")
+	if m.width > 0 {
+		return m.width
+	}
+	return 80
+}
 
-	var contentLines []string
-	for row := 0; row < maxRows; row++ {
-		var rowParts []string
-		for _, cat := range categories {
-			if row < len(cat.Items) {
-				item := cat.Items[row]
-				styledKey := keyStyle.Render(fmt.Sprintf("%-*s", maxKeyWidth, item.Keys))
-				styledDesc := descStyle.Render(item.Description)
-
-				plainText := fmt.Sprintf("%-*s %s", maxKeyWidth, item.Keys, item.Description)
-				plainTextWidth := lipgloss.Width(plainText)
-
-				if plainTextWidth > colWidth {
-					descWidth := colWidth - maxKeyWidth - 1
-					if descWidth > 0 && len(item.Description) > descWidth {
-						styledDesc = descStyle.Render(item.Description[:descWidth-3] + "...")
-						plainText = fmt.Sprintf("%-*s %s", maxKeyWidth, item.Keys, item.Description[:descWidth-3]+"...")
-						plainTextWidth = lipgloss.Width(plainText)
-					}
-				}
-
-				styledLine := styledKey + " " + styledDesc
-				paddingNeeded := colWidth - plainTextWidth
-				if paddingNeeded > 0 {
-					styledLine += strings.Repeat(" ", paddingNeeded)
-				}
-
-				rowParts = append(rowParts, styledLine)
-			} else {
-				rowParts = append(rowParts, strings.Repeat(" ", colWidth))
+// filteredCategories applies the app-level "/" query, keeping a category only
+// while it still has an item that matches.
+func (m *Model) filteredCategories() []HelpCategory {
+	if m.query == "" {
+		return m.categories
+	}
+	lower := strings.ToLower(m.query)
+	var filtered []HelpCategory
+	for _, cat := range m.categories {
+		var items []HelpItem
+		for _, item := range cat.Items {
+			if strings.Contains(strings.ToLower(item.Keys), lower) ||
+				strings.Contains(strings.ToLower(item.Description), lower) {
+				items = append(items, item)
 			}
 		}
-		contentLines = append(contentLines, strings.Join(rowParts, ""))
+		if len(items) > 0 {
+			filtered = append(filtered, HelpCategory{Title: cat.Title, Items: items})
+		}
+	}
+	return filtered
+}
+
+// scroll puts content in the viewport, sized to the rows the frame leaves, and
+// records whether any of it is out of sight so the footer can say so.
+//
+// The frame is measured from m.height rather than from the viewport's own
+// height, which this then overwrites: reading back what we set would shrink the
+// page a little more on every render.
+func (m *Model) scroll(content string) string {
+	frame := ui.ComputeFrameDimensions(m.contentWidth(), m.height, m.width, m.height, "", m.FrameFooter())
+	rows := frame.DesiredContentLines
+	if SupportContact != "" {
+		// The SUPPORT line and its spacer are pinned below the scrolling part.
+		rows = max(0, rows-2)
+	}
+	if rows < 1 {
+		rows = 1
 	}
 
-	fullContent := headerRow + "\n\n" + strings.Join(contentLines, "\n")
+	m.Viewable.Width = m.contentWidth()
+	m.Viewable.Height = rows
+	m.Viewable.SetContent(content)
+	// bubbles keeps YOffset across a height change, so a viewport that grew
+	// would pad the rows it gained until the next keypress clamped it.
+	m.Viewable.SetYOffset(m.Viewable.YOffset)
+	m.overflows = m.Viewable.TotalLineCount() > rows
 
-	footer := m.FrameFooter()
-	frame := ui.ComputeFrameDimensions(m.Viewable.Width, m.Viewable.Height, m.width, m.height, "", footer)
-	return appendSupportLine(fullContent, frame.DesiredContentLines)
+	out := m.Viewable.View()
+	if SupportContact == "" {
+		return out
+	}
+	support := categoryTitleStyle.Render("SUPPORT") + "  " + itemDescStyle.Render(SupportContact)
+	return ui.TrimOrPadContentToLines(out+"\n"+support, frame.DesiredContentLines)
 }
 
 // appendSupportLine fits content to total lines, pinning the edition SUPPORT


### PR DESCRIPTION
Follow-up to #593 — https://github.com/Eldara-Tech/swarmcli/pull/593#issuecomment-5315138544, "Can't read the whole sentence".

### What the screenshot was of

`buildCategorizedContent` took **one column per category**, each `terminalWidth / numCategories` wide, with a fixed 15-column key field, and cut the description to whatever was left. Six categories on a 200-column terminal leaves about seventeen columns of prose, hence `The recorded state of the release: wh...`.

The column count was a property of the content, not of the terminal: every category an author added took space away from all the others, and the only defence left was the cut.

### Three more things fell out of the same arithmetic

I probed every `GetXHelpContent()` in the repo from 60 to 300 columns.

- **It panics.** The charts sheet at width 102: `slice bounds out of range [:-2]`. The remaining space lands on one or two columns and the code slices `Description[:descWidth-3]`. Shipped content, ordinary terminal size.
- **It garbles narrow terminals.** At width 80 the same sheet renders content lines **324 characters wide**, because when the remaining space is ≤ 0 the cut is skipped and nothing constrains the text at all. The header row reads `THE LATEST COLUMNSORTING`.
- **It can emit invalid UTF-8.** The cut counts bytes, so it splits multi-byte runes; 8 of 12 offsets I tried on an em dash produced a `\xe2\x80` fragment. That sheet contains `—`, `←/→` and `↑/↓`.

Nine of the ten sheets truncated at 120 columns or less; `charts` truncated at every width up to 300 — its longest description would need 840 columns to fit the old layout.

### The fix

Categories are rendered as blocks and wrapped on **display width** (`lipgloss.Style.Width`, which never splits a rune), with the key column sized per category rather than a global 15 — and capped at half the block, so a category documenting values rather than keystrokes cannot leave its descriptions a sliver. Under that cap an item stacks: key on its own line, description indented below, the same fallback the per-command help already uses.

Columns are packed to fit the terminal: `width / 44`, capped at the number of categories. The split is the one that **minimises the tallest column**, found by binary search over the ceiling. Filling each column to an average and moving on does not work — whatever is left when the last column starts has to go in it, which is how the first attempt ended with three categories stacked beside three empty ones. If the balance settles on fewer columns than the width allows, the layout runs again in that many, so the columns that remain get the whole width.

Wrapping makes a screen taller than its frame possible, so the content now goes through `m.Viewable` — the viewport that was already on the model and already receiving ↑/↓/pgup from `Update`, but was never given this content. The footer offers the scroll keys when there is something to scroll to. **Before this, a sheet that outgrew its frame lost the rest with no indication.**

### Tests

`TestLayout_KeepsEveryWord` is the assertion the screenshot was of: for every sheet in the repo, at a width that forces one column, each description survives with its wrapping whitespace removed. `TestLayout_StaysInsideTheTerminal` renders all ten across eight widths — including 102 and 108 by name, where the old code panicked — asserting valid UTF-8 and no line wider than the terminal. Plus the wrap alignment, the phrase-shaped key, scrolling to the tail, and `TestPackColumns_IsTheBestSplitAvailable`, which checks the binary search against an exhaustive search of every contiguous split.

Each guard was checked by reverting the code under it. Worth noting one that did *not* bite at first: with the column padded to its width at the end, text that is never wrapped gets folded there anyway and stays inside the terminal — so the width test alone could not tell wrapping from no wrapping. `TestLayout_WrapsUnderTheDescription` closes that by asserting continuation lines start at the description column rather than under the key.

### Downstream

Business Edition's three sheets render through this. I ran its suite against this branch: green, and the container-statistics sheet — whose keys include a 25-rune phrase — lays out in three balanced columns with every sentence whole.

---

## Second commit: the LATEST column says ✓ when there is nothing to install

From the review — https://github.com/Eldara-Tech/swarmcli/pull/594#issuecomment-5315486030.

`—` stood for two different facts: *nothing newer is published*, and *this chart is in no cached index, so there is nothing to compare against*. An operator acts on those differently — the first is done, the second means a local chart or an uncached repo.

**The distinction was discarded a layer down.** `charts.Outdated` skips a release already at the newest version and one whose chart is in no index alike (`bestVer == "" || compareVersions(...) <= 0 → continue`), so the view could not tell them apart from what it was handed. `charts.Available` now reports what the indexes know about every release whose chart is in one — `Latest` plus a `Newer` flag — and `Outdated` is that filtered to the upgrades. Same entries, same signature, so `swarmcli charts outdated` is untouched; a test pins the two together so the filter cannot drift from the source.

The column now reads:

| cell | meaning |
|---|---|
| `0.2.0` | a newer version is published |
| `✓` | in a cached index, nothing newer |
| `—` | in no cached index — a local chart, nothing to compare against |
| `?` | no cached index at all, run `swarmcli charts repo update` |

A release *ahead* of every index reads `✓` too: there is nothing newer to install, and offering a downgrade in a column called LATEST would be worse than saying nothing.

The charts help screen documents all four — which is what ties this to the first commit, since that fourth row is only readable because the sheet now wraps.

While updating the view's test double I made it answer through the real `charts.Available` over a constructed index rather than re-implementing the rules by hand; the hand-rolled version compared versions with string equality, which is exactly how a fake comes to disagree with production.
