### PR TITLE
fix(context): resolve the active context without forking, and stop forgetting a declined drift

### DIFF
--- a/app/contextdrift.go
+++ b/app/contextdrift.go
@@ -20,9 +20,22 @@ import (
 // declining is remembered, so an operator who keeps two terminals on two swarms
 // is asked once per target rather than every five seconds.
 
-// contextDriftMsg reports the result of one drift check. Shell is the context
-// the config file now names, or "" when it agrees with the session pin.
-type contextDriftMsg struct{ Shell string }
+// contextDriftMsg reports the result of one drift check.
+//
+//	Shell != ""                    the config file names a different context
+//	Shell == "" && !Inconclusive    the config file agrees with the session pin
+//	Inconclusive                    the check could not be made, and says
+//	                                nothing either way
+//
+// The third case has to be distinct from the second. Both used to arrive as an
+// empty Shell, and handleContextDrift reads an empty Shell as "back in
+// agreement" — which clears the record of a drift the operator has already
+// declined. One transient lookup failure, or one tick while DOCKER_CONTEXT is
+// set, was enough to forget it and re-raise a prompt that had been answered.
+type contextDriftMsg struct {
+	Shell        string
+	Inconclusive bool
+}
 
 // Seams, so the drift logic is testable without a Docker CLI on PATH.
 var (
@@ -35,9 +48,9 @@ var (
 // checkContextDriftCmd compares the context Docker would use now against the
 // one this session is pinned to.
 //
-// A failed lookup reports "no drift" rather than an error: `docker context show`
-// can fail transiently, and a dialog raised over a subprocess hiccup would be
-// worse than a check that quietly runs again five seconds later.
+// A failed lookup is inconclusive, never drift: reading the config file can
+// fail transiently, and a dialog raised over that would be worse than a check
+// that quietly runs again five seconds later.
 func checkContextDriftCmd() tea.Cmd {
 	return func() tea.Msg {
 		// DOCKER_CONTEXT outranks the config file, so while it is set the two
@@ -45,14 +58,17 @@ func checkContextDriftCmd() tea.Cmd {
 		// not a switch. Offering to follow it would also be offering something
 		// the context switcher refuses to do.
 		if envPinsContextFn() {
-			return contextDriftMsg{}
+			return contextDriftMsg{Inconclusive: true}
 		}
 		pinned, err := sessionContextFn()
 		if err != nil || pinned == "" {
-			return contextDriftMsg{}
+			return contextDriftMsg{Inconclusive: true}
 		}
 		shell, err := configFileContextFn()
-		if err != nil || shell == "" || shell == pinned {
+		if err != nil || shell == "" {
+			return contextDriftMsg{Inconclusive: true}
+		}
+		if shell == pinned {
 			return contextDriftMsg{}
 		}
 		return contextDriftMsg{Shell: shell}
@@ -61,6 +77,13 @@ func checkContextDriftCmd() tea.Cmd {
 
 // handleContextDrift decides what one drift check means for the UI.
 func (m *Model) handleContextDrift(msg contextDriftMsg) tea.Cmd {
+	if msg.Inconclusive {
+		// Nothing was learned, so nothing is revised — in particular the
+		// declined record survives. Reading this as agreement is what used to
+		// clear it, so the next successful check re-raised a prompt the
+		// operator had already answered.
+		return nil
+	}
 	if msg.Shell == "" {
 		// Back in agreement. Clearing the record means a later switch to the
 		// same context is offered again — the operator declined one drift, not

--- a/app/contextdrift_test.go
+++ b/app/contextdrift_test.go
@@ -280,3 +280,59 @@ func TestHandleTick_ReArms(t *testing.T) {
 	_, isTick := batch[0]().(tickMsg)
 	require.True(t, isTick, "the tick must re-arm itself")
 }
+
+// TestHandleContextDrift_AnInconclusiveCheckKeepsTheRefusal is the regression
+// guard for a check that could not be made being read as agreement.
+//
+// A failed lookup and an environment pin both used to arrive as an empty Shell,
+// which handleContextDrift treats as "back in agreement" — so it cleared the
+// record of a drift the operator had already declined, and the next successful
+// check re-raised the prompt they had just answered.
+func TestHandleContextDrift_AnInconclusiveCheckKeepsTheRefusal(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		inconclusive func()
+	}{
+		{"the lookup failed", func() {
+			configFileContextFn = func() (string, error) { return "", errors.New("config unreadable") }
+		}},
+		{"the environment pins the context", func() {
+			envPinsContextFn = func() bool { return true }
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			m := newTestAppModel(&stubView{})
+			stubContexts(t, "swarm-a", "swarm-b")
+			workingConfig, workingEnv := configFileContextFn, envPinsContextFn
+
+			// The operator is asked once, and declines.
+			m.handleContextDrift(driftOf(t))
+			m.resolveContextDrift(false)
+			require.Equal(t, "swarm-b", m.declinedDriftContext)
+
+			// A tick the check cannot answer says nothing either way.
+			tc.inconclusive()
+			require.True(t, driftOf(t).Inconclusive)
+			m.handleContextDrift(driftOf(t))
+			require.Equal(t, "swarm-b", m.declinedDriftContext,
+				"a check that could not be made is not agreement")
+
+			// The check recovers, and the answer still stands.
+			configFileContextFn, envPinsContextFn = workingConfig, workingEnv
+			m.handleContextDrift(driftOf(t))
+			require.False(t, m.contextDriftDialogActive,
+				"the operator already answered this prompt")
+		})
+	}
+}
+
+// Agreement is still agreement: only an inconclusive check is exempt from
+// clearing the refusal, or declining one drift would silence that target
+// forever.
+func TestCheckContextDrift_AgreementIsNotInconclusive(t *testing.T) {
+	stubContexts(t, "swarm-a", "swarm-a")
+
+	msg := driftOf(t)
+	require.Empty(t, msg.Shell)
+	require.False(t, msg.Inconclusive)
+}

--- a/docker/context_list_test.go
+++ b/docker/context_list_test.go
@@ -15,7 +15,7 @@ import (
 // the contexts view display the very mismatch #611 is about, and it is also
 // where the view reads the context being left when a switch is confirmed.
 func TestListContexts_MarksTheSessionContextCurrent(t *testing.T) {
-	stubContextShow(t, "swarm-a")
+	stubActiveContext(t, "swarm-a")
 	_, err := SessionContext()
 	require.NoError(t, err)
 

--- a/docker/session_context.go
+++ b/docker/session_context.go
@@ -4,16 +4,33 @@
 package docker
 
 import (
+	"encoding/json"
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
-	"os/exec"
+	"path/filepath"
 	"strings"
 	"sync"
 )
 
-// envContextVar is the environment variable Docker resolves ahead of the
-// config file (docker/cli cli/command.EnvOverrideContext).
-const envContextVar = "DOCKER_CONTEXT"
+const (
+	// envContextVar is the environment variable Docker resolves ahead of the
+	// config file (docker/cli cli/command.EnvOverrideContext).
+	envContextVar = "DOCKER_CONTEXT"
+
+	// envHostVar forces Docker onto the `default` context, ahead of both the
+	// config file and DOCKER_CONTEXT.
+	envHostVar = "DOCKER_HOST"
+
+	// envConfigDirVar names the directory holding the CLI's config.json
+	// (docker/cli cli/config.EnvOverrideConfigDir).
+	envConfigDirVar = "DOCKER_CONFIG"
+
+	// defaultContextName is what Docker resolves to when nothing names a
+	// context.
+	defaultContextName = "default"
+)
 
 // envContext reports the context named by the environment, if any, trimmed.
 // The pin, ValidateContext's refusal guard and the drift check all read it
@@ -40,9 +57,9 @@ var (
 	sessionCtx   string
 )
 
-// showContextFn is the seam for `docker context show`, so the pin's behaviour
-// is testable without a Docker CLI on PATH.
-var showContextFn = runContextShow
+// activeContextFn is the seam for "what context is active right now", so the
+// pin's behaviour is testable without a Docker config file on disk.
+var activeContextFn = activeContextName
 
 // InitSessionContext resolves the session context and pins it, returning the
 // pinned name. Calling it again returns the existing pin without re-resolving,
@@ -134,13 +151,70 @@ func resolveContextName() (string, error) {
 	if ctxName := envContext(); ctxName != "" {
 		return ctxName, nil
 	}
-	return showContextFn()
+	return activeContextFn()
 }
 
-func runContextShow() (string, error) {
-	out, err := exec.Command("docker", "context", "show").Output()
-	if err != nil {
-		return "", fmt.Errorf("failed to get docker context: %w", err)
+// activeContextName reports the context `docker context show` would print,
+// computed here rather than by running it.
+//
+// It used to fork the docker CLI. That was affordable while it happened once,
+// at startup, to resolve the pin — but the drift check calls it on the app tick
+// too, so since the tick learned to re-arm it is a process start every five
+// seconds for the life of the session, to read one field. Everything that field
+// depends on is readable directly: $DOCKER_HOST forces `default`, and otherwise
+// the answer is `currentContext` from the CLI's config file.
+//
+// The failure modes follow Docker's, so swarmcli is never more broken than the
+// CLI is for the same file. A missing config file is a machine where nobody has
+// run `docker context use`, and Docker answers `default` there too. A malformed
+// one Docker warns about and then answers `default` anyway — verified against
+// `docker context show`, which exits 0 — so this warns and does the same rather
+// than failing a session the CLI would not. Only a file that exists and cannot
+// be read is an error, which is where Docker stops as well.
+func activeContextName() (string, error) {
+	// Docker resolves $DOCKER_HOST ahead of everything else and pins the
+	// `default` context to it. swarmcli does not honour the variable — it
+	// always builds its client from a context's stored endpoint, see
+	// SessionContext — but it must still agree with Docker about the *name*,
+	// or the drift check would report a switch that nobody made.
+	if strings.TrimSpace(os.Getenv(envHostVar)) != "" {
+		return defaultContextName, nil
 	}
-	return strings.TrimSpace(string(out)), nil
+
+	path, err := dockerConfigPath()
+	if err != nil {
+		return defaultContextName, nil // nowhere to look is the same as nothing to find
+	}
+	data, err := os.ReadFile(path)
+	if errors.Is(err, fs.ErrNotExist) {
+		return defaultContextName, nil
+	}
+	if err != nil {
+		return "", fmt.Errorf("reading Docker config %s: %w", path, err)
+	}
+
+	var cfg struct {
+		CurrentContext string `json:"currentContext"`
+	}
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		l().Infof("Docker config %s could not be parsed (%v); using the %q context, as docker does", path, err, defaultContextName)
+		return defaultContextName, nil
+	}
+	if name := strings.TrimSpace(cfg.CurrentContext); name != "" {
+		return name, nil
+	}
+	return defaultContextName, nil
+}
+
+// dockerConfigPath locates the CLI's config file the way Docker does:
+// $DOCKER_CONFIG names the directory, otherwise ~/.docker.
+func dockerConfigPath() (string, error) {
+	if dir := strings.TrimSpace(os.Getenv(envConfigDirVar)); dir != "" {
+		return filepath.Join(dir, "config.json"), nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".docker", "config.json"), nil
 }

--- a/docker/session_context_test.go
+++ b/docker/session_context_test.go
@@ -5,22 +5,24 @@ package docker
 
 import (
 	"errors"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
 
-// stubContextShow replaces the `docker context show` seam with a value the test
+// stubActiveContext replaces the active-context seam with a value the test
 // controls, and clears both the pin and DOCKER_CONTEXT so the case starts from
 // a known state. The returned function moves what the config file would say.
-func stubContextShow(t *testing.T, initial string) func(string) {
+func stubActiveContext(t *testing.T, initial string) func(string) {
 	t.Helper()
-	orig := showContextFn
+	orig := activeContextFn
 	current := initial
-	showContextFn = func() (string, error) { return current, nil }
+	activeContextFn = func() (string, error) { return current, nil }
 	ResetSessionContext()
 	t.Cleanup(func() {
-		showContextFn = orig
+		activeContextFn = orig
 		ResetSessionContext()
 	})
 	// Inherited from the developer's shell, this would outrank the stub.
@@ -34,7 +36,7 @@ func stubContextShow(t *testing.T, initial string) func(string) {
 // app — logs, deploy, stack rm — while the SDK client stayed connected to the
 // context the session started in, and the two addressed different swarms.
 func TestSessionContext_DoesNotFollowTheConfigFile(t *testing.T) {
-	move := stubContextShow(t, "swarm-a")
+	move := stubActiveContext(t, "swarm-a")
 
 	pinned, err := SessionContext()
 	require.NoError(t, err)
@@ -51,7 +53,7 @@ func TestSessionContext_DoesNotFollowTheConfigFile(t *testing.T) {
 // exported resolvers used to make the same lookup independently, so it was
 // possible for them to disagree with each other as well as with the client.
 func TestResolvers_AllReportThePin(t *testing.T) {
-	move := stubContextShow(t, "swarm-a")
+	move := stubActiveContext(t, "swarm-a")
 	_, err := SessionContext()
 	require.NoError(t, err)
 
@@ -74,7 +76,7 @@ func TestResolvers_AllReportThePin(t *testing.T) {
 // that is already running, which is the same promise made to a config-file
 // switch.
 func TestSessionContext_EnvironmentWinsAtResolution(t *testing.T) {
-	stubContextShow(t, "from-config")
+	stubActiveContext(t, "from-config")
 	t.Setenv(envContextVar, "from-env")
 
 	pinned, err := SessionContext()
@@ -91,7 +93,7 @@ func TestSessionContext_EnvironmentWinsAtResolution(t *testing.T) {
 // TestSetSessionContext_MovesThePin — a switch made inside swarmcli is the one
 // thing that moves it.
 func TestSetSessionContext_MovesThePin(t *testing.T) {
-	stubContextShow(t, "swarm-a")
+	stubActiveContext(t, "swarm-a")
 	_, err := SessionContext()
 	require.NoError(t, err)
 
@@ -106,7 +108,7 @@ func TestSetSessionContext_MovesThePin(t *testing.T) {
 // somewhere upstream, and adopting it would leave every shell-out without a
 // --context and back on the config file.
 func TestSetSessionContext_IgnoresAnEmptyName(t *testing.T) {
-	stubContextShow(t, "swarm-a")
+	stubActiveContext(t, "swarm-a")
 	_, err := SessionContext()
 	require.NoError(t, err)
 
@@ -120,7 +122,7 @@ func TestSetSessionContext_IgnoresAnEmptyName(t *testing.T) {
 // TestConfigFileContext_ReadsPastThePin — the drift check needs the live
 // answer, and it is the only caller that does.
 func TestConfigFileContext_ReadsPastThePin(t *testing.T) {
-	move := stubContextShow(t, "swarm-a")
+	move := stubActiveContext(t, "swarm-a")
 	_, err := SessionContext()
 	require.NoError(t, err)
 
@@ -139,13 +141,13 @@ func TestConfigFileContext_ReadsPastThePin(t *testing.T) {
 // the session permanently unable to name a context, with no way back short of
 // a restart.
 func TestSessionContext_AFailedLookupIsNotCached(t *testing.T) {
-	orig := showContextFn
+	orig := activeContextFn
 	ResetSessionContext()
-	t.Cleanup(func() { showContextFn = orig; ResetSessionContext() })
+	t.Cleanup(func() { activeContextFn = orig; ResetSessionContext() })
 	t.Setenv(envContextVar, "")
 
 	failing := true
-	showContextFn = func() (string, error) {
+	activeContextFn = func() (string, error) {
 		if failing {
 			return "", errors.New("docker not running")
 		}
@@ -180,7 +182,7 @@ func TestEnvPinsContext(t *testing.T) {
 // second call must report the pin rather than resolve a second time and
 // possibly land somewhere else.
 func TestInitSessionContext_IsIdempotent(t *testing.T) {
-	move := stubContextShow(t, "swarm-a")
+	move := stubActiveContext(t, "swarm-a")
 
 	first, err := InitSessionContext()
 	require.NoError(t, err)
@@ -191,4 +193,97 @@ func TestInitSessionContext_IsIdempotent(t *testing.T) {
 	second, err := InitSessionContext()
 	require.NoError(t, err)
 	require.Equal(t, "swarm-a", second)
+}
+
+// TestActiveContextName_NeedsNoDockerCLI is the regression guard for the fork.
+//
+// Resolving the active context used to run `docker context show`, which the
+// drift check calls on every app tick — a process start every five seconds to
+// read one field. PATH is emptied here, so a implementation that forks cannot
+// pass: the answer has to come from the config file directly.
+func TestActiveContextName_NeedsNoDockerCLI(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv(envConfigDirVar, dir)
+	t.Setenv(envHostVar, "")
+	t.Setenv("PATH", "")
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "config.json"),
+		[]byte(`{"currentContext":"swarm-b","auths":{}}`), 0o600))
+
+	got, err := activeContextName()
+	require.NoError(t, err)
+	require.Equal(t, "swarm-b", got)
+}
+
+func TestActiveContextName_MatchesDockersOwnAnswer(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		config  string // "" writes no file at all
+		dirTrap bool   // put a directory where config.json should be, so the read fails
+		host    string
+		want    string
+		wantErr bool
+	}{
+		{name: "a context the operator selected", config: `{"currentContext":"swarm-b"}`, want: "swarm-b"},
+		{name: "no config file yet", want: defaultContextName},
+		{name: "a config file that names none", config: `{"auths":{}}`, want: defaultContextName},
+		// `docker context show` prints the whitespace verbatim and the old
+		// fork trimmed it to "", which named nothing resolvable. Naming
+		// nothing is what `default` means, so it is answered directly.
+		{name: "a name that is only whitespace names nothing", config: `{"currentContext":"  "}`, want: defaultContextName},
+		{
+			// docker resolves DOCKER_HOST ahead of everything and pins `default`
+			// to it. swarmcli does not honour the variable, but it has to agree
+			// about the name or the drift check reports a switch nobody made.
+			name: "DOCKER_HOST outranks the config file", config: `{"currentContext":"swarm-b"}`,
+			host: "tcp://10.0.0.1:2376", want: defaultContextName,
+		},
+		{
+			// `docker context show` warns and exits 0 with "default" here, so
+			// failing the session would make swarmcli more broken than the CLI
+			// for a file the CLI tolerates.
+			name: "a malformed config file degrades as docker does", config: `{"currentContext":`, want: defaultContextName,
+		},
+		{
+			// A file that exists and cannot be read is where Docker stops too,
+			// and it is the one case worth surfacing: answering `default` would
+			// invent an agreement the caller has no way to check.
+			name: "a config file that cannot be read is an error", dirTrap: true, wantErr: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			t.Setenv(envConfigDirVar, dir)
+			t.Setenv(envHostVar, tc.host)
+			switch {
+			case tc.dirTrap:
+				require.NoError(t, os.Mkdir(filepath.Join(dir, "config.json"), 0o700))
+			case tc.config != "":
+				require.NoError(t, os.WriteFile(filepath.Join(dir, "config.json"), []byte(tc.config), 0o600))
+			}
+
+			got, err := activeContextName()
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// DOCKER_CONTEXT is still resolved ahead of the config file, as it was when the
+// lookup forked.
+func TestResolveContextName_TheEnvironmentStillOutranksTheFile(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv(envConfigDirVar, dir)
+	t.Setenv(envHostVar, "")
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "config.json"),
+		[]byte(`{"currentContext":"from-file"}`), 0o600))
+	t.Setenv(envContextVar, "from-env")
+
+	got, err := resolveContextName()
+	require.NoError(t, err)
+	require.Equal(t, "from-env", got)
 }

--- a/docker/stack_to_compose_args_test.go
+++ b/docker/stack_to_compose_args_test.go
@@ -15,7 +15,7 @@ import (
 // nor the one DOCKER_CONTEXT names. A stack selected from one swarm could be
 // reconstructed from another's services and networks (#611).
 func TestStackToComposeArgs_NameTheSessionContext(t *testing.T) {
-	stubContextShow(t, "swarm-a")
+	stubActiveContext(t, "swarm-a")
 	_, err := SessionContext()
 	require.NoError(t, err)
 
@@ -34,11 +34,11 @@ func TestStackToComposeArgs_NameTheSessionContext(t *testing.T) {
 // name, the command is better run against Docker's own default than not run at
 // all: that is the behaviour these call sites had before the flag was added.
 func TestStackToComposeArgs_UnresolvableContextStillRuns(t *testing.T) {
-	orig := showContextFn
+	orig := activeContextFn
 	ResetSessionContext()
-	t.Cleanup(func() { showContextFn = orig; ResetSessionContext() })
+	t.Cleanup(func() { activeContextFn = orig; ResetSessionContext() })
 	t.Setenv(envContextVar, "")
-	showContextFn = func() (string, error) { return "", errors.New("docker not running") }
+	activeContextFn = func() (string, error) { return "", errors.New("docker not running") }
 
 	require.Equal(t,
 		[]string{"service", "inspect", "web_api"},


### PR DESCRIPTION
Two defects in the context-drift path. Both were latent until #612 put the check on a tick that re-arms; neither is in the drift logic itself, which is why they survived review.

## 1. A docker CLI process every five seconds

Resolving *"what context is active right now"* ran `docker context show` (`docker/session_context.go`, `runContextShow`). That was affordable while it happened **once**, at startup, to resolve the session pin. The drift check calls the same resolver, so since `handleTick` learned to re-arm it is a full docker CLI process start every five seconds for the life of the session — to read one field.

Everything that field depends on is readable directly, so `activeContextName` now does:

- `$DOCKER_HOST` set → `default` (Docker resolves it ahead of everything and pins `default` to it; swarmcli does not honour the variable, but it has to agree about the **name** or the drift check reports a switch nobody made)
- otherwise `currentContext` from the CLI's config file, located the way Docker locates it — `$DOCKER_CONFIG`, else `~/.docker`

`$DOCKER_CONTEXT` is still resolved ahead of the file, exactly as before.

### The failure modes were checked against the real CLI, not assumed

I ran `docker context show` against each odd config file rather than guessing, and the answers changed the design twice:

| config.json | `docker context show` | this PR |
|---|---|---|
| missing | `default` | `default` |
| `{"auths":{}}` (names none) | `default` | `default` |
| malformed | warns on stderr, prints `default`, **exit 0** | logs the warning, `default` |
| exists, unreadable | fails | error |

My first draft errored on a malformed file. That would have made swarmcli **more broken than docker** for a file docker tolerates — a slightly corrupt `config.json` would fail the session while `docker` kept working. It now degrades the same way, and the warning docker writes to stderr (which the fork discarded) is logged instead.

## 2. A failed check forgot a declined drift

`checkContextDriftCmd` returned an empty `Shell` for **three** different situations: agreement, a failed lookup, and `DOCKER_CONTEXT` pinning the session. `handleContextDrift` reads an empty `Shell` as *"back in agreement"* and clears `declinedDriftContext`.

So one transient lookup failure — or one tick while `DOCKER_CONTEXT` is set — forgot the refusal, and the next successful check re-raised a prompt the operator had already answered. The file's own comment promises the opposite:

> declining is remembered, so an operator who keeps two terminals on two swarms is asked once per target rather than every five seconds

`contextDriftMsg` now distinguishes the three, and an inconclusive check revises nothing.

## Both guards were checked against the code they replace

- `TestActiveContextName_NeedsNoDockerCLI` empties `PATH`, so an implementation that forks **cannot** pass — confirmed failing against the old `runContextShow`.
- `TestHandleContextDrift_AnInconclusiveCheckKeepsTheRefusal` — confirmed failing against the old empty-`Shell` handling, for both the failed-lookup and env-pinned cases.

`TestActiveContextName_MatchesDockersOwnAnswer` doubles as a cross-check: on a machine with the docker CLI present it passes against the real `docker context show` for every row where the two are meant to agree.

## Note

`showContextFn` is renamed `activeContextFn` — it no longer runs `docker context show`, and a seam whose name says it does is the kind of thing that misleads the next reader.

`go test ./...`, `go vet ./...` and `golangci-lint run ./... --build-tags=integration` are clean.
