### PR TITLE
docs(ce): say plainly that swarmcli does not update itself

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -159,6 +159,19 @@ docker pull eldaratech/swarmcli-be:latest   # Docker
 For binary installs, replace the file on disk with the new archive's
 contents.
 
+**swarmcli does not update itself.** There is no `update` verb, no background
+download, and nothing that replaces the running binary — upgrading is always the
+package manager or the file on disk. If you have been told a swarm is running
+"the version the auto-updater installed", there is nothing behind that.
+
+What swarmcli does have is a **startup notice**: one request to
+`https://swarmcli.io/api/v1/version` at launch, a version badge in the
+system-info header, and a dismiss-only modal pointing back at this page. It tells
+you a newer release exists; it never fetches one.
+
+(The one thing that *does* renew itself is a managed licence's lease, which is
+unrelated to the binary — see [license.md](license.md).)
+
 The compatibility matrix between BE, the bundled CE codebase, and the
 agent/rbac-proxy versions is published in each release's notes — see
 [Releases](https://github.com/Eldara-Tech/swarmcli/releases).


### PR DESCRIPTION
*"The most recent one, installed with the auto updater"* is a natural thing to say — and there is nothing behind it.

Neither `swarmcli` nor `swarmcli-be` contains code that downloads, verifies or replaces the running binary: no `update` verb, no background download, no `selfupdate` dependency. `docs/` never said so, so the absence was only discoverable by grepping both `go.mod` files and every `.go`.

**An absence is exactly the kind of claim a doc has to make explicitly**, because a reader cannot find it by looking.

What exists is a **startup notice**: one `POST` to `swarmcli.io/api/v1/version` at launch, a version badge in the system-info header, and a dismiss-only modal pointing back at the install page. It reports; it never fetches.

Placed next to the upgrade commands, which is where somebody forms the belief in the first place. Also disambiguates the one thing that genuinely *does* renew itself — a managed licence's lease — since that is the likely source of the confusion and has nothing to do with the binary.

`go build ./...` passes.

---
Machine-generated by an AI agent (Claude Opus 5) via the `eldara-cruncher` bot, and not human-reviewed. Claims carry a file, a line or a reproducible check so they can be verified cheaply.