### PR TITLE
docs(release): upgrade notes for v2.0.0, and the trial expiry rule

### DIFF
--- a/.github/UPGRADE_NOTES.md
+++ b/.github/UPGRADE_NOTES.md
@@ -1,9 +1,46 @@
-<!--
-Upgrade Notes — curated breaking-change callout for the next release.
+### Trial licences must now carry an expiry
 
-Leave this file as-is (this comment only) when the release has no breaking
-changes. For a breaking release, replace the comment with migration prose in
-Markdown; the release workflow prepends it as a "## ⚠️ Upgrade Notes" section
-at the top of the GitHub release notes (see .github/workflows/release.yml).
-Clear it back to this comment once the GA is cut.
--->
+A `trial` licence with no expiry date no longer verifies. It is reported as
+**invalid** rather than expired — nothing has lapsed, so the remedy is a
+reissued trial key and not a renewal. Get a new one at
+[swarmcli.io/be](https://swarmcli.io/be) and install it as before.
+
+`be` (paid Business Edition) licences are unaffected and may still be perpetual.
+
+**This most likely reaches nobody.** Keys handed out by the issuing side have
+always carried an expiry, so one without is not believed to exist. Confirm in a
+second if you would rather be sure — a licence that reports valid on v1.14.0
+reports valid on v2.0.0:
+
+```bash
+swarmcli license status
+```
+
+Upgrade the pieces you run to the same version. Mixed versions can leave one of
+them honouring a key another refuses, which is awkward to diagnose rather than
+dangerous.
+
+### Importing `swarmcli` as a Go module? The path gained a `/v2`
+
+Go carries the major version in the module path from v2 on, so:
+
+```go
+import "github.com/Eldara-Tech/swarmcli/v2/charts"   // was .../swarmcli/charts
+```
+
+```bash
+go get github.com/Eldara-Tech/swarmcli/v2@v2.0.0
+```
+
+Nothing about the packages themselves changed — same names, same signatures, so
+the rewrite is the import lines and the `require`. Existing builds are not
+affected until they choose to move: a `require github.com/Eldara-Tech/swarmcli
+v1.14.0` goes on resolving v1.14.0 exactly as before.
+
+### Everything else
+
+There is no other breaking change. This repository carries none of its own in
+v2.0.0 — the major is shared across the SwarmCLI components and this release
+takes it for the licence change above. The Apache-2.0 build (`swarmcli_*_oss`,
+`eldaratech/swarmcli:<version>-oss`) contains no licensed code and is untouched
+by it; upgrading that one from v1.14.0 needs nothing at all.

--- a/docs/license.md
+++ b/docs/license.md
@@ -26,8 +26,10 @@ What a key records about you:
 
 - **Who it is for** — your customer identifier.
 - **Which tier** — `be` (Business Edition) or `trial`. Both grant the same
-  feature set today; `trial` is meant to be paired with a short expiry.
-- **When it expires**, if ever. A key may be issued without an expiry.
+  feature set today, so the expiry is what separates them — a `trial` must
+  carry one, and from v2.0.0 a key that does not is refused.
+- **When it expires**, if ever. A `be` key may be issued without an expiry; a
+  `trial` may not.
 - **Node and user limits**, if any. See [Limits](#limits).
 - **Which swarm it is bound to**, if any, and **how** — see
   [Per-swarm binding](#per-swarm-binding).


### PR DESCRIPTION
**Wording needs your eyes.** This is the first thing every v2.0.0 reader sees,
and I wrote it from the two closed PRs rather than from anyone's intent.

## Why

`.github/UPGRADE_NOTES.md` is still the shipped placeholder. `release.yml:54`
strips HTML comments and treats what is left as empty, so a GA tagged today
prepends nothing — a breaking major with no migration prose. RELEASING.md says
to fill it before tagging.

I ran the workflow's own test against the new file to be sure it is picked up,
rather than assuming:

```
NOTES=$(perl -0777 -pe 's/<!--.*?-->//gs' .github/UPGRADE_NOTES.md)
[ -z "$(printf '%s' "$NOTES" | tr -d '[:space:]')" ] && echo EMPTY || echo non-empty
→ non-empty — will be prepended as "## ⚠️ Upgrade Notes"
```

## What is in it

**The licence change that forces the major.** A trial with no expiry no longer
verifies; it reports invalid rather than expired, so the remedy is a reissued
key and not a renewal. Paid `be` keys are unaffected and may still be
perpetual. Framed around the question a reader actually has — *does this reach
me?* — because it almost certainly does not, and `swarmcli license status`
settles it in a second.

**The module path.** #604 gave this module its `/v2` suffix. It is labelled
`C0-breaks-nothing` and that is right in Go's terms — a `require … swarmcli
v1.14.0` goes on resolving v1.14.0 untouched — but it is still the migration
every importer has to make, and upgrade notes are where they would look. Two
lines showing the import and the `go get`.

**A note that nothing else is breaking**, and that the Apache-2.0 build is
untouched entirely.

## Disclosure

`swarmcli-be` and `swarmcli-agent` are private, so nothing from them appears
here: no payload field names, no tier or verifier symbols, no route names, no
threat-model reasoning, no private issue numbers. Only behaviour, how it fails
and the operator's remedy — the public half of CLAUDE.md's Pro Feature
Boundary. I diffed the added lines against that list before pushing.

Vocabulary is the vocabulary `docs/license.md` already uses publicly (`be` and
`trial` tiers, expiry, `swarmcli license status`).

## The docs/license.md hunk

Two sentences there stop being true: a trial "is meant to be paired with a
short expiry", and "a key may be issued without an expiry". Now a trial must
carry one, and only `be` may be perpetual.

## After the GA

RELEASING.md says to clear this file back to the placeholder once the GA is
cut. That is not part of this PR.

Machine-generated by an AI agent (Claude Opus 5) and not human-reviewed. Claims carry a file, a line or a reproducible check so they can be verified cheaply.
