### PR TITLE
fix(header): stop the resource-usage poll subscribing every container to dockerd

### DIFF
--- a/app/view_test.go
+++ b/app/view_test.go
@@ -60,8 +60,6 @@ func (stubClusterInfo) GetContainerCount() (int, error)       { return 0, nil }
 func (stubClusterInfo) GetServiceCount() (int, error)         { return 0, nil }
 func (stubClusterInfo) GetSwarmCPUCapacity() (float64, error) { return 0, nil }
 func (stubClusterInfo) GetSwarmMemCapacity() (int64, error)   { return 0, nil }
-func (stubClusterInfo) GetSwarmCPUUsage() (string, error)     { return "0%", nil }
-func (stubClusterInfo) GetSwarmMemUsage() (string, error)     { return "0%", nil }
 func (stubClusterInfo) GetSwarmResourceUsage() (string, string, error) {
 	return "0%", "0%", nil
 }

--- a/docker/clusterinfo_ops.go
+++ b/docker/clusterinfo_ops.go
@@ -10,8 +10,6 @@ type ClusterInfoOps interface {
 	GetServiceCount() (int, error)
 	GetSwarmCPUCapacity() (float64, error)
 	GetSwarmMemCapacity() (int64, error)
-	GetSwarmCPUUsage() (string, error)
-	GetSwarmMemUsage() (string, error)
 	GetSwarmResourceUsage() (cpuPct, memPct string, err error)
 	GetDockerVersion() (string, error)
 }
@@ -23,8 +21,6 @@ func (defaultClusterInfoOps) GetContainerCount() (int, error)       { return Get
 func (defaultClusterInfoOps) GetServiceCount() (int, error)         { return GetServiceCount() }
 func (defaultClusterInfoOps) GetSwarmCPUCapacity() (float64, error) { return GetSwarmCPUCapacity() }
 func (defaultClusterInfoOps) GetSwarmMemCapacity() (int64, error)   { return GetSwarmMemCapacity() }
-func (defaultClusterInfoOps) GetSwarmCPUUsage() (string, error)     { return GetSwarmCPUUsage() }
-func (defaultClusterInfoOps) GetSwarmMemUsage() (string, error)     { return GetSwarmMemUsage() }
 func (defaultClusterInfoOps) GetSwarmResourceUsage() (string, string, error) {
 	return GetSwarmResourceUsage()
 }

--- a/docker/info.go
+++ b/docker/info.go
@@ -113,102 +113,6 @@ func GetSwarmMemCapacity() (int64, error) {
 	return totalMem, nil
 }
 
-// GetSwarmCPUUsage returns actual CPU usage across running containers.
-func GetSwarmCPUUsage() (string, error) {
-	c, err := GetClient()
-	if err != nil {
-		l().Infof("GetSwarmCPUUsage: GetClient error: %v", err)
-		return "N/A", err
-	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), apiTimeout)
-	defer cancel()
-	containers, err := c.ContainerList(ctx, container.ListOptions{})
-	if err != nil {
-		l().Infof("GetSwarmCPUUsage: ContainerList error: %v", err)
-		return "N/A", err
-	}
-
-	if len(containers) == 0 {
-		return "0.0%", nil
-	}
-
-	l().Infof("GetSwarmCPUUsage: Collecting stats from %d containers in parallel", len(containers))
-
-	// Use goroutines to collect stats in parallel
-	type cpuResult struct {
-		percent float64
-		err     error
-	}
-
-	results := make(chan cpuResult, len(containers))
-	var wg sync.WaitGroup
-
-	for _, cont := range containers {
-		wg.Add(1)
-		go func(containerID string) {
-			defer wg.Done()
-
-			stats, err := c.ContainerStats(ctx, containerID, false)
-			if err != nil {
-				l().Infof("GetSwarmCPUUsage: ContainerStats error for %s: %v", containerID[:12], err)
-				results <- cpuResult{err: err}
-				return
-			}
-			defer func() { _ = stats.Body.Close() }()
-
-			var s container.StatsResponse
-			decodeErr := json.NewDecoder(stats.Body).Decode(&s)
-
-			if decodeErr != nil {
-				l().Infof("GetSwarmCPUUsage: Decode error for %s: %v", containerID[:12], decodeErr)
-				results <- cpuResult{err: decodeErr}
-				return
-			}
-
-			// Calculate CPU percentage
-			cpuDelta := float64(s.CPUStats.CPUUsage.TotalUsage - s.PreCPUStats.CPUUsage.TotalUsage)
-			systemDelta := float64(s.CPUStats.SystemUsage - s.PreCPUStats.SystemUsage)
-			onlineCPUs := float64(s.CPUStats.OnlineCPUs)
-
-			if onlineCPUs == 0 {
-				onlineCPUs = float64(len(s.CPUStats.CPUUsage.PercpuUsage))
-			}
-
-			var cpuPercent float64
-			if systemDelta > 0 && onlineCPUs > 0 {
-				cpuPercent = (cpuDelta / systemDelta) * onlineCPUs * 100.0
-			}
-
-			results <- cpuResult{percent: cpuPercent}
-		}(cont.ID)
-	}
-
-	// Close results channel after all goroutines complete
-	go func() {
-		wg.Wait()
-		close(results)
-	}()
-
-	// Collect results
-	var totalCPU float64
-	successCount := 0
-	for res := range results {
-		if res.err == nil {
-			totalCPU += res.percent
-			successCount++
-		}
-	}
-
-	if successCount == 0 {
-		return "0.0%", nil
-	}
-
-	result := fmt.Sprintf("%.1f%%", totalCPU)
-	l().Infof("GetSwarmCPUUsage: Final result: %s (from %d/%d containers)", result, successCount, len(containers))
-	return result, nil
-}
-
 // memUsageNoCache is the memory figure `docker stats` reports: the cgroup's
 // usage less the page cache, which is reclaimable and so is not the container's
 // working set. cgroup v1 names that quantity total_inactive_file and cgroup v2
@@ -229,99 +133,6 @@ func memUsageNoCache(mem container.MemoryStats) uint64 {
 	return mem.Usage
 }
 
-// GetSwarmMemUsage returns actual memory usage across running containers.
-func GetSwarmMemUsage() (string, error) {
-	c, err := GetClient()
-	if err != nil {
-		l().Infof("GetSwarmMemUsage: GetClient error: %v", err)
-		return "N/A", err
-	}
-
-	// Get total memory capacity from nodes
-	totalCapacity, err := GetSwarmMemCapacity()
-	if err != nil || totalCapacity == 0 {
-		l().Infof("GetSwarmMemUsage: failed to get capacity: %v", err)
-		return "N/A", err
-	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), apiTimeout)
-	defer cancel()
-	containers, err := c.ContainerList(ctx, container.ListOptions{})
-	if err != nil {
-		l().Infof("GetSwarmMemUsage: ContainerList error: %v", err)
-		return "N/A", err
-	}
-
-	if len(containers) == 0 {
-		return "0.0%", nil
-	}
-
-	l().Infof("GetSwarmMemUsage: Collecting stats from %d containers in parallel", len(containers))
-
-	// Use goroutines to collect stats in parallel
-	type memResult struct {
-		usage int64
-		err   error
-	}
-
-	results := make(chan memResult, len(containers))
-	var wg sync.WaitGroup
-
-	for _, cont := range containers {
-		wg.Add(1)
-		go func(containerID string) {
-			defer wg.Done()
-
-			stats, err := c.ContainerStats(ctx, containerID, false)
-			if err != nil {
-				l().Infof("GetSwarmMemUsage: ContainerStats error for %s: %v", containerID[:12], err)
-				results <- memResult{err: err}
-				return
-			}
-			defer func() { _ = stats.Body.Close() }()
-
-			var s container.StatsResponse
-			decodeErr := json.NewDecoder(stats.Body).Decode(&s)
-
-			if decodeErr != nil {
-				l().Infof("GetSwarmMemUsage: Decode error for %s: %v", containerID[:12], decodeErr)
-				results <- memResult{err: decodeErr}
-				return
-			}
-
-			results <- memResult{usage: int64(memUsageNoCache(s.MemoryStats))}
-		}(cont.ID)
-	}
-
-	// Close results channel after all goroutines complete
-	go func() {
-		wg.Wait()
-		close(results)
-	}()
-
-	// Collect results
-	var totalUsedBytes int64
-	successCount := 0
-	for res := range results {
-		if res.err == nil {
-			totalUsedBytes += res.usage
-			successCount++
-		}
-	}
-
-	if successCount == 0 {
-		return "0.0%", nil
-	}
-
-	// Calculate percentage
-	memPercent := (float64(totalUsedBytes) / float64(totalCapacity)) * 100.0
-
-	result := fmt.Sprintf("%.1f%%", memPercent)
-	l().Infof("GetSwarmMemUsage: Final result: %s (%.1f GB used of %.1f GB total, from %d/%d containers)",
-		result, float64(totalUsedBytes)/(1024*1024*1024), float64(totalCapacity)/(1024*1024*1024), successCount, len(containers))
-	return result, nil
-}
-
 func GetDockerVersion() (string, error) {
 	c, err := GetClient()
 	if err != nil {
@@ -337,10 +148,77 @@ func GetDockerVersion() (string, error) {
 	return info.Version, nil
 }
 
-// GetSwarmResourceUsage returns CPU and memory usage in a single pass,
-// making one ContainerList call and one ContainerStats call per container
-// instead of two separate passes. This halves the Docker API calls compared
-// to calling GetSwarmCPUUsage + GetSwarmMemUsage independently.
+// cpuBaseline is one container's cumulative CPU counters from the previous
+// sampling round.
+//
+// One-shot stats zeroes PreCPUStats, so a retained reading is the only source of
+// a previous value to difference against. That is the trade one-shot asks for,
+// and it is worth taking: the alternative — `stream=0` without `one-shot` —
+// makes the daemon subscribe the container to its global stats collector and
+// discard the first frame to prime the delta itself, which costs a second or two
+// per call and keeps every sampled container on a 1 Hz cgroup treadmill for as
+// long as the request is open (moby daemon/stats.go, daemon/stats/collector.go).
+// Differencing over our own longer window also gives a steadier figure than the
+// one-second window `docker stats` reads off.
+type cpuBaseline struct {
+	total  uint64
+	system uint64
+}
+
+var (
+	cpuBaselineMu sync.Mutex
+	cpuBaselines  = map[string]cpuBaseline{}
+)
+
+// cpuPercentSince differences a fresh reading against this container's retained
+// baseline and replaces it. ok is false when there is nothing to difference
+// against — the first time a container is seen — and when a counter has gone
+// backwards, which means the container restarted and the delta would be
+// nonsense. In both cases the caller omits this container from the CPU figure
+// rather than contributing a wrong number; the next round has a baseline.
+func cpuPercentSince(id string, s container.CPUStats) (float64, bool) {
+	cpuBaselineMu.Lock()
+	prev, seen := cpuBaselines[id]
+	cpuBaselines[id] = cpuBaseline{total: s.CPUUsage.TotalUsage, system: s.SystemUsage}
+	cpuBaselineMu.Unlock()
+
+	if !seen || s.CPUUsage.TotalUsage < prev.total || s.SystemUsage < prev.system {
+		return 0, false
+	}
+	systemDelta := float64(s.SystemUsage - prev.system)
+	if systemDelta <= 0 {
+		return 0, false
+	}
+	onlineCPUs := float64(s.OnlineCPUs)
+	if onlineCPUs == 0 {
+		onlineCPUs = float64(len(s.CPUUsage.PercpuUsage))
+	}
+	if onlineCPUs == 0 {
+		return 0, false
+	}
+	return (float64(s.CPUUsage.TotalUsage-prev.total) / systemDelta) * onlineCPUs * 100.0, true
+}
+
+// pruneCPUBaselines drops the baselines of containers that are no longer
+// running, so the map tracks the node rather than growing for the lifetime of
+// the process.
+func pruneCPUBaselines(live map[string]struct{}) {
+	cpuBaselineMu.Lock()
+	defer cpuBaselineMu.Unlock()
+	for id := range cpuBaselines {
+		if _, ok := live[id]; !ok {
+			delete(cpuBaselines, id)
+		}
+	}
+}
+
+// GetSwarmResourceUsage returns CPU and memory usage for the containers on the
+// connected node, in a single pass: one ContainerList plus one one-shot
+// ContainerStats per container.
+//
+// Memory is instantaneous and is reported from the first round. CPU is a rate,
+// so it needs two readings; a container is counted once it has a baseline (see
+// cpuBaseline).
 func GetSwarmResourceUsage() (cpuPct string, memPct string, err error) {
 	c, err := GetClient()
 	if err != nil {
@@ -360,6 +238,12 @@ func GetSwarmResourceUsage() (cpuPct string, memPct string, err error) {
 		return "N/A", "N/A", err
 	}
 
+	live := make(map[string]struct{}, len(containers))
+	for _, cont := range containers {
+		live[cont.ID] = struct{}{}
+	}
+	pruneCPUBaselines(live)
+
 	if len(containers) == 0 {
 		memStr := "0.0%"
 		if totalCapacity == 0 {
@@ -370,6 +254,7 @@ func GetSwarmResourceUsage() (cpuPct string, memPct string, err error) {
 
 	type result struct {
 		cpuPercent float64
+		hasCPU     bool
 		memUsage   int64
 		err        error
 	}
@@ -382,7 +267,7 @@ func GetSwarmResourceUsage() (cpuPct string, memPct string, err error) {
 		go func(containerID string) {
 			defer wg.Done()
 
-			stats, err := c.ContainerStats(ctx, containerID, false)
+			stats, err := c.ContainerStatsOneShot(ctx, containerID)
 			if err != nil {
 				results <- result{err: err}
 				return
@@ -395,19 +280,12 @@ func GetSwarmResourceUsage() (cpuPct string, memPct string, err error) {
 				return
 			}
 
-			// CPU
-			cpuDelta := float64(s.CPUStats.CPUUsage.TotalUsage - s.PreCPUStats.CPUUsage.TotalUsage)
-			systemDelta := float64(s.CPUStats.SystemUsage - s.PreCPUStats.SystemUsage)
-			onlineCPUs := float64(s.CPUStats.OnlineCPUs)
-			if onlineCPUs == 0 {
-				onlineCPUs = float64(len(s.CPUStats.CPUUsage.PercpuUsage))
+			pct, hasCPU := cpuPercentSince(containerID, s.CPUStats)
+			results <- result{
+				cpuPercent: pct,
+				hasCPU:     hasCPU,
+				memUsage:   int64(memUsageNoCache(s.MemoryStats)),
 			}
-			var cpuPct float64
-			if systemDelta > 0 && onlineCPUs > 0 {
-				cpuPct = (cpuDelta / systemDelta) * onlineCPUs * 100.0
-			}
-
-			results <- result{cpuPercent: cpuPct, memUsage: int64(memUsageNoCache(s.MemoryStats))}
 		}(cont.ID)
 	}
 
@@ -415,25 +293,29 @@ func GetSwarmResourceUsage() (cpuPct string, memPct string, err error) {
 
 	var totalCPU float64
 	var totalMem int64
-	successCount := 0
+	cpuCount, memCount := 0, 0
 	for res := range results {
-		if res.err == nil {
+		if res.err != nil {
+			continue
+		}
+		memCount++
+		totalMem += res.memUsage
+		if res.hasCPU {
+			cpuCount++
 			totalCPU += res.cpuPercent
-			totalMem += res.memUsage
-			successCount++
 		}
 	}
 
-	cpuPct = "0.0%"
-	if successCount > 0 {
+	// No baseline yet on any container (the very first round) reads as unknown,
+	// not as an idle cluster: "0.0%" there would be a measurement we did not make.
+	cpuPct = "N/A"
+	if cpuCount > 0 {
 		cpuPct = fmt.Sprintf("%.1f%%", totalCPU)
 	}
 
 	memPct = "N/A"
-	if totalCapacity > 0 && successCount > 0 {
+	if memCount > 0 && totalCapacity > 0 {
 		memPct = fmt.Sprintf("%.1f%%", (float64(totalMem)/float64(totalCapacity))*100.0)
-	} else if successCount > 0 {
-		memPct = "0.0%"
 	}
 
 	return cpuPct, memPct, nil

--- a/docker/info_test.go
+++ b/docker/info_test.go
@@ -81,3 +81,117 @@ func TestMemUsageNoCache_DiffersFromRawUsage(t *testing.T) {
 	require.Equal(t, uint64(256<<20), memUsageNoCache(m))
 	require.NotEqual(t, m.Usage, memUsageNoCache(m))
 }
+
+// cpuStats builds a reading with the two cumulative counters the percentage is
+// differenced from, plus the core count it is scaled by.
+func cpuStats(total, system uint64, online uint32) container.CPUStats {
+	return container.CPUStats{
+		CPUUsage:    container.CPUUsage{TotalUsage: total},
+		SystemUsage: system,
+		OnlineCPUs:  online,
+	}
+}
+
+// resetBaselines isolates a test from whatever a previous one left behind, since
+// the baselines are package state shared by every caller in the process.
+func resetBaselines(t *testing.T) {
+	t.Helper()
+	cpuBaselineMu.Lock()
+	cpuBaselines = map[string]cpuBaseline{}
+	cpuBaselineMu.Unlock()
+}
+
+func TestCPUPercentSince_FirstReadingHasNoBaseline(t *testing.T) {
+	resetBaselines(t)
+
+	_, ok := cpuPercentSince("c1", cpuStats(100, 1000, 2))
+	require.False(t, ok, "a rate needs two readings; the first must not be reported")
+
+	// ...but it is retained, so the second reading can be differenced.
+	pct, ok := cpuPercentSince("c1", cpuStats(200, 2000, 2))
+	require.True(t, ok)
+	require.InDelta(t, 20.0, pct, 0.001) // (100/1000) * 2 * 100
+}
+
+func TestCPUPercentSince_UsesPercpuWhenOnlineCPUsAbsent(t *testing.T) {
+	resetBaselines(t)
+
+	s := cpuStats(100, 1000, 0)
+	s.CPUUsage.PercpuUsage = []uint64{1, 2, 3, 4}
+	cpuPercentSince("c1", s)
+
+	s = cpuStats(200, 2000, 0)
+	s.CPUUsage.PercpuUsage = []uint64{1, 2, 3, 4}
+	pct, ok := cpuPercentSince("c1", s)
+	require.True(t, ok)
+	require.InDelta(t, 40.0, pct, 0.001) // (100/1000) * 4 * 100
+}
+
+func TestCPUPercentSince_NoCoreCountIsNotAPercentage(t *testing.T) {
+	resetBaselines(t)
+
+	cpuPercentSince("c1", cpuStats(100, 1000, 0))
+	_, ok := cpuPercentSince("c1", cpuStats(200, 2000, 0))
+	require.False(t, ok, "with neither OnlineCPUs nor PercpuUsage there is nothing to scale by")
+}
+
+func TestCPUPercentSince_StillSecondsOfSystemTimeIsNotZeroPercent(t *testing.T) {
+	resetBaselines(t)
+
+	cpuPercentSince("c1", cpuStats(100, 1000, 2))
+	_, ok := cpuPercentSince("c1", cpuStats(150, 1000, 2))
+	require.False(t, ok, "a zero system delta has no window to divide by")
+}
+
+func TestCPUPercentSince_RestartedCounterIsSkippedThenRecovers(t *testing.T) {
+	resetBaselines(t)
+
+	cpuPercentSince("c1", cpuStats(5000, 9000, 2))
+
+	// The container restarted: its cumulative CPU time went backwards, so the
+	// delta would be a large negative number rendered as a nonsense percentage.
+	_, ok := cpuPercentSince("c1", cpuStats(10, 10000, 2))
+	require.False(t, ok)
+
+	// The post-restart reading became the new baseline, so the next round works.
+	pct, ok := cpuPercentSince("c1", cpuStats(110, 11000, 2))
+	require.True(t, ok)
+	require.InDelta(t, 20.0, pct, 0.001) // (100/1000) * 2 * 100
+}
+
+func TestCPUPercentSince_BaselinesAreKeptPerContainer(t *testing.T) {
+	resetBaselines(t)
+
+	cpuPercentSince("c1", cpuStats(100, 1000, 1))
+	cpuPercentSince("c2", cpuStats(500, 1000, 1))
+
+	pct1, ok := cpuPercentSince("c1", cpuStats(200, 2000, 1))
+	require.True(t, ok)
+	require.InDelta(t, 10.0, pct1, 0.001)
+
+	pct2, ok := cpuPercentSince("c2", cpuStats(1000, 2000, 1))
+	require.True(t, ok)
+	require.InDelta(t, 50.0, pct2, 0.001)
+}
+
+func TestPruneCPUBaselines_DropsOnlyContainersThatAreGone(t *testing.T) {
+	resetBaselines(t)
+
+	cpuPercentSince("stays", cpuStats(100, 1000, 1))
+	cpuPercentSince("goes", cpuStats(100, 1000, 1))
+
+	pruneCPUBaselines(map[string]struct{}{"stays": {}})
+
+	cpuBaselineMu.Lock()
+	_, keptLive := cpuBaselines["stays"]
+	_, keptDead := cpuBaselines["goes"]
+	cpuBaselineMu.Unlock()
+
+	require.True(t, keptLive, "a still-running container keeps its baseline")
+	require.False(t, keptDead, "the map tracks the node, not the process lifetime")
+
+	// The dropped container is a first reading again, not a delta against a
+	// baseline from a previous incarnation.
+	_, ok := cpuPercentSince("goes", cpuStats(50, 3000, 1))
+	require.False(t, ok)
+}

--- a/views/stacks/model_test.go
+++ b/views/stacks/model_test.go
@@ -90,8 +90,6 @@ func (m *mockClusterInfoOps) GetContainerCount() (int, error)                { r
 func (m *mockClusterInfoOps) GetServiceCount() (int, error)                  { return 0, nil }
 func (m *mockClusterInfoOps) GetSwarmCPUCapacity() (float64, error)          { return 0, nil }
 func (m *mockClusterInfoOps) GetSwarmMemCapacity() (int64, error)            { return 0, nil }
-func (m *mockClusterInfoOps) GetSwarmCPUUsage() (string, error)              { return "", nil }
-func (m *mockClusterInfoOps) GetSwarmMemUsage() (string, error)              { return "", nil }
 func (m *mockClusterInfoOps) GetSwarmResourceUsage() (string, string, error) { return "", "", nil }
 func (m *mockClusterInfoOps) GetDockerVersion() (string, error)              { return "", nil }
 

--- a/views/systeminfo/model.go
+++ b/views/systeminfo/model.go
@@ -102,8 +102,15 @@ func New(deps docker.Deps, version, edition string) *Model {
 // update notice (the proactive notice is driven by LatestVersionMsg directly).
 func (m *Model) Latest() string { return m.latest }
 
+// Init starts the header's timers.
+//
+// It seeds the resource-usage loop with the first collection rather than with a
+// tick, because that loop re-arms its own tick from SlowStatusMsg (update.go):
+// arming one here as well would leave two chains running, and the collection is
+// a per-container fan-out at the other end of the Docker socket. One chain in,
+// one chain out — a round cannot start while a round is running.
 func (m *Model) Init() tea.Cmd {
-	cmds := []tea.Cmd{m.tickCmd(), m.spinnerTickCmd()}
+	cmds := []tea.Cmd{m.LoadSlowStatus(), m.spinnerTickCmd()}
 	if cmd := m.CheckLatestVersion(); cmd != nil {
 		cmds = append(cmds, cmd)
 	}

--- a/views/systeminfo/systeminfo_test.go
+++ b/views/systeminfo/systeminfo_test.go
@@ -23,8 +23,6 @@ type mockClusterInfoOps struct {
 	getServiceCountFn       func() (int, error)
 	getSwarmCPUCapacityFn   func() (float64, error)
 	getSwarmMemCapacityFn   func() (int64, error)
-	getSwarmCPUUsageFn      func() (string, error)
-	getSwarmMemUsageFn      func() (string, error)
 	getSwarmResourceUsageFn func() (string, string, error)
 	getDockerVersionFn      func() (string, error)
 }
@@ -44,12 +42,6 @@ func (m *mockClusterInfoOps) GetSwarmCPUCapacity() (float64, error) {
 func (m *mockClusterInfoOps) GetSwarmMemCapacity() (int64, error) {
 	return m.getSwarmMemCapacityFn()
 }
-func (m *mockClusterInfoOps) GetSwarmCPUUsage() (string, error) {
-	return m.getSwarmCPUUsageFn()
-}
-func (m *mockClusterInfoOps) GetSwarmMemUsage() (string, error) {
-	return m.getSwarmMemUsageFn()
-}
 func (m *mockClusterInfoOps) GetSwarmResourceUsage() (string, string, error) {
 	return m.getSwarmResourceUsageFn()
 }
@@ -66,8 +58,6 @@ func noopClusterInfoOps() *mockClusterInfoOps {
 		getServiceCountFn:       func() (int, error) { return 3, nil },
 		getSwarmCPUCapacityFn:   func() (float64, error) { return 4.0, nil },
 		getSwarmMemCapacityFn:   func() (int64, error) { return 8 * 1024 * 1024 * 1024, nil },
-		getSwarmCPUUsageFn:      func() (string, error) { return "12.5%", nil },
-		getSwarmMemUsageFn:      func() (string, error) { return "45.3%", nil },
 		getSwarmResourceUsageFn: func() (string, string, error) { return "12.5%", "45.3%", nil },
 		getDockerVersionFn:      func() (string, error) { return "27.0.0", nil },
 	}
@@ -126,7 +116,10 @@ func TestUpdate_Msg(t *testing.T) {
 	require.Equal(t, "ctx", m.context)
 	require.Equal(t, 3, m.containerCount)
 	require.Equal(t, 2, m.serviceCount)
-	require.NotNil(t, cmd) // triggers LoadSlowStatus
+	// No follow-on command: the counts land, and the resource-usage fan-out is
+	// left to the single loop SlowStatusMsg re-arms. Chaining it here gave that
+	// loop a second, unsynchronised driver on the app's 5s tick.
+	require.Nil(t, cmd)
 }
 
 func TestUpdate_SlowStatusMsg(t *testing.T) {

--- a/views/systeminfo/update.go
+++ b/views/systeminfo/update.go
@@ -16,8 +16,13 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 	switch msg := msg.(type) {
 	case Msg:
 		m.SetContent(msg)
-		// Trigger slow status load right after fast values
-		return m.LoadSlowStatus()
+		// Deliberately does NOT start a resource-usage collection. This message
+		// is the result of LoadStatus, which the app re-runs on its own 5s tick;
+		// chaining the collection off it ran a second, faster loop alongside the
+		// one SlowStatusMsg re-arms, and neither could see the other, so rounds
+		// piled up on the daemon. The counts here are cheap and stay on the app
+		// tick; the fan-out has exactly one driver.
+		return nil
 
 	case LatestVersionMsg:
 		m.latest = msg.LatestVersion


### PR DESCRIPTION
## What

The header's CPU/MEM figures were collected with `ContainerStats(ctx, id, false)` — `stream=0` **without** `one-shot=1`. That is the one shape of the stats endpoint that is expensive by construction: the daemon subscribes the container to its global stats collector and **discards the first frame** to prime the CPU delta itself, so each call costs a second or two and keeps the container on a 1 Hz cgroup treadmill for as long as the request is open (`moby daemon/stats.go:60-86`, `daemon/stats/collector.go:78-118` — one goroutine, sampling every subscribed container sequentially, then sleeping 1s; each sample reads cgroups, `/proc/stat` and enters the container's network sandbox).

It was also driven twice:

- `Init` armed the systeminfo tick. That 8s loop re-arms itself from `SlowStatusMsg`, so it cannot overlap with itself — fine on its own.
- The app's separate **5s** tick ran `LoadStatus`, and the resulting `Msg` chained straight into `LoadSlowStatus` as well.

Two unsynchronised drivers, no in-flight guard, and a round that takes longer than 5s under load. Rounds pile up, every container on the node stays permanently subscribed, and the daemon samples all of them forever whether or not anyone is looking at the header.

## How it surfaced

When a piled-up round finally hits the shared 10s `apiTimeout`, `defer cancel()` (`docker/info.go`) aborts every outstanding request at the same instant. An HTTP proxy in front of the daemon then logs one cancelled request per container, all sharing a single timestamp. A burst of exactly *N* identical cancellation lines, *N* = the node's running-container count, is what led here.

## Changes

- **One-shot sampling.** `ContainerStatsOneShot` + a retained per-container baseline to difference CPU against, pruned each round to the containers still running. One-shot zeroes `PreCPUStats`; the baseline is what replaces it. Differencing over our own longer window also gives a steadier figure than the one-second window `docker stats` reads off.
- **CPU is `N/A` until a container has a baseline.** A rate needs two readings, and `0.0%` there would be a measurement we did not make. Costs one refresh (~8s) of `N/A` at startup. Memory is instantaneous and is reported from the first round exactly as before.
- **One driver for the fan-out.** `Init` seeds it, `SlowStatusMsg` re-arms it, and the app tick's `Msg` no longer chains into it. The container/service counts that `Msg` does carry are cheap and stay on the 5s tick.
- **Deleted `GetSwarmCPUUsage` and `GetSwarmMemUsage`** and their `ClusterInfoOps` methods. They carried a third and fourth copy of the same call and nothing has called either since `GetSwarmResourceUsage` folded them into one pass. Only in-repo test mocks implemented the interface, so the narrowing is contained.

## Tests

`docker/info_test.go` covers the baseline logic directly: first reading is not reportable but is retained; the second differences correctly; `OnlineCPUs == 0` falls back to `len(PercpuUsage)` and reports nothing when both are absent; a zero system delta reports nothing; a restarted container (counter goes backwards) is skipped and **recovers on the round after**; baselines are per-container; `pruneCPUBaselines` drops only containers that are gone, and a dropped one is a first reading again rather than a delta against a previous incarnation.

`views/systeminfo` asserts `Msg` now returns no follow-on command — that is the regression guard for the second driver.

`go test ./...`, `go vet ./...` and `golangci-lint run ./... --build-tags=integration` are all clean.

## Risk

Behavioural change visible to users: CPU reads `N/A` for the first refresh after launch instead of a number. That number was previously computed from the daemon's own primed 1s window; it is now computed over our ~8s window, so values will be slightly steadier and can differ from `docker stats` for the same container.

## Why 1.14.0 is fine and 2.0.0-rc3 is not

Confirmed by bisect after a report that 1.14.0 is clean and a 2.0-rc build reproduces the burst on demand.

`docker/info.go` is **byte-identical** in v1.14.0 — same `ContainerStats(ctx, id, false)`, same `GetSwarmResourceUsage`, same shared 10s deadline. `views/systeminfo/update.go` is identical too: `Msg` chained into `LoadSlowStatus` there as well. So neither is the regression on its own.

What changed is `app/tick.go`:

```
v1.14.0     handleTick re-arms tick(): no
v2.0.0-rc1  handleTick re-arms tick(): no
v2.0.0-rc2  handleTick re-arms tick(): no
v2.0.0-rc3  handleTick re-arms tick(): YES   <- bf7101b, #612, 2026-08-26
```

Before bf7101b the app tick fired **exactly once** — armed in `Init`, never re-armed — so the `Msg → LoadSlowStatus` edge ran once at startup and then died. The only surviving driver was the systeminfo tick, which re-arms itself from `SlowStatusMsg` and therefore cannot overlap with itself. One driver, serialised, no pile-up.

#612 fixed the missing re-arm, and correctly: the header's context name and counts had been frozen a few seconds after launch. But the re-arm also brought a dormant edge back to life, and turned it into a permanent 5s driver of a per-container fan-out that already had another driver and no in-flight guard.

That is exactly the edge this PR removes. The one-shot change is the second half: it makes each round cheap enough that a round can no longer outlast the interval that starts the next one.
