### PR TITLE
docs(ce): two seams, the chart-record lifetime, and how to test the TUI

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,6 +35,39 @@ SwarmCLI is built in **Go**. To get started:
    SWARMCLI_ENV=dev LOG_LEVEL=debug go run .
    ```
 
+## Testing the TUI
+
+Two assertion mistakes recur here, both of which produce a green test that never
+reached the code it was written for.
+
+**Call the real factory, do not model it.** `app.switchToView` batches the *view
+factory's returned command* with `OnEnter()`. PR #574 gave eight views a test
+asserting that entry arms exactly one poll chain, and modelled the factory as
+`tea.Batch(m.Init(), m.OnEnter())`. Seven factories really did just return a load
+command, so the test was right about those — but `views/services/register.go`
+returns `tickCmd()` and `views/tasks/register.go` returns `model.OnEnter()`
+outright. Both double-armed, and both stayed green **in the very PR whose subject
+was that defect**. Calling `factory(m.deps, 80, 24, nil)` and putting *its*
+command in the batch fails on both.
+
+A hand-written stand-in encodes what you believe the caller does, so it can only
+fail where your belief was already right — and the views that break the pattern
+are exactly the ones the guess omits.
+
+**Count the rows that carry content, not the height.** When a layout pads to a
+fixed height, `require.Equal(t, height, lipgloss.Height(out))` passes whether the
+space is *used* or *wasted*. Writing the guard for swarmcli#560, the fullscreen
+frame trimmed and padded to exactly the terminal height, so a view sized three
+rows too small still rendered full-height and the mutation that undersized it
+stayed green.
+
+The property under test was never "how tall is the output" — it was "did the
+layout claim every row it was given". Give the fixture more content than can fit,
+then assert on the rows that carry content.
+
+**Mutation-check any guard you add**: break the thing it protects and confirm the
+test fails. A guard that has never failed is an untested claim.
+
 ## Pull Request Process
 
 1. Fork the repo and create your branch from `main`.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -96,6 +96,47 @@ utils/log/
 - **Snapshot Cache**: `docker.GetSnapshot()` / `docker.RefreshSnapshot()` — 3s TTL, background event-driven invalidation.
 - **Navigation**: `view.NavigateToMsg{ViewName, Payload, Replace}` dispatched in `update.go`.
 
+## Two seams worth knowing before you widen them
+
+**`charts.Backend` (`charts/release.go`) has exactly two implementers**: CE's own
+`dockerBackend`, and `swarmcli-cd`'s `backend.Backend`. `swarmcli-be` does *not*
+implement it — its `DeployStack` is `docker.DeployStack`, an unrelated two-arg
+shell-out used by `bootstrap`. So widening that interface is a contained
+cross-repo change (swarmcli#532 did it).
+
+The `docker.*` snapshot helpers are the opposite case. `RefreshSnapshot` and
+`GetOrRefreshSnapshot` keep their bare, context-free forms because `swarmcli-be`
+and the TUI depend on them; the context-taking variants are separate `…Ctx`
+functions rather than a signature change.
+
+**The help view has three layouts, and they are not interchangeable.**
+`views/help/register.go`'s factory routes by payload type:
+
+- `[]CommandInfo` → `New` — the command table behind `:help`.
+- `[]HelpCategory` → `NewDetailed` — a **multi-column** layout, one column per
+  category with a fixed key width, built for keybindings.
+- per-command help → `CommandHelp` — a vertical, long-form layout.
+
+Reaching for the columnar `NewDetailed` to render long prose produces a
+fixed-width column that truncates. Route by what the content *is*, not by which
+constructor is nearest.
+
+## The chart engine's release records outlive the stack
+
+Every revision is written as a Docker config named
+`swarmcli.release.<release>.v<n>`, labelled `com.swarmcli.type=release`. That
+label is **not** `com.docker.stack.namespace`, so `docker stack rm <name>`
+removes the services and leaves the records — which is why a torn-down
+application can still report as synced. See
+[troubleshooting.md](troubleshooting.md#charts) for the operator-facing symptom.
+
+Those records store the rendered manifest, and that is deliberate. swarmcli#465
+asked for a secret-redaction pass over them and was closed not-planned: an
+inlined `environment:` value is already readable from the service spec by anyone
+who can read the config, so the record duplicates an exposure rather than
+widening it — and redacting it would break rollback and `charts apply`, which
+need the manifest they actually deployed.
+
 ## What the Business Edition attaches to
 
 This repository is the open half of an open-core pair. `swarmcli-be` is a separate

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -277,3 +277,21 @@ If none of the above matches, capture:
 
 …and open a [issue](https://github.com/Eldara-Tech/swarmcli/issues)
 or contact the support channel that came with your license.
+
+## Charts
+
+**`docker stack rm` removed the services, but swarmcli still lists the release.**
+Expected. The chart engine stores each revision as a Docker config named
+`swarmcli.release.<release>.v<n>`, labelled `com.swarmcli.type=release` — not
+`com.docker.stack.namespace` — so a stack removal never touches them. A
+torn-down application can therefore still report as synced.
+
+Remove the release through swarmcli rather than through `docker stack rm`, or
+delete the configs by label:
+
+```bash
+docker config ls --filter label=com.swarmcli.type=release
+```
+
+Tearing the whole swarm down and re-initialising also clears them, which is what
+a test environment should do between runs.


### PR DESCRIPTION
Third wave of moving agent memory into the repos that own it.

One candidate was **dropped as already covered** rather than duplicated: `docker-context-env-beats-context-use`, because `docs/configuration.md` § "The Docker context" already states that swarmcli resolves the context once at startup, prefers `DOCKER_CONTEXT`, and that `docker context use` therefore does not move a running swarmcli.

### `docs/architecture.md` — two seams whose blast radius is not obvious

- **`charts.Backend` has exactly two implementers** — CE's `dockerBackend` and swarmcli-cd's `backend.Backend`. **Not** `swarmcli-be`, whose `DeployStack` is an unrelated two-arg shell-out. So widening it is a contained cross-repo change (#532).
- **The `docker.*` snapshot helpers are the opposite case.** `RefreshSnapshot` and `GetOrRefreshSnapshot` keep their bare forms because `swarmcli-be` and the TUI depend on them — which is *why* the context-taking variants are separate `…Ctx` functions rather than a signature change.
- **The help view has three layouts and they are not interchangeable.** Reaching for the columnar `NewDetailed` to render long prose produces a fixed-width column that truncates. Route by what the content is.

### The chart engine's release records

Caught people twice, in opposite directions:

- They are labelled `com.swarmcli.type=release`, **not** `com.docker.stack.namespace` — so `docker stack rm` leaves them and a torn-down application still reports **synced**.
- They store the rendered manifest **deliberately**. #465 asked for a redaction pass and was closed not-planned: an inlined `environment:` value is already readable from the service spec, so the record *duplicates* an exposure rather than widening one — and redacting it would break rollback and `charts apply`.

`docs/troubleshooting.md` gets the operator-facing half under a new **Charts** heading, with the `docker config ls --filter label=` incantation.

### `CONTRIBUTING.md` — "Testing the TUI"

Two assertion mistakes that both produce a green test that never reached the code:

- **Modelling the caller instead of calling it.** PR #574's entry test wrote `tea.Batch(m.Init(), m.OnEnter())` rather than invoking the factory. Seven views matched the guess; `views/services` returns `tickCmd()` and `views/tasks` returns `OnEnter()` outright — so both double-armed and **both stayed green in the very PR whose subject was that defect**.
- **Asserting total height on a padded layout.** `require.Equal` on `lipgloss.Height` passes whether the space is used or wasted, so a view sized three rows too small still rendered full-height (#560).

Plus the rule both point at: mutation-check any guard you add.

`go build ./...` and `go test ./views/...` pass.

---
Machine-generated by an AI agent (Claude Opus 5) via the `eldara-cruncher` bot, and not human-reviewed. Claims carry a file, a line or a reproducible check so they can be verified cheaply.