### PR TITLE
fix(charts): cache a verified chart archive, and retry a transient download

### DIFF
--- a/charts/README.md
+++ b/charts/README.md
@@ -532,10 +532,20 @@ manifest is validated as a Docker stack before use.
 
 A repository is an HTTPS-served `index.yaml` listing chart versions, each with
 a tarball URL (Helm repository format) — hostable on GitHub Pages/Releases, S3,
-or any static host. Configured repos and cached indexes live under
-`$XDG_STATE_HOME/swarmcli/charts` (default `~/.local/state/swarmcli/charts`); a
-repository's name is a component of its cache filename, so it is limited to
-letters, digits, `-`, `_` and `.`.
+or any static host. Configured repos, cached indexes and downloaded chart
+archives live under `$XDG_STATE_HOME/swarmcli/charts` (default
+`~/.local/state/swarmcli/charts`); a repository's name is a component of its
+cache filename, so it is limited to letters, digits, `-`, `_` and `.`.
+
+A chart archive is downloaded once. The index publishes a sha256 for it, which
+is checked on every download and again on every read of the cache, so a cached
+archive is used only while it still hashes to what the repository publishes
+*now* — a chart rebuilt and re-uploaded under one version misses the cache
+rather than resolving to the copy you already had. An entry that publishes no
+digest is never cached, because nothing could validate the read. A download that
+fails on the way — a gateway answering 502 or 504, a dropped connection — is
+retried twice before the command gives up, and each wait is reported. Archives
+are swept 30 days after the last time one was used.
 
 ### Staying current
 

--- a/charts/repo.go
+++ b/charts/repo.go
@@ -36,6 +36,21 @@ const maxIndexSize = 16 << 20 // 16 MiB
 // can be buffered and hashed before any of it reaches the archive parser.
 const maxChartArchiveSize = 20 << 20 // 20 MiB
 
+// pullBackoff is how long a chart download waits before each retry, one entry
+// per retry — so a tarball is fetched at most len(pullBackoff)+1 times. A var
+// rather than a const so tests can shrink it; nothing else writes it.
+//
+// Short, and few, on purpose. Pull takes no context, so every entry here is
+// time a shutdown cannot interrupt — and the failures worth waiting through, a
+// gateway between here and the archive answering 502 or 504, clear in seconds
+// or not at all.
+var pullBackoff = []time.Duration{500 * time.Millisecond, 2 * time.Second}
+
+// chartCacheTTL is how long an unused chart archive stays cached. A cache hit
+// refreshes the file's modification time, so what ages out is what stopped
+// being pulled: the versions a pinned release has moved past.
+const chartCacheTTL = 30 * 24 * time.Hour
+
 // staleAfter is how long a cached index may go unverified before reads of it
 // warn. Under RefreshAlways nothing gets that far — the index is refreshed
 // before it is read — so this is what is left for the cases where it was not:
@@ -286,9 +301,9 @@ func (s *RepoStore) Add(name, repoURL string) error {
 	return s.save(repos)
 }
 
-// writeCache replaces a cached index in one step. os.WriteFile truncates before
+// writeCache replaces a cached file in one step. os.WriteFile truncates before
 // it writes, so a reader that arrives mid-write sees an empty or half-written
-// index — and under RefreshAlways a write happens on every install, not only
+// one — and under RefreshAlways a write happens on every install, not only
 // on an explicit `repo update`, so two swarmcli processes sharing a state
 // directory (a CI matrix, an apply running beside an install) really do
 // overlap. Writing beside the target and renaming over it means a reader sees
@@ -662,23 +677,17 @@ func (s *RepoStore) Pull(entry IndexEntry, baseURL string) (*Chart, error) {
 	if err := s.checkPlaintext(u); err != nil {
 		return nil, err
 	}
-	resp, err := s.client.Get(tarURL)
+	// Before the network: this archive may already be on disk, and the entry
+	// carries the digest that decides whether what is on disk is still it. The
+	// checks above stay ahead of the lookup so that a repository this store
+	// refuses to download from is not one it serves out of cache either.
+	key := cacheKey(entry)
+	if body, ok := s.cachedArchive(key, entry); ok {
+		return LoadChartArchive(bytes.NewReader(body))
+	}
+	body, err := s.downloadArchive(tarURL)
 	if err != nil {
-		return nil, fmt.Errorf("download chart: %w", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, fmt.Errorf("download chart: HTTP %s", resp.Status)
-	}
-	// Buffer the whole archive before parsing it: the digest must be checked
-	// against the complete body, and a streaming parser would have consumed
-	// unverified bytes by the time the hash was known.
-	body, err := io.ReadAll(io.LimitReader(resp.Body, maxChartArchiveSize+1))
-	if err != nil {
-		return nil, fmt.Errorf("download chart: %w", err)
-	}
-	if len(body) > maxChartArchiveSize {
-		return nil, fmt.Errorf("chart archive exceeds %d bytes", maxChartArchiveSize)
+		return nil, err
 	}
 	if err := verifyDigest(entry, body); err != nil {
 		if errors.Is(err, errNoDigest) {
@@ -688,7 +697,73 @@ func (s *RepoStore) Pull(entry IndexEntry, baseURL string) (*Chart, error) {
 			return nil, err
 		}
 	}
+	s.cacheArchive(key, body)
 	return LoadChartArchive(bytes.NewReader(body))
+}
+
+// downloadArchive fetches a chart tarball, retrying a failure that says nothing
+// about this chart.
+//
+// The case it exists for is a gateway between here and the archive — a CDN, a
+// release-asset host — answering 502 or 504 for a few seconds. Without a retry
+// that is a failed apply and not merely a failed download: Pull's error is not
+// scoped to the release that could not be fetched, it propagates out of
+// PlanApply and takes the whole plan with it (#605).
+//
+// Every retry is announced. Pull takes no context, so the waits are time the
+// caller cannot interrupt, and an operator watching a pull take four seconds
+// instead of one is owed the reason.
+func (s *RepoStore) downloadArchive(tarURL string) ([]byte, error) {
+	for attempt := 0; ; attempt++ {
+		body, retry, err := s.fetchArchive(tarURL)
+		if err == nil || !retry || attempt == len(pullBackoff) {
+			return body, err
+		}
+		s.warnf("%v; retrying %s in %s\n", err, tarURL, pullBackoff[attempt])
+		time.Sleep(pullBackoff[attempt])
+	}
+}
+
+// fetchArchive is one download attempt. It reports whether the failure is one
+// another attempt could plausibly get past: a missing or oversized archive is
+// the repository's answer about this chart and will not change, while a
+// transport error or a temporary status is about the path to it.
+func (s *RepoStore) fetchArchive(tarURL string) (body []byte, retry bool, err error) {
+	resp, err := s.client.Get(tarURL)
+	if err != nil {
+		// Refused, reset, timed out, DNS. None of it is about this chart.
+		return nil, true, fmt.Errorf("download chart: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, transientStatus(resp.StatusCode), fmt.Errorf("download chart: HTTP %s", resp.Status)
+	}
+	// Buffer the whole archive before parsing it: the digest must be checked
+	// against the complete body, and a streaming parser would have consumed
+	// unverified bytes by the time the hash was known.
+	body, err = io.ReadAll(io.LimitReader(resp.Body, maxChartArchiveSize+1))
+	if err != nil {
+		return nil, true, fmt.Errorf("download chart: %w", err)
+	}
+	if len(body) > maxChartArchiveSize {
+		return nil, false, fmt.Errorf("chart archive exceeds %d bytes", maxChartArchiveSize)
+	}
+	return body, false, nil
+}
+
+// transientStatus reports a status code that says the request failed on the way
+// rather than that this archive is not there. 404 and 403 are the repository's
+// answer about the chart and repeating the question gets the same one; the
+// codes below come from a gateway, a load balancer or a rate limiter, which is
+// often enough not the same one next time to be worth asking again.
+func transientStatus(code int) bool {
+	switch code {
+	case http.StatusRequestTimeout, http.StatusTooManyRequests,
+		http.StatusInternalServerError, http.StatusBadGateway,
+		http.StatusServiceUnavailable, http.StatusGatewayTimeout:
+		return true
+	}
+	return false
 }
 
 // errNoDigest reports an index entry that carries no digest, so the archive
@@ -730,6 +805,113 @@ func verifyDigest(entry IndexEntry, body []byte) error {
 			entry.Name, entry.Version, want, got)
 	}
 	return nil
+}
+
+// chartCacheDir is where verified chart archives are kept, beside the cached
+// indexes they were resolved from.
+func (s *RepoStore) chartCacheDir() string { return filepath.Join(s.dir, "cache", "charts") }
+
+// cacheKey is the name a chart archive is cached under: the lowercase hex
+// sha256 the index publishes for it.
+//
+// Empty whenever the entry publishes no checkable sha256 — no digest at all, or
+// an algorithm this package cannot verify — and such an entry is never cached.
+// A cached archive is only as safe as the check that validates the read, and
+// for those there is none. Keying on name and version instead would mean
+// trusting a version to be immutable, which is precisely what a repository is
+// free to break by republishing one.
+//
+// The key is the content address and nothing else, which is also what makes it
+// safe as a path component: the digest is the only part of an IndexEntry that
+// has been validated by the time it gets here. Name and version are strings the
+// repository chose, and gluing one of those into a filename is how this file
+// got its last traversal (#527).
+func cacheKey(entry IndexEntry) string {
+	want := entry.Digest
+	if alg, hexsum, ok := strings.Cut(want, ":"); ok {
+		if alg != "sha256" {
+			return ""
+		}
+		want = hexsum
+	}
+	if len(want) != hex.EncodedLen(sha256.Size) {
+		return ""
+	}
+	if _, err := hex.DecodeString(want); err != nil {
+		return ""
+	}
+	return strings.ToLower(want)
+}
+
+// cachedArchive returns an archive downloaded by an earlier Pull, and whether
+// there was one to return.
+//
+// What makes this safe is that the file is accepted only if its bytes satisfy
+// verifyDigest against the entry the caller just resolved — the same check the
+// download path runs, against an index EnsureRepos has just refreshed. So a
+// chart republished under the same version, a truncated write and a hand-edited
+// file all miss and fall through to a download, rather than deploying something
+// the repository no longer serves.
+//
+// Every failure here is a miss and never an error. The cache is an
+// optimisation; the download behind it is the answer.
+func (s *RepoStore) cachedArchive(key string, entry IndexEntry) ([]byte, bool) {
+	if key == "" {
+		return nil, false
+	}
+	path := filepath.Join(s.chartCacheDir(), key+".tgz")
+	// Stat before read: an archive was size-checked before it was cached, so an
+	// oversized file here is not one this package wrote — and reading it to find
+	// that out is the thing maxChartArchiveSize exists to prevent.
+	info, err := os.Stat(path)
+	if err != nil || info.Size() > maxChartArchiveSize {
+		return nil, false
+	}
+	body, err := os.ReadFile(path)
+	if err != nil || verifyDigest(entry, body) != nil {
+		return nil, false
+	}
+	// Keep what is still in use from ageing out of the sweep in cacheArchive.
+	now := time.Now()
+	_ = os.Chtimes(path, now, now)
+	return body, true
+}
+
+// cacheArchive stores a verified archive under its content address.
+//
+// Best-effort throughout: a cache that cannot be written is slower, not wrong.
+func (s *RepoStore) cacheArchive(key string, body []byte) {
+	if key == "" {
+		return
+	}
+	dir := s.chartCacheDir()
+	if err := writeCache(filepath.Join(dir, key+".tgz"), body); err != nil {
+		return
+	}
+	// Swept on a write and not on every read, because a store that is pulling
+	// nothing new is a store whose cache is not growing.
+	sweepChartCache(dir)
+}
+
+// sweepChartCache deletes archives nothing has read for chartCacheTTL.
+//
+// That bounds the cache at the versions actually in use: a hit refreshes the
+// file's modification time, so what ages out is what a pinned release has moved
+// past — and the cost of ageing out something still wanted is one download,
+// which is what would have happened without a cache at all.
+func sweepChartCache(dir string) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return
+	}
+	cutoff := time.Now().Add(-chartCacheTTL)
+	for _, e := range entries {
+		info, err := e.Info()
+		if err != nil || !info.ModTime().Before(cutoff) {
+			continue
+		}
+		_ = os.Remove(filepath.Join(dir, e.Name()))
+	}
 }
 
 func (s *RepoStore) warnf(format string, a ...any) {

--- a/charts/repo_test.go
+++ b/charts/repo_test.go
@@ -395,6 +395,16 @@ entries:
 // store plus the resolved entry and base URL, ready to Pull.
 func serveChart(t *testing.T, digest string, tgz []byte) (*RepoStore, IndexEntry, string) {
 	t.Helper()
+	return serveChartFunc(t, digest, func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(tgz)
+	})
+}
+
+// serveChartFunc is serveChart with the tarball response under the test's
+// control, for the cases that are about what the repository does on the second
+// request rather than what it serves on the first.
+func serveChartFunc(t *testing.T, digest string, tarball http.HandlerFunc) (*RepoStore, IndexEntry, string) {
+	t.Helper()
 	digestLine := ""
 	if digest != "" {
 		digestLine = "\n      digest: " + digest
@@ -411,7 +421,7 @@ entries:
 		case strings.HasSuffix(r.URL.Path, "/index.yaml"):
 			_, _ = w.Write([]byte(idx))
 		case strings.HasSuffix(r.URL.Path, "demo-0.1.0.tgz"):
-			_, _ = w.Write(tgz)
+			tarball(w, r)
 		default:
 			http.NotFound(w, r)
 		}
@@ -492,6 +502,233 @@ func TestPullRejectsOversizedArchive(t *testing.T) {
 	s, e, base := serveChart(t, "", bytes.Repeat([]byte{0}, maxChartArchiveSize+1))
 	_, err := s.Pull(e, base)
 	require.ErrorContains(t, err, "exceeds")
+}
+
+// --- the archive cache: what a second Pull does, and what it refuses to do ---
+
+// fastPullBackoff shrinks the retry schedule for a test that means to exercise
+// it. The real one sleeps seconds, and the suite is not what it is there for.
+func fastPullBackoff(t *testing.T) {
+	t.Helper()
+	saved := pullBackoff
+	pullBackoff = []time.Duration{time.Millisecond, time.Millisecond}
+	t.Cleanup(func() { pullBackoff = saved })
+}
+
+func TestPullCachesTheArchive(t *testing.T) {
+	tgz := []byte(packDirToTgz(t, "testdata/demo", "demo"))
+	sum := sha256.Sum256(tgz)
+	digest := "sha256:" + hex.EncodeToString(sum[:])
+
+	// counting serves the archive and records how many times it was asked for.
+	counting := func(hits *int) http.HandlerFunc {
+		return func(w http.ResponseWriter, _ *http.Request) {
+			*hits++
+			_, _ = w.Write(tgz)
+		}
+	}
+
+	t.Run("a second pull does not download again", func(t *testing.T) {
+		var hits int
+		s, e, base := serveChartFunc(t, digest, counting(&hits))
+		for range 3 {
+			ch, err := s.Pull(e, base)
+			require.NoError(t, err)
+			require.Equal(t, "demo", ch.Metadata.Name)
+		}
+		require.Equal(t, 1, hits, "a pinned, digest-verified archive is worth downloading once")
+	})
+
+	// The failure this whole thing is about: swarmcli-cd re-plans every three
+	// minutes, and a gateway blip on any one of those ticks used to fail the
+	// application's whole reconcile (#605).
+	t.Run("the cache answers when the repository is down", func(t *testing.T) {
+		down := false
+		s, e, base := serveChartFunc(t, digest, func(w http.ResponseWriter, _ *http.Request) {
+			if down {
+				http.Error(w, "gateway timeout", http.StatusGatewayTimeout)
+				return
+			}
+			_, _ = w.Write(tgz)
+		})
+		_, err := s.Pull(e, base)
+		require.NoError(t, err)
+
+		down = true
+		ch, err := s.Pull(e, base)
+		require.NoError(t, err)
+		require.Equal(t, "demo", ch.Metadata.Name)
+	})
+
+	// The shape that makes this cache worth having: swarmcli-cd constructs a
+	// fresh RepoStore for every reconcile, against the same directory. The win
+	// has to survive the store, not merely the call.
+	t.Run("a second store at the same directory reuses the cache", func(t *testing.T) {
+		var hits int
+		s, e, base := serveChartFunc(t, digest, counting(&hits))
+		_, err := s.Pull(e, base)
+		require.NoError(t, err)
+
+		next := NewRepoStoreAt(s.dir)
+		next.AllowPlaintext = true
+		ch, err := next.Pull(e, base)
+		require.NoError(t, err)
+		require.Equal(t, "demo", ch.Metadata.Name)
+		require.Equal(t, 1, hits)
+	})
+
+	// What a chart rebuilt and re-uploaded under one version looks like from
+	// here. The cache is keyed on the digest and the bytes are re-checked
+	// against it, so the stale copy cannot answer for the new entry — which is
+	// the whole reason this cache is safe and a name-and-version one would not
+	// be.
+	t.Run("a moved digest misses, and the download is judged by the new one", func(t *testing.T) {
+		var hits int
+		s, e, base := serveChartFunc(t, digest, counting(&hits))
+		_, err := s.Pull(e, base)
+		require.NoError(t, err)
+		require.Equal(t, 1, hits)
+
+		moved := e
+		moved.Digest = "sha256:" + strings.Repeat("a", 64)
+		_, err = s.Pull(moved, base)
+		require.ErrorContains(t, err, "digest mismatch")
+		require.Equal(t, 2, hits, "the cache must not answer for a digest it does not hold")
+	})
+
+	t.Run("an entry with no digest is never cached", func(t *testing.T) {
+		var hits int
+		s, e, base := serveChartFunc(t, "", counting(&hits))
+		s.Warnf = func(string, ...any) {}
+		for range 2 {
+			_, err := s.Pull(e, base)
+			require.NoError(t, err)
+		}
+		require.Equal(t, 2, hits, "nothing could validate the read, so there is nothing to cache")
+		require.NoDirExists(t, s.chartCacheDir())
+	})
+
+	t.Run("a corrupted cache file falls through to a download", func(t *testing.T) {
+		var hits int
+		s, e, base := serveChartFunc(t, digest, counting(&hits))
+		_, err := s.Pull(e, base)
+		require.NoError(t, err)
+
+		cached := filepath.Join(s.chartCacheDir(), cacheKey(e)+".tgz")
+		require.NoError(t, os.WriteFile(cached, []byte("not a chart"), 0o644))
+
+		ch, err := s.Pull(e, base)
+		require.NoError(t, err)
+		require.Equal(t, "demo", ch.Metadata.Name)
+		require.Equal(t, 2, hits)
+	})
+
+	// The half of the TTL bound that keeps it from evicting the one archive
+	// every tick is using.
+	t.Run("a hit keeps the archive from ageing out", func(t *testing.T) {
+		s, e, base := serveChart(t, digest, tgz)
+		_, err := s.Pull(e, base)
+		require.NoError(t, err)
+
+		cached := filepath.Join(s.chartCacheDir(), cacheKey(e)+".tgz")
+		old := time.Now().Add(-chartCacheTTL - time.Hour)
+		require.NoError(t, os.Chtimes(cached, old, old))
+
+		_, err = s.Pull(e, base)
+		require.NoError(t, err)
+		info, err := os.Stat(cached)
+		require.NoError(t, err)
+		require.WithinDuration(t, time.Now(), info.ModTime(), time.Minute,
+			"otherwise a pinned chart ages out of its own cache and is downloaded again")
+	})
+}
+
+func TestCacheKey(t *testing.T) {
+	hexsum := strings.Repeat("ab", sha256.Size)
+	require.Equal(t, hexsum, cacheKey(IndexEntry{Digest: "sha256:" + hexsum}))
+	// `helm repo index` writes a bare hex sum, and hex is case-insensitive.
+	require.Equal(t, hexsum, cacheKey(IndexEntry{Digest: hexsum}))
+	require.Equal(t, hexsum, cacheKey(IndexEntry{Digest: strings.ToUpper(hexsum)}))
+
+	// Anything this package cannot verify is not cacheable: a read of it would
+	// have nothing to validate it against.
+	require.Empty(t, cacheKey(IndexEntry{}))
+	require.Empty(t, cacheKey(IndexEntry{Digest: "sha512:" + hexsum}))
+	require.Empty(t, cacheKey(IndexEntry{Digest: "sha256:" + hexsum[:32]}))
+	require.Empty(t, cacheKey(IndexEntry{Digest: "sha256:" + strings.Repeat("zz", sha256.Size)}))
+	// The key becomes a path component, and the digest is repository-supplied.
+	require.Empty(t, cacheKey(IndexEntry{Digest: "sha256:../../../etc/passwd"}))
+}
+
+func TestSweepChartCacheDropsWhatNothingReads(t *testing.T) {
+	dir := t.TempDir()
+	fresh, stale := filepath.Join(dir, "fresh.tgz"), filepath.Join(dir, "stale.tgz")
+	require.NoError(t, os.WriteFile(fresh, []byte("f"), 0o644))
+	require.NoError(t, os.WriteFile(stale, []byte("s"), 0o644))
+	old := time.Now().Add(-chartCacheTTL - time.Hour)
+	require.NoError(t, os.Chtimes(stale, old, old))
+
+	sweepChartCache(dir)
+
+	require.FileExists(t, fresh)
+	require.NoFileExists(t, stale)
+}
+
+func TestPullRetriesATransientFailure(t *testing.T) {
+	tgz := []byte(packDirToTgz(t, "testdata/demo", "demo"))
+	sum := sha256.Sum256(tgz)
+	digest := "sha256:" + hex.EncodeToString(sum[:])
+
+	t.Run("a 504 that clears is ridden out", func(t *testing.T) {
+		fastPullBackoff(t)
+		var hits int
+		s, e, base := serveChartFunc(t, digest, func(w http.ResponseWriter, _ *http.Request) {
+			hits++
+			if hits <= len(pullBackoff) {
+				http.Error(w, "gateway timeout", http.StatusGatewayTimeout)
+				return
+			}
+			_, _ = w.Write(tgz)
+		})
+		var warnings []string
+		s.Warnf = func(format string, a ...any) { warnings = append(warnings, fmt.Sprintf(format, a...)) }
+
+		ch, err := s.Pull(e, base)
+		require.NoError(t, err)
+		require.Equal(t, "demo", ch.Metadata.Name)
+		require.Equal(t, len(pullBackoff)+1, hits)
+		require.Len(t, warnings, len(pullBackoff), "every wait the caller cannot interrupt is announced")
+		require.Contains(t, warnings[0], "504")
+	})
+
+	t.Run("a persistent 504 gives up", func(t *testing.T) {
+		fastPullBackoff(t)
+		var hits int
+		s, e, base := serveChartFunc(t, digest, func(w http.ResponseWriter, _ *http.Request) {
+			hits++
+			http.Error(w, "gateway timeout", http.StatusGatewayTimeout)
+		})
+		s.Warnf = func(string, ...any) {}
+
+		_, err := s.Pull(e, base)
+		require.ErrorContains(t, err, "504")
+		require.Equal(t, len(pullBackoff)+1, hits, "the schedule is the whole budget")
+	})
+
+	// A repository that does not have this chart has said so. Asking twice more
+	// gets the same answer, three times as slowly.
+	t.Run("a 404 is not retried", func(t *testing.T) {
+		fastPullBackoff(t)
+		var hits int
+		s, e, base := serveChartFunc(t, digest, func(w http.ResponseWriter, r *http.Request) {
+			hits++
+			http.NotFound(w, r)
+		})
+
+		_, err := s.Pull(e, base)
+		require.ErrorContains(t, err, "404")
+		require.Equal(t, 1, hits)
+	})
 }
 
 func TestCompareVersions(t *testing.T) {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -48,6 +48,7 @@ between `SWARMCLI_LICENSE` and the license file, and
 | `~/.local/state/swarmcli/app-debug.log` | both | `0600` | Human-readable logs (`SWARMCLI_ENV=dev`), rotated the same way. |
 | `~/.local/state/swarmcli/charts/repos.json` | both | `0644` | Chart repositories configured with `swarmcli charts repo add`. |
 | `~/.local/state/swarmcli/charts/cache/index-<repo>.yaml` | both | `0644` | Cached repository index per configured repository. |
+| `~/.local/state/swarmcli/charts/cache/charts/<sha256>.tgz` | both | `0644` | Chart archives already downloaded, kept under the sha256 their repository index publishes. Re-verified on every read, and swept 30 days after the last one. |
 | `~/.config/swarmcli/update-notice.json` | both | `0644` | The release version at which the startup update notice was dismissed. |
 | `~/.config/swarmcli/license.key` | BE | `0600` | Active license key. Created by the startup prompt or by `:license <s>`. |
 | `~/.config/swarmcli/certs/<stack>/ca.pem` | BE | `0600` | CA cert from `:bootstrap`. |


### PR DESCRIPTION
Closes #605.

## The failure

`RepoStore.Pull` fetched a chart tarball with one `client.Get` and treated any
non-2xx as fatal, with nothing on disk to fall back to. The error is not scoped
to the release that could not be downloaded — it travels
`Pull` → `repoSource.Load` → `planRelease` → `PlanApply` — so a release-asset
host answering `504 Gateway Timeout` for a couple of seconds failed three
applications' entire reconcile and sent each into an escalating backoff, for
charts that were version-pinned, digest-published and already deployed from
those exact bytes.

Three calls earlier, `EnsureRepos` already makes the opposite decision for the
*index*, and says why: refreshing is best-effort because every version in the
manifest is pinned, so a stale cache can only fail to resolve a chart and never
resolve one wrongly. The index — mutable — falls back. The tarball — pinned,
immutable, covered by a sha256 the index just published — did not.

## What changed

**A content-addressed cache**, `<store>/cache/charts/<sha256>.tgz`, consulted
before the network. The read is gated by `verifyDigest` against the entry the
caller just resolved: the same check the download path runs, against an index
`EnsureRepos` has just refreshed. So the dangerous cases miss rather than
mislead — a chart rebuilt and re-uploaded under one version, a truncated write,
a hand-edited file all fall through to a download. An entry publishing no digest
is never cached, because nothing could validate the read; keying on name and
version instead would mean trusting a version to be immutable, which is exactly
what a repository is free to break.

The URL, scheme and plaintext checks stay ahead of the lookup, so a repository
this store refuses to download from is not one it serves out of cache either.

**Bounded retry** on 408, 429, 500, 502, 503, 504 and transport errors — two
retries, 0.5s then 2s, each announced through `Warnf`. `Pull` takes no context,
so an uninterruptible wait is one the caller is owed a reason for. 404 and 403
are the repository's answer about the chart and are not retried. This is what
covers a cold cache: a first deploy, a version bump, an application just added.

**Bounding the cache**: a hit refreshes the file's mtime, and a write sweeps
archives nothing has read for 30 days — so what ages out is the versions a
pinned release has moved past, and the cost of ageing out something still wanted
is the one download that would have happened anyway. Under `swarmcli-cd` the
cache sits in `<data>/charts/<app>/repositories/`, which `reclaim` already
deletes when an application leaves the set.

`writeCache` gained a second caller and its doc's first sentence stopped saying
"index"; nothing else in it changed.

## Cost

A persistent transient failure takes ~2.5s longer to report, and up to three
times the 30s client timeout against a blackholed host. In exchange the steady
state stops touching the network at all: a `swarmcli-cd` controller with six
chart applications on the 3-minute default was re-downloading six byte-identical
archives every three minutes, roughly 2,880 a day.

## Testing

`go test ./...`, `go vet`, `golangci-lint run ./charts/...` — all clean.

New coverage in `charts/repo_test.go`, each case mutation-checked (the guard was
confirmed to fail when the behaviour it asserts is removed):

- a second pull does not download again, and **a second `RepoStore` at the same
  directory reuses the cache** — the shape `swarmcli-cd` actually has, since it
  builds a fresh store per reconcile
- the cache answers when the repository is down (the reported failure)
- a moved digest misses, and the download it falls through to is judged by the
  new digest
- an entry with no digest is never cached, and leaves no cache directory
- a corrupted cache file falls through to a download
- a hit keeps an archive from ageing out of the sweep
- a 504 that clears is ridden out; a persistent 504 gives up after the schedule;
  a 404 is not retried
- `cacheKey` normalisation: prefixed, bare and uppercase hex accepted; absent,
  `sha512:`, short, non-hex and `../`-bearing digests refused

Not run: no chart repository outage was available to reproduce against, so the
504 path is exercised by an `httptest` server rather than by the real one.

Machine-generated by an AI agent (Claude Opus 5) and not human-reviewed. Claims carry a file, a line or a reproducible check so they can be verified cheaply.
