### PR TITLE
docs(ce): give the package map a home a contributor will find

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,81 +32,23 @@ tail -f ~/.local/state/swarmcli/app.log          # prod mode (JSON)
 
 ## Architecture
 
-```
-main.go                    Entry point; version injection via ldflags. With args, dispatches non-interactive CLI subcommands via cli.Dispatch(); bare invocation launches the TUI (tea.NewProgram())
-cli/                       Arg-based CLI dispatch (cli.Dispatch): `charts`, `version`, `help`; cli/commands.go holds chartsCommands — the table dispatch, the usage text, per-command --help and the generated README blocks all read from; cli/apply.go holds the GitOps subcommands (`charts apply`, `charts outdated`)
-charts/                    Helm-like package manager (repos, chart rendering, releases) + declarative releases (releasefile.go, apply.go, outdated.go). charts.ChartSource (source.go) is the seam that resolves a chart ref — repo or local path — so release planning is testable without Docker, a network or a filesystem. charts.NewDockerBackend(ctxName) + NewEngineWith is the seam that targets a *specific* swarm: the default backend uses the ambient Docker context, the SDK client singleton and the shared snapshot cache, all three of which are process-global
-app/
-  app.go                   Init(); triggers command autoload via _ "github.com/Eldara-Tech/swarmcli/v2/commands" and view autoload via _ "github.com/Eldara-Tech/swarmcli/v2/views" (view factory registry lives in views/view/registry.go)
-  hooks.go                 PreUpdateHook registration; StartupOverlay; RegisterShutdownHook / RunShutdownHooks (extension builds register cleanup for long-lived resources here)
-  model.go                 Central state: Model struct (viewport, currentView, viewStack, commandInput, searchInput, systemInfo)
-  update.go                Main message router: navigation, resize, events, key dispatch
-views/
-  view/interface.go        View contract: Update/View/Init/Name/OnEnter/OnExit/HasErrors/ShortHelpItems + Filterable interface
-  stacks/                  Stack list → drill into services
-  services/                Service list (filterable by stack/node/all), scale/restart actions
-  tasks/                   Task list per service/stack
-  nodes/                   Cluster node list
-  secrets/                 Secret management
-  configs/                 Config management
-  logs/                    Service log streaming
-  contexts/                Docker context switcher
-  help/                    Keybinding cheat sheet
-  inspect/                 JSON inspect viewer
-  networks/                Network list
-  loading/                 Loading spinner
-  commandinput/            ":" command bar
-  searchinput/             "/" search filter bar (app-level, drives Filterable views)
-  confirmdialog/           Confirmation prompts
-  scaledialog/             Scale replica input
-  helpbar/                 Dynamic keybinding bar
-  systeminfo/              Header with cluster info
-  viewstack/               Navigation stack (push/pop)
-  charts/                  The `:charts` browser — the chart-engine's TUI surface
-  volumes/                 Volume list and file browser. This is the view the `volumes-all-nodes` Pro gate below applies to
-  taskutil/                Shared task helpers used by the task-bearing views
-  unlockdialog/            Secret/config unlock prompt
-commands/
-  api/                     Command context & arg parsing
-  command/                 Top-level built-in commands (help.go, contexts.go, quit.go, alias.go, bootstrap.go, devupdate.go); docker-entity commands live under command/docker/<entity>/ls.go (service, node, network, volume, secret, config). devupdate.go registers `:dev-update` only when SWARMCLI_ENV=dev (force-shows the update-available notice for previewing)
-  autoload.go              Blank import triggers init() registration
-docker/
-  client.go                Context-aware Docker client factory
-  snapshot.go              In-memory cache (3s TTL, sync.RWMutex, atomic refresh flag)
-  events.go                Docker event stream subscription
-  service.go               Service ops: scale, restart, update
-  node.go, task.go         Entity queries (TaskEntry includes ContainerID, populated from task.Status.ContainerStatus.ContainerID with nil-guard)
-  stack.go                 Stack queries
-  secret.go, config.go     Secret/config CRUD
-registry/
-  registry.go              Global command map: Register(), Get(), All(), Suggest()
-features/
-  features.go              Feature-flag registry. The base build enables nothing; extension builds call Enable() from init(). This is the seam swarmcli-be's profeatures/ drives from the licence, so a change here is a cross-repo change
-args/
-  args.go                  Argument parsing shared by the CLI dispatch path
-settings/
-  settings.go              Persists small single-purpose CLI preferences to the user config dir
-ui/
-  columns.go, dialog/, components/, framebox
-                           Shared widgets nearly every view under views/ builds on — the filterable list, dialog styling, the frame box
-core/primitives/hash/      Small shared primitives
-assets/                    Logos and the demo GIF (no Go code)
-utils/log/
-  logger.go                zap wrapper: Init(), L(), Sync(), SetLevel(), lumberjack rotation
-  slogcore.go              InitSlog(slog.Handler): forwards this package's output into a host program's log/slog handler instead of a file. For consumers importing swarmcli as a library (swarmcli-cd), where Init's lumberjack file is wrong and not initialising at all silently discards everything L()'s callers write
-```
+The package map and the registration patterns moved to
+**[docs/architecture.md](docs/architecture.md)** — a contributor needs them as much
+as an agent does, and while they lived here they drifted: six top-level and four
+view packages were missing by the time #620 restored them.
 
-## Key Patterns
+Two rules from that page are worth having in front of you, because breaking either
+is silent:
 
-- **Bubble Tea MVC**: Input → Update() → tea.Cmd → View(). All state changes via `tea.Msg` types.
-- **View Stack**: `viewStack.Push(old)` / `Pop()` for breadcrumb navigation.
-- **View Factory**: Views auto-register via `init()` + `view.RegisterView(name, factory)` in each view's `register.go` (registry in `views/view/registry.go`, looked up with `GetFactory`). `app/app.go`'s blank import `_ "github.com/Eldara-Tech/swarmcli/v2/views"` pulls `views/autoload.go`, which blank-imports every view — exactly mirroring the command autoload pattern.
-- **Command Registry**: Commands in `commands/command/` auto-register via `init()` + `registry.Register()`. Accessed via `:` input.
-- **Command Spec**: Commands optionally implement `registry.CommandWithSpec` (`Spec() registry.CommandSpec`, discovered by type assertion like `Aliaser`). The spec declares `Usage`, `Flags` (the allow-list), and `Examples`. `api.ParseInput` is the single chokepoint that, in order: short-circuits `Passthrough` specs, intercepts `--help`/`-h`/`-help` (and `:help <cmd>`) into a per-command help screen reusing the detailed help view, then rejects any undeclared flag (**global strict**, with a `did you mean --x?` suggestion). Unknown-flag rejection means every registered command MUST declare a spec — a missing/empty spec rejects all flags. `Passthrough:true` is the narrow escape-hatch for delegating/unavailable stubs (e.g. the OSS `bootstrap` stub): it skips both help interception and validation so every arg reaches `Execute` unchanged and the command keeps its own messaging (and no Pro flag internals leak into OSS — see Pro Feature Boundary).
-- **CLI Command Seam**: `cli.RegisterCommand(name, summary, run)` adds a top-level *non-interactive* verb (`swarmcli <name> …`) from a build embedding this module — the headless counterpart of `registry.Register`, which only reaches the TUI's `:` palette because `Execute` returns a `tea.Cmd`. `run` gets everything after the verb and returns the exit code (2 usage / 1 failure / 0, per `cli/output.go`). It panics on a duplicate or on a name this package dispatches itself, so the vocabulary can be extended and never re-pointed. This repository registers nothing, so `swarmcli help` still lists exactly its own verbs.
+- **The seams are a published contract.** `registry`, `views/view`, `features` and
+  the `docker` operation interfaces are consumed by `swarmcli-be`, a private module
+  you cannot see from this repo. Renaming or narrowing one is a cross-repo change,
+  and the BE side has to merge first or its CI breaks on `undefined:`.
+- **Ask `features.IsEnabled`, never assume an edition.** The base build enables
+  nothing; the paid build calls `features.Enable()` from `init()` after a licence
+  verifies.
+
 - **Error text quotes with `'…'`, not `%q`**: an error names things in single quotes — `chart '%s' version '%s' not found`. `swarmcli-cd` consumes `charts/` and `docker/` and logs their errors through logfmt, which escapes every `"` inside a value, so `%q` reached an operator as `chart \"x\" version \"1\" not found`. Applies to anything constructing an error (`fmt.Errorf`, `errf`, `usageErr`) and to status text that travels with one (`Convergence.Reason`, compat `Reason`, preflight reasons, `RepoStore.Warnf` — cd routes that straight into `slog`). **Keep `%q`** for the zap logs (`l().Infof`), TUI presentation (dialogs, toasts, the status bar), CLI success output, and anywhere the escaping is the point — a content `preview: %q`, a keypress, a rune. See swarmcli-cd#157.
-- **Snapshot Cache**: `docker.GetSnapshot()` / `docker.RefreshSnapshot()` — 3s TTL, background event-driven invalidation.
-- **Navigation**: `view.NavigateToMsg{ViewName, Payload, Replace}` dispatched in `update.go`.
 
 ## Adding New Functionality
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,11 @@ We love your input! We want to make contributing to SwarmCLI as easy and transpa
 
 ## Development Setup
 
+Before changing anything non-trivial, read
+[docs/architecture.md](docs/architecture.md) — it maps the packages, explains how
+views and commands self-register through `init()`, and names the seams the
+Business Edition attaches to (renaming one of those is a cross-repo change).
+
 SwarmCLI is built in **Go**. To get started:
 
 1. **Clone the repository**:

--- a/docs/README.md
+++ b/docs/README.md
@@ -39,6 +39,13 @@ features a licence unlocks. On top of the Community Edition it adds:
 For install commands see [Installation](installation.md), or the
 [repository README](../README.md) for a quickstart.
 
+### For contributors
+
+- [Architecture](architecture.md) — the package map, how views and commands
+  self-register, and which seams the Business Edition attaches to.
+- [CONTRIBUTING.md](../CONTRIBUTING.md) — building, testing, and opening a pull
+  request.
+
 ## Reporting issues
 
 Bugs and feature requests for either edition belong in this repository's

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,123 @@
+# Architecture
+
+SwarmCLI is a single static Go binary: a Bubble Tea TUI for Docker Swarm, plus a
+small non-interactive CLI reached by passing arguments. This page is the map — what
+each package is for and how the pieces find each other at startup.
+
+It is written for someone about to change the code. For installing and using the
+binary, start at [README.md](README.md); for what the Business Edition adds, see
+[editions.md](editions.md).
+
+## Entry points
+
+`main.go` does one branch. With arguments it dispatches a non-interactive
+subcommand through `cli.Dispatch`; with none it launches the TUI via
+`tea.NewProgram`. Version strings are injected at build time with `ldflags`.
+
+Almost nothing is wired by hand after that. Views and commands register themselves
+from `init()` and are pulled in by blank imports, so adding one is a matter of
+creating the package and adding it to the right autoload file — see
+[Key patterns](#key-patterns) below.
+
+## Layout
+
+```
+main.go                    Entry point; version injection via ldflags. With args, dispatches non-interactive CLI subcommands via cli.Dispatch(); bare invocation launches the TUI (tea.NewProgram())
+cli/                       Arg-based CLI dispatch (cli.Dispatch): `charts`, `version`, `help`; cli/commands.go holds chartsCommands — the table dispatch, the usage text, per-command --help and the generated README blocks all read from; cli/apply.go holds the GitOps subcommands (`charts apply`, `charts outdated`)
+charts/                    Helm-like package manager (repos, chart rendering, releases) + declarative releases (releasefile.go, apply.go, outdated.go). charts.ChartSource (source.go) is the seam that resolves a chart ref — repo or local path — so release planning is testable without Docker, a network or a filesystem. charts.NewDockerBackend(ctxName) + NewEngineWith is the seam that targets a *specific* swarm: the default backend uses the ambient Docker context, the SDK client singleton and the shared snapshot cache, all three of which are process-global
+app/
+  app.go                   Init(); triggers command autoload via _ "github.com/Eldara-Tech/swarmcli/v2/commands" and view autoload via _ "github.com/Eldara-Tech/swarmcli/v2/views" (view factory registry lives in views/view/registry.go)
+  hooks.go                 PreUpdateHook registration; StartupOverlay; RegisterShutdownHook / RunShutdownHooks (extension builds register cleanup for long-lived resources here)
+  model.go                 Central state: Model struct (viewport, currentView, viewStack, commandInput, searchInput, systemInfo)
+  update.go                Main message router: navigation, resize, events, key dispatch
+views/
+  view/interface.go        View contract: Update/View/Init/Name/OnEnter/OnExit/HasErrors/ShortHelpItems + Filterable interface
+  stacks/                  Stack list → drill into services
+  services/                Service list (filterable by stack/node/all), scale/restart actions
+  tasks/                   Task list per service/stack
+  nodes/                   Cluster node list
+  secrets/                 Secret management
+  configs/                 Config management
+  logs/                    Service log streaming
+  contexts/                Docker context switcher
+  help/                    Keybinding cheat sheet
+  inspect/                 JSON inspect viewer
+  networks/                Network list
+  loading/                 Loading spinner
+  commandinput/            ":" command bar
+  searchinput/             "/" search filter bar (app-level, drives Filterable views)
+  confirmdialog/           Confirmation prompts
+  scaledialog/             Scale replica input
+  helpbar/                 Dynamic keybinding bar
+  systeminfo/              Header with cluster info
+  viewstack/               Navigation stack (push/pop)
+  charts/                  The `:charts` browser — the chart-engine's TUI surface
+  volumes/                 Volume list and file browser. This is the view the `volumes-all-nodes` Pro gate below applies to
+  taskutil/                Shared task helpers used by the task-bearing views
+  unlockdialog/            Secret/config unlock prompt
+commands/
+  api/                     Command context & arg parsing
+  command/                 Top-level built-in commands (help.go, contexts.go, quit.go, alias.go, bootstrap.go, devupdate.go); docker-entity commands live under command/docker/<entity>/ls.go (service, node, network, volume, secret, config). devupdate.go registers `:dev-update` only when SWARMCLI_ENV=dev (force-shows the update-available notice for previewing)
+  autoload.go              Blank import triggers init() registration
+docker/
+  client.go                Context-aware Docker client factory
+  snapshot.go              In-memory cache (3s TTL, sync.RWMutex, atomic refresh flag)
+  events.go                Docker event stream subscription
+  service.go               Service ops: scale, restart, update
+  node.go, task.go         Entity queries (TaskEntry includes ContainerID, populated from task.Status.ContainerStatus.ContainerID with nil-guard)
+  stack.go                 Stack queries
+  secret.go, config.go     Secret/config CRUD
+registry/
+  registry.go              Global command map: Register(), Get(), All(), Suggest()
+features/
+  features.go              Feature-flag registry. The base build enables nothing; extension builds call Enable() from init(). This is the seam swarmcli-be's profeatures/ drives from the licence, so a change here is a cross-repo change
+args/
+  args.go                  Argument parsing shared by the CLI dispatch path
+settings/
+  settings.go              Persists small single-purpose CLI preferences to the user config dir
+ui/
+  columns.go, dialog/, components/, framebox
+                           Shared widgets nearly every view under views/ builds on — the filterable list, dialog styling, the frame box
+core/primitives/hash/      Small shared primitives
+assets/                    Logos and the demo GIF (no Go code)
+utils/log/
+  logger.go                zap wrapper: Init(), L(), Sync(), SetLevel(), lumberjack rotation
+  slogcore.go              InitSlog(slog.Handler): forwards this package's output into a host program's log/slog handler instead of a file. For consumers importing swarmcli as a library (swarmcli-cd), where Init's lumberjack file is wrong and not initialising at all silently discards everything L()'s callers write
+```
+
+## Key patterns
+
+- **Bubble Tea MVC**: Input → Update() → tea.Cmd → View(). All state changes via `tea.Msg` types.
+- **View Stack**: `viewStack.Push(old)` / `Pop()` for breadcrumb navigation.
+- **View Factory**: Views auto-register via `init()` + `view.RegisterView(name, factory)` in each view's `register.go` (registry in `views/view/registry.go`, looked up with `GetFactory`). `app/app.go`'s blank import `_ "github.com/Eldara-Tech/swarmcli/v2/views"` pulls `views/autoload.go`, which blank-imports every view — exactly mirroring the command autoload pattern.
+- **Command Registry**: Commands in `commands/command/` auto-register via `init()` + `registry.Register()`. Accessed via `:` input.
+- **Command Spec**: Commands optionally implement `registry.CommandWithSpec` (`Spec() registry.CommandSpec`, discovered by type assertion like `Aliaser`). The spec declares `Usage`, `Flags` (the allow-list), and `Examples`. `api.ParseInput` is the single chokepoint that, in order: short-circuits `Passthrough` specs, intercepts `--help`/`-h`/`-help` (and `:help <cmd>`) into a per-command help screen reusing the detailed help view, then rejects any undeclared flag (**global strict**, with a `did you mean --x?` suggestion). Unknown-flag rejection means every registered command MUST declare a spec — a missing/empty spec rejects all flags. `Passthrough:true` is the narrow escape-hatch for delegating/unavailable stubs (e.g. the OSS `bootstrap` stub): it skips both help interception and validation so every arg reaches `Execute` unchanged and the command keeps its own messaging (and no Pro flag internals leak into OSS — see Pro Feature Boundary).
+- **CLI Command Seam**: `cli.RegisterCommand(name, summary, run)` adds a top-level *non-interactive* verb (`swarmcli <name> …`) from a build embedding this module — the headless counterpart of `registry.Register`, which only reaches the TUI's `:` palette because `Execute` returns a `tea.Cmd`. `run` gets everything after the verb and returns the exit code (2 usage / 1 failure / 0, per `cli/output.go`). It panics on a duplicate or on a name this package dispatches itself, so the vocabulary can be extended and never re-pointed. This repository registers nothing, so `swarmcli help` still lists exactly its own verbs.
+- **Snapshot Cache**: `docker.GetSnapshot()` / `docker.RefreshSnapshot()` — 3s TTL, background event-driven invalidation.
+- **Navigation**: `view.NavigateToMsg{ViewName, Payload, Replace}` dispatched in `update.go`.
+
+## What the Business Edition attaches to
+
+This repository is the open half of an open-core pair. `swarmcli-be` is a separate
+private module that imports this one and registers additional views, commands and
+middleware through the same `init()` seams described above — it does not fork or
+patch anything here.
+
+Two consequences matter when changing this repo:
+
+- **The seams are a published contract.** `registry`, `views/view`, `features` and
+  the `docker` operations interfaces are consumed by a module you cannot see from
+  here. Renaming or narrowing one is a cross-repo change, and the BE side must
+  merge first or its CI breaks.
+- **`features/` is the licence seam.** The base build enables nothing; the paid
+  build calls `features.Enable()` from `init()` once a licence verifies. Code here
+  should ask `features.IsEnabled` rather than assume an edition.
+
+[editions.md](editions.md) describes the split from a user's point of view.
+
+## Related
+
+- [configuration.md](configuration.md) — environment variables and on-disk paths
+- [features.md](features.md) — what the TUI can do
+- [rbac.md](rbac.md), [bootstrap.md](bootstrap.md) — the managed-infrastructure path
+- [troubleshooting.md](troubleshooting.md) — known environment traps


### PR DESCRIPTION
`docs/` is entirely operator-facing — install, licence, RBAC, troubleshooting — so the only description of how this codebase is put together lived in `CLAUDE.md`, a file a new contributor has no reason to open.

It drifted there, too. By the time #620 restored them, six top-level and four view packages were missing — including `features/` (the seam `swarmcli-be` drives) and `ui/` (the widgets nearly every *listed* view is built from).

### `docs/architecture.md` (new)

Takes the package map and the registration patterns, framed for someone about to change the code rather than as a bare tree: what `main.go` branches on, why almost nothing is wired by hand, and a section naming **what the Business Edition attaches to**.

That last part was not written down anywhere:

- `registry`, `views/view`, `features` and the `docker` operation interfaces are a **published contract** consumed by a private module you cannot see from this repo
- renaming or narrowing one is a cross-repo change
- the BE side has to merge **first**, or its CI breaks on `undefined:`

### Discoverability

Linked from `docs/README.md` under a new **"For contributors"** heading, and from `CONTRIBUTING.md`'s Development Setup — which previously said only *"SwarmCLI is built in Go. To get started:"* and sent people straight to `go build`.

### What stays in CLAUDE.md

A pointer, plus the two rules that are silent when broken: the seam contract, and asking `features.IsEnabled` rather than assuming an edition.

It also keeps the **error-quoting convention** in full. That one is genuinely agent-operational — it is a downstream-consumer constraint (`swarmcli-cd` parses these through logfmt, where `%q` reaches an operator as `chart \"x\" not found`), it has a cited regression in swarmcli-cd#157, and it is easy to violate without noticing.

```
CLAUDE.md   227 -> 169 lines,  19,346 -> 12,191 bytes
```

`go build ./...` passes. Every relative doc link resolves.

---
Machine-generated by an AI agent (Claude Opus 5) via the `eldara-cruncher` bot, and not human-reviewed. Claims carry a file, a line or a reproducible check so they can be verified cheaply.
