### PR TITLE
docs(ce): the free tier, and what actually bounds it

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,10 @@ commercial superset that adds:
 - Interactive shell into a running service task.
 - Reveal-secret for debugging.
 
+The licence that turns them on need not be a paid one: the [free
+tier](docs/license.md#the-free-tier) grants the same features on a swarm of up
+to three nodes.
+
 The binary on disk is named `swarmcli` (BE is a strict superset of CE — same
 binary name, expanded feature set), so existing scripts and aliases continue to
 work.

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,11 +22,15 @@ features a licence unlocks. On top of the Community Edition it adds:
 - **Volume management across all swarm nodes** — list, create, delete, prune,
   and browse files inside volumes.
 
+The licence that unlocks them need not be a paid one: the [free
+tier](license.md#the-free-tier) grants the same features on a swarm of up to
+three nodes.
+
 ## Contents
 
 - [Editions](editions.md) — the two artefacts one tag publishes, and which one you have.
 - [Installation](installation.md) — install channels, first run, edition check.
-- [License](license.md) — acquiring a key, activation paths, grace period, tiers.
+- [License](license.md) — the tiers including the free one, acquiring a key, activation paths, grace period.
 - [Bootstrap](bootstrap.md) — `:bootstrap` end-to-end: what gets deployed and how.
 - [Migration](migration.md) — moving an existing stack to application-layer mTLS (`:bootstrap --migrate`).
 - [RBAC](rbac.md) — managing users, roles, onboarding, and revocation.

--- a/docs/editions.md
+++ b/docs/editions.md
@@ -82,6 +82,10 @@ A licence is installed into the swarm and read at startup. It turns features on
 in the merged build only — there is nothing in the OSS build for it to unlock,
 and installing one there changes nothing and reports nothing.
 
+A licence need not be a paid one: the [free tier](license.md#the-free-tier) is a
+licence like any other and turns the same features on, on a swarm of up to three
+nodes.
+
 The Business Edition documentation covers acquiring, installing and managing a
 key, and what each feature does.
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -346,5 +346,5 @@ active license grants it:
 - Port-forward
 - Container statistics
 
-Tier-to-feature mapping is centralised: today, both `be` and `trial`
-tiers grant all four features. See [License — Model](license.md#model).
+Tier-to-feature mapping is centralised: today the `be`, `free` and `trial`
+tiers all grant the four features. See [License — Model](license.md#model).

--- a/docs/license.md
+++ b/docs/license.md
@@ -25,11 +25,16 @@ step on top — never verification, and there is an offline path for both.
 What a key records about you:
 
 - **Who it is for** — your customer identifier.
-- **Which tier** — `be` (Business Edition) or `trial`. Both grant the same
-  feature set today, so the expiry is what separates them — a `trial` must
-  carry one, and from v2.0.0 a key that does not is refused.
-- **When it expires**, if ever. A `be` key may be issued without an expiry; a
-  `trial` may not.
+- **Which tier** — `be` (Business Edition), `free` or `trial`. All three grant
+  the same feature set today, so the tier does not decide which features you
+  get; it decides what surrounds the key. A `trial` and a `free` key must carry
+  an expiry — from v2.0.0 a key on either tier that does not is refused — and a
+  `free` key carries a node allowance somebody actually judges. See [The free
+  tier](#the-free-tier).
+- **When it expires**, if ever. A `be` key may be issued without an expiry;
+  `trial` and `free` may not. A free licence's expiry is not a countdown to the
+  end of the tier, because it is rolled forward — see [The free
+  tier](#the-free-tier).
 - **Node and user limits**, if any. See [Limits](#limits).
 - **Which swarm it is bound to**, if any, and **how** — see
   [Per-swarm binding](#per-swarm-binding).
@@ -41,9 +46,58 @@ from the tier, so adding a capability to a tier benefits every outstanding key
 for that tier without re-issuing — and no key can claim a feature its tier does
 not grant.
 
+## The free tier
+
+There is a permanent free tier, and it is a licence like any other: a signed key
+you install into a swarm, verified offline, granting the same features a paid
+`be` key grants — the Business Edition features these pages describe, and the
+licensed swarmcli-cd features beside them, since one licence covers both
+products. It is not a reduced feature set under a different name, and nothing
+about installing, renewing or moving it differs from what the rest of this page
+describes.
+
+What bounds it is not the features. It is the two things around the key:
+
+- **Three nodes.** The allowance is recorded on the key as `max_nodes`, the same
+  field a paid licence carries, and swarmcli does not refuse anything on the
+  strength of it — the count is judged elsewhere, and [Limits](#limits) is where
+  that is spelled out, because "soft limit" on its own leads a reader to the
+  wrong conclusion here.
+- **A term, rather than a perpetual grant.** A free key is signed for 365 days,
+  and the term is rolled forward for you: it reaches the swarm on the same daily
+  token refresh that carries a renewal or a tier change (see
+  [Privacy](#privacy)), and it arrives before the date it replaces rather than
+  on it. Rolling it forward is the only lever there is — a free licence ends by
+  no longer being rolled, never by anything switching off from our side — and
+  that is also why the expiry is mandatory rather than optional. A free key with
+  no expiry would be a permanent grant on every swarm it reached, and nothing
+  could ever end it.
+
+A swarm that cannot reach us keeps the term it was signed with and stops when it
+runs out, and there is no offline substitute: a free licence has no lease, so
+there is no lease file to hand-carry in its place. Air-gapped and
+policy-restricted deployments are what the paid tiers' offline paths are for.
+
+One free licence per account, and it is [bound to one
+swarm](#per-swarm-binding) at issuance like any other key — `bind: static`, so
+there is no lease and no activation step. Installing the key is the whole of it.
+Registering the cluster is the same flow as for a paid licence, see [Getting a
+bound license](#getting-a-bound-license); moving it to another swarm is the same
+dashboard action, and asking for a second free key is refused naming the cluster
+the first one is on.
+
+The tier is new: a free key is accepted from v2.0.0. An older swarmcli does not
+know the word `free` — it verifies the signature, finds a tier it has no
+entitlements for, and reports `Invalid` on the `:license` view. The key is fine;
+upgrade rather than ask for a different one. See [Key
+versioning](#key-versioning).
+
 ## Acquiring a key
 
-Get a key (including a free trial) at [swarmcli.io/be](https://swarmcli.io/be).
+Get a key at [swarmcli.io/be](https://swarmcli.io/be) — a
+[free-tier](#the-free-tier) key, a time-boxed trial, or a paid subscription. All
+three are the same kind of artifact, are installed the same way, and everything
+below applies to each of them.
 
 ## Activation
 
@@ -191,6 +245,12 @@ The view also shows:
   shown only when the swarm has more nodes than `max_nodes`. It is a report and
   not a status: the `Status:` line above is unaffected and every feature stays
   on. See [Limits](#limits).
+- `Allowance: 5 of 3 nodes, as the licence service sees it`, and beside it
+  `Term: stops rolling 2026-09-12 unless the count comes down` — what the
+  licence service last said about the allowance, shown only while it says this
+  licence is over it, and abbreviated into the status bar as well because the
+  swarm nobody opens `:license` on is the one that lapses. Also a report and not
+  a status. See [Limits](#limits).
 
 Key bindings inside the view:
 
@@ -307,7 +367,8 @@ binding modes, and `:license` names which one you hold.
   signed. Matching is business as usual; on any other swarm the key is
   cryptographically valid but Business Edition features disable and
   `:license` shows `Wrong swarm`. Switching back restores it immediately,
-  with no waiting period.
+  with no waiting period. Every [free-tier](#the-free-tier) key is one of
+  these, which is why a free licence has no activation step.
 - **Managed**: the swarm is named in the key as above, but the binding is also
   kept current — features work only while the swarm holds a live lease, which
   it renews by itself. See
@@ -450,6 +511,11 @@ doesn't take a production cluster offline. A managed license's renewal
 window works the same way and for the same reason: features stay on while
 the renewal is overdue, and the countdown says how long that lasts.
 
+Being over a node allowance is deliberately not one of these states. It is a
+report rather than a status, it takes nothing away on the day it appears, and
+the state it eventually leads to is the ordinary `Expired` above — see
+[Limits](#limits).
+
 Two states are worth telling apart, because the fix is different and only
 one of them involves us. **Not activated** means the swarm has no lease —
 install the one you were sent. **Activation expired** means it had one and
@@ -474,9 +540,11 @@ thing that proves entitlement.
 
 ## Limits
 
-`max_nodes` and `max_users` are **soft** limits. Exceeding them does not
-block any operation and does not change the status the `:license` view
-reports, and the expiry is recorded on the key at issuance time.
+`max_nodes` and `max_users` are **soft** limits *in the binary*: swarmcli
+reports what it observes and never denies on a count. Exceeding either blocks no
+operation, changes no status the `:license` view reports and switches no feature
+off — on every tier, the free one included — and the expiry is recorded on the
+key at issuance time.
 
 - `max_nodes` is compared against the swarm's node count, refreshed on each
   TUI update tick. Over the limit, `:license` reports the pair and leaves
@@ -485,6 +553,44 @@ reports, and the expiry is recorded on the key at issuance time.
   but no part of the product counts users against it.
 
 Either limit set to `0` is treated as unlimited.
+
+### The node allowance is judged elsewhere
+
+Soft in the binary is not the same as unbounded, and on the [free
+tier](#the-free-tier) the difference is the whole of the tier's boundary. Every
+licensing request reports the node count this swarm observed (see
+[Privacy](#privacy)), and on a free licence that count is compared against the
+allowance *there* rather than here. Nothing switches off when it is exceeded.
+What is at stake is the roll of the term:
+
+1. Over the allowance, the next answer says so, and `:license` grows an
+   `Allowance:` line and a `Term:` line naming **the date after which the term
+   stops being rolled forward**; the status bar carries a short form of the
+   same. Every feature stays on, the `Status:` line is unchanged, and renewals
+   and refreshes carry on exactly as before.
+2. Come back under the allowance before that date and the clock stops. The
+   report goes quiet and the term rolls again.
+3. Stay over it, and on that date nothing happens — which is the part worth
+   knowing in advance. The licence keeps working until the expiry already signed
+   into the key, then through the [grace period](#lifecycle-states), and only
+   then do Business Edition features stop. How long that is depends on where in
+   the term the swarm was when the rolling stopped: it may be days or most of a
+   year, and the `Expires:` line on `:license` is the date to plan around.
+
+So an exceeded allowance is a dated warning rather than an outage, and the
+outage it can become arrives long after the warning that named it. Bringing the
+count back under the allowance or moving to a paid licence resolves it, at any
+point before the term runs out.
+
+Two node figures can be on screen at once, and they are allowed to disagree. The
+`Nodes:` line is this process's own count against the allowance signed into the
+key; the `Allowance:` line is what the licence service last recorded and last
+decided. Each names its source, so a stale report beside a fresh count is two
+views of one swarm rather than a contradiction.
+
+Neither of the service's two lines reaches `swarmcli license status`, which
+reports the observed count and the signed `max_nodes` and nothing the service
+said about them.
 
 ## Key versioning
 
@@ -495,6 +601,12 @@ the floor, and a release that does so says as much in its upgrade notes.
 
 In practice this has happened once: per-swarm binding was added without
 invalidating anything, and keys issued before it remain valid and portable.
+
+A tier is not a version, and the two fail differently. A key whose *version* is
+newer than the build reports `Newer than this build`; a key naming a tier the
+build has no entitlements for — a `free` key on a swarmcli that predates the
+free tier — reports `Invalid`. Both are fixed by upgrading swarmcli, and neither
+is a reason to ask for a different key.
 
 ## Privacy
 
@@ -512,9 +624,10 @@ The first is a **token refresh**, made by every license that carries a
 tier, node count and binding mode are *signed*, so changing any of them means
 re-signing your key, and a key we re-signed is no use sitting on our side. Once
 a day swarmcli asks whether we hold different bytes for the license it already
-has, and installs them if we do. It is how a renewal or a tier change reaches
-your swarm without you copying a key out of the dashboard by hand. Nothing is
-written unless the bytes actually differ.
+has, and installs them if we do. It is how a renewal, a tier change or a rolled
+[free-tier term](#the-free-tier) reaches your swarm without you copying a key
+out of the dashboard by hand. Nothing is written unless the bytes actually
+differ.
 
 The second is a **lease renewal**, and only a managed license makes it: the
 activation lease expires, so getting the next one means asking for it.
@@ -527,12 +640,17 @@ Both requests send:
   than staying on the machine;
 - the **license id** (`lic_…`) — which license is asking;
 - the **cluster id** of the swarm it is asking for;
+- the **number of nodes** in the swarm, once swarmcli has observed one. A single
+  integer, and the count the [node allowance](#limits) is judged against; it is
+  left out altogether until the first observation lands, because a zero would
+  claim a swarm with no nodes rather than a swarm not yet looked at;
 - the **swarmcli version** making the request; and
 - the time and network origin of the request, as with any HTTPS call.
 
-Nothing else. Not your services, nodes, images, users, configuration, or
-anything else read from your Docker daemon — swarmcli does not gather it and
-the request has nowhere to put it.
+Nothing else. Not your services, images, users, configuration, node names,
+addresses or roles, or anything else read from your Docker daemon — swarmcli
+does not gather it and the request has nowhere to put it. The node count is a
+count: how many, never which ones or what runs on them.
 
 Four things about these requests are worth being precise on, because they are
 the questions people actually ask:

--- a/docs/volumes.md
+++ b/docs/volumes.md
@@ -18,9 +18,9 @@ Open it from the command bar:
 
 What you can do depends on two things:
 
-- **License.** The `volumes-all-nodes` entitlement (granted on the `be` and
-  `trial` tiers — see [License](license.md)) unlocks cross-node listing and all
-  management actions.
+- **License.** The `volumes-all-nodes` entitlement (granted on the `be`, `free`
+  and `trial` tiers — see [License](license.md)) unlocks cross-node listing and
+  all management actions.
 - **Context.** Cross-node operations talk to the per-node agents through the
   RBAC proxy, so they need a managed Docker context (a swarm that has been put
   through [`:bootstrap`](bootstrap.md)). On a non-managed context the view falls
@@ -154,7 +154,7 @@ node that is unreachable is reported as such rather than silently omitted.
 
 ## Permissions and gating
 
-`volumes-all-nodes` is granted on the `be` and `trial` tiers (see
+`volumes-all-nodes` is granted on the `be`, `free` and `trial` tiers (see
 [License — Model](license.md#model)). When it is off — no license, an expired or
 wrong-swarm license, or a non-managed context — the view shows the read-only
 connected-node listing and the management keys open the "Business Edition


### PR DESCRIPTION
`grep -ri "free tier" docs/` returned nothing. `docs/license.md` named two tiers, `be` and `trial`; `Limits` described `max_nodes` as soft and enforced nowhere and stopped there. A reader of the public docs could not learn that a permanent free tier exists, what it grants, what bounds it, or how to get one.

## What the docs now say

**A `## The free tier` section**, after `Model` and before `Acquiring a key`, because the tier is part of the model rather than a purchasing note. It grants what `be` grants — the same feature list, swarmcli-cd's entitlements included — so the section says what the tier actually decides, which is what surrounds the key: three nodes, a 365-day term rolled forward rather than perpetual, one licence per account, `bind: static` like any other bound key and therefore no lease and no activation step. Two things a customer will hit are stated rather than glossed: a swarm with no path to us keeps the term it holds and has no lease file to hand-carry in its place, and a free licence is bound to one swarm exactly as a paid one is.

**`Limits` gains the other half.** "Soft" remains true and is now scoped — *in the binary*: swarmcli reports what it observes and never denies on a count, on every tier — beside a `### The node allowance is judged elsewhere` subsection saying what a free swarm over three nodes experiences, in order: a dated warning on `:license` and in the status bar with every feature still on; the clock stopping if the count comes back down; and, if it does not, the term no longer being rolled forward on that date, after which the licence keeps working until the expiry already signed into the key, then the grace period, and only then do features stop. A reader who only saw "soft" would draw the opposite conclusion, which is why both halves are on the same page.

Also: the two report lines the `:license` view grows (`Allowance:` / `Term:`) and why they may legitimately disagree with the `Nodes:` line above them; a note that being over an allowance is deliberately *not* a lifecycle state; the `static` binding bullet naming free keys; and a `Key versioning` paragraph separating "version newer than this build" (`Newer than this build`) from "tier this build has no entitlements for" (`Invalid`).

**Two accuracy fixes fall out of the same change.**

- `Privacy` enumerated everything the two licensing requests send and no longer matched them. Both now carry the observed node count (`licenseclient/client.go`, on `RenewLease` and `FetchToken`), which is the number the allowance is judged against, so the list gains a bullet and "Nothing else…" is narrowed from "not your nodes" to "not node names, addresses or roles — the count is a count".
- `docs/features.md` and `docs/volumes.md` (×2) said `volumes-all-nodes` and the four gated features are granted on the `be` and `trial` tiers.

Beyond the two pages I was asked to check (`docs/editions.md`, `docs/README.md`), one sentence in the root `README.md`: its Business Edition section presents the same two-way split the free tier now sits inside. Easy to drop if you would rather it stayed as it was.

## The caveat: nothing released accepts `tier: free` yet

The tier landed on **2026-08-28**; the newest tags are `swarmcli-be v2.0.0-rc2` (**2026-08-25**) and `swarmcli-agent v2.0.0-rc1`. `git show v2.0.0-rc2:license/scheme.go` has `TierBE` and `TierTrial` and no `TierFree`, and `git tag --contains` on the tier's commit is empty. So **this page documents behaviour that ships with the next release**, and until then a free key on any released binary reports `Invalid`.

I followed the page's own convention for that rather than inventing one — `docs/license.md` already writes *"from v2.0.0 a key that does not carry one is refused"* — so the section says "a free key is accepted from v2.0.0" and the version bullet extends the existing v2.0.0 sentence to cover both tiers. **Please confirm the number before merging:** it is right if v2.0.0 GA is cut from a commit that contains the tier, and wrong if GA is cut from rc2's tree, in which case both mentions become v2.1.0. That is the only thing in this PR that a release decision can falsify.

## What in the brief the code contradicted

Nothing material. Everything checked out against `license/scheme.go`, `license/entitlement.go` and `license/license.go` (`GracePeriodDays = 5`, `TierRequiresExpiry` covering `trial` and `free`, `TierFree`'s entry in `TierFeatures` identical to `TierBE`'s after #396). Three notes:

- The **365-day term and the three-node allowance** are named in swarmcli-be only in comments; the issuing side is where the numbers live. Both are confirmed there, so the doc states them as facts about the product rather than as observations of the client.
- The **advisory report does not reach `swarmcli license status`**. `buildLicenseReport` reports the observed count and the signed `max_nodes` and nothing the licence service said, so the cron-shaped surface documented on this page cannot see the one warning a free swarm gets. The page says so; whether that is worth closing is a product call, not a docs one.
- Pre-existing and untouched: the four licence-prompt blocks quoted under **The license prompt** no longer match the dialog copy (it now leads with the swarm cluster id and a per-cluster link, and no longer says "Get a free trial license at"). Out of scope here, worth its own change.

## Verification

Docs only — no Go files, so `licence.yml`'s SPDX job filters out and skips. SPDX headers untouched. Every added cross-reference resolves to a heading on its page.

---
Machine-generated by an AI agent (Claude Opus 5) via the `eldara-cruncher` bot, and not human-reviewed. Claims carry a file, a line or a reproducible check so they can be verified cheaply.
