### PR TITLE
feat(logs): a separator you can put in, and new lines that announce themselves

### DIFF
--- a/ui/ui.go
+++ b/ui/ui.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/x/ansi"
+	"github.com/muesli/termenv"
 )
 
 // Styles (you can override these per-view if desired)
@@ -433,24 +434,23 @@ func TruncateANSIAfter(s string, skipWidth int) string {
 	return ansi.TruncateLeft(s, skipWidth, "")
 }
 
-// SGR escapes used to embolden a line that already carries its own colours.
-const (
-	sgrBold  = "\x1b[1m"
-	sgrReset = "\x1b[0m"
-)
+// sgrReset ends the attribute this file asserts over a line.
+const sgrReset = "\x1b[0m"
 
-// BoldANSI renders s bold without discarding the colours it already carries.
-// A log line arrives with its own escapes — our own node prefix ends in a reset
-// — and a reset clears the bold along with everything else, so a plain
-// sgrBold+s would embolden the text only as far as the first one. Bold is
-// therefore re-asserted after every reset the line contains.
-func BoldANSI(s string) string {
+// BackgroundANSI draws s over background colour bg without discarding the
+// colours it already carries. A log line arrives with its own escapes — our own
+// node prefix ends in a reset — and a reset clears the background along with
+// everything else, so a plain sequence+s would tint the text only as far as the
+// first one. The background is therefore re-asserted after everything that
+// turns one off.
+func BackgroundANSI(s string, bg termenv.Color) string {
 	if s == "" {
 		return ""
 	}
+	sgrBg := termenv.CSI + bg.Sequence(true) + "m"
 	var b strings.Builder
-	b.Grow(len(s) + 2*len(sgrBold) + len(sgrReset))
-	b.WriteString(sgrBold)
+	b.Grow(len(s) + 2*len(sgrBg) + len(sgrReset))
+	b.WriteString(sgrBg)
 	for i := 0; i < len(s); {
 		seq, ok := csiAt(s, i)
 		if !ok {
@@ -460,9 +460,10 @@ func BoldANSI(s string) string {
 		}
 		b.WriteString(seq)
 		i += len(seq)
-		// seq is "\x1b[" + params + final; re-assert only after an SGR reset.
-		if seq[len(seq)-1] == 'm' && sgrResets(seq[2:len(seq)-1]) {
-			b.WriteString(sgrBold)
+		// seq is "\x1b[" + params + final; re-assert only where the line has
+		// turned the background off.
+		if seq[len(seq)-1] == 'm' && sgrClearsBackground(seq[2:len(seq)-1]) {
+			b.WriteString(sgrBg)
 		}
 	}
 	b.WriteString(sgrReset)
@@ -486,17 +487,42 @@ func csiAt(s string, i int) (string, bool) {
 	return s[i : j+1], true
 }
 
-// sgrResets reports whether an SGR parameter list turns attributes off. An
-// empty list is "\x1b[m", the shorthand for a full reset, and an omitted
-// parameter defaults to 0 — so "0", "" and "00" all reset.
-func sgrResets(params string) bool {
+// sgrClearsBackground reports whether an SGR parameter list turns the
+// background off: a reset — 0, an omitted parameter, or the empty "\x1b[m"
+// shorthand — or 49, which restores the default background without touching
+// anything else. The arguments of an extended colour are stepped over rather
+// than read: the 0 in "38;5;0" is a colour index, and a line that set its own
+// background must keep it across one.
+func sgrClearsBackground(params string) bool {
 	if params == "" {
 		return true
 	}
-	for _, p := range strings.Split(params, ";") {
-		if p == "" || strings.Trim(p, "0") == "" {
+	ps := strings.Split(params, ";")
+	for i := 0; i < len(ps); i++ {
+		switch strings.TrimLeft(ps[i], "0") {
+		case "": // "0", "00" and an omitted parameter all reset
 			return true
+		case "49":
+			return true
+		case "38", "48", "58":
+			i += extendedColorArgs(ps[i+1:])
 		}
 	}
 	return false
+}
+
+// extendedColorArgs is how many parameters follow a 38/48/58 selector: two for
+// "5;n" and four for "2;r;g;b". A form that is neither consumes nothing, which
+// leaves the walk exactly where it was.
+func extendedColorArgs(rest []string) int {
+	if len(rest) == 0 {
+		return 0
+	}
+	switch strings.TrimLeft(rest[0], "0") {
+	case "5":
+		return min(2, len(rest))
+	case "2":
+		return min(4, len(rest))
+	}
+	return 0
 }

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -432,3 +432,71 @@ func TruncateANSIAfter(s string, skipWidth int) string {
 	}
 	return ansi.TruncateLeft(s, skipWidth, "")
 }
+
+// SGR escapes used to embolden a line that already carries its own colours.
+const (
+	sgrBold  = "\x1b[1m"
+	sgrReset = "\x1b[0m"
+)
+
+// BoldANSI renders s bold without discarding the colours it already carries.
+// A log line arrives with its own escapes — our own node prefix ends in a reset
+// — and a reset clears the bold along with everything else, so a plain
+// sgrBold+s would embolden the text only as far as the first one. Bold is
+// therefore re-asserted after every reset the line contains.
+func BoldANSI(s string) string {
+	if s == "" {
+		return ""
+	}
+	var b strings.Builder
+	b.Grow(len(s) + 2*len(sgrBold) + len(sgrReset))
+	b.WriteString(sgrBold)
+	for i := 0; i < len(s); {
+		seq, ok := csiAt(s, i)
+		if !ok {
+			b.WriteByte(s[i])
+			i++
+			continue
+		}
+		b.WriteString(seq)
+		i += len(seq)
+		// seq is "\x1b[" + params + final; re-assert only after an SGR reset.
+		if seq[len(seq)-1] == 'm' && sgrResets(seq[2:len(seq)-1]) {
+			b.WriteString(sgrBold)
+		}
+	}
+	b.WriteString(sgrReset)
+	return b.String()
+}
+
+// csiAt returns the complete CSI sequence starting at i, if one starts there.
+// Parameter and intermediate bytes run 0x20–0x3f and the final byte ends the
+// sequence; an unterminated escape at the end of the string is not one.
+func csiAt(s string, i int) (string, bool) {
+	if s[i] != 0x1b || i+1 >= len(s) || s[i+1] != '[' {
+		return "", false
+	}
+	j := i + 2
+	for j < len(s) && s[j] >= 0x20 && s[j] <= 0x3f {
+		j++
+	}
+	if j >= len(s) {
+		return "", false
+	}
+	return s[i : j+1], true
+}
+
+// sgrResets reports whether an SGR parameter list turns attributes off. An
+// empty list is "\x1b[m", the shorthand for a full reset, and an omitted
+// parameter defaults to 0 — so "0", "" and "00" all reset.
+func sgrResets(params string) bool {
+	if params == "" {
+		return true
+	}
+	for _, p := range strings.Split(params, ";") {
+		if p == "" || strings.Trim(p, "0") == "" {
+			return true
+		}
+	}
+	return false
+}

--- a/ui/ui_test.go
+++ b/ui/ui_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/charmbracelet/lipgloss"
+	"github.com/muesli/termenv"
 	"github.com/stretchr/testify/require"
 )
 
@@ -147,7 +148,13 @@ func TestRenderFramedBoxHeightCannotShrinkBelowItsChrome(t *testing.T) {
 	require.Greater(t, len(strings.Split(out, "\n")), 6)
 }
 
-func TestBoldANSI_ReAssertsPastEveryReset(t *testing.T) {
+// bg is the 256-colour background these tests assert with, and its escape.
+var (
+	bg    = termenv.ANSI256Color(24)
+	sgrBg = "\x1b[48;5;24m"
+)
+
+func TestBackgroundANSI_ReAssertsPastEverythingThatClearsIt(t *testing.T) {
 	tests := []struct {
 		name string
 		in   string
@@ -156,29 +163,55 @@ func TestBoldANSI_ReAssertsPastEveryReset(t *testing.T) {
 		{
 			name: "plain text is wrapped once",
 			in:   "hello",
-			want: "\x1b[1mhello\x1b[0m",
+			want: sgrBg + "hello\x1b[0m",
 		},
 		{
 			// The log view's own node prefix: a colour, then a reset, then the
-			// message. Without the re-assertion the message would not be bold.
+			// message. Without the re-assertion the band would stop at the "|".
 			name: "a colour ending in a reset",
 			in:   "\x1b[38;5;117mweb.task@node\x1b[0m | msg",
-			want: "\x1b[1m\x1b[38;5;117mweb.task@node\x1b[0m\x1b[1m | msg\x1b[0m",
+			want: sgrBg + "\x1b[38;5;117mweb.task@node\x1b[0m" + sgrBg + " | msg\x1b[0m",
 		},
 		{
 			name: "a reset folded into a composite SGR",
 			in:   "a\x1b[0;32mb",
-			want: "\x1b[1ma\x1b[0;32m\x1b[1mb\x1b[0m",
+			want: sgrBg + "a\x1b[0;32m" + sgrBg + "b\x1b[0m",
 		},
 		{
 			name: "the empty-parameter reset shorthand",
 			in:   "a\x1b[mb",
-			want: "\x1b[1ma\x1b[m\x1b[1mb\x1b[0m",
+			want: sgrBg + "a\x1b[m" + sgrBg + "b\x1b[0m",
+		},
+		{
+			// 49 restores the default background without resetting anything
+			// else, so it clears the band while a bold would have survived it.
+			name: "the default-background code",
+			in:   "a\x1b[49mb",
+			want: sgrBg + "a\x1b[49m" + sgrBg + "b\x1b[0m",
 		},
 		{
 			name: "a colour that does not reset is left alone",
 			in:   "a\x1b[32mb",
-			want: "\x1b[1ma\x1b[32mb\x1b[0m",
+			want: sgrBg + "a\x1b[32mb\x1b[0m",
+		},
+		{
+			// The 0 is a colour index, not a reset. Re-asserting here would
+			// take a background the line set for itself away from it.
+			name: "an extended colour whose index looks like a reset",
+			in:   "\x1b[41ma\x1b[38;5;0mb",
+			want: sgrBg + "\x1b[41ma\x1b[38;5;0mb\x1b[0m",
+		},
+		{
+			name: "a truecolour component that looks like a default background",
+			in:   "a\x1b[38;2;0;49;120mb",
+			want: sgrBg + "a\x1b[38;2;0;49;120mb\x1b[0m",
+		},
+		{
+			// Past the arguments of the extended colour, an ordinary reset is
+			// still a reset.
+			name: "a reset after an extended colour",
+			in:   "a\x1b[38;5;117;0mb",
+			want: sgrBg + "a\x1b[38;5;117;0m" + sgrBg + "b\x1b[0m",
 		},
 		{
 			name: "empty in, empty out",
@@ -188,22 +221,22 @@ func TestBoldANSI_ReAssertsPastEveryReset(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			require.Equal(t, tc.want, BoldANSI(tc.in))
+			require.Equal(t, tc.want, BackgroundANSI(tc.in, bg))
 		})
 	}
 }
 
-func TestBoldANSI_PreservesWidthAndText(t *testing.T) {
+func TestBackgroundANSI_PreservesWidthAndText(t *testing.T) {
 	in := "\x1b[38;5;117mweb\x1b[0m | msg"
-	out := BoldANSI(in)
-	require.Equal(t, lipgloss.Width(in), lipgloss.Width(out), "bold adds no printable cells")
+	out := BackgroundANSI(in, bg)
+	require.Equal(t, lipgloss.Width(in), lipgloss.Width(out), "the band adds no printable cells")
 	require.Equal(t, "web | msg", stripSGR(out))
 }
 
-func TestBoldANSI_LeavesAnUnterminatedEscapeAlone(t *testing.T) {
+func TestBackgroundANSI_LeavesAnUnterminatedEscapeAlone(t *testing.T) {
 	// A truncated escape at the end of a line must not send the scan past the
 	// end of the string.
-	require.Equal(t, "\x1b[1mabc\x1b[38;5\x1b[0m", BoldANSI("abc\x1b[38;5"))
+	require.Equal(t, sgrBg+"abc\x1b[38;5\x1b[0m", BackgroundANSI("abc\x1b[38;5", bg))
 }
 
 // stripSGR removes CSI sequences so a test can assert on the text alone.

--- a/ui/ui_test.go
+++ b/ui/ui_test.go
@@ -146,3 +146,76 @@ func TestRenderFramedBoxHeightCannotShrinkBelowItsChrome(t *testing.T) {
 	out := RenderFramedBoxHeight("Title", "one\ntwo\nthree", "footer\nsecond", "x", 40, 6)
 	require.Greater(t, len(strings.Split(out, "\n")), 6)
 }
+
+func TestBoldANSI_ReAssertsPastEveryReset(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "plain text is wrapped once",
+			in:   "hello",
+			want: "\x1b[1mhello\x1b[0m",
+		},
+		{
+			// The log view's own node prefix: a colour, then a reset, then the
+			// message. Without the re-assertion the message would not be bold.
+			name: "a colour ending in a reset",
+			in:   "\x1b[38;5;117mweb.task@node\x1b[0m | msg",
+			want: "\x1b[1m\x1b[38;5;117mweb.task@node\x1b[0m\x1b[1m | msg\x1b[0m",
+		},
+		{
+			name: "a reset folded into a composite SGR",
+			in:   "a\x1b[0;32mb",
+			want: "\x1b[1ma\x1b[0;32m\x1b[1mb\x1b[0m",
+		},
+		{
+			name: "the empty-parameter reset shorthand",
+			in:   "a\x1b[mb",
+			want: "\x1b[1ma\x1b[m\x1b[1mb\x1b[0m",
+		},
+		{
+			name: "a colour that does not reset is left alone",
+			in:   "a\x1b[32mb",
+			want: "\x1b[1ma\x1b[32mb\x1b[0m",
+		},
+		{
+			name: "empty in, empty out",
+			in:   "",
+			want: "",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, BoldANSI(tc.in))
+		})
+	}
+}
+
+func TestBoldANSI_PreservesWidthAndText(t *testing.T) {
+	in := "\x1b[38;5;117mweb\x1b[0m | msg"
+	out := BoldANSI(in)
+	require.Equal(t, lipgloss.Width(in), lipgloss.Width(out), "bold adds no printable cells")
+	require.Equal(t, "web | msg", stripSGR(out))
+}
+
+func TestBoldANSI_LeavesAnUnterminatedEscapeAlone(t *testing.T) {
+	// A truncated escape at the end of a line must not send the scan past the
+	// end of the string.
+	require.Equal(t, "\x1b[1mabc\x1b[38;5\x1b[0m", BoldANSI("abc\x1b[38;5"))
+}
+
+// stripSGR removes CSI sequences so a test can assert on the text alone.
+func stripSGR(s string) string {
+	var b strings.Builder
+	for i := 0; i < len(s); {
+		if seq, ok := csiAt(s, i); ok {
+			i += len(seq)
+			continue
+		}
+		b.WriteByte(s[i])
+		i++
+	}
+	return b.String()
+}

--- a/views/logs/handlekey.go
+++ b/views/logs/handlekey.go
@@ -4,6 +4,8 @@
 package logsview
 
 import (
+	"time"
+
 	tea "github.com/charmbracelet/bubbletea"
 )
 
@@ -130,8 +132,18 @@ func HandleKey(m *Model, k tea.KeyMsg) tea.Cmd {
 		m.searchIndex = 0
 		return nil
 	case "enter":
-		// In normal mode, enter doesn't do anything
-		return nil
+		// The bash gesture: hitting enter under a `tail -f` pushes what has
+		// been read up the screen, so whatever arrives next is unmistakably
+		// new. There is no scrollback to push here, so the break goes into the
+		// buffer instead — at the end, under everything read so far.
+		m.mu.Lock()
+		m.appendLine(time.Now().Format(markTimeFormat), "", "", lineMark, time.Time{})
+		m.trimToMaxLines()
+		m.mu.Unlock()
+		l().Debugf("[logsview] 'enter' key pressed: separator inserted")
+		return func() tea.Msg {
+			return MarkInsertedMsg{}
+		}
 	case "n":
 		if len(m.searchMatches) > 0 {
 			m.searchIndex = (m.searchIndex + 1) % len(m.searchMatches)

--- a/views/logs/logs_test.go
+++ b/views/logs/logs_test.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/Eldara-Tech/swarmcli/v2/docker"
 
@@ -1113,4 +1114,330 @@ func TestSearchSurvivesTheBufferWrapping(t *testing.T) {
 		m.Update(LineMsg{Line: "node-a\x00task-run\x00needle"})
 	}
 	require.Equal(t, []int{1, 2, 3}, m.searchMatches)
+}
+
+// --- separator ("enter" mark) tests ---
+
+// markedModel returns a model holding one log line and then a separator.
+func markedModel(t *testing.T) *Model {
+	t.Helper()
+	m := testModel()
+	m.mu.Lock()
+	m.appendLine("first line", "node1", "task-1", lineLog, time.Time{})
+	m.mu.Unlock()
+	m.Update(key("enter"))
+	return m
+}
+
+func TestKey_Enter_InsertsMark(t *testing.T) {
+	m := testModel()
+	cmd := m.Update(key("enter"))
+
+	m.mu.Lock()
+	require.Len(t, m.lines, 1)
+	require.Equal(t, lineMark, m.lineKinds[0])
+	require.True(t, m.lineAt[0].IsZero(), "a separator is never new")
+	m.mu.Unlock()
+
+	require.NotNil(t, cmd)
+	require.IsType(t, MarkInsertedMsg{}, cmd())
+}
+
+func TestKey_Enter_MarkIsARuleAtViewportWidth(t *testing.T) {
+	m := markedModel(t)
+	rows := strings.Split(m.buildContent(), "\n")
+	require.Len(t, rows, 3, "one log line, then a blank row and the rule")
+	require.Equal(t, "", rows[1], "the rule is preceded by a blank row")
+	require.Equal(t, m.viewport.Width, lipgloss.Width(rows[2]))
+	require.Contains(t, ansi.Strip(rows[2]), "─")
+}
+
+func TestKey_Enter_MarkFollowsTheWidth(t *testing.T) {
+	m := markedModel(t)
+	m.Update(tea.WindowSizeMsg{Width: 40, Height: 24})
+
+	rows := strings.Split(m.buildContent(), "\n")
+	require.Equal(t, 40, lipgloss.Width(rows[len(rows)-1]),
+		"the rule is rendered at build time, so a resize re-cuts it")
+}
+
+func TestKey_Enter_MarkKeepsAFollowerAtTheBottom(t *testing.T) {
+	m := testModel()
+	m.viewport.Height = 3
+	m.mu.Lock()
+	for i := range 20 {
+		m.appendLine(fmt.Sprintf("line %d", i), "", "", lineLog, time.Time{})
+	}
+	m.mu.Unlock()
+	m.setFollow(true)
+	m.viewport.SetContent(m.buildContent())
+	m.viewport.GotoTop()
+
+	m.Update(key("enter"))
+	m.Update(MarkInsertedMsg{})
+	require.True(t, m.viewport.AtBottom(), "a follower must be shown the separator they just made")
+}
+
+func TestKey_Enter_InsertsNothingWhileTheNodeDialogIsOpen(t *testing.T) {
+	m := testModel()
+	m.mu.Lock()
+	m.nodeSelectVisible = true
+	m.nodeSelectNodes = []string{"All nodes", "node1"}
+	m.mu.Unlock()
+
+	m.Update(key("enter"))
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	require.Empty(t, m.lines, "enter selects a node there; it does not also mark the log")
+}
+
+func TestBuildContent_MarkSurvivesEveryFilter(t *testing.T) {
+	m := markedModel(t)
+	m.deps = docker.Deps{Snapshot: &mockSnapshotOps{snap: &docker.SwarmSnapshot{
+		Tasks: []swarm.Task{{ID: "task-1", ServiceID: "svc-123",
+			Status: swarm.TaskStatus{State: swarm.TaskStateShutdown}}},
+	}}}
+	m.setNodeFilter("some-other-node")
+	m.setHideStopped(true)
+	m.ApplySearchQuery("nothing matches this")
+
+	content := m.buildContent()
+	require.NotContains(t, content, "first line", "every filter hides the log line")
+	require.Contains(t, ansi.Strip(content), "─", "but never the separator")
+}
+
+func TestBuildContent_MarkIsNotCounted(t *testing.T) {
+	m := markedModel(t)
+	m.buildContent()
+	require.Equal(t, 1, m.getVisibleCount(), "a separator is not a log line")
+}
+
+func TestBuildContent_MarkIsNotASearchMatch(t *testing.T) {
+	m := testModel()
+	m.mu.Lock()
+	m.appendLine("12:34:56", "", "", lineMark, time.Time{})
+	m.searchTerm = ":"
+	m.mu.Unlock()
+
+	m.buildContent()
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	require.Empty(t, m.searchMatches, "a query must not land on a timestamp the reader did not write")
+}
+
+func TestBuildContent_NoWrap_MarkIgnoresHorizontalOffset(t *testing.T) {
+	m := markedModel(t)
+	m.setWrap(false)
+	m.horizontalOffset = 200
+
+	rows := strings.Split(m.buildContent(), "\n")
+	require.Equal(t, "", rows[0], "the log line has scrolled out of frame")
+	require.Equal(t, m.viewport.Width, lipgloss.Width(rows[2]),
+		"a separator that scrolled away would leave nothing to have marked")
+}
+
+// --- new-line highlight tests ---
+
+// fastFade shrinks the highlight timings for the duration of a test: a tea.Tick
+// cmd invoked synchronously blocks for its whole interval.
+func fastFade(t *testing.T) {
+	t.Helper()
+	prevTick, prevDur := fadeTickInterval, highlightDuration
+	fadeTickInterval, highlightDuration = time.Millisecond, 50*time.Millisecond
+	t.Cleanup(func() { fadeTickInterval, highlightDuration = prevTick, prevDur })
+}
+
+// armedModel returns a model past the backlog replay, so lines it receives from
+// here on are news and get highlighted.
+func armedModel() *Model {
+	m := testModel()
+	m.Visible = true
+	m.linesChan = make(chan string, 10)
+	m.errChan = make(chan error, 1)
+	m.mu.Lock()
+	m.highlightArmed = true
+	m.mu.Unlock()
+	return m
+}
+
+func TestBuildContent_FreshLineIsBold(t *testing.T) {
+	m := armedModel()
+	m.Update(LineMsg{Line: "node1\x00task-1\x00hello"})
+	require.Contains(t, m.buildContent(), "\x1b[1mhello")
+}
+
+func TestBuildContent_ExpiredLineIsPlain(t *testing.T) {
+	m := armedModel()
+	m.Update(LineMsg{Line: "node1\x00task-1\x00hello"})
+
+	m.mu.Lock()
+	m.lineAt[0] = time.Now().Add(-2 * highlightDuration)
+	m.mu.Unlock()
+
+	require.Equal(t, "hello", m.buildContent(), "the highlight expires back to the original line")
+}
+
+func TestBuildContent_FreshLineKeepsItsOwnColours(t *testing.T) {
+	m := armedModel()
+	// The node prefix formatLogLineWithNode builds ends in a reset, which would
+	// otherwise drop the bold from the message after it.
+	m.Update(LineMsg{Line: "node1\x00task-1\x00\x1b[38;5;117mweb.task@node1\x1b[0m | hello"})
+
+	content := m.buildContent()
+	require.Contains(t, content, "\x1b[38;5;117m", "the line keeps the colour it arrived with")
+	require.Contains(t, content, "\x1b[0m\x1b[1m | hello", "bold is re-asserted past the prefix's reset")
+}
+
+func TestBuildContent_FreshLineStaysBoldPastASearchHit(t *testing.T) {
+	m := armedModel()
+	m.Update(LineMsg{Line: "node1\x00task-1\x00before HIT after"})
+	m.mu.Lock()
+	m.searchTerm = "HIT"
+	m.mu.Unlock()
+
+	content := m.buildContent()
+	require.Contains(t, content, "\x1b[0m\x1b[1m after",
+		"the search highlight ends in a reset, and the rest of the line is still new")
+}
+
+func TestHighlight_BacklogDoesNotArm(t *testing.T) {
+	m := testModel()
+	m.Visible = true
+	m.linesChan = make(chan string, 10)
+	m.errChan = make(chan error, 1)
+
+	// The replay arrives back to back, which is exactly what makes it a replay.
+	for i := range 3 {
+		m.Update(LineMsg{Line: fmt.Sprintf("node1\x00task-1\x00backlog %d", i)})
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	require.False(t, m.highlightArmed)
+	for i, at := range m.lineAt {
+		require.True(t, at.IsZero(), "backlog line %d must never be highlighted", i)
+	}
+}
+
+func TestUpdate_InitStreamMsg_DisarmsForTheNewBacklog(t *testing.T) {
+	m := armedModel()
+	m.Update(LineMsg{Line: "node1\x00task-1\x00hello"})
+
+	m.Update(InitStreamMsg{Lines: make(chan string, 1), Errs: make(chan error, 1)})
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	require.False(t, m.highlightArmed, "a re-opened stream replays history, not news")
+	require.Zero(t, m.linesSinceInit)
+	require.True(t, m.lastLineAt.IsZero())
+}
+
+func TestHighlight_ArmsAfterAQuietGap(t *testing.T) {
+	m := testModel()
+	m.mu.Lock()
+	m.linesSinceInit = 1
+	m.lastLineAt = time.Now().Add(-highlightArmDelay)
+	m.armHighlight(time.Now())
+	armed := m.highlightArmed
+	m.mu.Unlock()
+	require.True(t, armed, "a gap between arrivals ends the replay")
+}
+
+func TestHighlight_ArmsPastTheBacklogSize(t *testing.T) {
+	m := testModel()
+	m.mu.Lock()
+	// A service logging faster than the gap gives no gap to read; the only
+	// other signal is having received more lines than the replay can hold.
+	m.linesSinceInit = backlogTail + 1
+	m.lastLineAt = time.Now()
+	m.armHighlight(time.Now())
+	armed := m.highlightArmed
+	m.mu.Unlock()
+	require.True(t, armed)
+}
+
+func TestHighlight_FirstLineEverDoesNotArm(t *testing.T) {
+	m := testModel()
+	m.mu.Lock()
+	m.linesSinceInit = 1
+	m.armHighlight(time.Now())
+	armed := m.highlightArmed
+	m.mu.Unlock()
+	require.False(t, armed, "with no previous line there is no gap, only an unset clock")
+}
+
+func TestFadeTickCmd_NilAtRest(t *testing.T) {
+	m := testModel()
+	require.Nil(t, m.fadeTickCmd(), "nothing is fresh, so nothing needs redrawing")
+}
+
+func TestFadeTickCmd_ArmsOnceForABurst(t *testing.T) {
+	fastFade(t)
+	m := armedModel()
+	for i := range 5 {
+		m.Update(LineMsg{Line: fmt.Sprintf("node1\x00task-1\x00line %d", i)})
+	}
+	require.True(t, m.fadeArmed)
+	require.Nil(t, m.fadeTickCmd(), "one beat must not gain a successor per line")
+}
+
+func TestUpdate_FadeTickMsg_ReArmsWhileFresh(t *testing.T) {
+	fastFade(t)
+	m := armedModel()
+	m.Update(LineMsg{Line: "node1\x00task-1\x00hello"})
+
+	cmd := m.Update(FadeTickMsg(time.Now()))
+	require.NotNil(t, cmd, "the highlight needs redraws to expire on time")
+}
+
+func TestUpdate_FadeTickMsg_StopsWhenNothingIsFresh(t *testing.T) {
+	fastFade(t)
+	m := armedModel()
+	m.Update(LineMsg{Line: "node1\x00task-1\x00hello"})
+
+	m.mu.Lock()
+	m.lineAt[0] = time.Now().Add(-2 * highlightDuration)
+	m.mu.Unlock()
+
+	require.Nil(t, m.Update(FadeTickMsg(time.Now())), "the beat must not run on at rest")
+}
+
+func TestAnyFresh_LooksPastATrailingMark(t *testing.T) {
+	m := armedModel()
+	m.Update(LineMsg{Line: "node1\x00task-1\x00hello"})
+	m.Update(key("enter"))
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	require.True(t, m.anyFresh(time.Now()), "a separator on top of a fresh line does not end the fade")
+}
+
+// --- viewport bookkeeping ---
+
+func TestSyncViewport_KeepsOffsetWhenNotFollowing(t *testing.T) {
+	m := armedModel()
+	m.setFollow(false)
+	m.viewport.Height = 3
+	for i := range 20 {
+		m.Update(LineMsg{Line: fmt.Sprintf("node1\x00task-1\x00line %d", i)})
+	}
+	m.viewport.YOffset = 5
+
+	m.Update(LineMsg{Line: "node1\x00task-1\x00one more"})
+	require.Equal(t, 5, m.viewport.YOffset, "a reader who scrolled up stays where they were")
+}
+
+func TestSyncViewport_TrimShiftsTheOffset(t *testing.T) {
+	m := armedModel()
+	m.setFollow(false)
+	m.MaxLines = 10
+	m.viewport.Height = 3
+	for i := range 10 {
+		m.Update(LineMsg{Line: fmt.Sprintf("node1\x00task-1\x00line %d", i)})
+	}
+	m.viewport.YOffset = 5
+
+	// The buffer is full, so this line pushes the oldest one out and every
+	// remaining line moves up by one row.
+	m.Update(LineMsg{Line: "node1\x00task-1\x00one more"})
+	require.Equal(t, 4, m.viewport.YOffset)
 }

--- a/views/logs/logs_test.go
+++ b/views/logs/logs_test.go
@@ -1441,3 +1441,104 @@ func TestSyncViewport_TrimShiftsTheOffset(t *testing.T) {
 	m.Update(LineMsg{Line: "node1\x00task-1\x00one more"})
 	require.Equal(t, 4, m.viewport.YOffset)
 }
+
+// --- stream notice tests ---
+
+// The filters key off a node and a task a notice does not have, so before
+// lineNotice existed a reader filtered to one node watched the stream die and
+// was told nothing at all.
+
+func TestStreamNotice_SurvivesTheNodeFilter(t *testing.T) {
+	m := testModel()
+	m.setNodeFilter("node-1")
+	m.mu.Lock()
+	m.appendLine("real log", "node-1", "t1", lineLog, time.Time{})
+	m.mu.Unlock()
+
+	m.Update(StreamErrMsg{Err: errors.New("connection lost")})
+	require.Contains(t, m.buildContent(), "connection lost")
+}
+
+func TestStreamNotice_SurvivesTheTextFilter(t *testing.T) {
+	m := testModel()
+	m.ApplySearchQuery("nginx")
+
+	m.Update(StreamDoneMsg{})
+	require.Contains(t, m.buildContent(), "stream closed")
+}
+
+func TestStreamNotice_IsNotCountedAsALogLine(t *testing.T) {
+	m := testModel()
+	m.mu.Lock()
+	m.appendLine("real log", "n1", "t1", lineLog, time.Time{})
+	m.mu.Unlock()
+
+	m.Update(StreamDoneMsg{})
+	m.buildContent()
+	require.Equal(t, 1, m.getVisibleCount(), "the view speaking is not the service logging")
+}
+
+func TestStreamNotice_IsStillFoundByTheSearch(t *testing.T) {
+	m := testModel()
+	m.Update(StreamErrMsg{Err: errors.New("connection lost")})
+	m.mu.Lock()
+	m.searchTerm = "connection"
+	m.mu.Unlock()
+
+	m.buildContent()
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	require.Len(t, m.searchMatches, 1, "ctrl+f seeks rather than hides, so a notice is still a hit")
+}
+
+// bothNotices is every message that makes the view speak for itself. They are
+// separate cases in Update, so a test that exercises one proves nothing about
+// the other.
+func bothNotices() map[string]tea.Msg {
+	return map[string]tea.Msg{
+		"error":  StreamErrMsg{Err: errors.New("connection lost")},
+		"closed": StreamDoneMsg{},
+	}
+}
+
+func TestStreamNotice_ShownToAFollower(t *testing.T) {
+	for name, msg := range bothNotices() {
+		t.Run(name, func(t *testing.T) {
+			m := testModel()
+			m.viewport.Height = 3
+			m.setFollow(true)
+			m.mu.Lock()
+			for i := range 20 {
+				m.appendLine(fmt.Sprintf("line %d", i), "n1", "t1", lineLog, time.Time{})
+			}
+			m.mu.Unlock()
+			m.viewport.SetContent(m.buildContent())
+			m.viewport.GotoBottom()
+
+			m.Update(msg)
+			require.True(t, m.viewport.AtBottom(),
+				"the one line saying why nothing else is coming must not land below the window")
+		})
+	}
+}
+
+func TestStreamNotice_RespectsMaxLines(t *testing.T) {
+	for name, msg := range bothNotices() {
+		t.Run(name, func(t *testing.T) {
+			m := testModel()
+			m.MaxLines = 2
+			m.mu.Lock()
+			for i := range 2 {
+				m.appendLine(fmt.Sprintf("line %d", i), "n1", "t1", lineLog, time.Time{})
+			}
+			m.mu.Unlock()
+
+			m.Update(msg)
+
+			m.mu.Lock()
+			defer m.mu.Unlock()
+			require.Len(t, m.lines, 2, "a notice is bounded by the buffer like everything else")
+			require.Len(t, m.lineKinds, 2, "and trimmed in lock-step")
+		})
+	}
+}

--- a/views/logs/logs_test.go
+++ b/views/logs/logs_test.go
@@ -1260,10 +1260,59 @@ func armedModel() *Model {
 	return m
 }
 
-func TestBuildContent_FreshLineIsBold(t *testing.T) {
+// freshBg is the escape the band opens with, spelled out rather than derived
+// from freshBackground: a test that built it the way the code does would follow
+// the colour anywhere, including to a colour nobody can see.
+const freshBg = "\x1b[48;5;24m"
+
+func TestBuildContent_FreshLineIsHighlighted(t *testing.T) {
 	m := armedModel()
 	m.Update(LineMsg{Line: "node1\x00task-1\x00hello"})
-	require.Contains(t, m.buildContent(), "\x1b[1mhello")
+	require.Contains(t, m.buildContent(), freshBg+"hello")
+}
+
+func TestBuildContent_FreshLineSpansTheFrame(t *testing.T) {
+	m := armedModel()
+	m.Update(LineMsg{Line: "node1\x00task-1\x00hello"})
+
+	row := m.buildContent()
+	require.Equal(t, m.viewport.Width, lipgloss.Width(row), "the band is the row, not the text on it")
+	require.Equal(t, "hello"+strings.Repeat(" ", m.viewport.Width-len("hello")), ansi.Strip(row))
+}
+
+func TestBuildContent_Wrap_EveryRowOfAFreshLineIsHighlighted(t *testing.T) {
+	m := armedModel()
+	m.Update(LineMsg{Line: "node1\x00task-1\x00" + strings.Repeat("word ", 40)})
+
+	rows := strings.Split(m.buildContent(), "\n")
+	require.Greater(t, len(rows), 1, "the line has to wrap for this to test anything")
+	for i, row := range rows {
+		require.True(t, strings.HasPrefix(row, freshBg), "row %d is a row of a new line", i)
+		require.Equal(t, m.viewport.Width, lipgloss.Width(row), "row %d", i)
+	}
+}
+
+func TestBuildContent_MarkDoesNotShiftTheHighlight(t *testing.T) {
+	m := armedModel()
+	m.Update(key("enter")) // one line in the buffer, two rows on the screen
+	m.Update(LineMsg{Line: "node1\x00task-1\x00hello"})
+
+	rows := strings.Split(m.buildContent(), "\n")
+	require.Len(t, rows, 3)
+	require.True(t, strings.HasPrefix(rows[2], freshBg), "the new line is the row that gets the band")
+	require.NotContains(t, rows[0]+rows[1], freshBg, "a separator is not new")
+}
+
+func TestBuildContent_NoWrap_FreshBandIsPaintedAfterTheScroll(t *testing.T) {
+	m := armedModel()
+	m.setWrap(false)
+	m.Update(LineMsg{Line: "node1\x00task-1\x00hello"})
+	m.horizontalOffset = 2
+
+	row := m.buildContent()
+	require.Equal(t, "llo", strings.TrimRight(ansi.Strip(row), " "), "the row has scrolled")
+	require.Equal(t, m.viewport.Width, lipgloss.Width(row),
+		"padding measured before the scroll would come up short by the offset")
 }
 
 func TestBuildContent_ExpiredLineIsPlain(t *testing.T) {
@@ -1280,15 +1329,15 @@ func TestBuildContent_ExpiredLineIsPlain(t *testing.T) {
 func TestBuildContent_FreshLineKeepsItsOwnColours(t *testing.T) {
 	m := armedModel()
 	// The node prefix formatLogLineWithNode builds ends in a reset, which would
-	// otherwise drop the bold from the message after it.
+	// otherwise end the band at the message after it.
 	m.Update(LineMsg{Line: "node1\x00task-1\x00\x1b[38;5;117mweb.task@node1\x1b[0m | hello"})
 
 	content := m.buildContent()
 	require.Contains(t, content, "\x1b[38;5;117m", "the line keeps the colour it arrived with")
-	require.Contains(t, content, "\x1b[0m\x1b[1m | hello", "bold is re-asserted past the prefix's reset")
+	require.Contains(t, content, "\x1b[0m"+freshBg+" | hello", "the band is re-asserted past the prefix's reset")
 }
 
-func TestBuildContent_FreshLineStaysBoldPastASearchHit(t *testing.T) {
+func TestBuildContent_FreshLineStaysHighlightedPastASearchHit(t *testing.T) {
 	m := armedModel()
 	m.Update(LineMsg{Line: "node1\x00task-1\x00before HIT after"})
 	m.mu.Lock()
@@ -1296,7 +1345,7 @@ func TestBuildContent_FreshLineStaysBoldPastASearchHit(t *testing.T) {
 	m.mu.Unlock()
 
 	content := m.buildContent()
-	require.Contains(t, content, "\x1b[0m\x1b[1m after",
+	require.Contains(t, content, "\x1b[0m"+freshBg+" after",
 		"the search highlight ends in a reset, and the rest of the line is still new")
 }
 

--- a/views/logs/messages.go
+++ b/views/logs/messages.go
@@ -3,6 +3,8 @@
 
 package logsview
 
+import "time"
+
 type InitStreamMsg struct {
 	Lines    chan string
 	Errs     chan error
@@ -24,3 +26,29 @@ type WrapToggledMsg struct{}
 type NodeFilterToggledMsg struct{}
 
 type HideStoppedToggledMsg struct{}
+
+// MarkInsertedMsg signals that the reader put a separator in the buffer, so the
+// viewport has to be rebuilt around it.
+type MarkInsertedMsg struct{}
+
+// FadeTickMsg drives the expiry of the new-line highlight: without a beat, a
+// line that arrives into silence has nothing to redraw it back to normal.
+type FadeTickMsg time.Time
+
+// Highlight timings. All three are vars, not consts, so tests can shrink them:
+// a tea.Tick cmd invoked synchronously blocks for its whole interval, and a
+// test that waited out a real highlight would sit here for over a second.
+var (
+	// highlightDuration is how long a freshly arrived line stays bold.
+	highlightDuration = 1200 * time.Millisecond
+	// fadeTickInterval is how closely the expiry follows highlightDuration.
+	fadeTickInterval = 150 * time.Millisecond
+	// highlightArmDelay is the gap between arrivals that marks the end of the
+	// backlog replay a stream opens with.
+	highlightArmDelay = 300 * time.Millisecond
+)
+
+// backlogTail is how many lines of history the stream asks Docker to replay.
+// The highlight reads it too — it is the upper bound on the lines that are
+// history rather than news — so the two cannot drift.
+const backlogTail = 200

--- a/views/logs/model.go
+++ b/views/logs/model.go
@@ -10,6 +10,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/charmbracelet/bubbles/viewport"
 	tea "github.com/charmbracelet/bubbletea"
@@ -25,9 +26,11 @@ type Model struct {
 	searchTerm    string
 	searchIndex   int
 	searchMatches []int
-	lines         []string // bounded: only last MaxLines kept
-	lineNodes     []string // node name for each line (parallel to lines)
-	lineTasks     []string // full task ID for each line (parallel to lines), "" if unparseable
+	lines         []string    // bounded: only last MaxLines kept
+	lineNodes     []string    // node name for each line (parallel to lines)
+	lineTasks     []string    // full task ID for each line (parallel to lines), "" if unparseable
+	lineKinds     []lineKind  // log line or separator (parallel to lines)
+	lineAt        []time.Time // arrival time (parallel to lines), zero when the line is not new
 	MaxLines      int
 	ready         bool
 	// visibleCount is how many lines passed the filters the last time content
@@ -62,6 +65,12 @@ type Model struct {
 	filterQuery string
 	// when true, hide log lines from tasks that are no longer running
 	hideStopped bool
+
+	// new-line highlight state
+	linesSinceInit int       // lines received since the stream opened
+	lastLineAt     time.Time // when the previous line arrived
+	highlightArmed bool      // false until the backlog replay is over
+	fadeArmed      bool      // a fade tick is already scheduled
 	// node selection dialog
 	nodeSelectVisible bool
 	nodeSelectCursor  int
@@ -80,6 +89,8 @@ func New(width, height int, maxLines int, service docker.ServiceEntry) *Model {
 		lines:             make([]string, 0, 1024),
 		lineNodes:         make([]string, 0, 1024),
 		lineTasks:         make([]string, 0, 1024),
+		lineKinds:         make([]lineKind, 0, 1024),
+		lineAt:            make([]time.Time, 0, 1024),
 		MaxLines:          maxLines,
 		StreamCtx:         ctx,
 		StreamCancel:      cancel,
@@ -95,6 +106,111 @@ func New(width, height int, maxLines int, service docker.ServiceEntry) *Model {
 		nodeSelectCursor:  0,
 		nodeSelectNodes:   []string{},
 	}
+}
+
+// lineKind distinguishes a streamed log line from a separator the reader asked
+// for with "enter". A mark carries no node or task and no arrival time, and is
+// rendered at build time rather than stored, so it follows the current width.
+type lineKind uint8
+
+const (
+	lineLog lineKind = iota
+	lineMark
+)
+
+// appendLine grows the per-line slices in lock-step. They are indexed together
+// everywhere, so growing them anywhere but here is how they come apart.
+// Callers hold m.mu.
+func (m *Model) appendLine(text, node, task string, kind lineKind, at time.Time) {
+	m.lines = append(m.lines, text)
+	m.lineNodes = append(m.lineNodes, node)
+	m.lineTasks = append(m.lineTasks, task)
+	m.lineKinds = append(m.lineKinds, kind)
+	m.lineAt = append(m.lineAt, at)
+}
+
+// trimToMaxLines drops the oldest lines once the buffer is over MaxLines and
+// returns how many it dropped — which is what a viewport that is not following
+// has to take off its offset to keep showing the same lines. Callers hold m.mu.
+func (m *Model) trimToMaxLines() int {
+	if m.MaxLines <= 0 || len(m.lines) <= m.MaxLines {
+		return 0
+	}
+	start := len(m.lines) - m.MaxLines
+	m.lines = append(make([]string, 0, m.MaxLines), m.lines[start:]...)
+	m.lineNodes = append(make([]string, 0, m.MaxLines), m.lineNodes[start:]...)
+	m.lineTasks = append(make([]string, 0, m.MaxLines), m.lineTasks[start:]...)
+	m.lineKinds = append(make([]lineKind, 0, m.MaxLines), m.lineKinds[start:]...)
+	m.lineAt = append(make([]time.Time, 0, m.MaxLines), m.lineAt[start:]...)
+	return start
+}
+
+// kindAt and arrivedAt read the newer per-line slices tolerantly: a caller that
+// set m.lines wholesale — SetContent, and every test that builds a buffer by
+// hand — leaves them short, and a short slice means "an ordinary log line that
+// is not new" rather than an index panic.
+func (m *Model) kindAt(i int) lineKind {
+	if i < len(m.lineKinds) {
+		return m.lineKinds[i]
+	}
+	return lineLog
+}
+
+func (m *Model) arrivedAt(i int) time.Time {
+	if i < len(m.lineAt) {
+		return m.lineAt[i]
+	}
+	return time.Time{}
+}
+
+// armHighlight opens the highlight once the backlog replay is over. A stream
+// opens with the lines Docker replays for the tail request: that is history,
+// not news, and highlighting it would flash the whole screen at open. Two
+// signals end the replay, and each covers the other's blind spot — a gap
+// between arrivals, which a quiet service gives immediately, and more lines
+// than the backlog can hold, which is the only signal a service logging
+// faster than the gap will ever give. Callers hold m.mu.
+func (m *Model) armHighlight(now time.Time) {
+	if m.highlightArmed {
+		return
+	}
+	if m.linesSinceInit > backlogTail ||
+		(!m.lastLineAt.IsZero() && now.Sub(m.lastLineAt) >= highlightArmDelay) {
+		m.highlightArmed = true
+	}
+}
+
+// stamp is the arrival time to record for a line landing now: the real time
+// once highlighting is armed, and the zero time before that, which is what
+// makes a line permanently not new. Callers hold m.mu.
+func (m *Model) stamp(now time.Time) time.Time {
+	if !m.highlightArmed {
+		return time.Time{}
+	}
+	return now
+}
+
+// isFresh reports whether the line at i is still inside its highlight window.
+// Callers hold m.mu.
+func (m *Model) isFresh(i int, now time.Time) bool {
+	if m.kindAt(i) == lineMark {
+		return false
+	}
+	at := m.arrivedAt(i)
+	return !at.IsZero() && now.Sub(at) < highlightDuration
+}
+
+// anyFresh reports whether any line is still highlighted. Arrival times only
+// ever grow, so the newest log line settles it — the walk exists to step over
+// marks, which carry no arrival time of their own. Callers hold m.mu.
+func (m *Model) anyFresh(now time.Time) bool {
+	for i := len(m.lines) - 1; i >= 0; i-- {
+		if m.kindAt(i) == lineMark {
+			continue
+		}
+		return m.isFresh(i, now)
+	}
+	return false
 }
 
 func (m *Model) Init() tea.Cmd { return nil }
@@ -240,6 +356,7 @@ func (m *Model) ShortHelpItems() []helpbar.HelpEntry {
 		{Key: "w", Desc: "Toggle wrap"},
 		{Key: "o", Desc: "Filter node"},
 		{Key: "t", Desc: "Show/hide stopped"},
+		{Key: "enter", Desc: "Mark"},
 	}
 
 	// Show left/right help only when wrap is off
@@ -301,6 +418,12 @@ func (m *Model) stoppedTaskIDs() map[string]bool {
 // (node filter, "/" text filter, hide-stopped). Callers must hold m.mu and pass
 // the precomputed stopped-task set (nil = don't apply the hide-stopped filter).
 func (m *Model) lineVisible(i int, stopped map[string]bool) bool {
+	// A separator the reader put in is exempt from every filter. It is their
+	// mark of where they had read to, and a filter that swallowed it would
+	// answer a keypress with nothing at all.
+	if m.kindAt(i) == lineMark {
+		return true
+	}
 	// node filter
 	if m.nodeFilter != "" && (i >= len(m.lineNodes) || m.lineNodes[i] != m.nodeFilter) {
 		return false

--- a/views/logs/model.go
+++ b/views/logs/model.go
@@ -108,14 +108,18 @@ func New(width, height int, maxLines int, service docker.ServiceEntry) *Model {
 	}
 }
 
-// lineKind distinguishes a streamed log line from a separator the reader asked
-// for with "enter". A mark carries no node or task and no arrival time, and is
-// rendered at build time rather than stored, so it follows the current width.
+// lineKind distinguishes what the view itself put in the buffer from what the
+// service actually logged. A mark is the separator the reader asked for with
+// "enter": it carries no node or task and no arrival time, and is rendered at
+// build time rather than stored, so it follows the current width. A notice is
+// the view speaking about the stream — an error, or the stream closing. Only a
+// lineLog is filterable and counted; see lineVisible and renderRows.
 type lineKind uint8
 
 const (
 	lineLog lineKind = iota
 	lineMark
+	lineNotice
 )
 
 // appendLine grows the per-line slices in lock-step. They are indexed together
@@ -418,10 +422,14 @@ func (m *Model) stoppedTaskIDs() map[string]bool {
 // (node filter, "/" text filter, hide-stopped). Callers must hold m.mu and pass
 // the precomputed stopped-task set (nil = don't apply the hide-stopped filter).
 func (m *Model) lineVisible(i int, stopped map[string]bool) bool {
-	// A separator the reader put in is exempt from every filter. It is their
-	// mark of where they had read to, and a filter that swallowed it would
-	// answer a keypress with nothing at all.
-	if m.kindAt(i) == lineMark {
+	// Anything the view itself put in the buffer is exempt from every filter.
+	// A separator is the reader's mark of where they had read to, and a filter
+	// that swallowed it would answer a keypress with nothing at all. A notice
+	// is worse: the filters key off a node and a task a notice does not have,
+	// so a reader filtered to one node would watch the stream die and be told
+	// nothing. A notice is still matched by the "ctrl+f" search — that seeks
+	// rather than hides, and finding one is no reason to hide the rest.
+	if m.kindAt(i) != lineLog {
 		return true
 	}
 	// node filter

--- a/views/logs/register.go
+++ b/views/logs/register.go
@@ -18,5 +18,5 @@ func factory(deps docker.Deps, w, h int, payload any) (view.View, tea.Cmd) {
 	service := payload.(docker.ServiceEntry)
 	v := New(w, h, 10000, service)
 	v.deps = deps
-	return v, v.startStreamingCmd(v.StreamCtx, service, 200, v.MaxLines)
+	return v, v.startStreamingCmd(v.StreamCtx, service, backlogTail, v.MaxLines)
 }

--- a/views/logs/update.go
+++ b/views/logs/update.go
@@ -8,6 +8,7 @@ import (
 	"github.com/Eldara-Tech/swarmcli/v2/ui"
 	"github.com/Eldara-Tech/swarmcli/v2/utils"
 	"strings"
+	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
@@ -23,6 +24,14 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 		m.linesChan = msg.Lines
 		m.errChan = msg.Errs
 		m.Visible = true
+		// A re-opened stream replays its backlog again, so everything that
+		// decides when the replay is over starts over with it — otherwise the
+		// second open would highlight its own history.
+		m.mu.Lock()
+		m.linesSinceInit = 0
+		m.lastLineAt = time.Time{}
+		m.highlightArmed = false
+		m.mu.Unlock()
 		l().Debugf("[logsview] stream initialized")
 		return m.readOneLineCmd()
 
@@ -42,93 +51,43 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 		actualLine = strings.ReplaceAll(actualLine, "\r", "")
 
 		// append line into bounded buffer (store line, node and task)
+		now := time.Now()
 		m.mu.Lock()
+		m.linesSinceInit++
+		// Read before lastLineAt moves: the gap that ends the backlog replay is
+		// the one between this line and the one before it.
+		m.armHighlight(now)
 		// store line as-is (no newline); rendering will join with '\n'
-		m.lines = append(m.lines, actualLine)
-		m.lineNodes = append(m.lineNodes, nodeName)
-		m.lineTasks = append(m.lineTasks, taskID)
-
-		// track how many lines we're dropping from the top
-		linesDropped := 0
-
-		// trim if over MaxLines
-		if m.MaxLines > 0 && len(m.lines) > m.MaxLines {
-			// drop older lines from both slices
-			start := len(m.lines) - m.MaxLines
-			linesDropped = start
-			newBuf := make([]string, 0, m.MaxLines)
-			newBuf = append(newBuf, m.lines[start:]...)
-			m.lines = newBuf
-
-			newNodeBuf := make([]string, 0, m.MaxLines)
-			newNodeBuf = append(newNodeBuf, m.lineNodes[start:]...)
-			m.lineNodes = newNodeBuf
-
-			newTaskBuf := make([]string, 0, m.MaxLines)
-			newTaskBuf = append(newTaskBuf, m.lineTasks[start:]...)
-			m.lineTasks = newTaskBuf
-		}
-
-		shouldFollow := m.follow
+		m.appendLine(actualLine, nodeName, taskID, lineLog, m.stamp(now))
+		m.lastLineAt = now
+		linesDropped := m.trimToMaxLines()
 		m.mu.Unlock()
 
-		if m.ready {
-			// auto-follow behavior: only scroll to bottom when follow is enabled
-			if shouldFollow {
-				m.viewport.SetContent(m.buildContent())
-				m.viewport.GotoBottom()
-			} else {
-				// Save current offset before updating content
-				savedOffset := m.viewport.YOffset
-				m.viewport.SetContent(m.buildContent())
-
-				// Adjust offset if we dropped lines from the top
-				newOffset := savedOffset
-				if linesDropped > 0 {
-					newOffset = savedOffset - linesDropped
-					if newOffset < 0 {
-						newOffset = 0
-					}
-				}
-
-				// Ensure offset is within bounds (important when wrapping changes line count)
-				maxOffset := m.viewport.TotalLineCount() - m.viewport.Height
-				if maxOffset < 0 {
-					maxOffset = 0
-				}
-				if newOffset > maxOffset {
-					newOffset = maxOffset
-				}
-
-				m.viewport.YOffset = newOffset
-			}
-		}
-		return m.readOneLineCmd()
+		m.syncViewport(linesDropped)
+		return tea.Batch(m.readOneLineCmd(), m.fadeTickCmd())
 
 	case StreamErrMsg:
 		// append an error line and stop
+		now := time.Now()
 		m.mu.Lock()
-		m.lines = append(m.lines, fmt.Sprintf("Error: %v", msg.Err))
-		m.lineNodes = append(m.lineNodes, "")
-		m.lineTasks = append(m.lineTasks, "")
+		m.appendLine(fmt.Sprintf("Error: %v", msg.Err), "", "", lineLog, m.stamp(now))
 		m.mu.Unlock()
 		l().Errorf("[logsview] stream error: %v", msg.Err)
 		if m.ready {
 			m.viewport.SetContent(m.buildContent())
 		}
-		return nil
+		return m.fadeTickCmd()
 
 	case StreamDoneMsg:
+		now := time.Now()
 		m.mu.Lock()
-		m.lines = append(m.lines, "--- stream closed ---")
-		m.lineNodes = append(m.lineNodes, "")
-		m.lineTasks = append(m.lineTasks, "")
+		m.appendLine("--- stream closed ---", "", "", lineLog, m.stamp(now))
 		m.mu.Unlock()
 		l().Debugf("[logsview] stream closed")
 		if m.ready {
 			m.viewport.SetContent(m.buildContent())
 		}
-		return nil
+		return m.fadeTickCmd()
 
 	case WrapToggledMsg:
 		// Refresh viewport content with new wrap setting
@@ -178,6 +137,24 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 			}
 		}
 		return nil
+
+	case MarkInsertedMsg:
+		// The separator goes in at the end of the buffer, so it lands under
+		// everything read so far and above everything still to come.
+		m.syncViewport(0)
+		return nil
+
+	case FadeTickMsg:
+		m.mu.Lock()
+		m.fadeArmed = false
+		m.mu.Unlock()
+		if m.ready {
+			// Only the highlight expired: the rendered row count is unchanged,
+			// so SetContent leaves a reader who scrolled up exactly where they
+			// were, and a follower already at the bottom stays there.
+			m.viewport.SetContent(m.buildContent())
+		}
+		return m.fadeTickCmd()
 
 	case tea.WindowSizeMsg:
 		// Safety check: ensure dimensions are positive
@@ -283,9 +260,13 @@ func (m *Model) SetContent(content string) {
 	}
 	// SetContent carries no per-line node/task metadata; reset the parallel
 	// slices to empty (length-aligned) so all lines are treated as
-	// unfilterable (always visible) and indices stay aligned.
+	// unfilterable (always visible) and indices stay aligned. The zero lineKind
+	// is an ordinary log line and the zero time is "not new", which is what
+	// content that did not arrive over the stream should be.
 	m.lineNodes = make([]string, len(m.lines))
 	m.lineTasks = make([]string, len(m.lines))
+	m.lineKinds = make([]lineKind, len(m.lines))
+	m.lineAt = make([]time.Time, len(m.lines))
 	m.searchMatches = nil
 	m.searchTerm = ""
 	m.searchIndex = 0
@@ -313,75 +294,148 @@ func (m *Model) highlightContent() {
 	}
 }
 
-// buildContent returns the full content (required by viewport) — HighlightMatches may return colored output.
+// syncViewport rebuilds the content and keeps the reader where they were:
+// pinned to the bottom while following, and otherwise on the same lines, which
+// means taking off the offset however many lines the trim just dropped.
+func (m *Model) syncViewport(linesDropped int) {
+	if !m.ready {
+		return
+	}
+	if m.getFollow() {
+		m.viewport.SetContent(m.buildContent())
+		m.viewport.GotoBottom()
+		return
+	}
+	savedOffset := m.viewport.YOffset
+	m.viewport.SetContent(m.buildContent())
+
+	newOffset := savedOffset - linesDropped
+	if newOffset < 0 {
+		newOffset = 0
+	}
+	// Keep the offset in bounds — wrapping changes how many rows the same
+	// lines occupy, so an offset that was valid before need not be now.
+	maxOffset := m.viewport.TotalLineCount() - m.viewport.Height
+	if maxOffset < 0 {
+		maxOffset = 0
+	}
+	if newOffset > maxOffset {
+		newOffset = maxOffset
+	}
+	m.viewport.YOffset = newOffset
+}
+
+// fadeTickCmd schedules the redraw that lets a highlight expire, and only when
+// one is live and no beat is already in flight. Arming from every arriving line
+// would give one beat as many successors as there were lines, and each of those
+// would do the same — the rate would not merely multiply once, it would
+// multiply again on every beat.
+func (m *Model) fadeTickCmd() tea.Cmd {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.fadeArmed || !m.anyFresh(time.Now()) {
+		return nil
+	}
+	m.fadeArmed = true
+	return tea.Tick(fadeTickInterval, func(t time.Time) tea.Msg { return FadeTickMsg(t) })
+}
+
+// buildContent returns the full content (required by viewport) — rows may carry
+// search highlighting and the bold of a freshly arrived line.
 func (m *Model) buildContent() string {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
+	rows, isMark := m.renderRows(time.Now())
+
+	// Apply wrapping based on wrap setting
+	// BUT: skip wrapping if node selection dialog is visible to avoid overlay issues
+	if m.wrap && m.viewport.Width > 0 && !m.nodeSelectVisible {
+		// Wrap the entire content to viewport width
+		return wordwrap.String(strings.Join(rows, "\n"), m.viewport.Width)
+	}
+	if m.viewport.Width > 0 {
+		m.scrollRows(rows, isMark)
+	}
+	return strings.Join(rows, "\n")
+}
+
+// renderRows turns the line buffer into the rows to draw, and reports which of
+// them belong to a separator. It also collects the search matches and the
+// visible count in the same pass: both are positions in the rows it is
+// building, so deriving them anywhere else means a second copy of this walk,
+// and the two drifting apart is what froze the match counter (#586).
+// Callers hold m.mu.
+func (m *Model) renderRows(now time.Time) (rows []string, isMark []bool) {
 	// Apply all active filters (node, "/" text, hide-stopped) in a single pass
 	// via the shared predicate so the visible set matches highlightContent.
 	var stopped map[string]bool
 	if m.hideStopped {
 		stopped = m.stoppedTaskIDs()
 	}
-	// Collect the search matches in the same pass. They are indices into the
-	// visible lines, so they can only be counted where the visible set is
-	// built — deriving them anywhere else means a second copy of this walk,
-	// and the two drifting apart is what froze the match counter (#586).
 	lower := strings.ToLower(m.searchTerm)
 	m.searchMatches = nil
-	var filteredLines []string
+	visible := 0
+
 	for i, line := range m.lines {
 		if !m.lineVisible(i, stopped) {
 			continue
 		}
+		// A separator is drawn, not stored: rendering it here is what lets it
+		// follow the viewport across a resize. It is not a log line, so it is
+		// out of the count in the title and out of the search matches — a
+		// query of "0" must not land on a timestamp the reader did not write.
+		if m.kindAt(i) == lineMark {
+			rows = append(rows, "", renderMark(line, m.viewport.Width))
+			isMark = append(isMark, true, true)
+			continue
+		}
 		if lower != "" && strings.Contains(strings.ToLower(line), lower) {
-			m.searchMatches = append(m.searchMatches, len(filteredLines))
+			m.searchMatches = append(m.searchMatches, len(rows))
 		}
-		filteredLines = append(filteredLines, line)
-	}
-	m.visibleCount = len(filteredLines)
-
-	// Join lines first
-	full := strings.Join(filteredLines, "\n")
-
-	// Apply wrapping based on wrap setting
-	// BUT: skip wrapping if node selection dialog is visible to avoid overlay issues
-	if m.wrap && m.viewport.Width > 0 && !m.nodeSelectVisible {
-		// Wrap the entire content to viewport width
-		full = wordwrap.String(full, m.viewport.Width)
-	} else if (!m.wrap || m.nodeSelectVisible) && m.viewport.Width > 0 {
-		// When wrap is off, apply horizontal scrolling using ANSI-aware operations
-		// to avoid splitting escape sequences in colored log lines.
-		processedLines := make([]string, len(filteredLines))
-
-		for i, line := range filteredLines {
-			lineWidth := lipgloss.Width(line)
-			if lineWidth <= m.horizontalOffset {
-				processedLines[i] = ""
-			} else {
-				visiblePart := ui.TruncateANSIAfter(line, m.horizontalOffset)
-				visibleWidth := lipgloss.Width(visiblePart)
-
-				if visibleWidth > m.viewport.Width {
-					if m.viewport.Width > 1 {
-						processedLines[i] = ui.TruncateANSI(visiblePart, m.viewport.Width-1) + ">"
-					} else {
-						processedLines[i] = ">"
-					}
-				} else {
-					processedLines[i] = visiblePart
-				}
-			}
+		// Highlight first, embolden second: the search highlight ends in a
+		// reset, and BoldANSI re-asserts across it. The other order would drop
+		// the bold from the rest of a line that happens to hold a match.
+		if m.searchTerm != "" {
+			line = utils.HighlightMatches(line, m.searchTerm)
 		}
-		full = strings.Join(processedLines, "\n")
+		if m.isFresh(i, now) {
+			line = ui.BoldANSI(line)
+		}
+		rows = append(rows, line)
+		isMark = append(isMark, false)
+		visible++
 	}
+	m.visibleCount = visible
+	return rows, isMark
+}
 
-	// Apply highlighting if we have an active search, regardless of mode
-	if m.searchTerm != "" {
-		return utils.HighlightMatches(full, m.searchTerm)
+// scrollRows applies the horizontal offset in place, using ANSI-aware
+// operations so an escape sequence in a coloured log line is never split.
+// Separators are left alone: they carry no content that scrolls, and one that
+// slid out of frame would leave the reader nothing to have marked.
+// Callers hold m.mu.
+func (m *Model) scrollRows(rows []string, isMark []bool) {
+	for i, line := range rows {
+		if isMark[i] {
+			continue
+		}
+		lineWidth := lipgloss.Width(line)
+		if lineWidth <= m.horizontalOffset {
+			rows[i] = ""
+			continue
+		}
+		visiblePart := ui.TruncateANSIAfter(line, m.horizontalOffset)
+		if lipgloss.Width(visiblePart) <= m.viewport.Width {
+			rows[i] = visiblePart
+			continue
+		}
+		if m.viewport.Width > 1 {
+			rows[i] = ui.TruncateANSI(visiblePart, m.viewport.Width-1) + ">"
+		} else {
+			rows[i] = ">"
+		}
 	}
-	return full
 }
 
 // scrollToMatch centers the viewport on the selected match

--- a/views/logs/update.go
+++ b/views/logs/update.go
@@ -70,23 +70,21 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 		// append an error line and stop
 		now := time.Now()
 		m.mu.Lock()
-		m.appendLine(fmt.Sprintf("Error: %v", msg.Err), "", "", lineLog, m.stamp(now))
+		m.appendLine(fmt.Sprintf("Error: %v", msg.Err), "", "", lineNotice, m.stamp(now))
+		linesDropped := m.trimToMaxLines()
 		m.mu.Unlock()
 		l().Errorf("[logsview] stream error: %v", msg.Err)
-		if m.ready {
-			m.viewport.SetContent(m.buildContent())
-		}
+		m.syncViewport(linesDropped)
 		return m.fadeTickCmd()
 
 	case StreamDoneMsg:
 		now := time.Now()
 		m.mu.Lock()
-		m.appendLine("--- stream closed ---", "", "", lineLog, m.stamp(now))
+		m.appendLine("--- stream closed ---", "", "", lineNotice, m.stamp(now))
+		linesDropped := m.trimToMaxLines()
 		m.mu.Unlock()
 		l().Debugf("[logsview] stream closed")
-		if m.ready {
-			m.viewport.SetContent(m.buildContent())
-		}
+		m.syncViewport(linesDropped)
 		return m.fadeTickCmd()
 
 	case WrapToggledMsg:
@@ -404,7 +402,9 @@ func (m *Model) renderRows(now time.Time) (rows []string, isMark []bool) {
 		}
 		rows = append(rows, line)
 		isMark = append(isMark, false)
-		visible++
+		if m.kindAt(i) == lineLog {
+			visible++
+		}
 	}
 	m.visibleCount = visible
 	return rows, isMark

--- a/views/logs/update.go
+++ b/views/logs/update.go
@@ -344,18 +344,60 @@ func (m *Model) buildContent() string {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	rows, isMark := m.renderRows(time.Now())
+	rows, isMark, isFresh := m.renderRows(time.Now())
 
 	// Apply wrapping based on wrap setting
 	// BUT: skip wrapping if node selection dialog is visible to avoid overlay issues
 	if m.wrap && m.viewport.Width > 0 && !m.nodeSelectVisible {
-		// Wrap the entire content to viewport width
-		return wordwrap.String(strings.Join(rows, "\n"), m.viewport.Width)
+		return m.wrapRows(rows, isFresh)
 	}
 	if m.viewport.Width > 0 {
 		m.scrollRows(rows, isMark)
 	}
+	// Paint last, so the band covers the row the reader actually sees rather
+	// than the text the scroll then cuts out of it.
+	for i, fresh := range isFresh {
+		if fresh {
+			rows[i] = m.highlightRow(rows[i])
+		}
+	}
 	return strings.Join(rows, "\n")
+}
+
+// wrapRows wraps each row to the viewport width and paints the fresh ones.
+// Wrapping row by row rather than over the joined buffer is what keeps the two
+// in step: after a single wrap of everything, which output row came from which
+// line is no longer knowable. A row that already fits is handed back untouched
+// — wrapping one that cannot break costs an allocation per line of the buffer.
+// Callers hold m.mu.
+func (m *Model) wrapRows(rows []string, isFresh []bool) string {
+	out := make([]string, 0, len(rows))
+	for i, row := range rows {
+		wrapped := []string{row}
+		if lipgloss.Width(row) > m.viewport.Width {
+			wrapped = strings.Split(wordwrap.String(row, m.viewport.Width), "\n")
+		}
+		if isFresh[i] {
+			// Every row a new line wrapped onto is new as well.
+			for j := range wrapped {
+				wrapped[j] = m.highlightRow(wrapped[j])
+			}
+		}
+		out = append(out, wrapped...)
+	}
+	return strings.Join(out, "\n")
+}
+
+// highlightRow draws a freshly arrived row over freshBackground, padded to the
+// viewport width so the band spans the frame instead of stopping wherever the
+// text happens to end. It is applied after the search highlight, which ends in
+// a reset the band is re-asserted past; the other order would leave the rest of
+// a line holding a match unpainted. Callers hold m.mu.
+func (m *Model) highlightRow(row string) string {
+	if pad := m.viewport.Width - lipgloss.Width(row); pad > 0 {
+		row += strings.Repeat(" ", pad)
+	}
+	return ui.BackgroundANSI(row, freshBackground)
 }
 
 // renderRows turns the line buffer into the rows to draw, and reports which of
@@ -364,7 +406,7 @@ func (m *Model) buildContent() string {
 // building, so deriving them anywhere else means a second copy of this walk,
 // and the two drifting apart is what froze the match counter (#586).
 // Callers hold m.mu.
-func (m *Model) renderRows(now time.Time) (rows []string, isMark []bool) {
+func (m *Model) renderRows(now time.Time) (rows []string, isMark, isFresh []bool) {
 	// Apply all active filters (node, "/" text, hide-stopped) in a single pass
 	// via the shared predicate so the visible set matches highlightContent.
 	var stopped map[string]bool
@@ -386,28 +428,26 @@ func (m *Model) renderRows(now time.Time) (rows []string, isMark []bool) {
 		if m.kindAt(i) == lineMark {
 			rows = append(rows, "", renderMark(line, m.viewport.Width))
 			isMark = append(isMark, true, true)
+			isFresh = append(isFresh, false, false)
 			continue
 		}
 		if lower != "" && strings.Contains(strings.ToLower(line), lower) {
 			m.searchMatches = append(m.searchMatches, len(rows))
 		}
-		// Highlight first, embolden second: the search highlight ends in a
-		// reset, and BoldANSI re-asserts across it. The other order would drop
-		// the bold from the rest of a line that happens to hold a match.
 		if m.searchTerm != "" {
 			line = utils.HighlightMatches(line, m.searchTerm)
 		}
-		if m.isFresh(i, now) {
-			line = ui.BoldANSI(line)
-		}
 		rows = append(rows, line)
 		isMark = append(isMark, false)
+		// The band itself is painted later, once the wrap or the scroll has
+		// settled what the row is; here it is only recorded.
+		isFresh = append(isFresh, m.isFresh(i, now))
 		if m.kindAt(i) == lineLog {
 			visible++
 		}
 	}
 	m.visibleCount = visible
-	return rows, isMark
+	return rows, isMark, isFresh
 }
 
 // scrollRows applies the horizontal offset in place, using ANSI-aware

--- a/views/logs/view.go
+++ b/views/logs/view.go
@@ -5,6 +5,8 @@ package logsview
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/Eldara-Tech/swarmcli/v2/ui"
 	"github.com/Eldara-Tech/swarmcli/v2/ui/dialog"
 
@@ -88,6 +90,30 @@ func (m *Model) searchToggle() (ui.Toggle, bool) {
 }
 
 func (m *Model) FrameFooter() string { return "" }
+
+// markStyle dims a separator: it is punctuation between reads, and has to stay
+// quieter than the log lines it separates.
+var markStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("240"))
+
+// markTimeFormat is what a separator records — the wall-clock time it was made,
+// which is the one thing about it worth reading.
+const markTimeFormat = "15:04:05"
+
+// renderMark draws a separator as a rule carrying the time it was made, filling
+// width exactly. It is called at build time rather than stored, so a resize
+// re-cuts it instead of leaving a rule from the old width behind.
+func renderMark(stamp string, width int) string {
+	if width <= 0 {
+		return ""
+	}
+	label := " " + stamp + " "
+	if len(label)+2 > width {
+		return markStyle.Render(strings.Repeat("─", width))
+	}
+	left := (width - len(label)) / 2
+	right := width - len(label) - left
+	return markStyle.Render(strings.Repeat("─", left) + label + strings.Repeat("─", right))
+}
 
 func (m *Model) FrameContent() string {
 	width := m.viewport.Width

--- a/views/logs/view.go
+++ b/views/logs/view.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Eldara-Tech/swarmcli/v2/ui/dialog"
 
 	"github.com/charmbracelet/lipgloss"
+	"github.com/muesli/termenv"
 )
 
 func (m *Model) FrameTitle() string {
@@ -94,6 +95,12 @@ func (m *Model) FrameFooter() string { return "" }
 // markStyle dims a separator: it is punctuation between reads, and has to stay
 // quieter than the log lines it separates.
 var markStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("240"))
+
+// freshBackground is the band a line that has just arrived is drawn over —
+// the colour a picked-out row already carries elsewhere in the app. Only the
+// background is set: the line keeps the colours it arrived with, which is the
+// point of highlighting it at all.
+var freshBackground = termenv.ANSI256Color(24)
 
 // markTimeFormat is what a separator records — the wall-clock time it was made,
 // which is the one thing about it worth reading.


### PR DESCRIPTION
Closes #608.

Two things a reader watching a `tail` asked for, and could not have here.

### A separator you can put in

Under `tail -f` you hit enter to push what you have read up the screen, so
whatever arrives next is unmistakably new. There is no scrollback to push in a
viewport, so `enter` — until now an explicit no-op in the logs view's normal
mode — puts the break into the buffer instead:

```
web.a1b2c3d4e5f6@node-1 | backlog request served 2

─────────────────────────────── 13:05:48 ───────────────────────────────
web.a1b2c3d4e5f6@node-1 | LIVE request served 9        (banded, for 1.2s)
```

It is stored as a sentinel rather than as rendered text, so a resize re-cuts the
rule instead of leaving one from the old width behind. It is exempt from the
node, `/` and hide-stopped filters — a filter that swallowed it would answer the
keypress with nothing at all — and from the horizontal scroll, since a separator
that slid out of frame leaves nothing to have marked. It is not a log line, so
it stays out of the count in the title and out of the search matches: a query of
`0` must not land on a timestamp the reader did not write.

### A highlight that expires

A line that has just arrived is drawn over background `24` — the colour a
picked-out row carries elsewhere in the app — for 1.2s, and then goes back to
exactly what it was, keeping the colours it arrived with. Only the background is
set: the foreground stays whatever the line arrived with, which is what the issue
asks for, and a dark background keeps a container's own red, dim or bright text
readable on it.

*(This was bold until review: @mosonyi found it not recognizable enough, which it
is not — half the lines a service logs are bold somewhere already.)*

The band is re-asserted past everything the line does that would clear it
(`ui.BackgroundANSI`): every reset — our own node prefix ends in one, and a plain
`\x1b[48;5;24m` + line would tint the text only as far as that — and `\x1b[49m`,
which restores the default background without resetting anything else. The
arguments of an extended colour are stepped over rather than read: the `0` in
`38;5;0` is a colour index, not a reset, and a line that set its own background
has to keep it across one.

The band covers the whole row, padded to the viewport width, so it reads as a
band and not as a differently-tinted sentence. That has to be the last thing
done to a row: padding measured before the horizontal scroll comes up short by
the offset, and a band painted before the wrap stops at the first break, leaving
the rest of a wrapped line looking old. `renderRows` therefore only records which
rows are fresh. Wrapping moved from one pass over the joined buffer to one per
row — after a single wrap of everything, which output row came from which line is
no longer knowable — and a row that already fits is not wrapped at all, which is
nearly all of them. The search highlight ends in a reset the band is re-asserted
past, and the ordering that used to be a rule inside `renderRows` is now
structural.

A stream opens with the backlog Docker replays for the tail request. That is
history, not news, and highlighting it would flash the whole screen at open. The
highlight therefore arms only once the replay is over, on either of two signals,
each covering the other's blind spot: a gap between arrivals, which a quiet
service gives immediately, or more lines than the backlog can hold, which is the
only signal a service logging faster than the gap will ever give.

The beat that expires a highlight is armed once and re-arms only while something
is still fresh — nothing ticks at rest, and a burst of lines cannot give one
beat a successor per line.

### Groundwork

`lines`, `lineNodes` and `lineTasks` were appended and trimmed in lock-step at
four sites, and this adds two more slices to them (kind, arrival time). Both
operations now go through `appendLine` / `trimToMaxLines`, so five parallel
slices are only ever grown and cut in one place, and the viewport bookkeeping
that follows a trim is `syncViewport` rather than a copy per caller.

### Not done, deliberately

No automatic separator after a quiet stream, no toggle key, no persisted
setting, and no true colour-interpolated fade — interpolating a foreground
colour means overriding the colours the issue asks to preserve, and it costs a
full rebuild of a 10 000-line buffer every animation frame.

### Verification

`go test ./...`, `golangci-lint run ./... --build-tags=integration`, `go vet`
and `go test -race -count=2` are all clean. Every new behaviour was
mutation-checked: nineteen mutations (drop the filter exemption, drop the band,
drop the blank row, drop the scroll exemption, count marks as lines, treat marks
as searchable, stamp the backlog, arm per line, never stop the beat, look past
marks in `anyFresh`, ignore the trim in the offset, drop the re-assertion, drop
the padding, paint before the scroll, wrap the joined buffer instead of row by
row, one `false` per mark row instead of two, drop the `49` case, read an
extended colour's arguments instead of stepping over them, and step over a
fixed number of them) each failed the test written for it, and none survived.

