### PR TITLE
fix(views): a task that ran to completion is not a warning

### DIFF
--- a/views/services/columns_test.go
+++ b/views/services/columns_test.go
@@ -159,8 +159,10 @@ func TestExpandedRow_ContainerStateFallback(t *testing.T) {
 }
 
 // The tint rule itself is tested in views/taskutil; what this asserts is that
-// the expanded rows go through it, and that a replica swarm stopped on purpose
-// no longer reads like the one that crashed next to it (issue #601).
+// the expanded rows go through it, that a replica swarm stopped on purpose no
+// longer reads like the one that crashed next to it (issue #601), and that a
+// task which ran to completion reads like an ordinary row whether or not its
+// container is still on the node to report "exited" (issue #613).
 func TestExpandedRow_TintsByTaskState(t *testing.T) {
 	trueColour(t)
 	m := testModel()
@@ -173,6 +175,10 @@ func TestExpandedRow_TintsByTaskState(t *testing.T) {
 			CurrentState: "shutdown 11 minutes ago", ContainerState: "exited"},
 		{Name: "web.3", NodeName: "node-bad", DesiredState: "Shutdown", State: "failed",
 			CurrentState: "failed 19 minutes ago", ContainerState: "exited", Error: "task: non-zero exit (1)"},
+		{Name: "web.4", NodeName: "node-done", DesiredState: "Shutdown", State: "complete",
+			CurrentState: "complete 44 seconds ago", ContainerState: "exited"},
+		{Name: "web.5", NodeName: "node-old", DesiredState: "Shutdown", State: "complete",
+			CurrentState: "complete 3 days ago"},
 	}
 	m.setRenderItem()
 
@@ -180,6 +186,11 @@ func TestExpandedRow_TintsByTaskState(t *testing.T) {
 	require.Equal(t, fgSeq(lipgloss.Color("7")), rowTint(t, out, "node-up"))
 	require.Equal(t, fgSeq(lipgloss.Color("3")), rowTint(t, out, "node-gone"))
 	require.Equal(t, fgSeq(lipgloss.Color("9")), rowTint(t, out, "node-bad"))
+	// The two rows issue #613 was reported on: same state, and they differ only
+	// in whether the node has pruned the container out of the health decorator's
+	// inventory. They must not differ in colour.
+	require.Equal(t, fgSeq(lipgloss.Color("7")), rowTint(t, out, "node-done"))
+	require.Equal(t, fgSeq(lipgloss.Color("7")), rowTint(t, out, "node-old"))
 }
 
 // trueColour makes a test's assertions run against the tinted rows: the default

--- a/views/taskutil/style.go
+++ b/views/taskutil/style.go
@@ -18,10 +18,10 @@ var (
 // TaskRowStyle tints one task row by what the row is telling the operator, and
 // returns base for a task with nothing to say. Red is kept for a task that went
 // wrong — it failed, was rejected, orphaned, recorded an error, or its
-// healthcheck is failing. A task that is simply not running gets yellow: swarm
-// stops a replica on purpose on every update, scale-down and node drain, and
-// the container's docker-ps state is "exited" for that exactly as it is for a
-// crash, so the swarm task state is what tells the two apart (issue #601).
+// healthcheck is failing. A task swarm stopped on purpose gets yellow: that
+// happens on every update, scale-down and node drain, and the container's
+// docker-ps state is "exited" for it exactly as it is for a crash, so the swarm
+// task state is what tells the two apart (issue #601).
 //
 // base is the caller's normal row style rather than a colour of ours: the three
 // views showing tasks each render an ordinary row in their own colour, and only
@@ -31,6 +31,13 @@ func TaskRowStyle(t docker.TaskEntry, base lipgloss.Style) lipgloss.Style {
 	case isFailedState(t.State), t.Error != "",
 		t.Health == "unhealthy", t.ContainerState == "dead":
 		return taskFailedStyle
+	// A task that ran to completion is the outcome that was wanted, not
+	// something to flag: swarm reaches "complete" only when the container
+	// exited 0, and anything else is "failed". It needs an arm of its own ahead
+	// of the stopped case because the container's docker-ps state is "exited"
+	// here too, exactly as it is for a replica swarm retired (issue #613).
+	case swarm.TaskState(t.State) == swarm.TaskStateComplete:
+		return base
 	case isStoppedState(t.State), t.Health == "starting",
 		t.ContainerState == "restarting", t.ContainerState == "exited":
 		return taskStoppedStyle
@@ -50,11 +57,13 @@ func isFailedState(state string) bool {
 	return false
 }
 
-// isStoppedState reports whether a swarm task state means the task is over
-// without having failed — stopped by swarm, or finished on its own.
+// isStoppedState reports whether a swarm task state means swarm ended the task
+// rather than the task ending itself — retired by an update, a scale-down or a
+// node drain, or on its way out of the task list. A task that ran to completion
+// is not one of these; it is the success TaskRowStyle leaves alone.
 func isStoppedState(state string) bool {
 	switch swarm.TaskState(state) {
-	case swarm.TaskStateShutdown, swarm.TaskStateComplete, swarm.TaskStateRemove:
+	case swarm.TaskStateShutdown, swarm.TaskStateRemove:
 		return true
 	}
 	return false

--- a/views/taskutil/style_test.go
+++ b/views/taskutil/style_test.go
@@ -30,7 +30,13 @@ func TestTaskRowStyle(t *testing.T) {
 		{"running", docker.TaskEntry{State: "running", Health: "healthy", ContainerState: "running"}, base.GetForeground()},
 		{"running, no healthcheck", docker.TaskEntry{State: "running"}, base.GetForeground()},
 		{"still coming up", docker.TaskEntry{State: "preparing"}, base.GetForeground()},
-		{"finished on its own", docker.TaskEntry{State: "complete", ContainerState: "exited"}, yellow},
+		// #613: "complete" is the one state that proves exit 0 — swarm reaches
+		// it only when the container exited cleanly, and anything else is
+		// "failed". A job's whole task history is complete, so tinting it at
+		// all would make the tint meaningless the way #601's red was.
+		{"finished on its own, exit 0", docker.TaskEntry{State: "complete", ContainerState: "exited"}, base.GetForeground()},
+		{"finished, container already pruned", docker.TaskEntry{State: "complete"}, base.GetForeground()},
+		{"complete but carrying an error", docker.TaskEntry{State: "complete", Error: "boom"}, red},
 		{"marked for removal", docker.TaskEntry{State: "remove"}, yellow},
 		{"rejected by the node", docker.TaskEntry{State: "rejected", Error: "invalid mount config"}, red},
 		{"rejected without a message", docker.TaskEntry{State: "rejected"}, red},


### PR DESCRIPTION
An expanded service listed every finished job task in the "stopped" colour, so a migration that had done exactly what it was asked read like something to look at. On a job service — `restart_policy: none` or `on-failure`, which is what `isJobService` already calls a job — the entire task history is `complete`, so the tint applied to every row and stopped meaning anything, the way red did before #602.

### Why `complete` is different from `shutdown`

`complete` is the one swarm task state that proves a clean exit. The agent reaches it only by `transition(api.TaskStateCompleted, "finished")` after `ctlr.Wait(ctx)` returns nil (`swarmkit@v2.1.2 agent/exec/controller.go:322-327`), and the container executor's `Wait` returns nil only when `status.ExitCode() == 0` — anything else is wrapped in an `exitError` and becomes `fatal(err)` → `failed` with `task: non-zero exit (N)` (`docker@v28.5.2 daemon/cluster/executor/container/controller.go:321-339`).

#602 filed `complete` into `isStoppedState` as "over without having failed". That is true, and not the point: `shutdown` is swarm ending a replica that meant to keep running, `complete` is the task ending itself successfully. The rest of the tree already draws that line — `docker/convergence.go:114` counts a `complete` job task as *completed*, and both error detectors explicitly skip `DesiredState=shutdown && State=complete` rather than flag the service (`views/services/update.go:693`, `views/stacks/update.go:1317`).

### The change

`complete` returns the caller's own row style, and `isStoppedState` is left to the two states swarm ends. It needs an arm of its own rather than just leaving that helper, because the container's docker-ps state is `exited` here too and the `t.ContainerState == "exited"` clause would tint the row regardless. The arm sits *after* the failure case, so a `complete` task carrying an `Error`, `Health == "unhealthy"` or `ContainerState == "dead"` is still red.

Red stays for failed / rejected / orphaned / error / unhealthy. Yellow stays for shutdown / remove / starting / restarting, so #601 is unaffected.

Nothing is lost by not tinting it: the CURRENT STATE column already reads `complete 44 seconds ago` next to `running 18 minutes ago`.

### Tests

`views/taskutil/style_test.go` flips the `complete` case and adds two: a completed task whose container has already been pruned off the node, and a `complete` row carrying an error, which pins the arm order so a later reshuffle of the switch can't go unnoticed.

`views/services/columns_test.go` grows the two rows the issue was actually reported on — same state, differing only in whether the health decorator still has the container in its inventory. In the reporter's screenshot those two groups rendered in different colours; they must not.

Both new assertion sets were checked against the unfixed rule and fail there.

### Note on the reported screenshot

The colour in #613 is red rather than yellow because that build predates #602: sampling the image gives `#E74856` (colour 9) for the tinted rows and `#CCCCCC` (colour 7) for the untinted ones, which is the old `taskRowStyle(firstNonEmpty(Health, ContainerState))` rule keying on the container state — the new rule keys on the task state and would have tinted all five rows alike. #602 shipped in v2.0.0-rc2; this PR removes the yellow it left behind.

Closes #613
