### PR TITLE
docs(ce): the package tree lost six packages, and the label table one label

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,6 +62,10 @@ views/
   helpbar/                 Dynamic keybinding bar
   systeminfo/              Header with cluster info
   viewstack/               Navigation stack (push/pop)
+  charts/                  The `:charts` browser — the chart-engine's TUI surface
+  volumes/                 Volume list and file browser. This is the view the `volumes-all-nodes` Pro gate below applies to
+  taskutil/                Shared task helpers used by the task-bearing views
+  unlockdialog/            Secret/config unlock prompt
 commands/
   api/                     Command context & arg parsing
   command/                 Top-level built-in commands (help.go, contexts.go, quit.go, alias.go, bootstrap.go, devupdate.go); docker-entity commands live under command/docker/<entity>/ls.go (service, node, network, volume, secret, config). devupdate.go registers `:dev-update` only when SWARMCLI_ENV=dev (force-shows the update-available notice for previewing)
@@ -76,6 +80,17 @@ docker/
   secret.go, config.go     Secret/config CRUD
 registry/
   registry.go              Global command map: Register(), Get(), All(), Suggest()
+features/
+  features.go              Feature-flag registry. The base build enables nothing; extension builds call Enable() from init(). This is the seam swarmcli-be's profeatures/ drives from the licence, so a change here is a cross-repo change
+args/
+  args.go                  Argument parsing shared by the CLI dispatch path
+settings/
+  settings.go              Persists small single-purpose CLI preferences to the user config dir
+ui/
+  columns.go, dialog/, components/, framebox
+                           Shared widgets nearly every view under views/ builds on — the filterable list, dialog styling, the frame box
+core/primitives/hash/      Small shared primitives
+assets/                    Logos and the demo GIF (no Go code)
 utils/log/
   logger.go                zap wrapper: Init(), L(), Sync(), SetLevel(), lumberjack rotation
   slogcore.go              InitSlog(slog.Handler): forwards this package's output into a host program's log/slog handler instead of a file. For consumers importing swarmcli as a library (swarmcli-cd), where Init's lumberjack file is wrong and not initialising at all silently discards everything L()'s callers write
@@ -180,7 +195,7 @@ Every PR to `main` must pass the `check_labels.yml` workflow which requires one 
 
 | Group | Labels | Meaning |
 |---|---|---|
-| A — Change type | `A0-ui`, `A1-feature`, `A2-bugfix`, `A3-technical` | What kind of change |
+| A — Change type | `A0-ui`, `A1-feature`, `A2-bugfix`, `A3-technical`, `D0-dependency` | What kind of change (`D0-dependency` is the Dependabot one, and counts as an A label) |
 | B — Urgency | `B0-low-priority`, `B2-high-priority` | How urgent |
 | C — Breaking | `C0-breaks-nothing`, `C1-breaking-change` | Backward compatibility |
 
@@ -192,11 +207,15 @@ When a PR fixes a GitHub issue, copy the issue's labels to the PR and add any mi
 
 ## CI Workflows (.github/workflows/)
 
+All seven:
+
 - `ci.yml`: go fmt, golangci-lint, go build, Docker image build
 - `integration-tests.yml`: Full E2E
 - `release.yml`: GoReleaser on tags (multi-platform, Homebrew tap)
-- `check_labels.yml`: PR label validation
+- `check_labels.yml`: PR label validation — it reads labels from the `pull_request` **event payload**, not the API, so a run queued from `opened` sees none; only a new event fixes that, never a job re-run
 - `licence.yml`: License header check
+- `govulncheck.yml`: scheduled vulnerability scan
+- `dependabot-tidy.yml`: keeps `go.sum` tidy on Dependabot PRs (which carry `D0-dependency`)
 
 ## Go Version & Build
 


### PR DESCRIPTION
Every gap here is one an agent or a new contributor hits immediately.

### The PR label table omits a label CI enforces

`check_labels.yml` enforces `A0-ui,A1-feature,A2-bugfix,A3-technical,D0-dependency` as the A group. The table lists four of the five.

`D0-dependency` is the label Dependabot PRs carry — so the one case where the table is consulted by someone who did not open the PR by hand is the case it gets wrong.

### Six top-level packages were missing from the architecture tree

`args/`, `assets/`, `core/primitives/`, `features/`, `settings/`, `ui/`.

Two are not incidental:

- **`features/`** is the seam `swarmcli-be`'s `profeatures/` drives from the licence. This file's own "Pro Feature Boundary" section leans on it 60 lines later.
- **`ui/`** carries the shared widgets — filterable list, dialog styling, framebox — that nearly every *listed* view is built from.

### Four view packages were missing

`charts/`, `volumes/`, `taskutil/`, `unlockdialog/`.

`volumes/` is the sharpest: the Pro Feature Boundary section documents the `volumes-all-nodes` gate that applies to **exactly this view**, in the same file that does not list it.

### The CI section listed five of seven workflows

Presented as if exhaustive. `govulncheck.yml` appears only in prose eight lines later; `dependabot-tidy.yml` nowhere — which is the same omission as the missing `D0-dependency`, since that workflow is what raises the PRs carrying it.

Added the `check_labels` event-payload note while there: a run queued from `opened` sees no labels, and "re-run the job" is the intuitive response that never works.

`go build ./...` passes. Documentation only.

---
Machine-generated by an AI agent (Claude Opus 5) via the `eldara-cruncher` bot, and not human-reviewed. Claims carry a file, a line or a reproducible check so they can be verified cheaply.
