### PR TITLE
fix(context): one Docker context per session, and a prompt when the shell leaves it

### DIFF
--- a/app/contextdrift.go
+++ b/app/contextdrift.go
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package app
+
+import (
+	"fmt"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/Eldara-Tech/swarmcli/v2/docker"
+)
+
+// The Docker context is pinned for the life of the session (docker.SessionContext),
+// so a `docker context use` run in another terminal moves nothing here. That is
+// the fix for #611 — but a switch the operator made deliberately should not be
+// silently ignored either, so the app watches for the divergence and offers it.
+//
+// Watching, not following: the prompt is the only thing that moves the pin, and
+// declining is remembered, so an operator who keeps two terminals on two swarms
+// is asked once per target rather than every five seconds.
+
+// contextDriftMsg reports the result of one drift check. Shell is the context
+// the config file now names, or "" when it agrees with the session pin.
+type contextDriftMsg struct{ Shell string }
+
+// Seams, so the drift logic is testable without a Docker CLI on PATH.
+var (
+	sessionContextFn    = docker.SessionContext
+	configFileContextFn = docker.ConfigFileContext
+	setSessionContextFn = docker.SetSessionContext
+	envPinsContextFn    = docker.EnvPinsContext
+)
+
+// checkContextDriftCmd compares the context Docker would use now against the
+// one this session is pinned to.
+//
+// A failed lookup reports "no drift" rather than an error: `docker context show`
+// can fail transiently, and a dialog raised over a subprocess hiccup would be
+// worse than a check that quietly runs again five seconds later.
+func checkContextDriftCmd() tea.Cmd {
+	return func() tea.Msg {
+		// DOCKER_CONTEXT outranks the config file, so while it is set the two
+		// naming different contexts is the arrangement the operator asked for,
+		// not a switch. Offering to follow it would also be offering something
+		// the context switcher refuses to do.
+		if envPinsContextFn() {
+			return contextDriftMsg{}
+		}
+		pinned, err := sessionContextFn()
+		if err != nil || pinned == "" {
+			return contextDriftMsg{}
+		}
+		shell, err := configFileContextFn()
+		if err != nil || shell == "" || shell == pinned {
+			return contextDriftMsg{}
+		}
+		return contextDriftMsg{Shell: shell}
+	}
+}
+
+// handleContextDrift decides what one drift check means for the UI.
+func (m *Model) handleContextDrift(msg contextDriftMsg) tea.Cmd {
+	if msg.Shell == "" {
+		// Back in agreement. Clearing the record means a later switch to the
+		// same context is offered again — the operator declined one drift, not
+		// that context forever.
+		m.declinedDriftContext = ""
+		return nil
+	}
+	if msg.Shell == m.declinedDriftContext {
+		return nil
+	}
+	if m.dialogActive() {
+		// Try again on the next tick rather than stacking a second dialog on
+		// top of one the user is reading.
+		return nil
+	}
+	m.showContextDriftNotice(msg.Shell)
+	return nil
+}
+
+// dialogActive reports whether something already owns the screen. The startup
+// overlay is included: a BE proactive nudge is the first thing an operator
+// sees, and a drift prompt drawn over it would be unreadable.
+func (m *Model) dialogActive() bool {
+	if startupOverlay != nil && startupOverlay.Active() {
+		return true
+	}
+	return m.appErrorDialogActive ||
+		m.unlockDialogActive ||
+		m.updateDialogActive ||
+		m.contextDriftDialogActive
+}
+
+// showContextDriftNotice raises the confirm-mode dialog offering the switch.
+func (m *Model) showContextDriftNotice(shell string) {
+	pinned, _ := sessionContextFn()
+	m.contextDriftDialog.Visible = true
+	m.contextDriftDialog.ErrorMode = false
+	m.contextDriftDialog.InfoMode = false
+	m.contextDriftDialog.CheckboxLabel = ""
+	m.contextDriftDialog.CheckboxChecked = false
+	m.contextDriftDialog.Message = contextDriftMessage(pinned, shell)
+	m.contextDriftDialogActive = true
+	m.pendingDriftContext = shell
+}
+
+// contextDriftMessage builds the prompt body. It names both contexts in every
+// line that matters: "the context changed" is not actionable without knowing
+// which one is still being used.
+func contextDriftMessage(pinned, shell string) string {
+	return fmt.Sprintf(
+		"The Docker context changed outside swarmcli: '%s' → '%s'.\n\n"+
+			"swarmcli is still using '%s'. Switch to '%s'?\n\n"+
+			"y — switch to '%s' and reload the cluster\n"+
+			"n — keep using '%s' (swarmcli will not ask again for '%s')",
+		pinned, shell, pinned, shell, shell, pinned, shell)
+}
+
+// resolveContextDrift applies the answer to the drift prompt.
+func (m *Model) resolveContextDrift(confirmed bool) tea.Cmd {
+	shell := m.pendingDriftContext
+	m.contextDriftDialogActive = false
+	m.contextDriftDialog.Visible = false
+	m.pendingDriftContext = ""
+
+	if !confirmed {
+		m.declinedDriftContext = shell
+		return nil
+	}
+	m.declinedDriftContext = ""
+
+	previous, _ := sessionContextFn()
+	setSessionContextFn(shell)
+	// No `docker context use` here, unlike a switch made from the contexts
+	// view: the config file already names shell — that is what drift means —
+	// and for the same reason a revert must not write it back.
+	return m.enterContext(previous, false)
+}

--- a/app/contextdrift_test.go
+++ b/app/contextdrift_test.go
@@ -1,0 +1,282 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package app
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/stretchr/testify/require"
+
+	"github.com/Eldara-Tech/swarmcli/v2/docker"
+	"github.com/Eldara-Tech/swarmcli/v2/views/confirmdialog"
+	contextsview "github.com/Eldara-Tech/swarmcli/v2/views/contexts"
+	systeminfoview "github.com/Eldara-Tech/swarmcli/v2/views/systeminfo"
+)
+
+// stubContexts points the drift check at values the test controls: what this
+// session is pinned to, and what the config file says right now.
+func stubContexts(t *testing.T, pinned, shell string) (setPinned, setShell func(string)) {
+	t.Helper()
+	origSession, origConfig := sessionContextFn, configFileContextFn
+	origSet, origEnv := setSessionContextFn, envPinsContextFn
+	t.Cleanup(func() {
+		sessionContextFn, configFileContextFn = origSession, origConfig
+		setSessionContextFn, envPinsContextFn = origSet, origEnv
+	})
+
+	sessionContextFn = func() (string, error) { return pinned, nil }
+	configFileContextFn = func() (string, error) { return shell, nil }
+	setSessionContextFn = func(name string) { pinned = name }
+	envPinsContextFn = func() bool { return false }
+	return func(s string) { pinned = s }, func(s string) { shell = s }
+}
+
+// driftOf runs one drift check and returns what it found.
+func driftOf(t *testing.T) contextDriftMsg {
+	t.Helper()
+	msg, ok := checkContextDriftCmd()().(contextDriftMsg)
+	require.True(t, ok)
+	return msg
+}
+
+func TestCheckContextDrift_AgreementReportsNoDrift(t *testing.T) {
+	stubContexts(t, "swarm-a", "swarm-a")
+	require.Empty(t, driftOf(t).Shell)
+}
+
+func TestCheckContextDrift_ReportsTheContextTheConfigNowNames(t *testing.T) {
+	stubContexts(t, "swarm-a", "swarm-b")
+	require.Equal(t, "swarm-b", driftOf(t).Shell)
+}
+
+// A subprocess that fails for a moment must not raise a dialog over the
+// operator's screen; the check runs again five seconds later.
+func TestCheckContextDrift_AFailedLookupIsNotDrift(t *testing.T) {
+	origSession, origConfig := sessionContextFn, configFileContextFn
+	t.Cleanup(func() { sessionContextFn, configFileContextFn = origSession, origConfig })
+
+	sessionContextFn = func() (string, error) { return "swarm-a", nil }
+	configFileContextFn = func() (string, error) { return "", errors.New("docker not running") }
+	require.Empty(t, driftOf(t).Shell)
+
+	configFileContextFn = func() (string, error) { return "swarm-b", nil }
+	sessionContextFn = func() (string, error) { return "", errors.New("docker not running") }
+	require.Empty(t, driftOf(t).Shell)
+}
+
+// DOCKER_CONTEXT is resolved ahead of ~/.docker/config.json, so while it is set
+// the two naming different contexts is the documented arrangement — and the
+// context switcher would refuse the move anyway. Prompting at every startup
+// that uses the variable, including the DinD test flow, would be pure noise.
+func TestCheckContextDrift_TheEnvironmentPinIsNotDrift(t *testing.T) {
+	stubContexts(t, "from-env", "from-config")
+	envPinsContextFn = func() bool { return true }
+
+	require.Empty(t, driftOf(t).Shell)
+}
+
+func TestHandleContextDrift_RaisesThePrompt(t *testing.T) {
+	m := newTestAppModel(&stubView{})
+	stubContexts(t, "swarm-a", "swarm-b")
+
+	require.Nil(t, m.handleContextDrift(contextDriftMsg{Shell: "swarm-b"}))
+
+	require.True(t, m.contextDriftDialogActive)
+	require.True(t, m.contextDriftDialog.Visible)
+	require.Equal(t, "swarm-b", m.pendingDriftContext)
+	// Both names, or "the context changed" is not actionable.
+	require.Contains(t, m.contextDriftDialog.Message, "swarm-a")
+	require.Contains(t, m.contextDriftDialog.Message, "swarm-b")
+}
+
+// Declining is remembered, or an operator keeping two terminals on two swarms
+// is asked again every five seconds.
+func TestHandleContextDrift_DecliningSuppressesTheSameTarget(t *testing.T) {
+	m := newTestAppModel(&stubView{})
+	stubContexts(t, "swarm-a", "swarm-b")
+
+	m.handleContextDrift(contextDriftMsg{Shell: "swarm-b"})
+	m.resolveContextDrift(false)
+
+	require.False(t, m.contextDriftDialogActive)
+	require.Equal(t, "swarm-b", m.declinedDriftContext)
+
+	m.handleContextDrift(contextDriftMsg{Shell: "swarm-b"})
+	require.False(t, m.contextDriftDialogActive, "the same target must not be offered twice")
+}
+
+// Declining one context is not declining every context.
+func TestHandleContextDrift_ADifferentTargetIsStillOffered(t *testing.T) {
+	m := newTestAppModel(&stubView{})
+	stubContexts(t, "swarm-a", "swarm-b")
+
+	m.handleContextDrift(contextDriftMsg{Shell: "swarm-b"})
+	m.resolveContextDrift(false)
+
+	m.handleContextDrift(contextDriftMsg{Shell: "swarm-c"})
+	require.True(t, m.contextDriftDialogActive)
+	require.Equal(t, "swarm-c", m.pendingDriftContext)
+}
+
+// Switching the shell back and away again is a new decision, not the one that
+// was already declined.
+func TestHandleContextDrift_ReturningToThePinClearsTheRefusal(t *testing.T) {
+	m := newTestAppModel(&stubView{})
+	stubContexts(t, "swarm-a", "swarm-b")
+
+	m.handleContextDrift(contextDriftMsg{Shell: "swarm-b"})
+	m.resolveContextDrift(false)
+
+	m.handleContextDrift(contextDriftMsg{}) // back in agreement
+	require.Empty(t, m.declinedDriftContext)
+
+	m.handleContextDrift(contextDriftMsg{Shell: "swarm-b"})
+	require.True(t, m.contextDriftDialogActive)
+}
+
+// A dialog drawn on top of the one the user is reading is worse than one that
+// arrives five seconds later.
+func TestHandleContextDrift_WaitsForTheScreen(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		set  func(*Model)
+	}{
+		{"an app error is up", func(m *Model) { m.appErrorDialogActive = true }},
+		{"the unlock dialog is up", func(m *Model) { m.unlockDialogActive = true }},
+		{"the update notice is up", func(m *Model) { m.updateDialogActive = true }},
+		{"the prompt is already up", func(m *Model) { m.contextDriftDialogActive = true }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			m := newTestAppModel(&stubView{})
+			stubContexts(t, "swarm-a", "swarm-b")
+			tc.set(m)
+			before := m.contextDriftDialog.Visible
+
+			m.handleContextDrift(contextDriftMsg{Shell: "swarm-b"})
+
+			require.Equal(t, before, m.contextDriftDialog.Visible)
+			require.Empty(t, m.pendingDriftContext)
+		})
+	}
+}
+
+// Accepting moves the pin and drops what was built for the context being left.
+func TestResolveContextDrift_AcceptingMovesThePinAndReloads(t *testing.T) {
+	m := newTestAppModel(&stubView{})
+	stubContexts(t, "swarm-a", "swarm-b")
+
+	m.handleContextDrift(contextDriftMsg{Shell: "swarm-b"})
+	cmd := m.resolveContextDrift(true)
+
+	require.NotNil(t, cmd, "the switch has to reload the cluster")
+	pinned, err := sessionContextFn()
+	require.NoError(t, err)
+	require.Equal(t, "swarm-b", pinned, "the pin moves to the context being entered")
+	require.False(t, m.contextDriftDialogActive)
+	require.Empty(t, m.pendingDriftContext)
+	require.Empty(t, m.declinedDriftContext)
+	require.Equal(t, "swarm-a", m.previousContext, "kept so a failed load can revert")
+}
+
+// A switch made in the contexts view wrote ~/.docker/config.json, so undoing it
+// has to write it back. One accepted at the drift prompt did not.
+func TestEnterContext_RecordsWhetherARevertMayWriteTheConfigFile(t *testing.T) {
+	m := newTestAppModel(&stubView{})
+	stubContexts(t, "swarm-a", "swarm-b")
+
+	m.handleContextDrift(contextDriftMsg{Shell: "swarm-b"})
+	m.resolveContextDrift(true)
+	require.False(t, m.revertWritesConfig, "the operator's own switch is not ours to take back")
+
+	m.Update(contextsview.ContextChangedNotification{PreviousContext: "swarm-a"})
+	require.True(t, m.revertWritesConfig, "swarmcli wrote the config file, so it reverts it")
+}
+
+// A context accepted at the prompt but unable to load must put the session back
+// where it was, and stop offering the context that failed — otherwise the
+// prompt returns on the next tick, and every tick after that.
+func TestSnapshotFailureAfterDrift_RevertsThePinAndStopsAsking(t *testing.T) {
+	m := newTestAppModel(&stubView{})
+
+	docker.SetSessionContext("swarm-a")
+	t.Cleanup(docker.ResetSessionContext)
+	m.previousContext = "swarm-a"
+	m.revertWritesConfig = false
+	docker.SetSessionContext("swarm-b") // what accepting the prompt did
+
+	m.Update(snapshotLoadedMsg{Err: errors.New("cannot connect to the docker daemon")})
+
+	pinned, err := docker.SessionContext()
+	require.NoError(t, err)
+	require.Equal(t, "swarm-a", pinned, "the session goes back to the context that worked")
+	require.Equal(t, "swarm-b", m.declinedDriftContext, "the failed context is not offered again")
+	require.Empty(t, m.previousContext)
+}
+
+// The prompt is a y/n question. An info-mode dialog would close on any key and
+// report Confirmed:false, so "switch" would be unreachable.
+func TestContextDriftPrompt_IsAConfirmation(t *testing.T) {
+	m := newTestAppModel(&stubView{})
+	stubContexts(t, "swarm-a", "swarm-b")
+	m.handleContextDrift(contextDriftMsg{Shell: "swarm-b"})
+
+	require.False(t, m.contextDriftDialog.InfoMode)
+	require.False(t, m.contextDriftDialog.ErrorMode)
+
+	cmd := m.contextDriftDialog.Update(runeKey('y'))
+	require.NotNil(t, cmd)
+	res, ok := cmd().(confirmdialog.ResultMsg)
+	require.True(t, ok)
+	require.True(t, res.Confirmed)
+}
+
+// While the prompt is up it owns the keyboard, or "y" reaches the view behind
+// it and does something else entirely.
+func TestContextDriftPrompt_TakesTheKeyboard(t *testing.T) {
+	v := &hidingStubView{}
+	m := newTestAppModel(v)
+	stubContexts(t, "swarm-a", "swarm-b")
+	m.handleContextDrift(contextDriftMsg{Shell: "swarm-b"})
+
+	m.handleKey(runeKey('n'))
+
+	require.Empty(t, v.received, "the view behind the prompt must not see the answer")
+}
+
+// The guard runs both ways: an update notice drawn over the drift prompt would
+// take the keyboard from a question the operator is in the middle of, and leave
+// the prompt visible underneath it.
+func TestUpdateNotice_WaitsForTheContextDriftPrompt(t *testing.T) {
+	t.Setenv("HOME", t.TempDir()) // redirect the settings file
+	m := newTestAppModel(&stubView{})
+	stubContexts(t, "swarm-a", "swarm-b")
+	m.handleContextDrift(contextDriftMsg{Shell: "swarm-b"})
+
+	m.Update(systeminfoview.LatestVersionMsg{LatestVersion: "v1.9.0"})
+
+	require.False(t, m.updateDialogActive, "the drift prompt owns the screen")
+	require.True(t, m.contextDriftDialogActive)
+}
+
+// TestHandleTick_ReArms — the timer armed in Init fired once and stopped,
+// which froze the header and would have made the drift check a one-shot.
+func TestHandleTick_ReArms(t *testing.T) {
+	orig := tickInterval
+	tickInterval = time.Millisecond
+	t.Cleanup(func() { tickInterval = orig })
+
+	m := newTestAppModel(&stubView{})
+	_, cmd := m.handleTick(tickMsg(time.Now()))
+	require.NotNil(t, cmd)
+
+	batch, ok := cmd().(tea.BatchMsg)
+	require.True(t, ok)
+	require.Len(t, batch, 3, "re-arm, header refresh, drift check")
+	// tea.Batch keeps the order it was given, and the re-arm is first.
+	_, isTick := batch[0]().(tickMsg)
+	require.True(t, isTick, "the tick must re-arm itself")
+}

--- a/app/model.go
+++ b/app/model.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/Eldara-Tech/swarmcli/v2/docker"
+	swarmlog "github.com/Eldara-Tech/swarmcli/v2/utils/log"
 	"github.com/Eldara-Tech/swarmcli/v2/views/commandinput"
 	"github.com/Eldara-Tech/swarmcli/v2/views/confirmdialog"
 	loadingview "github.com/Eldara-Tech/swarmcli/v2/views/loading"
@@ -53,12 +54,26 @@ type Model struct {
 	updateDialogActive   bool
 	pendingUpdateVersion string // version to persist if the opt-out box is ticked
 
+	// App-level "the Docker context changed outside swarmcli" prompt. The
+	// session is pinned to one context (docker.SessionContext), so a
+	// `docker context use` elsewhere moves nothing until this is answered.
+	contextDriftDialog       *confirmdialog.Model
+	contextDriftDialogActive bool
+	pendingDriftContext      string // context the prompt is offering to switch to
+	declinedDriftContext     string // context the user chose not to follow; not offered again
+
 	// Terminal dimensions
 	terminalWidth  int
 	terminalHeight int
 
 	// Previous context name, set on context switch for revert on failure
 	previousContext string
+	// revertWritesConfig records whether reverting previousContext should also
+	// rewrite ~/.docker/config.json. A switch made inside swarmcli wrote it, so
+	// undoing the switch has to undo that too; one made in another terminal and
+	// accepted at the drift prompt did not, and swarmcli has no business
+	// reaching into the operator's shell context to take it back.
+	revertWritesConfig bool
 
 	// Fullscreen mode — hides helpbar/stackbar, uses full terminal
 	fullscreen bool
@@ -82,6 +97,18 @@ func buildDeps() docker.Deps {
 }
 
 func InitialModel() *Model {
+	// Pin the Docker context before anything resolves it lazily, so every part
+	// of the session addresses the same swarm even if the operator runs
+	// `docker context use` in another terminal a moment later. Resolved here
+	// rather than in Init(), which also runs for `swarmcli --version` and has
+	// no business spawning a docker subprocess. A failure is only logged: the
+	// loading view is where the user gets told a daemon is unreachable.
+	if ctxName, err := docker.InitSessionContext(); err != nil {
+		swarmlog.L().Infow("could not resolve the Docker context at startup", "error", err)
+	} else {
+		swarmlog.L().Infow("pinned the Docker context for this session", "context", ctxName)
+	}
+
 	// Use larger initial dimensions that will be adjusted by first WindowSizeMsg
 	// This avoids the loading view appearing too small on the first render
 	terminalWidth, terminalHeight := 200, 50
@@ -99,18 +126,19 @@ func InitialModel() *Model {
 	deps := buildDeps()
 
 	return &Model{
-		deps:           deps,
-		viewport:       vp,
-		currentView:    loading,
-		systemInfo:     systeminfoview.New(deps, version, edition),
-		viewStack:      viewstack.Stack{},
-		commandInput:   cmdBar(),
-		searchInput:    searchinput.New(),
-		errorDialog:    confirmdialog.New(terminalWidth, terminalHeight),
-		unlockDialog:   unlockdialog.New(terminalWidth, terminalHeight),
-		updateDialog:   confirmdialog.New(terminalWidth, terminalHeight),
-		terminalWidth:  terminalWidth,
-		terminalHeight: terminalHeight,
+		deps:               deps,
+		viewport:           vp,
+		currentView:        loading,
+		systemInfo:         systeminfoview.New(deps, version, edition),
+		viewStack:          viewstack.Stack{},
+		commandInput:       cmdBar(),
+		searchInput:        searchinput.New(),
+		errorDialog:        confirmdialog.New(terminalWidth, terminalHeight),
+		unlockDialog:       unlockdialog.New(terminalWidth, terminalHeight),
+		updateDialog:       confirmdialog.New(terminalWidth, terminalHeight),
+		contextDriftDialog: confirmdialog.New(terminalWidth, terminalHeight),
+		terminalWidth:      terminalWidth,
+		terminalHeight:     terminalHeight,
 	}
 }
 

--- a/app/tick.go
+++ b/app/tick.go
@@ -10,12 +10,26 @@ import (
 
 type tickMsg time.Time
 
+// tickInterval is a variable so a test can arm the timer without waiting for
+// it: invoking a tea.Tick command runs its sleep synchronously.
+var tickInterval = 5 * time.Second
+
 func tick() tea.Cmd {
-	return tea.Tick(time.Second*5, func(t time.Time) tea.Msg {
+	return tea.Tick(tickInterval, func(t time.Time) tea.Msg {
 		return tickMsg(t)
 	})
 }
 
+// handleTick drives the app's periodic work and re-arms itself.
+//
+// The re-arm was missing, so the timer armed in Init fired once and stopped:
+// the header's context name and its container and service counts froze a few
+// seconds after launch and never moved again. The drift check needs a timer
+// that keeps running, and the header was always meant to have one.
 func (m *Model) handleTick(msg tickMsg) (tea.Model, tea.Cmd) {
-	return m, m.systemInfo.LoadStatus()
+	return m, tea.Batch(
+		tick(),
+		m.systemInfo.LoadStatus(),
+		checkContextDriftCmd(),
+	)
 }

--- a/app/update.go
+++ b/app/update.go
@@ -70,7 +70,19 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case snapshotLoadedMsg:
 		if msg.Err != nil {
 			if m.previousContext != "" {
-				_ = docker.UseContext(m.previousContext)
+				if m.revertWritesConfig {
+					_ = docker.UseContext(m.previousContext)
+				} else {
+					// The config file still names the context that would not
+					// load, and it is not ours to change. Stop offering it, or
+					// the drift prompt asks again on the next tick and every
+					// tick after that.
+					failed, _ := docker.SessionContext()
+					m.declinedDriftContext = failed
+				}
+				// The pin comes back either way, or the session is left
+				// addressing the context whose snapshot just failed.
+				docker.SetSessionContext(m.previousContext)
 				docker.ResetClient()
 				m.previousContext = ""
 				m.showAppError(
@@ -281,10 +293,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// owns the screen, another app dialog is up, or the user opted out of
 		// this version.
 		cmd := m.systemInfo.Update(msg)
-		if startupOverlay != nil && startupOverlay.Active() {
-			return m, cmd
-		}
-		if m.appErrorDialogActive || m.unlockDialogActive || m.updateDialogActive {
+		if m.dialogActive() {
 			return m, cmd
 		}
 		if msg.LatestVersion != settings.Load().DismissedUpdateVersion {
@@ -297,22 +306,10 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case contextsview.ContextChangedNotification:
 		// Context has changed - show loading view then navigate to stacks
-		m.previousContext = msg.PreviousContext
-		// Close cached Docker client so a fresh one is created for the new context
-		docker.ResetClient()
-		// Invalidate snapshot cache so stacks load fresh data for new context
-		docker.InvalidateSnapshot()
-		cmd := m.replaceView(loadingview.ViewName, map[string]string{
-			"title":   "Loading",
-			"header":  "Fetching cluster info",
-			"message": "Loading Swarm nodes and stacks...",
-		})
-		return m, tea.Batch(
-			m.systemInfo.LoadStatus(),
-			cmd,
-			// Load snapshot and navigate to stacks when ready
-			loadSnapshotAsync(),
-		)
+		return m, m.enterContext(msg.PreviousContext, true)
+
+	case contextDriftMsg:
+		return m, m.handleContextDrift(msg)
 
 	case view.AppErrorMsg:
 		m.showAppError(msg.Error, msg.FallbackView)
@@ -323,6 +320,9 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case confirmdialog.ResultMsg:
+		if m.contextDriftDialogActive {
+			return m, m.resolveContextDrift(msg.Confirmed)
+		}
 		if m.updateDialogActive {
 			m.updateDialogActive = false
 			m.updateDialog.Visible = false
@@ -390,6 +390,36 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		cmd := m.delegateToCurrentView(msg)
 		return m, cmd
 	}
+}
+
+// enterContext takes the session into the context the pin now names: it drops
+// the client and the snapshot built for the previous one, shows the loading
+// view, and reloads. previous is remembered so a snapshot that fails to load
+// can be reverted, and writesConfig says whether that revert may write
+// ~/.docker/config.json — true only when this switch wrote it in the first
+// place.
+//
+// Both ways into a new context go through here — a switch made from the
+// contexts view and an accepted drift prompt — because a second copy of this
+// sequence is a second chance to forget one of the four things it does.
+func (m *Model) enterContext(previous string, writesConfig bool) tea.Cmd {
+	m.previousContext = previous
+	m.revertWritesConfig = writesConfig
+	// Close cached Docker client so a fresh one is created for the new context
+	docker.ResetClient()
+	// Invalidate snapshot cache so stacks load fresh data for new context
+	docker.InvalidateSnapshot()
+	cmd := m.replaceView(loadingview.ViewName, map[string]string{
+		"title":   "Loading",
+		"header":  "Fetching cluster info",
+		"message": "Loading Swarm nodes and stacks...",
+	})
+	return tea.Batch(
+		m.systemInfo.LoadStatus(),
+		cmd,
+		// Load snapshot and navigate to stacks when ready
+		loadSnapshotAsync(),
+	)
 }
 
 // unlockResultMsg carries the outcome of a docker.UnlockSwarm call.
@@ -507,6 +537,12 @@ func (m *Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	// If the update notice is active, forward keys to it exclusively
 	if m.updateDialogActive {
 		cmd := m.updateDialog.Update(msg)
+		return m, cmd
+	}
+
+	// If the context drift prompt is active, forward keys to it exclusively
+	if m.contextDriftDialogActive {
+		cmd := m.contextDriftDialog.Update(msg)
 		return m, cmd
 	}
 

--- a/app/update_test.go
+++ b/app/update_test.go
@@ -58,17 +58,18 @@ func (v *searchingStubView) Update(msg tea.Msg) tea.Cmd {
 // rather than failing.
 func newTestAppModel(cv view.View) *Model {
 	return &Model{
-		viewport:       viewport.New(200, 50),
-		currentView:    cv,
-		viewStack:      viewstack.Stack{},
-		commandInput:   commandinput.New(),
-		searchInput:    searchinput.New(),
-		errorDialog:    confirmdialog.New(200, 50),
-		unlockDialog:   unlockdialog.New(200, 50),
-		updateDialog:   confirmdialog.New(200, 50),
-		systemInfo:     systeminfoview.New(docker.DefaultDeps(), "test", "test"),
-		terminalWidth:  200,
-		terminalHeight: 50,
+		viewport:           viewport.New(200, 50),
+		currentView:        cv,
+		viewStack:          viewstack.Stack{},
+		commandInput:       commandinput.New(),
+		searchInput:        searchinput.New(),
+		errorDialog:        confirmdialog.New(200, 50),
+		unlockDialog:       unlockdialog.New(200, 50),
+		updateDialog:       confirmdialog.New(200, 50),
+		contextDriftDialog: confirmdialog.New(200, 50),
+		systemInfo:         systeminfoview.New(docker.DefaultDeps(), "test", "test"),
+		terminalWidth:      200,
+		terminalHeight:     50,
 	}
 }
 

--- a/app/view.go
+++ b/app/view.go
@@ -37,7 +37,7 @@ func (m *Model) View() string {
 		if inputBar != "" {
 			out = lipgloss.JoinVertical(lipgloss.Left, inputBar, out)
 		}
-		return m.overlayStartup(m.overlayUnlock(m.overlayAppError(m.overlayUpdate(out))))
+		return m.overlayStartup(m.overlayUnlock(m.overlayAppError(m.overlayUpdate(m.overlayContextDrift(out)))))
 	}
 
 	systemInfo := m.systemInfo.View()
@@ -65,7 +65,7 @@ func (m *Model) View() string {
 	rows = append(rows, framedView, m.renderStackBar())
 
 	out := lipgloss.JoinVertical(lipgloss.Left, rows...)
-	return m.overlayStartup(m.overlayUnlock(m.overlayAppError(m.overlayUpdate(out))))
+	return m.overlayStartup(m.overlayUnlock(m.overlayAppError(m.overlayUpdate(m.overlayContextDrift(out)))))
 }
 
 // renderInputBar renders whichever of the ":" command bar and the "/" search
@@ -129,6 +129,14 @@ func (m *Model) overlayUpdate(base string) string {
 		return base
 	}
 	return ui.OverlayCentered(base, m.updateDialog.View(), m.terminalWidth, 0)
+}
+
+// overlayContextDrift overlays the "context changed outside swarmcli" prompt.
+func (m *Model) overlayContextDrift(base string) string {
+	if !m.contextDriftDialog.Visible {
+		return base
+	}
+	return ui.OverlayCentered(base, m.contextDriftDialog.View(), m.terminalWidth, 0)
 }
 
 // overlayStartup composites the startup overlay on top of the rendered output.

--- a/app/view_test.go
+++ b/app/view_test.go
@@ -71,16 +71,17 @@ func (stubClusterInfo) GetDockerVersion() (string, error) { return "27.0.0", nil
 func newLayoutTestModel(cv view.View) *Model {
 	deps := docker.Deps{ClusterInfo: stubClusterInfo{}}
 	return &Model{
-		deps:         deps,
-		viewport:     viewport.New(0, 0),
-		currentView:  cv,
-		viewStack:    viewstack.Stack{},
-		commandInput: commandinput.New(),
-		searchInput:  searchinput.New(),
-		errorDialog:  confirmdialog.New(0, 0),
-		unlockDialog: unlockdialog.New(0, 0),
-		updateDialog: confirmdialog.New(0, 0),
-		systemInfo:   systeminfoview.New(deps, "test", "ce"),
+		deps:               deps,
+		viewport:           viewport.New(0, 0),
+		currentView:        cv,
+		viewStack:          viewstack.Stack{},
+		commandInput:       commandinput.New(),
+		searchInput:        searchinput.New(),
+		errorDialog:        confirmdialog.New(0, 0),
+		unlockDialog:       unlockdialog.New(0, 0),
+		updateDialog:       confirmdialog.New(0, 0),
+		contextDriftDialog: confirmdialog.New(0, 0),
+		systemInfo:         systeminfoview.New(deps, "test", "ce"),
 	}
 }
 

--- a/charts/backend_docker.go
+++ b/charts/backend_docker.go
@@ -16,10 +16,11 @@ import (
 // dockerBackend implements Backend against the live github.com/Eldara-Tech/swarmcli/v2/docker package.
 //
 // Every operation is addressed to one Docker context. When ctxName is empty that
-// is the ambient one — whatever DOCKER_CONTEXT or `docker context show` resolves
-// to — which is what the CLI has always used and what NewEngine still builds.
-// When it is set, the backend resolves its own client and its own snapshots and
-// touches no process-wide state, so two backends can target two swarms at once.
+// is the ambient one — the session pin, resolved once from DOCKER_CONTEXT or
+// `docker context show` and held for the life of the process — which is what
+// the CLI has always used and what NewEngine still builds. When it is set, the
+// backend resolves its own client and its own snapshots and touches no
+// process-wide state, so two backends can target two swarms at once.
 type dockerBackend struct {
 	ctxName string
 }
@@ -34,8 +35,8 @@ var _ Backend = (*dockerBackend)(nil)
 // the process happens to be pointed at.
 //
 // Pair it with NewEngineWith. The three pieces of process-global state this
-// avoids are the SDK client singleton, the `docker context show` lookup the
-// exec-based stack commands do, and the shared snapshot cache — all three, not
+// avoids are the SDK client singleton, the session context pin the exec-based
+// stack commands name, and the shared snapshot cache — all three, not
 // just the last: a backend that deployed to one swarm and read its history,
 // networks and convergence from another would be worse than an honestly
 // single-swarm one, because nothing would report the mismatch.

--- a/docker/client.go
+++ b/docker/client.go
@@ -66,11 +66,11 @@ func GetClient() (*client.Client, error) {
 // ClientFor returns a client for an explicitly named Docker context, cached per
 // name.
 //
-// It is the seam that lets a caller address a specific swarm. GetClient resolves
-// DOCKER_CONTEXT or `docker context show` and caches one client for the whole
-// process — correct for a single-swarm CLI, and unusable for anything that has
-// to reconcile two swarms at once, because there is no argument by which to ask
-// for the other one.
+// It is the seam that lets a caller address a specific swarm. GetClient builds
+// from the session pin and caches one client for the whole process — correct
+// for a single-swarm CLI, and unusable for anything that has to reconcile two
+// swarms at once, because there is no argument by which to ask for the other
+// one.
 func ClientFor(ctxName string) (*client.Client, error) {
 	if ctxName == "" {
 		return nil, fmt.Errorf("docker context name is required")
@@ -214,37 +214,23 @@ func fileExists(path string) bool {
 	return err == nil
 }
 
-// GetCurrentContext returns the name of the active Docker context.
+// GetCurrentContext returns the name of the Docker context this session uses.
+//
+// It reports the session pin, not whatever ~/.docker/config.json says at the
+// moment of the call: the name shown in the header has to be the name the
+// client is connected to. See SessionContext.
 func GetCurrentContext() (string, error) {
-	ctxNameBytes, err := exec.Command("docker", "context", "show").Output()
-	if err != nil {
-		return "", fmt.Errorf("failed to get docker context: %w", err)
-	}
-	ctxName := string(ctxNameBytes)
-	if len(ctxName) > 0 && ctxName[len(ctxName)-1] == '\n' {
-		ctxName = ctxName[:len(ctxName)-1]
-	}
-	return ctxName, nil
+	return SessionContext()
 }
 
-// GetContextFromEnv returns the docker context to use. It prefers the
-// DOCKER_CONTEXT environment variable (so the app can be run against a
-// specific context, e.g. in CI or local testing). If that variable is not
-// set, it falls back to calling `docker context show` to retrieve the active
-// context. The returned string will not contain a trailing newline.
+// GetContextFromEnv returns the docker context to use: the DOCKER_CONTEXT
+// environment variable if set (so the app can be run against a specific
+// context, e.g. in CI or local testing), otherwise the context that was active
+// when the session started. The returned string will not contain a trailing
+// newline.
+//
+// The resolution happens once — see SessionContext for why this does not
+// follow a `docker context use` run in another terminal.
 func GetContextFromEnv() (string, error) {
-	ctxName := os.Getenv("DOCKER_CONTEXT")
-	if ctxName != "" {
-		return ctxName, nil
-	}
-
-	ctxNameBytes, err := exec.Command("docker", "context", "show").Output()
-	if err != nil {
-		return "", fmt.Errorf("failed to get docker context: %w", err)
-	}
-	ctxName = string(ctxNameBytes)
-	if len(ctxName) > 0 && ctxName[len(ctxName)-1] == '\n' {
-		ctxName = ctxName[:len(ctxName)-1]
-	}
-	return ctxName, nil
+	return SessionContext()
 }

--- a/docker/context.go
+++ b/docker/context.go
@@ -104,13 +104,25 @@ type contextInspectResult struct {
 	} `json:"Endpoints"`
 }
 
-// ListContexts returns all available Docker contexts using docker CLI
+// ListContexts returns all available Docker contexts using docker CLI.
+//
+// `docker context ls` marks whichever context ~/.docker/config.json says is
+// current, which is not necessarily the one this session is talking to. The
+// current flag is recomputed against the session pin: a list that marked the
+// externally-switched context current while every read came from the pinned
+// one would be reporting the very mismatch #611 is about. The pin is also
+// where the contexts view reads the context being left when a switch is
+// confirmed.
 func ListContexts() ([]ContextInfo, error) {
-	cmd := exec.Command("docker", "context", "ls", "--format", "json")
-	output, err := cmd.Output()
+	output, err := listContextsFn()
 	if err != nil {
 		return nil, fmt.Errorf("failed to list contexts: %w", err)
 	}
+
+	// An unresolvable pin leaves every entry unmarked rather than failing the
+	// list: the names are still worth showing, and a switch is how the user
+	// would recover.
+	sessionName, _ := SessionContext()
 
 	var contexts []ContextInfo
 	scanner := bufio.NewScanner(bytes.NewReader(output))
@@ -123,7 +135,7 @@ func ListContexts() ([]ContextInfo, error) {
 
 		contexts = append(contexts, ContextInfo{
 			Name:        item.Name,
-			Current:     item.Current,
+			Current:     item.Name == sessionName,
 			Description: item.Description,
 			DockerHost:  item.DockerEndpoint,
 			TLS:         checkContextTLS(item.Name),
@@ -135,6 +147,14 @@ func ListContexts() ([]ContextInfo, error) {
 	}
 
 	return contexts, nil
+}
+
+// listContextsFn is the seam for `docker context ls`, so which entry ListContexts
+// marks current is testable without a Docker CLI on PATH.
+var listContextsFn = runContextList
+
+func runContextList() ([]byte, error) {
+	return exec.Command("docker", "context", "ls", "--format", "json").Output()
 }
 
 // checkContextTLS checks if a context has TLS enabled
@@ -214,6 +234,7 @@ var (
 	useContextFn     = UseContext
 	resetClientFn    = ResetClient
 	currentContextFn = GetCurrentContext
+	setContextFn     = SetSessionContext
 	probeContextFn   = probeActiveContext
 )
 
@@ -222,7 +243,7 @@ func ValidateContext(ctx context.Context, contextName string) error {
 	// A switch cannot take effect while DOCKER_CONTEXT names something else,
 	// so report that instead of writing config.json and claiming success.
 	// Naming the same context is not a conflict — nothing has to move.
-	if env := os.Getenv("DOCKER_CONTEXT"); env != "" && env != contextName {
+	if env := envContext(); env != "" && env != contextName {
 		return fmt.Errorf("%w to '%s' — unset it to switch to '%s'", ErrContextPinnedByEnv, env, contextName)
 	}
 
@@ -236,15 +257,20 @@ func ValidateContext(ctx context.Context, contextName string) error {
 	if err := useContextFn(contextName); err != nil {
 		return err
 	}
-	// The client is a process-wide singleton built for the context we just
-	// left. Without dropping it, every check below would describe that
-	// context and pass whatever the new one is doing.
+	// Two pieces of state, both stale until moved: the session pin every
+	// caller resolves its context through, and the process-wide client
+	// singleton built for the context we just left. Without dropping the
+	// client, every check below would describe that context and pass whatever
+	// the new one is doing; without moving the pin, the probe below would
+	// build the replacement for the old context all over again.
+	setContextFn(contextName)
 	resetClientFn()
 
 	if err := probeContextFn(ctx, contextName); err != nil {
 		// Switch back to original context, and drop the client built for the
 		// one being rejected.
 		_ = useContextFn(currentCtx)
+		setContextFn(currentCtx)
 		resetClientFn()
 		return err
 	}

--- a/docker/context_list_test.go
+++ b/docker/context_list_test.go
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package docker
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestListContexts_MarksTheSessionContextCurrent — `docker context ls` reports
+// whichever context ~/.docker/config.json names, which after a switch made in
+// another terminal is not the one this session is talking to. Trusting it made
+// the contexts view display the very mismatch #611 is about, and it is also
+// where the view reads the context being left when a switch is confirmed.
+func TestListContexts_MarksTheSessionContextCurrent(t *testing.T) {
+	stubContextShow(t, "swarm-a")
+	_, err := SessionContext()
+	require.NoError(t, err)
+
+	origList := listContextsFn
+	t.Cleanup(func() { listContextsFn = origList })
+	// swarm-b is what the config file now says. swarm-a is what we are using.
+	listContextsFn = func() ([]byte, error) {
+		return []byte(`{"Name":"swarm-a","Current":false,"Description":"a","DockerEndpoint":"tcp://a:2376"}
+{"Name":"swarm-b","Current":true,"Description":"b","DockerEndpoint":"tcp://b:2376"}
+`), nil
+	}
+
+	contexts, err := ListContexts()
+	require.NoError(t, err)
+	require.Len(t, contexts, 2)
+
+	current := map[string]bool{}
+	for _, c := range contexts {
+		current[c.Name] = c.Current
+	}
+	require.True(t, current["swarm-a"], "the pinned context is the one in use")
+	require.False(t, current["swarm-b"], "the config file's choice is not this session's")
+}

--- a/docker/context_validate_test.go
+++ b/docker/context_validate_test.go
@@ -27,9 +27,11 @@ func stubValidateSeams(t *testing.T, s *validateSeams) {
 	t.Helper()
 	origUse, origReset := useContextFn, resetClientFn
 	origCurrent, origProbe := currentContextFn, probeContextFn
+	origSet := setContextFn
 	t.Cleanup(func() {
 		useContextFn, resetClientFn = origUse, origReset
 		currentContextFn, probeContextFn = origCurrent, origProbe
+		setContextFn = origSet
 	})
 
 	if s.current == "" {
@@ -40,6 +42,7 @@ func stubValidateSeams(t *testing.T, s *validateSeams) {
 		return s.useErr
 	}
 	resetClientFn = func() { s.trace = append(s.trace, "reset") }
+	setContextFn = func(name string) { s.trace = append(s.trace, "pin:"+name) }
 	currentContextFn = func() (string, error) { return s.current, s.curErr }
 	probeContextFn = func(context.Context, string) error {
 		s.trace = append(s.trace, "probe")
@@ -50,15 +53,16 @@ func stubValidateSeams(t *testing.T, s *validateSeams) {
 	t.Setenv("DOCKER_CONTEXT", "")
 }
 
-// The cached client is a process-wide singleton built for the previous
-// context. Probing before dropping it validates the context being left, which
-// is how an unreachable target used to pass.
-func TestValidateContext_DropsTheCachedClientBeforeProbing(t *testing.T) {
+// Two pieces of process-wide state describe the previous context: the session
+// pin every caller resolves through, and the cached client built from it.
+// Probing before both have moved validates the context being left, which is how
+// an unreachable target used to pass.
+func TestValidateContext_MovesThePinAndDropsTheClientBeforeProbing(t *testing.T) {
 	s := &validateSeams{}
 	stubValidateSeams(t, s)
 
 	require.NoError(t, ValidateContext(context.Background(), "new"))
-	require.Equal(t, []string{"use:new", "reset", "probe"}, s.trace)
+	require.Equal(t, []string{"use:new", "pin:new", "reset", "probe"}, s.trace)
 }
 
 // A target that does not answer must leave the machine exactly as it was —
@@ -70,7 +74,9 @@ func TestValidateContext_UnreachableTargetRevertsAndDropsItsClient(t *testing.T)
 
 	err := ValidateContext(context.Background(), "new")
 	require.ErrorIs(t, err, boom, "the probe's reason must reach the caller unchanged")
-	require.Equal(t, []string{"use:new", "reset", "probe", "use:old", "reset"}, s.trace)
+	require.Equal(t,
+		[]string{"use:new", "pin:new", "reset", "probe", "use:old", "pin:old", "reset"},
+		s.trace)
 }
 
 // DOCKER_CONTEXT is resolved ahead of ~/.docker/config.json, so switching
@@ -96,7 +102,7 @@ func TestValidateContext_EnvNamingTheSameContextIsNotAConflict(t *testing.T) {
 	t.Setenv("DOCKER_CONTEXT", "new")
 
 	require.NoError(t, ValidateContext(context.Background(), "new"))
-	require.Equal(t, []string{"use:new", "reset", "probe"}, s.trace)
+	require.Equal(t, []string{"use:new", "pin:new", "reset", "probe"}, s.trace)
 }
 
 // Without a context to revert to there is nothing safe to do, so the switch

--- a/docker/session_context.go
+++ b/docker/session_context.go
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package docker
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"sync"
+)
+
+// envContextVar is the environment variable Docker resolves ahead of the
+// config file (docker/cli cli/command.EnvOverrideContext).
+const envContextVar = "DOCKER_CONTEXT"
+
+// envContext reports the context named by the environment, if any, trimmed.
+// The pin, ValidateContext's refusal guard and the drift check all read it
+// through here, so they cannot disagree about what "pinned by the environment"
+// means — including for a value that is only whitespace, which names nothing.
+func envContext() string { return strings.TrimSpace(os.Getenv(envContextVar)) }
+
+// The Docker context this process addresses, resolved once.
+//
+// swarmcli used to answer "which context?" twice, differently: the SDK client
+// resolved it on first use and cached the connection for the life of the
+// process, while every other caller shelled out to `docker context show` again
+// and re-read ~/.docker/config.json. A `docker context use` in another terminal
+// moved the second answer and not the first, so the lists kept describing one
+// swarm while `stack deploy`, `stack rm` and the raw log fallbacks addressed
+// another — see #611.
+//
+// The pin is the single answer. It does not follow the config file: a context
+// switch made outside swarmcli must not move a running session between swarms
+// under the operator's feet. The app watches for that drift and offers the
+// switch instead (app/contextdrift.go).
+var (
+	sessionCtxMu sync.RWMutex
+	sessionCtx   string
+)
+
+// showContextFn is the seam for `docker context show`, so the pin's behaviour
+// is testable without a Docker CLI on PATH.
+var showContextFn = runContextShow
+
+// InitSessionContext resolves the session context and pins it, returning the
+// pinned name. Calling it again returns the existing pin without re-resolving,
+// so the entry points may both call it (the TUI does, and so does the
+// non-interactive CLI) without one of them winning a race.
+func InitSessionContext() (string, error) {
+	return SessionContext()
+}
+
+// SessionContext returns the pinned Docker context, resolving it on first call.
+//
+// Resolution order is Docker's own, minus the parts a library cannot see:
+// $DOCKER_CONTEXT, then the active context from the config file. Note that
+// Docker resolves $DOCKER_HOST ahead of $DOCKER_CONTEXT and lets it force the
+// `default` context; swarmcli has never honoured $DOCKER_HOST — it always
+// builds its client from a context's stored endpoint — which is why every
+// shell-out names the pin with an explicit `--context`, the one thing that
+// outranks $DOCKER_HOST.
+func SessionContext() (string, error) {
+	sessionCtxMu.RLock()
+	pinned := sessionCtx
+	sessionCtxMu.RUnlock()
+	if pinned != "" {
+		return pinned, nil
+	}
+
+	sessionCtxMu.Lock()
+	defer sessionCtxMu.Unlock()
+	// Another goroutine may have resolved it while this one waited.
+	if sessionCtx != "" {
+		return sessionCtx, nil
+	}
+
+	name, err := resolveContextName()
+	if err != nil {
+		return "", err
+	}
+	sessionCtx = name
+	return sessionCtx, nil
+}
+
+// SetSessionContext moves the pin. It is how a switch made inside swarmcli —
+// from the contexts view, or by accepting the drift prompt — takes effect: the
+// client cache must be dropped separately with ResetClient, because a pinned
+// name and a live connection are two different pieces of state.
+func SetSessionContext(name string) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return
+	}
+	sessionCtxMu.Lock()
+	sessionCtx = name
+	sessionCtxMu.Unlock()
+}
+
+// EnvPinsContext reports whether DOCKER_CONTEXT names the context.
+//
+// While it does, ~/.docker/config.json cannot move this session — Docker
+// resolves the variable ahead of the file — so the two naming different
+// contexts is the documented arrangement rather than a switch to react to.
+// ValidateContext refuses to move off it for the same reason.
+func EnvPinsContext() bool {
+	return envContext() != ""
+}
+
+// ResetSessionContext drops the pin, so the next SessionContext call resolves
+// afresh.
+//
+// For tests. The pin is deliberately sticky — that is the whole point of it —
+// which is exactly what makes a test that changes DOCKER_CONTEXT or the active
+// context read a stale answer without this. Production moves the pin with
+// SetSessionContext, which names the new context rather than re-reading the
+// config file.
+func ResetSessionContext() {
+	sessionCtxMu.Lock()
+	sessionCtx = ""
+	sessionCtxMu.Unlock()
+}
+
+// ConfigFileContext reports the context Docker itself would use right now,
+// reading past the pin. It is what the drift check compares against, and the
+// only caller that wants the live answer rather than the session's.
+func ConfigFileContext() (string, error) {
+	return resolveContextName()
+}
+
+// resolveContextName performs the lookup the pin caches.
+func resolveContextName() (string, error) {
+	if ctxName := envContext(); ctxName != "" {
+		return ctxName, nil
+	}
+	return showContextFn()
+}
+
+func runContextShow() (string, error) {
+	out, err := exec.Command("docker", "context", "show").Output()
+	if err != nil {
+		return "", fmt.Errorf("failed to get docker context: %w", err)
+	}
+	return strings.TrimSpace(string(out)), nil
+}

--- a/docker/session_context_test.go
+++ b/docker/session_context_test.go
@@ -1,0 +1,194 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package docker
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// stubContextShow replaces the `docker context show` seam with a value the test
+// controls, and clears both the pin and DOCKER_CONTEXT so the case starts from
+// a known state. The returned function moves what the config file would say.
+func stubContextShow(t *testing.T, initial string) func(string) {
+	t.Helper()
+	orig := showContextFn
+	current := initial
+	showContextFn = func() (string, error) { return current, nil }
+	ResetSessionContext()
+	t.Cleanup(func() {
+		showContextFn = orig
+		ResetSessionContext()
+	})
+	// Inherited from the developer's shell, this would outrank the stub.
+	t.Setenv(envContextVar, "")
+	return func(next string) { current = next }
+}
+
+// TestSessionContext_DoesNotFollowTheConfigFile is the regression test for
+// #611. swarmcli used to answer "which context?" per call, so a
+// `docker context use` in another terminal moved the exec-based half of the
+// app — logs, deploy, stack rm — while the SDK client stayed connected to the
+// context the session started in, and the two addressed different swarms.
+func TestSessionContext_DoesNotFollowTheConfigFile(t *testing.T) {
+	move := stubContextShow(t, "swarm-a")
+
+	pinned, err := SessionContext()
+	require.NoError(t, err)
+	require.Equal(t, "swarm-a", pinned)
+
+	move("swarm-b")
+
+	got, err := SessionContext()
+	require.NoError(t, err)
+	require.Equal(t, "swarm-a", got, "the pin must not follow the config file")
+}
+
+// TestResolvers_AllReportThePin covers the other half of the same defect: three
+// exported resolvers used to make the same lookup independently, so it was
+// possible for them to disagree with each other as well as with the client.
+func TestResolvers_AllReportThePin(t *testing.T) {
+	move := stubContextShow(t, "swarm-a")
+	_, err := SessionContext()
+	require.NoError(t, err)
+
+	move("swarm-b")
+
+	fromEnv, err := GetContextFromEnv()
+	require.NoError(t, err)
+	current, err := GetCurrentContext()
+	require.NoError(t, err)
+	forStacks, err := GetDockerContext()
+	require.NoError(t, err)
+
+	require.Equal(t, "swarm-a", fromEnv)
+	require.Equal(t, "swarm-a", current)
+	require.Equal(t, "swarm-a", forStacks)
+}
+
+// TestSessionContext_EnvironmentWinsAtResolution keeps DOCKER_CONTEXT's meaning:
+// it selects the context at startup. Setting it later does not move a session
+// that is already running, which is the same promise made to a config-file
+// switch.
+func TestSessionContext_EnvironmentWinsAtResolution(t *testing.T) {
+	stubContextShow(t, "from-config")
+	t.Setenv(envContextVar, "from-env")
+
+	pinned, err := SessionContext()
+	require.NoError(t, err)
+	require.Equal(t, "from-env", pinned)
+
+	t.Setenv(envContextVar, "changed-later")
+
+	got, err := SessionContext()
+	require.NoError(t, err)
+	require.Equal(t, "from-env", got)
+}
+
+// TestSetSessionContext_MovesThePin — a switch made inside swarmcli is the one
+// thing that moves it.
+func TestSetSessionContext_MovesThePin(t *testing.T) {
+	stubContextShow(t, "swarm-a")
+	_, err := SessionContext()
+	require.NoError(t, err)
+
+	SetSessionContext("swarm-b")
+
+	got, err := SessionContext()
+	require.NoError(t, err)
+	require.Equal(t, "swarm-b", got)
+}
+
+// TestSetSessionContext_IgnoresAnEmptyName — an empty name is a failed lookup
+// somewhere upstream, and adopting it would leave every shell-out without a
+// --context and back on the config file.
+func TestSetSessionContext_IgnoresAnEmptyName(t *testing.T) {
+	stubContextShow(t, "swarm-a")
+	_, err := SessionContext()
+	require.NoError(t, err)
+
+	SetSessionContext("   ")
+
+	got, err := SessionContext()
+	require.NoError(t, err)
+	require.Equal(t, "swarm-a", got)
+}
+
+// TestConfigFileContext_ReadsPastThePin — the drift check needs the live
+// answer, and it is the only caller that does.
+func TestConfigFileContext_ReadsPastThePin(t *testing.T) {
+	move := stubContextShow(t, "swarm-a")
+	_, err := SessionContext()
+	require.NoError(t, err)
+
+	move("swarm-b")
+
+	live, err := ConfigFileContext()
+	require.NoError(t, err)
+	require.Equal(t, "swarm-b", live)
+
+	pinned, err := SessionContext()
+	require.NoError(t, err)
+	require.Equal(t, "swarm-a", pinned, "reading the live value must not move the pin")
+}
+
+// TestSessionContext_AFailedLookupIsNotCached — pinning a failure would make
+// the session permanently unable to name a context, with no way back short of
+// a restart.
+func TestSessionContext_AFailedLookupIsNotCached(t *testing.T) {
+	orig := showContextFn
+	ResetSessionContext()
+	t.Cleanup(func() { showContextFn = orig; ResetSessionContext() })
+	t.Setenv(envContextVar, "")
+
+	failing := true
+	showContextFn = func() (string, error) {
+		if failing {
+			return "", errors.New("docker not running")
+		}
+		return "swarm-a", nil
+	}
+
+	_, err := SessionContext()
+	require.Error(t, err)
+
+	failing = false
+
+	got, err := SessionContext()
+	require.NoError(t, err)
+	require.Equal(t, "swarm-a", got)
+}
+
+// TestEnvPinsContext — the drift check and ValidateContext both key off this,
+// and disagreeing would either prompt for a switch the switcher then refuses,
+// or refuse one nothing warned about.
+func TestEnvPinsContext(t *testing.T) {
+	t.Setenv(envContextVar, "")
+	require.False(t, EnvPinsContext())
+
+	t.Setenv(envContextVar, "swarm-a")
+	require.True(t, EnvPinsContext())
+
+	t.Setenv(envContextVar, "   ")
+	require.False(t, EnvPinsContext(), "whitespace names no context")
+}
+
+// TestInitSessionContext_IsIdempotent — both entry points may call it, and a
+// second call must report the pin rather than resolve a second time and
+// possibly land somewhere else.
+func TestInitSessionContext_IsIdempotent(t *testing.T) {
+	move := stubContextShow(t, "swarm-a")
+
+	first, err := InitSessionContext()
+	require.NoError(t, err)
+	require.Equal(t, "swarm-a", first)
+
+	move("swarm-b")
+
+	second, err := InitSessionContext()
+	require.NoError(t, err)
+	require.Equal(t, "swarm-a", second)
+}

--- a/docker/stack_deploy.go
+++ b/docker/stack_deploy.go
@@ -103,9 +103,8 @@ func DeployStackResolved(ctx context.Context, stackName string, yamlContent stri
 // DeployStackInContext deploys a stack to an explicitly named Docker context.
 //
 // `docker stack deploy` has no SDK equivalent, so this shells out; naming the
-// context is what keeps the target an argument rather than whatever
-// DOCKER_CONTEXT or `docker context show` happens to say at the moment the
-// command runs.
+// context is what keeps the target an argument rather than the session pin the
+// whole process shares.
 //
 // Cancelling ctx kills the child. Nothing else can reach it: the CLI holds its
 // own connection to the daemon, so a caller being torn down while the daemon is
@@ -313,23 +312,12 @@ func cleanupNetworks(stackName string, networkNames []string) {
 	}
 }
 
-// GetDockerContext returns the current Docker context name.
+// GetDockerContext returns the Docker context name this session addresses,
+// which is what the exec-based stack commands name with `--context`.
+//
+// It reports the session pin rather than re-reading the config file, so a
+// stack shown from one swarm cannot be deployed to another that was made
+// current in some other terminal meanwhile. See SessionContext.
 func GetDockerContext() (string, error) {
-	// Check DOCKER_CONTEXT environment variable first
-	if ctx := os.Getenv("DOCKER_CONTEXT"); ctx != "" {
-		return ctx, nil
-	}
-
-	// Fall back to running "docker context show"
-	output, err := exec.Command("docker", "context", "show").Output()
-	if err != nil {
-		return "", fmt.Errorf("failed to get current docker context: %w", err)
-	}
-
-	// Parse output and return trimmed context name
-	ctx := string(output)
-	if len(ctx) > 0 && ctx[len(ctx)-1] == '\n' {
-		ctx = ctx[:len(ctx)-1]
-	}
-	return ctx, nil
+	return SessionContext()
 }

--- a/docker/stack_to_compose.go
+++ b/docker/stack_to_compose.go
@@ -713,9 +713,38 @@ func (cf *ComposeFile) buildService(si *ServiceInspect, stackName string, netID2
 	return cs
 }
 
+// contextArgs prefixes a docker CLI invocation with the session's context.
+//
+// Without it these commands follow ~/.docker/config.json, which is neither the
+// context the SDK client is connected to nor the one $DOCKER_CONTEXT names —
+// so a stack read here could describe a different swarm from the one it was
+// selected in (#611).
+func contextArgs(extra ...string) []string {
+	args := make([]string, 0, 2+len(extra))
+	if ctxName, err := SessionContext(); err == nil && strings.TrimSpace(ctxName) != "" {
+		args = append(args, "--context", ctxName)
+	}
+	return append(args, extra...)
+}
+
+// stackServicesArgs builds the argument list for listing a stack's services.
+func stackServicesArgs(stackName string) []string {
+	return contextArgs("stack", "services", stackName, "--format", "{{.Name}}")
+}
+
+// serviceInspectArgs builds the argument list for inspecting one service.
+func serviceInspectArgs(serviceName string) []string {
+	return contextArgs("service", "inspect", serviceName)
+}
+
+// networkListArgs builds the argument list for the id-to-name network listing.
+func networkListArgs() []string {
+	return contextArgs("network", "ls", "--no-trunc", "--format", "{{.ID}}\t{{.Name}}")
+}
+
 // getStackServices returns the list of service names for a stack
 func getStackServices(stackName string) ([]string, error) {
-	cmd := exec.Command("docker", "stack", "services", stackName, "--format", "{{.Name}}")
+	cmd := exec.Command("docker", stackServicesArgs(stackName)...)
 	var out bytes.Buffer
 	var errb bytes.Buffer
 	cmd.Stdout = &out
@@ -738,7 +767,7 @@ func getStackServices(stackName string) ([]string, error) {
 
 // inspectService returns the inspect data for a service
 func inspectService(serviceName string) (*ServiceInspect, error) {
-	cmd := exec.Command("docker", "service", "inspect", serviceName)
+	cmd := exec.Command("docker", serviceInspectArgs(serviceName)...)
 	var out bytes.Buffer
 	var errb bytes.Buffer
 	cmd.Stdout = &out
@@ -757,7 +786,7 @@ func inspectService(serviceName string) (*ServiceInspect, error) {
 
 // dockerNetworkIDToNameMap builds a map of network IDs to names
 func dockerNetworkIDToNameMap() (map[string]string, error) {
-	cmd := exec.Command("docker", "network", "ls", "--no-trunc", "--format", "{{.ID}}\t{{.Name}}")
+	cmd := exec.Command("docker", networkListArgs()...)
 	var out bytes.Buffer
 	var errb bytes.Buffer
 	cmd.Stdout = &out

--- a/docker/stack_to_compose_args_test.go
+++ b/docker/stack_to_compose_args_test.go
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package docker
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// These three commands used to carry no --context at all, so they followed
+// ~/.docker/config.json — neither the context the SDK client is connected to
+// nor the one DOCKER_CONTEXT names. A stack selected from one swarm could be
+// reconstructed from another's services and networks (#611).
+func TestStackToComposeArgs_NameTheSessionContext(t *testing.T) {
+	stubContextShow(t, "swarm-a")
+	_, err := SessionContext()
+	require.NoError(t, err)
+
+	require.Equal(t,
+		[]string{"--context", "swarm-a", "stack", "services", "web", "--format", "{{.Name}}"},
+		stackServicesArgs("web"))
+	require.Equal(t,
+		[]string{"--context", "swarm-a", "service", "inspect", "web_api"},
+		serviceInspectArgs("web_api"))
+	require.Equal(t,
+		[]string{"--context", "swarm-a", "network", "ls", "--no-trunc", "--format", "{{.ID}}\t{{.Name}}"},
+		networkListArgs())
+}
+
+// TestStackToComposeArgs_UnresolvableContextStillRuns — with no context to
+// name, the command is better run against Docker's own default than not run at
+// all: that is the behaviour these call sites had before the flag was added.
+func TestStackToComposeArgs_UnresolvableContextStillRuns(t *testing.T) {
+	orig := showContextFn
+	ResetSessionContext()
+	t.Cleanup(func() { showContextFn = orig; ResetSessionContext() })
+	t.Setenv(envContextVar, "")
+	showContextFn = func() (string, error) { return "", errors.New("docker not running") }
+
+	require.Equal(t,
+		[]string{"service", "inspect", "web_api"},
+		serviceInspectArgs("web_api"))
+}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -15,7 +15,7 @@ apply to every build.
 |---|---|---|---|---|
 | `SWARMCLI_ENV` | both | `dev` writes human-readable logs, `prod` writes JSON. | `prod` | startup |
 | `LOG_LEVEL` | both | Log verbosity: `debug`, `info`, `warn`, `error`. | `debug` in dev, `info` in prod | startup |
-| `DOCKER_CONTEXT` | both | Docker context to talk to. It overrides `docker context use`, so while it is set the context switcher refuses to move to a different context rather than writing a switch that could not take effect. | the active context | startup, and every Docker client |
+| `DOCKER_CONTEXT` | both | Docker context to talk to. It overrides `docker context use`, so while it is set the context switcher refuses to move to a different context rather than writing a switch that could not take effect. | the active context | startup |
 | `SWARMCLI_DISABLE_VERSION_CHECK` | both | Disables the startup request to `https://swarmcli.io/api/v1/version` that checks whether a newer release is available. | unset | startup |
 | `SWARMCLI_CHARTS_ALLOW_PLAINTEXT` | both | Allows chart repositories served over plain `http://`, which are refused by default (see [charts/README.md](../charts/README.md#transport)). | unset (https only) | `charts` commands |
 | `SWARMCLI_CHARTS_NO_AUTO_UPDATE` | both | Stops a `charts` command refreshing a repository index before resolving a chart from it. `--no-repo-update` does the same for one invocation. | unset (refreshes) | `charts` commands |
@@ -39,6 +39,29 @@ See [License — Activation](license.md#activation) for the precedence
 between `SWARMCLI_LICENSE` and the license file, and
 [Features](features.md) for how `SWARMCLI_REVEAL_IMAGE`,
 `SWARMCLI_SHELL_CMD`, and `SWARMCLI_FORWARD_IDLE_TIMEOUT` are used.
+
+## The Docker context
+
+swarmcli resolves the Docker context once, at startup — from `DOCKER_CONTEXT`
+if it is set, otherwise from the active context — and then addresses that one
+context for the rest of the session. Everything it does goes to the same
+swarm: the lists, the logs, `stack deploy`, and every `docker` command it runs
+for you.
+
+So running `docker context use <other>` in another terminal does **not** move a
+running swarmcli. Instead, within a few seconds it asks:
+
+```
+The Docker context changed outside swarmcli: 'a' → 'b'.
+
+swarmcli is still using 'a'. Switch to 'b'?
+```
+
+Answer `y` to follow the switch — swarmcli drops its connection, reconnects to
+`b` and reloads the cluster. Answer `n` to stay on `a`; you are not asked about
+`b` again unless the context changes to something else, or changes back to `a`
+and away again. Switching from inside swarmcli, with `:contexts`, needs no
+prompt and still runs `docker context use`, so your shell follows along.
 
 ## On-disk paths
 

--- a/integration-tests/docker/get_context_test.go
+++ b/integration-tests/docker/get_context_test.go
@@ -15,6 +15,11 @@ import (
 func TestGetContextFromEnv_EnvOverride(t *testing.T) {
 	const want = "ci-test-context"
 	t.Setenv("DOCKER_CONTEXT", want)
+	// The context is resolved once per process and then pinned, so a test that
+	// changes what the resolution would return has to drop the pin first — and
+	// leave the next test to resolve its own.
+	docker.ResetSessionContext()
+	t.Cleanup(docker.ResetSessionContext)
 
 	ctx, err := docker.GetContextFromEnv()
 	if err != nil {
@@ -31,16 +36,21 @@ func TestGetContextFromEnv_FallbackToDocker(t *testing.T) {
 		t.Skip("docker not available; skipping integration test")
 	}
 
-	// Ensure env is empty so the function falls back to calling
+	// Ensure env is empty so the resolution falls back to calling
 	// `docker context show`.
 	t.Setenv("DOCKER_CONTEXT", "")
+	docker.ResetSessionContext()
+	t.Cleanup(docker.ResetSessionContext)
 
 	ctxFromFunc, err := docker.GetContextFromEnv()
 	if err != nil {
 		t.Fatalf("GetContextFromEnv failed: %v", err)
 	}
 
-	// Compare against the public helper which also queries docker.
+	// Compare against the public helper. Both report the session pin, and that
+	// they cannot disagree is the point: they used to make the lookup
+	// separately, so a `docker context use` between the two calls moved one and
+	// not the other.
 	ctxCurrent, err := docker.GetCurrentContext()
 	if err != nil {
 		t.Fatalf("GetCurrentContext failed: %v", err)
@@ -48,5 +58,49 @@ func TestGetContextFromEnv_FallbackToDocker(t *testing.T) {
 
 	if ctxFromFunc != ctxCurrent {
 		t.Fatalf("mismatch: GetContextFromEnv=%q GetCurrentContext=%q", ctxFromFunc, ctxCurrent)
+	}
+}
+
+// TestSessionContext_SurvivesAContextSwitch is the daemon-backed half of the
+// #611 regression test: a real `docker context use` run against the real config
+// file must not move a session that has already resolved its context.
+func TestSessionContext_SurvivesAContextSwitch(t *testing.T) {
+	if _, err := exec.LookPath("docker"); err != nil {
+		t.Skip("docker not available; skipping integration test")
+	}
+	t.Setenv("DOCKER_CONTEXT", "")
+	docker.ResetSessionContext()
+	t.Cleanup(docker.ResetSessionContext)
+
+	pinned, err := docker.SessionContext()
+	if err != nil {
+		t.Fatalf("SessionContext failed: %v", err)
+	}
+
+	other := "default"
+	if pinned == other {
+		t.Skip("already on the default context; nothing to switch away to")
+	}
+	if err := exec.Command("docker", "context", "use", other).Run(); err != nil {
+		t.Skipf("could not switch context: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = exec.Command("docker", "context", "use", pinned).Run()
+	})
+
+	live, err := docker.ConfigFileContext()
+	if err != nil {
+		t.Fatalf("ConfigFileContext failed: %v", err)
+	}
+	if live != other {
+		t.Fatalf("expected the config file to name %q, got %q", other, live)
+	}
+
+	got, err := docker.SessionContext()
+	if err != nil {
+		t.Fatalf("SessionContext failed: %v", err)
+	}
+	if got != pinned {
+		t.Fatalf("the session moved with the config file: pinned %q, now %q", pinned, got)
 	}
 }

--- a/integration-tests/swarmlock/locked_swarm_test.go
+++ b/integration-tests/swarmlock/locked_swarm_test.go
@@ -67,6 +67,7 @@ func TestLockedSwarm_SwitchSnapshotAndUnlock(t *testing.T) {
 	_, _ = hostDocker(t, "rm", "-f", containerName)
 	_ = exec.Command("docker", "context", "rm", "-f", lockedContext).Run()
 	t.Cleanup(func() {
+		docker.ResetSessionContext()
 		docker.ResetClient()
 		// The context must not be current when we remove it.
 		_ = exec.Command("docker", "context", "use", "default").Run()
@@ -111,6 +112,10 @@ func TestLockedSwarm_SwitchSnapshotAndUnlock(t *testing.T) {
 		t.Fatalf("creating context: %v\n%s", err, out)
 	}
 	t.Setenv("DOCKER_CONTEXT", lockedContext)
+	// The context is resolved once per process and then pinned, so setting the
+	// variable is not enough: drop the pin as well, or the client is rebuilt
+	// for whatever context this binary resolved first.
+	docker.ResetSessionContext()
 	docker.ResetClient()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)


### PR DESCRIPTION
Fixes #611.

## The defect

The report is the inverse of its title: swarmcli *does* discover the switch — in some code paths and not others, and they disagree.

swarmcli held two independent notions of "the current Docker context":

- `docker.GetClient()` — a process-wide singleton built on first use and never rebuilt unless something calls `ResetClient()` (only the in-app switch did);
- `GetContextFromEnv`, `GetCurrentContext` and `GetDockerContext` — three near-identical resolvers, each shelling out to `docker context show` on **every call**.

`docker context use b` in another terminal moved the second and not the first. From then on:

| surface | addressed |
|---|---|
| stacks/services/nodes lists, log streaming | swarm **a** (cached client) |
| raw-CLI log fallback (`docker/service.go`, `views/logs/stream.go`) | swarm **b** |
| `stack deploy`, `stack rm` (`docker/stack_deploy.go`) | swarm **b** |
| `docker stack services` / `service inspect` / `network ls` (`stack_to_compose.go`) | **the config file**, always — no `--context` at all, so these ignored `DOCKER_CONTEXT` too |
| contexts view's "current" marker | swarm **b** |
| header "Context:" | frozen (see below) |

The reported logs failure is `docker --context b service logs <id-from-a>`. **Deploying a stack shown from `a` into `b`, with no warning, is the same defect and worse.**

## The fix

**One session pin.** `docker/session_context.go` resolves the context once — `DOCKER_CONTEXT`, else `docker context show` — and holds it. `buildClient` builds from it, the three resolvers return it, `ListContexts` recomputes `Current` against it instead of trusting `docker context ls`, and the three unflagged `stack_to_compose` commands now name it with `--context`. Only a switch made inside swarmcli moves it.

`--context` rather than exporting `DOCKER_CONTEXT`: `docker/cli@v28.5.1 cli/command/cli.go:461` resolves `--context` > `$DOCKER_HOST` (which forces `default`) > `$DOCKER_CONTEXT`, so the variable is not a reliable pin for a child process. The flag is.

**A prompt, not silence.** A deliberate switch should not be ignored either, so a tick compares the config file against the pin and offers to follow:

```
The Docker context changed outside swarmcli: 'a' → 'b'.

swarmcli is still using 'a'. Switch to 'b'?

y — switch to 'b' and reload the cluster
n — keep using 'a' (swarmcli will not ask again for 'b')
```

- Declining is remembered **per target**, so two terminals on two swarms means one question, not one every five seconds. A drift to a *third* context still asks, and returning to the pin clears the refusal.
- `DOCKER_CONTEXT` being set is never drift — it outranks the config file by design, and `ValidateContext` refuses to move off it anyway (#563/#565). Prompting there would offer a switch the switcher then refuses, at every startup of the DinD test flow.
- The prompt waits for the screen: no dialog over the startup overlay, an app error, the unlock dialog or the update notice — and the update notice now yields to it in return.
- Accepting does **not** run `docker context use` (the config file already says `b`), and a revert after a failed load writes `~/.docker/config.json` only when swarmcli was the one that wrote it. Undoing the operator's own shell switch would be reaching outside our own state.
- Both ways into a new context now go through one `enterContext` helper, so the client drop, the snapshot invalidation, the loading view and the revert bookkeeping cannot drift apart.

**An adjacent defect the prompt needed fixed.** `app/tick.go`'s `handleTick` never returned `tick()`, so the timer armed in `Init` fired once and stopped — untouched since `app` was extracted from `main` in #26. That is why the header's context name *and* its container/service counts froze seconds after launch. The drift check needs a live timer, and the header was always meant to have one. Note this means `LoadStatus` (two API calls against the cached client) now runs every 5 s where it effectively ran once.

## Tests

24 new unit tests, no daemon required. The regression test for this issue is `TestSessionContext_DoesNotFollowTheConfigFile` plus `TestResolvers_AllReportThePin`: resolve, move what `docker context show` would return, assert all three resolvers still agree on the first answer. Also covered: the env pin, `SetSessionContext`, a failed lookup not being cached, `ListContexts` marking the pin over `docker context ls`'s own flag, the three `--context` arg builders, the whole drift state machine (raise / decline / third target / return clears / waits for the screen / accepts), the prompt being a `y/n` confirmation that owns the keyboard, the revert not writing the config file, and `handleTick` re-arming.

`integration-tests/docker/get_context_test.go` gains a daemon-backed half — a real `docker context use` against the real config file must not move a resolved session — and both it and `swarmlock` now drop the pin where they change what resolution would return.

## Deviation from the plan

`InitSessionContext()` is called from `app.InitialModel()`, not `app.Init()` or `cli.Dispatch()`: `Init()` also runs for `swarmcli --version`, which has no business spawning a `docker` subprocess. The lazy path in `SessionContext()` covers the non-interactive CLI and library consumers, and a short-lived CLI process cannot drift anyway.

## Verification

`go build ./...`, `go vet ./...`, `go vet -tags integration ./...`, `go test ./...`, `golangci-lint run ./... --build-tags=integration` — all clean. Integration tests not run here (no DinD swarm in this environment).

---
Machine-generated by an AI agent (Claude Opus 5) and not human-reviewed. Claims carry a file, a line or a reproducible check so they can be verified cheaply.
