### PR TITLE
docs(license): the licensing docs describe a licence we refuse to issue

### DIFF
--- a/docs/license.md
+++ b/docs/license.md
@@ -71,10 +71,10 @@ stored on the swarm:
 
 ### Managed licenses: activation is a second step
 
-A **managed** license is issued to you rather than to one swarm, and then
-*activated* for each swarm you run it on. Installing the key is the first
-step; the second is an **activation lease** — a short-lived signed artifact
-naming that license and that swarm.
+A **managed** license names its swarm in the key, exactly as a key bound at
+issuance does, and is then *activated* for that swarm. Installing the key is
+the first step; the second is an **activation lease** — a short-lived signed
+artifact naming that license and that swarm.
 
 On a swarm that can reach us, the second step takes care of itself. A managed
 license with no lease installed is due for renewal by definition, and the
@@ -105,8 +105,8 @@ low-touch deployments, and are worth asking for **before** your first outage
 rather than after: `:license` will tell you which state you are in, but only if
 somebody opens it.
 
-Managed licenses are being rolled out; keys issued today are unbound or bound
-at issuance, and nothing about them changes.
+Managed licenses are being rolled out; keys issued today are bound at
+issuance, and nothing about them changes.
 
 All of them require a Docker context pointing at a swarm manager, and all
 of them validate the key before storing it.
@@ -176,19 +176,21 @@ Inside the TUI, `:license` shows current state:
 
 | Shown | Meaning |
 |---|---|
-| Status: Valid | Key verified, not expired, within limits, bound swarm matches (or unbound). |
+| Status: Valid | Key verified, not expired, bound swarm matches (or unbound). |
 | Status: Grace Period (N days remaining) | Key expired, features still enabled (see below). |
 | Status: Expired | Key past grace; features disabled. |
 | Status: No license | No key present. |
 | Status: Invalid | The key did not verify, or names a tier this build does not know. |
-| Status: Node limit exceeded | Cluster has more nodes than `max_nodes`. |
-| Status: User limit exceeded | RBAC store has more users than `max_users`. |
 | Status: Wrong swarm (license bound to a different cluster) | The connected swarm differs from the one the license is bound to. See [Per-swarm binding](#per-swarm-binding). |
 
 The view also shows:
 
 - `Source: swarm config (swarmcli-license)` — where the active key was loaded from.
 - `Binding: Bound to <id> | Unbound (portable across swarms) | Expected/Observed mismatch` — the current binding state.
+- `Nodes: 12 of 10 — nothing is switched off`, with a portal link beside it —
+  shown only when the swarm has more nodes than `max_nodes`. It is a report and
+  not a status: the `Status:` line above is unaffected and every feature stays
+  on. See [Limits](#limits).
 
 Key bindings inside the view:
 
@@ -231,8 +233,9 @@ swarmcli license sync   [--json]   # renew this swarm's activation now
 
 Both read the license from the swarm's Docker Config exactly as the TUI does, so
 they need a Docker context pointing at a swarm manager. `status` prints one
-`key=value` per line — status, tier, license id, binding, the lease's dates, and
-what the last renewal answered — or the same fields as an object with `--json`.
+`key=value` per line — status, tier, license id, binding, the node count and its
+allowance, the lease's dates, and what the last renewal answered — or the same
+fields as an object with `--json`.
 
 The exit codes answer two different questions, which is what makes them useful in
 a cron job:
@@ -297,17 +300,21 @@ of the license.
 A license key may be bound to a single Docker Swarm. There are three
 binding modes, and `:license` names which one you hold.
 
-- **Unbound**: the key verifies on any swarm. This is the legacy / portable
-  behaviour; `trial` keys are typically unbound.
+- **Unbound**: the key verifies on any swarm. Legacy only — issuance refuses
+  to sign an unbound key, trials included, so no key issued today is one of
+  these.
 - **Bound at issuance** (*static*): the swarm is named in the key when it is
   signed. Matching is business as usual; on any other swarm the key is
   cryptographically valid but Business Edition features disable and
   `:license` shows `Wrong swarm`. Switching back restores it immediately,
   with no waiting period.
-- **Managed**: the key is issued to you, and each swarm is *activated*
-  separately with a lease — see
-  [Managed licenses](#managed-licenses-activation-is-a-second-step). Moving
-  the license to a different swarm does not need a new key.
+- **Managed**: the swarm is named in the key as above, but the binding is also
+  kept current — features work only while the swarm holds a live lease, which
+  it renews by itself. See
+  [Managed licenses](#managed-licenses-activation-is-a-second-step). Moving it
+  to another swarm is a dashboard action that issues a new key, and is allowed
+  at most once per lease window — see [Moving a managed
+  license](#moving-a-managed-license-to-another-swarm).
 
 ### Moving a managed license to another swarm
 
@@ -468,13 +475,14 @@ thing that proves entitlement.
 ## Limits
 
 `max_nodes` and `max_users` are **soft** limits. Exceeding them does not
-block any operation; they appear as a warning state in the `:license`
-view, and the expiry is recorded on the key at issuance time.
+block any operation and does not change the status the `:license` view
+reports, and the expiry is recorded on the key at issuance time.
 
-- `max_nodes` is checked against the swarm's current node count, refreshed
-  on each TUI update tick.
-- `max_users` is checked against the rbac-proxy's user store after each
-  RBAC change.
+- `max_nodes` is compared against the swarm's node count, refreshed on each
+  TUI update tick. Over the limit, `:license` reports the pair and leaves
+  every feature on — see [`:license` view](#license-view).
+- `max_users` is compared against nothing. The number is recorded on the key,
+  but no part of the product counts users against it.
 
 Either limit set to `0` is treated as unlimited.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -21,10 +21,12 @@ and if that does not help, contact whoever issued it.
 The key is past its grace window. Paste a fresh key at the prompt, or set
 `SWARMCLI_LICENSE` and restart. See [License — Lifecycle](license.md#lifecycle-states).
 
-**`:license` shows "Node limit exceeded" / "User limit exceeded".**
-Soft limit warning; nothing is blocked. Either upgrade the license, scale
-the cluster down, or treat it as informational. See
-[License — Limits](license.md#limits).
+**`:license` shows `Nodes: 12 of 10 — nothing is switched off`.**
+The swarm has more nodes than the license allows. Nothing is blocked and no
+feature is switched off — it is a commercial limit, not a technical one.
+Either upgrade from the portal link beside it, scale the cluster down, or
+treat it as informational. There is no equivalent line for users: nothing
+counts against `max_users`. See [License — Limits](license.md#limits).
 
 ## Bootstrap
 


### PR DESCRIPTION
Companion to **swarmcli-website#124** on GitLab ([MR !183](https://gitlab.esix.hu/eldara-tech/swarmcli-website/-/merge_requests/183)), which found three wrong statements
in the licensing docs at swarmcli.io/docs/cli. All three are published here too, in
`docs/license.md` — the canonical prose — and reading it against the issuer turned up
four more that the website's page does not have.

Every claim below was checked against HEAD of the signer (`swarmcli-website`,
`backend/src/services/`) and of `swarmcli-be`, not against the issue's line numbers,
which had already moved.

## Managed was backwards — `license.md:74`, `:307`

> A **managed** license is issued to you rather than to one swarm, and then
> *activated* for each swarm you run it on.

Every licence the issuer signs is bound to exactly one swarm. `license.ts:532`
refuses to sign **any** licence without a cluster id; `:505` gives the
managed-specific reason — an older `agent-manager` reads the token as statically
bound, and the rollout depends on managed tokens keeping `cluster_id` populated. And
`lease.ts:1131` says it outright:

> `generateLicenseKey` refuses to sign `managed` without a swarm, so it never starts
> life this way.

What actually distinguishes managed is not *where* the binding lives but that it has
to be kept current: the token names its swarm exactly as a static one does, and a
live lease is a second condition on top. Both bullets now say that.

## A move needs a new key — `:310`

> Moving the license to a different swarm does not need a new key.

The opposite of what happens. Both halves of a move clear `license_key` — the portal
unbind (`license.ts:727`) and the verified surrender (`lease.ts:1082`) — so the old
key stops working and registering the new cluster signs a fresh one. `Getting a bound
license`, sixty lines further down this same file, already described it correctly.
Also added: managed moves at most once per lease window, which that bullet omitted.

## Trials are bound — `:301`, `:105`

> `trial` keys are typically unbound.

Not since swarmcli-website#111 — issuance refuses to sign an unbound key at all,
trials included, because an unbound key verifies on every swarm and `:license export`
hands it to anyone. `:105`'s "keys issued today are unbound or bound at issuance"
carries the same stale half.

## Two statuses the view cannot show — `:184`, `:185`

`Check()` never returns `NodeLimitExceeded` or `UserLimitExceeded`, and
`CheckNodeLimit` / `IsNodeLimitExceeded` had no caller outside their own tests, so
neither table row could ever appear. `Status: Valid` claimed to mean "within limits"
for the same reason, and did not.

**swarmcli-be#386** (open, for #381) wires the node half up — deliberately as a
*report* rather than a status, so the status line is untouched and every feature
stays on. The table, the `Limits` section, the `swarmcli license status` field list
and `troubleshooting.md` now describe that.

⚠️ **This documents behaviour that is not released yet.** The strings here are taken
from #386 as pushed (`Nodes: 12 of 10 — nothing is switched off`, `nodes` /
`max_nodes`). If that PR changes its wording before merging, this PR changes with it;
if it is rejected, these paragraphs go back to describing nothing rather than to the
old text, which was wrong either way.

## The user half stays unwired, and now says so

`SetUserCount` has no caller anywhere — #386 leaves users out for exactly that
reason. The `Limits` section claimed `max_users` "is checked against the rbac-proxy's
user store after each RBAC change". It is checked against nothing.

## Verification

Docs only — no Go changed, so `fmt`/`lint`/`vet`/`test` have nothing to act on. Every
anchor added resolves within the file: `#limits` and
`#moving-a-managed-license-to-another-swarm` were already linked elsewhere in it, and
`#license-view` matches `### \`:license\` view`.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BDAjiQHTMtW4xiTbEVVuAT
