### PR TITLE
docs(license): the licensing docs describe a product we no longer ship

### DIFF
--- a/.github/UPGRADE_NOTES.md
+++ b/.github/UPGRADE_NOTES.md
@@ -1,9 +1,66 @@
-### Trial licences must now carry an expiry
+### Every package, formula and image dropped the `-be`
 
-A `trial` licence with no expiry date no longer verifies. It is reported as
-**invalid** rather than expired — nothing has lapsed, so the remedy is a
-reissued trial key and not a renewal. Get a new one at
+The Business Edition artefacts were renamed on 2026-08-07. The build is
+unchanged and the executable on disk was always `swarmcli`; what changed is what
+you ask the package manager for:
+
+```bash
+brew install Eldara-Tech/tap/swarmcli   # was swarmcli-be
+scoop install swarmcli                  # was swarmcli-be
+docker pull eldaratech/swarmcli         # was eldaratech/swarmcli-be
+```
+
+Release archives changed with them: `swarmcli_Linux_x86_64.tar.gz` for this
+build and `swarmcli_Linux_x86_64_oss.tar.gz` for the wholly Apache-2.0 one, with
+`checksums-merged.txt` and `checksums-oss.txt` beside them. There is no
+unqualified `checksums.txt`, because a release carries two sets of artefacts and
+one file would not say which set it verified.
+
+The old names keep receiving the same build for a deprecation window. Homebrew
+warns on install *and* upgrade — `deprecate!`, not a caveat, because someone who
+only ever runs `brew upgrade` never reads caveats — and Scoop prints a rename
+notice. Neither tool can express this as a rename, which is why it is here.
+
+**One consequence is worth naming.** Anyone who was already on the `swarmcli`
+cask or Scoop manifest — the Community Edition names — moves onto the merged
+build with this release. Nothing they run changes: the licensed code is inert
+until a licence verifies, and the binary behaves exactly as the Community
+Edition did. If you need an artefact that provably contains no proprietary code,
+that is `swarmcli-oss`, and it ships from every release — see
+[docs/editions.md](../docs/editions.md).
+
+### There is a permanent free tier
+
+A licence need not be a paid one. The free tier is a signed key like any other,
+verified offline, granting the same thirteen entitlements a paid `be` key grants
+— including the five consumed by swarmcli-cd. It is not a reduced feature set
+under a different name.
+
+What bounds it is around the key rather than in it: **three nodes**, recorded as
+`max_nodes`, and a **365-day term** that is rolled forward for you inside its
+last 30 days. Nothing switches off on the node count; declining to roll the term
+is the only lever, and that is also why the expiry is mandatory (below).
+
+Get one with `swarmcli license activate`, or Register Cluster at
+[swarmcli.io/licenses](https://swarmcli.io/licenses). One per account, bound to
+one swarm, `bind: static` — so it has no lease and nothing to renew by hand.
+
+**An older swarmcli cannot read a free key.** It verifies the signature, finds a
+tier it has no entitlements for, and reports **Invalid**. The key is fine;
+upgrade rather than ask for a different one.
+
+### Trial *and free* licences must now carry an expiry
+
+A `trial` or `free` licence with no expiry date no longer verifies. It is
+reported as **invalid** rather than expired — nothing has lapsed, so the remedy
+is a reissued key and not a renewal. Get a new one at
 [swarmcli.io/be](https://swarmcli.io/be) and install it as before.
+
+The two tiers fail the same way for different reasons. A trial's expiry is the
+whole of the difference between it and a paid licence. A free licence's expiry
+is the only thing that can ever *end* it, because the term is what the issuer
+rolls forward — unexpiring, a free key would be a perpetual grant on every swarm
+it reached.
 
 `be` (paid Business Edition) licences are unaffected and may still be perpetual.
 
@@ -19,6 +76,77 @@ swarmcli license status
 Upgrade the pieces you run to the same version. Mixed versions can leave one of
 them honouring a key another refuses, which is awkward to diagnose rather than
 dangerous.
+
+### A paid licence is now signed `managed`, and activation is a second step
+
+Binding used to be a property of the key alone: the swarm was named in it at
+issuance and that was the end of it. A **managed** licence names the swarm the
+same way and is then *activated* for it by a short-lived signed **lease**.
+Installing the key is the first step; the lease is the second.
+
+Paid licences issued from now on are signed `bind: managed`. Free-tier keys are
+signed `bind: static` and have no lease. Keys issued before managed binding
+existed are unaffected and keep working exactly as they did.
+
+On a swarm that can reach the licence service, the second step takes care of
+itself — the renewal check runs on a timer and again whenever you open
+`:license`, so activation follows the key install on its own. Until a lease is
+in place, `:license` reports **Not activated for this swarm** and Business
+Edition features stay off. That is deliberate: with a managed licence the lease
+*is* the binding, so its absence is an answer rather than an unknown.
+
+Air-gapped and policy-restricted swarms take a lease as a file instead:
+
+```bash
+swarmcli license lease install ~/swarm.lease   # or :license lease install
+```
+
+**The client half of this ships in v2.0.0; lease issuance turns on separately
+and is not live in production yet.** Nothing you run needs to change for it, and
+`swarmcli license status` is the check that says which state a swarm is in.
+
+Two consequences worth knowing before you meet them:
+
+- A managed licence moves between swarms **at most once per lease window** — a
+  lease that has been issued cannot be recalled. Unbind Cluster in the dashboard
+  names the date the next move becomes possible. A licence bound at issuance has
+  no such cap.
+- `swarmcli license install` exits `0` on a managed key that grants nothing yet,
+  and that is correct: the key is stored, and a managed key is not an activated
+  licence until a lease arrives. `swarmcli license status` is the verb that
+  answers "are the features on".
+
+### `swarmcli license activate` — a licence in one command
+
+The whole licence lifecycle is now reachable without a person at a TUI, which
+matters for controllers, CI runners and any swarm nobody opens swarmcli
+against:
+
+```bash
+swarmcli license activate                # get a licence for this swarm
+swarmcli license install <file>          # store a key you already hold
+swarmcli license lease install <file>    # activate from a lease file
+swarmcli license status  [--json]        # what this swarm holds
+swarmcli license sync    [--json]        # bring it up to date now
+swarmcli license id                      # the id support asks for
+```
+
+`activate` opens an activation, prints a short code and a link, waits while you
+confirm in a browser, and installs what comes back. It is the free tier's
+primary path as well as a paid one's, and it makes no outbound call at all when
+`SWARMCLI_DISABLE_LICENSE_RENEWAL` is set.
+
+`:bootstrap` now deploys a fourth service, `licence-renewer`, which runs
+`license sync` on a timer so a swarm nobody logs into keeps its licence current.
+It is the only service in the stack with a route off the cluster, on a network
+of its own, and `:bootstrap --no-renewer` omits it. A swarm bootstrapped before
+the service existed cannot gain one from `--upgrade`; `:license` says so on an
+`Auto-renewal:` line — see [docs/bootstrap.md](../docs/bootstrap.md).
+
+`SWARMCLI_DISABLE_LICENSE_RENEWAL` switches off **both** licensing requests, on
+every licence type — not only a managed licence's lease renewal. The other is a
+daily token refresh, and it is what carries a renewal, a plan change or a rolled
+free-tier term onto a swarm.
 
 ### Importing `swarmcli` as a Go module? The path gained a `/v2`
 
@@ -41,6 +169,6 @@ v1.14.0` goes on resolving v1.14.0 exactly as before.
 
 There is no other breaking change. This repository carries none of its own in
 v2.0.0 — the major is shared across the SwarmCLI components and this release
-takes it for the licence change above. The Apache-2.0 build (`swarmcli_*_oss`,
+takes it for the licence changes above. The Apache-2.0 build (`swarmcli_*_oss`,
 `eldaratech/swarmcli:<version>-oss`) contains no licensed code and is untouched
-by it; upgrading that one from v1.14.0 needs nothing at all.
+by any of them; upgrading that one from v1.14.0 needs nothing at all.

--- a/README.md
+++ b/README.md
@@ -152,8 +152,12 @@ commercial superset that adds:
   per-node agent stack onto your existing Swarm.
 - Per-user RBAC, identity by client certificate, role-gated mutation and
   exec.
-- Interactive shell into a running service task.
-- Reveal-secret for debugging.
+- Thirteen licensed entitlements. Eight in this TUI — shell into a running
+  service task, reveal-secret, port-forward, volumes across all nodes, RBAC
+  user management, service health, pull progress and container statistics —
+  and five more consumed by swarmcli-cd, because one licence covers both
+  products. See
+  [docs/features.md](docs/features.md#where-the-gates-live).
 
 The licence that turns them on need not be a paid one: the [free
 tier](docs/license.md#the-free-tier) grants the same features on a swarm of up

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,10 +17,13 @@ features a licence unlocks. On top of the Community Edition it adds:
   per-node agent stack onto your existing Swarm.
 - **Per-user RBAC** — identity by client certificate, role-based gating of
   destructive and exec endpoints.
-- **Interactive shell into running services** (`x` on a service).
-- **Reveal-secret** for debugging (`x` on a secret).
-- **Volume management across all swarm nodes** — list, create, delete, prune,
-  and browse files inside volumes.
+- **Thirteen licensed entitlements.** Eight are this TUI's — interactive shell
+  into a running service (`x` on a service), reveal-secret (`x` on a secret),
+  port-forward, volume management across all swarm nodes, RBAC user and role
+  management, service health, pull progress and container statistics. The
+  other five are consumed by swarmcli-cd, since one licence covers both
+  products. [Features — Where the gates
+  live](features.md#where-the-gates-live) is the list.
 
 The licence that unlocks them need not be a paid one: the [free
 tier](license.md#the-free-tier) grants the same features on a swarm of up to

--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -31,10 +31,14 @@ flowchart TB
   subgraph mgr["Swarm manager node"]
     proxy["rbac-proxy<br/>:2376 mTLS"]
     am["agent-manager"]
+    ren["licence-renewer<br/>swarmcli license sync"]
     sock1[("/var/run/docker.sock")]
     proxy --> sock1
     am --> sock1
+    ren --> sock1
   end
+
+  ren -- "HTTPS" --> svc["swarmcli.io<br/>licence service"]
 
   subgraph node["Each Swarm node"]
     ag["agent (global)"]
@@ -49,7 +53,7 @@ flowchart TB
 
 The bootstrap command creates the following artifacts:
 
-**Stack** `swarmcli-infra`, three services:
+**Stack** `swarmcli-infra`, four services:
 
 - `rbac-proxy` — mTLS-fronted Docker API proxy. Listens on the chosen port
   (default `2376`). One replica, pinned to a manager node. Uses a SQLite
@@ -59,9 +63,25 @@ The bootstrap command creates the following artifacts:
 - `agent-manager` — one replica on a manager. Companion to `agent`: the
   rbac-proxy connects here on port `8080` to locate and reach per-node
   agents over the overlay.
+- `licence-renewer` — one replica on a manager, running this same swarmcli
+  image as `license sync --interval 6h`. It keeps the swarm's licence current
+  while nobody has a TUI open: it collects a token we re-signed — a renewal, a
+  plan change, a rolled [free-tier](license.md#the-free-tier) term — and, on a
+  [managed](license.md#managed-licenses-activation-is-a-second-step) licence,
+  renews the activation lease. Omitted by `--no-renewer`, and omitted by a
+  development build, which publishes no image to deploy.
 
-**Network** `swarmcli-agent-net` — encrypted, internal overlay shared by all
-three services. Protected against accidental deletion from the TUI.
+Six hours is a wake-up rather than a request rate: the client's own gates decide
+whether anything is actually asked, and most passes ask nothing. A failed pass
+logs and waits rather than exiting, because a service that exited on a transient
+outage would be restarted into a crash loop.
+
+**Networks.** `swarmcli-agent-net` — internal overlay shared by the proxy, the
+agent and the agent-manager, and protected against accidental deletion from the
+TUI. When the renewer is deployed it gets a second overlay of its own,
+`swarmcli-renewal-net`, which is deliberately **not** internal: it is the only
+network in the stack with a route off the cluster, and the renewer is the only
+service on it, so the egress is confined to the one container that needs it.
 
 **Docker secrets** (prefixed with the stack name, default `swarmcli-infra_`):
 
@@ -143,6 +163,30 @@ To skip the interactive prompt, pass `--port`:
 | `--port N` | Use port `N` (1–65535). Skips the interactive prompt. |
 | `--host H` | Pre-fill or override the proxy host. Pre-fills the field in the interactive prompt; combined with `--port`, runs unattended. See [Host autodetection](#host-autodetection). |
 | `--force` | Redeploy even if the stack is already running. **Not recommended on a live cluster** — see [Re-bootstrap](#re-bootstrap-and-teardown). |
+| `--no-renewer` | Omit the `licence-renewer` service — the only one that talks outside the cluster. For air-gapped swarms, and for anyone running `swarmcli license sync` from their own scheduler. |
+
+### The `Auto-renewal:` warning on `:license`
+
+A swarm bootstrapped before the renewer existed cannot gain one from
+`:bootstrap --upgrade`, which is images-only. Nothing renews the licence while
+swarmcli is closed, and until this line existed that happened in silence — so
+`:license` reports it:
+
+```
+Auto-renewal: no licence-renewer service on this swarm
+  Nothing renews the licence while swarmcli is closed, so this licence's term
+  stops being rolled forward.
+```
+
+The consequence named depends on the licence: a managed one loses its
+activation renewal, a static one — every [free-tier](license.md#the-free-tier)
+key among them — loses the annual roll of its term, which is the only thing
+keeping it alive. The fix is `:bootstrap --force` from the original
+(non-managed) context, which redeploys the stack and keeps the CA, users,
+contexts and RBAC data; or run `swarmcli license sync` on your own schedule and
+leave the stack alone. The line does not appear when there is nothing to say —
+a perpetual key, `SWARMCLI_DISABLE_LICENSE_RENEWAL`, or a build with no renewer
+image.
 
 ## Host autodetection
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -21,8 +21,8 @@ apply to every build.
 | `SWARMCLI_CHARTS_NO_AUTO_UPDATE` | both | Stops a `charts` command refreshing a repository index before resolving a chart from it. `--no-repo-update` does the same for one invocation. | unset (refreshes) | `charts` commands |
 | `EDITOR` | both | Editor invoked by the in-TUI edit actions (stack, config, secret). | `nano` | edit action |
 | `XDG_STATE_HOME` | both | Base directory for logs and chart state — see [On-disk paths](#on-disk-paths). | `~/.local/state` | startup, `charts` commands |
-| `SWARMCLI_LICENSE` | BE | License key. Takes priority over the license file. | unset | startup |
-| `SWARMCLI_DISABLE_LICENSE_RENEWAL` | BE | Stops swarmcli asking the license service to renew a [managed license](license.md#managed-licenses-activation-is-a-second-step)'s activation. Leases are then installed from a file. No effect on any other license type, which never make the request at all. | unset | startup |
+| `SWARMCLI_LICENSE` | BE | A license key to install *from*. It is never loaded on its own — the active key is the one stored on the swarm — so setting this and restarting licenses nothing. When it is set, the `:license` view offers `<e>` to install it into the connected swarm. | unset | `:license` view |
+| `SWARMCLI_DISABLE_LICENSE_RENEWAL` | BE | Stops **both** licensing requests, on every license type: swarmcli builds no license client at all, so neither the daily token refresh nor a [managed license](license.md#managed-licenses-activation-is-a-second-step)'s lease renewal has anything to make it. Leases are then installed from a file, and `swarmcli license activate` refuses rather than hanging. The token refresh is the one a static or unbound license makes — it is what carries a renewal, a tier change or a rolled [free-tier](license.md#the-free-tier) term — so this switches something off for those too. | unset | startup |
 | `SWARMCLI_LICENSE_API_URL` | BE | Base URL of the license service renewals are asked of. Pointing it elsewhere cannot grant anything — every artifact is verified against a key compiled into swarmcli. | `https://swarmcli.io/api/v1` | startup |
 | `SWARMCLI_PROXY_URL` | BE | WebSocket URL of the rbac-proxy. Auto-derived from the active Docker context if unset. | unset | shell connect |
 | `SWARMCLI_REVEAL_IMAGE` | BE | Image used for the temporary service that reveals a secret. | `alpine:latest` | reveal action |
@@ -35,8 +35,9 @@ The four on/off variables (`SWARMCLI_DISABLE_VERSION_CHECK`,
 values Go's `strconv.ParseBool` does — `1`, `t`, `true`, `TRUE` and their false
 counterparts. Anything else is treated as unset.
 
-See [License — Activation](license.md#activation) for the precedence
-between `SWARMCLI_LICENSE` and the license file, and
+See [License — Activation](license.md#activation) for how `SWARMCLI_LICENSE`
+and the license file are installed into a swarm. There is no precedence between
+them, because neither is loaded on its own, and
 [Features](features.md) for how `SWARMCLI_REVEAL_IMAGE`,
 `SWARMCLI_SHELL_CMD`, and `SWARMCLI_FORWARD_IDLE_TIMEOUT` are used.
 
@@ -73,7 +74,7 @@ prompt and still runs `docker context use`, so your shell follows along.
 | `~/.local/state/swarmcli/charts/cache/index-<repo>.yaml` | both | `0644` | Cached repository index per configured repository. |
 | `~/.local/state/swarmcli/charts/cache/charts/<sha256>.tgz` | both | `0644` | Chart archives already downloaded, kept under the sha256 their repository index publishes. Re-verified on every read, and swept 30 days after the last one. |
 | `~/.config/swarmcli/update-notice.json` | both | `0644` | The release version at which the startup update notice was dismissed. |
-| `~/.config/swarmcli/license.key` | BE | `0600` | Active license key. Created by the startup prompt or by `:license <s>`. |
+| `~/.config/swarmcli/license.key` | BE | `0600` | A license key to install *from*, if you put one there. Nothing in swarmcli writes this file and nothing loads it automatically; when it exists, the `:license` view offers `<m>` to install it into the connected swarm. The active key lives in the swarm, as the Docker config `swarmcli-license`. |
 | `~/.config/swarmcli/certs/<stack>/ca.pem` | BE | `0600` | CA cert from `:bootstrap`. |
 | `~/.config/swarmcli/certs/<stack>/cert.pem` | BE | `0600` | Admin client cert (CN = seed username). |
 | `~/.config/swarmcli/certs/<stack>/key.pem` | BE | `0600` | Admin client private key. |

--- a/docs/editions.md
+++ b/docs/editions.md
@@ -79,8 +79,10 @@ is behaving as. Do not use it to answer this question.
 ## What a licence changes, and when
 
 A licence is installed into the swarm and read at startup. It turns features on
-in the merged build only — there is nothing in the OSS build for it to unlock,
-and installing one there changes nothing and reports nothing.
+in the merged build only, and the OSS build has nothing to install one *with*:
+the `license` command and the `:license` view are both part of the licensed
+code, so `swarmcli license …` exits `2` with `unknown command "license"` and
+`:license` is not a command the TUI knows.
 
 A licence need not be a paid one: the [free tier](license.md#the-free-tier) is a
 licence like any other and turns the same features on, on a swarm of up to three
@@ -129,8 +131,11 @@ the artefact, not on the source:
 module graph Go stamped into each published binary and fails if the main module
 is not this repository or if anything private is linked. It runs from
 `.goreleaser.yml`'s per-build hook on every binary the release publishes, and
-from `ci.yml` on every change — so it is not a gate that only ever fires on a
-tag.
+from `ci.yml` on every change that could affect it — the build job is gated
+on a paths filter of `**.go`, `go.mod`, `go.sum`, the Dockerfiles, `ci.yml`
+itself and `scripts/check-oss-artefact.sh`, so a change that weakens the guard
+has to run the guard. A docs-only pull request does not. Either way it is not a
+gate that only ever fires on a tag.
 
 It also fails when it cannot read a module stamp at all, rather than passing.
 A binary whose graph is unreadable looks exactly like a binary with no private

--- a/docs/features.md
+++ b/docs/features.md
@@ -5,8 +5,10 @@ Copyright © 2026 Eldara Tech
 
 # Pro features
 
-Four license-gated capabilities ride on top of the standard SwarmCLI TUI.
-All of them require:
+Four of the license-gated capabilities are covered in detail here — shell,
+reveal-secret, port-forward and container statistics. They are four of the
+thirteen entitlements a license grants; [Where the gates
+live](#where-the-gates-live) is the full list. All four require:
 
 - A valid (or in-grace) Business Edition license — see [License](license.md).
 - A managed Docker context (i.e. a Swarm that has been put through
@@ -338,13 +340,32 @@ metrics stack (cAdvisor, Prometheus) alongside.
 
 ## Where the gates live
 
-All four features are license-gated — each is enabled only when the
-active license grants it:
+A license grants **thirteen** entitlements, and each gated action is enabled
+only when the active license carries the one it names. Eight are this TUI's:
 
-- Shell
-- Reveal-secret
-- Port-forward
-- Container statistics
+- `shell` — shell into a service task
+- `reveal-secret` — reveal a secret's value
+- `port-forward` — forward a container port (two views: the forward itself and
+  the list of active ones)
+- `volumes-all-nodes` — the cross-node [volume](volumes.md) views: browse,
+  create, delete, prune
+- `user-management` — the [RBAC](rbac.md) user and role views
+- `service-health`
+- `pull-progress`
+- `container-stats` — the graph above
 
-Tier-to-feature mapping is centralised: today the `be`, `free` and `trial`
-tiers all grant the four features. See [License — Model](license.md#model).
+Five of those eight back **nine** registered gated actions, which is why the
+count of entitlements and the count of things that can be greyed out differ:
+`port-forward` gates two (the forward and the list of active ones) and
+`volumes-all-nodes` gates four (browse, create, delete, prune). The other three
+gate elsewhere — `user-management` on the `:users` command, `service-health` and
+`pull-progress` inside the service fan-out that fills those columns.
+
+The remaining five entitlements are consumed by
+[swarmcli-cd](https://swarmcli.io), not by this TUI, and one license covers both
+products: `cd-multi-swarm`, `cd-sso`, `cd-projects`, `cd-audit` and
+`cd-notifications`.
+
+Tier-to-feature mapping is centralised, and today the `be`, `free` and `trial`
+tiers grant the identical thirteen — the tier decides what surrounds the key,
+not which features you get. See [License — Model](license.md#model).

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -11,46 +11,54 @@ superset of CE: the OSS feature set is included unchanged. Aliases, scripts,
 and CI invocations from a CE installation continue to work without
 modification when you switch to BE.
 
-The package/formula/image names *are* `swarmcli-be`, so the package manager
-can offer both editions side by side. They install the same binary name, so
-**you can have either CE or BE at any time, but not both**. See
-[CE vs BE](#ce-vs-be) below.
+The package/formula/image names are `swarmcli` for this build and
+`swarmcli-oss` for the wholly Apache-2.0 one, so the package manager can offer
+both artefacts side by side. They install the same binary name, so **you can
+have either at any time, but not both**. See [CE and BE are one
+download](#ce-and-be-are-one-download) below. The older `swarmcli-be` formula,
+manifest and image were renamed on 2026-08-07; they still receive the same build
+for a deprecation window, and Homebrew now warns on install and upgrade.
 
 ## Channels
 
 ### Homebrew (macOS / Linux)
 
 ```bash
-brew install Eldara-Tech/tap/swarmcli-be
+brew install Eldara-Tech/tap/swarmcli
 ```
 
 The formula is hosted at
 [Eldara-Tech/homebrew-tap](https://github.com/Eldara-Tech/homebrew-tap).
-It conflicts with the CE `swarmcli` formula; brew will refuse to install
-both at once and will offer to remove the other one.
+It conflicts with the `swarmcli-oss` cask and with the deprecated
+`swarmcli-be` one; brew will refuse to install two at once and will offer to
+remove the other.
 
 ### Scoop (Windows)
 
 ```powershell
 scoop bucket add eldara https://github.com/Eldara-Tech/scoop-bucket
-scoop install swarmcli-be
+scoop install swarmcli
 ```
 
 ### Docker
 
 ```bash
-docker pull eldaratech/swarmcli-be:latest
+docker pull eldaratech/swarmcli:latest
 docker run --rm -it \
   -v /var/run/docker.sock:/var/run/docker.sock \
   -v "$HOME/.docker/contexts:/root/.docker/contexts" \
   -v "$HOME/.config/swarmcli:/root/.config/swarmcli" \
-  eldaratech/swarmcli-be:latest
+  eldaratech/swarmcli:latest
 ```
 
 The container runs as root (matching the upstream `docker:N-cli` base, so
 the mounted Docker socket works without `--group-add`). Mounting
-`~/.docker/contexts` and `~/.config/swarmcli` keeps your Docker contexts
-and license file persistent across container runs.
+`~/.docker/contexts` and `~/.config/swarmcli` keeps your Docker contexts and
+your bootstrap certificates persistent across container runs. The license is
+**not** among them — it lives in the swarm's own Raft state, as the Docker
+config `swarmcli-license`, so it is already persistent and follows the context
+rather than the container (see
+[License — Per-swarm storage](license.md#per-swarm-storage)).
 
 Available tags: `latest`, `vX.Y.Z`. Multi-arch images cover `linux/amd64`
 and `linux/arm64`.
@@ -61,14 +69,21 @@ Download platform archives from the
 [Releases page](https://github.com/Eldara-Tech/swarmcli/releases).
 Each release ships:
 
-- `swarmcli-be_<version>_<os>_<arch>.tar.gz` (Linux/macOS/FreeBSD) or `.zip` (Windows)
-- `checksums.txt` — SHA-256 of every archive
+- `swarmcli_<Os>_<arch>.tar.gz` (Linux/macOS/FreeBSD) or `.zip` (Windows) —
+  this build. There is no version component in the name, the OS is capitalised,
+  and `amd64` is written `x86_64`: `swarmcli_Linux_x86_64.tar.gz`.
+- `swarmcli_<Os>_<arch>_oss.tar.gz` — the wholly Apache-2.0 artefact, see
+  [Editions](editions.md).
+- `checksums-merged.txt` — SHA-256 of this build's archives, and
+  `checksums-oss.txt` for the OSS ones. There is deliberately no unqualified
+  `checksums.txt`: a release carries two sets of artefacts, and one file would
+  not say which set it verified.
 
 Verify and install:
 
 ```bash
-sha256sum -c checksums.txt --ignore-missing
-tar -xzf swarmcli-be_<version>_linux_amd64.tar.gz
+sha256sum -c checksums-merged.txt --ignore-missing
+tar -xzf swarmcli_Linux_x86_64.tar.gz
 install -m 0755 swarmcli /usr/local/bin/swarmcli
 ```
 
@@ -86,10 +101,19 @@ Build matrix per release:
 swarmcli
 ```
 
-If no license is present, you'll see a startup prompt asking for a license
-key (or to continue in Community Edition mode). The detail of every state
-the prompt can show is in [License — Activation](license.md#activation).
-Once you have a valid license, every subsequent run starts silently.
+With no license, swarmcli starts normally as the Community Edition — there is
+no startup prompt. The status bar says so, and the license dialog appears
+just-in-time, the first time you ask for a feature a license gates. The fastest
+way to a licensed swarm is one command:
+
+```bash
+swarmcli license activate
+```
+
+which covers the [free tier](license.md#the-free-tier) as well as a paid plan.
+[License — Start to finish](license.md#start-to-finish) is the whole sequence,
+and the detail of every state the dialog can show is in [License — The license
+prompt](license.md#the-license-prompt).
 
 If your terminal does not look right (colors, key handling), check that
 your `TERM` is set to a 256-color value — SwarmCLI expects `xterm-256color`
@@ -97,7 +121,8 @@ or equivalent.
 
 ## Verifying version and edition
 
-There is no `--version` flag today. Two ways to check:
+`swarmcli version` is the direct answer, and `--version` and `-v` are accepted
+as aliases for it. Two more ways to check:
 
 - **Inside the TUI**: the version is shown in the header bar; `:license`
   additionally shows license status (see [License](license.md)).
@@ -151,10 +176,14 @@ build for a deprecation window, so nothing breaks if you track one — but
 ## Upgrade
 
 ```bash
-brew upgrade swarmcli-be          # Homebrew
-scoop update swarmcli-be          # Scoop
-docker pull eldaratech/swarmcli-be:latest   # Docker
+brew upgrade swarmcli             # Homebrew
+scoop update swarmcli             # Scoop
+docker pull eldaratech/swarmcli:latest      # Docker
 ```
+
+If you still track the deprecated `swarmcli-be` names, those commands keep
+working and install the same build — but switch, because the deprecation is
+where they end.
 
 For binary installs, replace the file on disk with the new archive's
 contents.

--- a/docs/license.md
+++ b/docs/license.md
@@ -80,11 +80,21 @@ policy-restricted deployments are what the paid tiers' offline paths are for.
 
 One free licence per account, and it is [bound to one
 swarm](#per-swarm-binding) at issuance like any other key — `bind: static`, so
-there is no lease and no activation step. Installing the key is the whole of it.
-Registering the cluster is the same flow as for a paid licence, see [Getting a
-bound license](#getting-a-bound-license); moving it to another swarm is the same
-dashboard action, and asking for a second free key is refused naming the cluster
-the first one is on.
+there is **no lease**, and nothing to renew or hand-carry after the key is in.
+That is the step a paid licence has and this one does not; getting the key is
+still a step, and it is one command:
+
+```bash
+swarmcli license activate
+```
+
+It prints a short code and a link, waits while you pick the free tier in the
+browser, and installs what comes back. Register Cluster in the dashboard is the
+same thing done by hand — see [Getting a bound
+license](#getting-a-bound-license) — and either way installing the key is the
+end of it. Moving it to another swarm is the same dashboard action as for a paid
+licence, and asking for a second free key is refused naming the cluster the
+first one is on.
 
 The tier is new: a free key is accepted from v2.0.0. An older swarmcli does not
 know the word `free` — it verifies the signature, finds a tier it has no
@@ -98,6 +108,75 @@ Get a key at [swarmcli.io/be](https://swarmcli.io/be) — a
 [free-tier](#the-free-tier) key, a time-boxed trial, or a paid subscription. All
 three are the same kind of artifact, are installed the same way, and everything
 below applies to each of them.
+
+## Start to finish
+
+The rest of this page is organised by mechanism. This section is the same
+material in the order you actually meet it, on a swarm that has never held a
+license. Every command needs a Docker context pointing at a **swarm manager**.
+
+**1. Get a key.** One command, from a machine that can reach us:
+
+```bash
+swarmcli license activate
+```
+
+It reads this swarm's cluster id, prints a short code and a link, opens a
+browser if there is one, and waits while you choose — the [free
+tier](#the-free-tier), a trial, or a paid plan. What comes back is installed
+into the swarm before the command returns. It refuses on a swarm that already
+holds a working license, and makes no call at all when
+`SWARMCLI_DISABLE_LICENSE_RENEWAL` is set.
+
+The dashboard is the same thing done by hand: **Register Cluster** at
+[swarmcli.io/licenses](https://swarmcli.io/licenses), which wants the cluster id
+`:license cluster-id` prints.
+
+**2. Install a key you were sent.** Skip this if step 1 did it for you.
+
+```bash
+swarmcli license install ~/license.key       # or :license install ~/license.key
+```
+
+or press `s` on the `:license` view and paste. Either way the key is verified
+before it is stored, and it is stored on the swarm rather than on your laptop —
+see [Per-swarm storage](#per-swarm-storage).
+
+**3. Activate, if the license is managed.** A paid license is signed
+`bind: managed`: the key names your swarm, and the swarm is then activated for
+it with a short-lived [lease](#managed-licenses-activation-is-a-second-step).
+Until the lease lands, `:license` says **Not activated for this swarm** and
+Business Edition features stay off. On a swarm that can reach us this takes care
+of itself within a few minutes; air-gapped, it is a file:
+
+```bash
+swarmcli license lease install ~/swarm.lease
+```
+
+A [free-tier](#the-free-tier) license is signed `bind: static` and has no lease,
+so this step does not exist for it. Step 2 was the whole of it.
+
+**4. Confirm.**
+
+```bash
+swarmcli license status
+```
+
+Exit `0` means the license grants its features; `1` means it does not. In the
+TUI, `:license` says the same thing at more length, and the edition label in the
+header reads *Business Edition*.
+
+**5. Renewal is not a thing you do.** A rolled [free-tier](#the-free-tier) term,
+a plan change and a lease renewal all arrive over the same requests, attempted
+on a timer and again whenever you open `:license`. On a swarm nobody opens a TUI
+against, [`:bootstrap`](bootstrap.md) deploys a `licence-renewer` service that
+makes them for you. See [Renewing a license](#renewing-a-license).
+
+**6. What running out looks like.** The key's `expires_at` passes, five days of
+[grace](#lifecycle-states) follow with every feature still on, and then features
+stop. Nothing prompts you at startup: the status bar carries the state and the
+license dialog opens when a gated feature is next asked for. Installing a fresh
+key at any point in that sequence is a single paste, with no uninstall step.
 
 ## Activation
 
@@ -171,8 +250,9 @@ low-touch deployments, and are worth asking for **before** your first outage
 rather than after: `:license` will tell you which state you are in, but only if
 somebody opens it.
 
-Managed licenses are being rolled out; keys issued today are bound at
-issuance, and nothing about them changes.
+A paid license issued today is signed `managed`; a [free-tier](#the-free-tier)
+key is signed `static` and has no lease. Keys issued before managed binding
+existed are bound at issuance, and nothing about them changes.
 
 All of them require a Docker context pointing at a swarm manager, and all
 of them validate the key before storing it.
@@ -181,47 +261,125 @@ of them validate the key before storing it.
 
 The prompt appears when you ask for a Business Edition feature and no
 usable key is available — i.e. there's no key, the key is invalid, or the
-key is past its grace period. You see one of:
+key is past its grace period. It is never shown at startup; see
+[Lifecycle states](#lifecycle-states).
+
+Every state is the same dialog, and only the message inside it changes.
+With no license at all:
 
 ```
+ License
+
 No Business Edition license found.
 
-Get a free trial license at: https://swarmcli.io/be
+Swarm cluster ID:
+  <cluster-id>
 
-Paste your license key below, or press Enter to continue
-with Community Edition.
+Get a license at:
+  https://swarmcli.io/licenses?cluster_id=<cluster-id>
 
-You can also set the SWARMCLI_LICENSE environment variable.
+Paste your license key:
+>
 
-License key:
+<Enter> submit  <Esc> cancel  <ctrl+o> open
 ```
+
+`<ctrl+o>` opens the link the message names, `<ctrl+y>` copies it, and
+`<ctrl+g>` copies the bare cluster id — for filling the form in on another
+machine without mouse-selecting an id out of a bordered box. The rest of
+this section quotes only the message, since the frame around it does not
+change.
+
+**Invalid** — the key did not verify:
 
 ```
 Your license key is invalid.
-
-Paste a valid license key below, or press Enter to continue
-with Community Edition.
-
-License key:
 ```
 
+**Expired** — past the grace window:
+
 ```
-Your license expired on YYYY-MM-DD. The 5-day grace period has ended.
+Your license expired on 2026-03-01.
+The 5-day grace period has ended.
 Business Edition features are now disabled.
 
-Paste a new license key below, or press Enter to continue
-with Community Edition.
-
-License key:
+Renew, or ask about the free tier for up to 3 nodes:
+  https://swarmcli.io/licenses?cluster_id=<cluster-id>
 ```
+
+**Grace period** — expired, features still on:
+
+```
+Your license expired on 2026-03-01.
+Grace period: 3 of 5 days remaining.
+
+Renew at:
+  https://swarmcli.io/licenses?cluster_id=<cluster-id>
+```
+
+**Wrong swarm** — the key names a different cluster:
 
 ```
 This license is bound to swarm <expected-id>.
 You are connected to swarm <observed-id>.
 Business Edition features are disabled.
-Switch context (:contexts) or contact support to rebind.
 
-License key:
+Switch context (:contexts), or request a license for this swarm at:
+  https://swarmcli.io/licenses?cluster_id=<observed-id>
+```
+
+**Newer than this build** — nothing is wrong with the key:
+
+```
+This license is newer than this build of swarmcli.
+The key is fine; this binary cannot read it.
+
+Upgrade swarmcli.
+```
+
+**Valid but not saved** — the signature verified and the swarm did not
+take it, so pasting the same key again is the right move once the reason
+is fixed:
+
+```
+Your license key is valid but is not installed in this swarm:
+  <reason>
+
+Business Edition features stay disabled until it is stored in the
+swarm. Connect to a swarm manager (:contexts), then try again.
+```
+
+Three more belong to a [managed
+license](#managed-licenses-activation-is-a-second-step), and are about the
+activation lease rather than the key. **Not activated** — the key is
+installed and the swarm has no lease:
+
+```
+This license is installed, but this swarm is not activated yet.
+
+Install the lease file you were sent:
+  :license lease install <file>
+```
+
+**Renewal overdue** — the lease's renewal date has passed, and features
+stay on to the date named:
+
+```
+This swarm's activation is overdue for renewal.
+Business Edition features stay on until 2026-04-15.
+
+Renew it, or install a fresh lease:
+  :license lease install <file>
+```
+
+**Activation expired** — the grace window ran out:
+
+```
+This swarm's activation has expired.
+Business Edition features are disabled.
+
+Renew it, then install the fresh lease:
+  :license lease install <file>
 ```
 
 Pressing **Enter** with no input dismisses the prompt and leaves you in
@@ -248,11 +406,29 @@ Inside the TUI, `:license` shows current state:
 | Status: No license | No key present. |
 | Status: Invalid | The key did not verify, or names a tier this build does not know. |
 | Status: Wrong swarm (license bound to a different cluster) | The connected swarm differs from the one the license is bound to. See [Per-swarm binding](#per-swarm-binding). |
+| Status: Valid, but not saved: `<reason>` | The signature verified and the swarm did not take the key. Named rather than reported as an unknown, because the reason is the remedy. |
+| Status: Newer than this build (upgrade swarmcli) | The key's version is above what this build accepts. The key is fine — see [Key versioning](#key-versioning). |
+| Status: Not activated for this swarm | A [managed](#managed-licenses-activation-is-a-second-step) key with no lease. |
+| Status: Activated — renewal overdue | The lease's renewal date has passed; features are still on. |
+| Status: Activation expired | The lease's grace window ran out; features are off. |
 
 The view also shows:
 
 - `Source: swarm config (swarmcli-license)` — where the active key was loaded from.
-- `Binding: Bound to <id> | Unbound (portable across swarms) | Expected/Observed mismatch` — the current binding state.
+- `Bound to: <id>` — the binding line. It reads `Unbound (portable across
+  swarms)` for a legacy unbound key, `Bound to: <id> (waiting for swarm
+  observation)` before the first swarm read lands, and `Expected: <id>` over
+  `Observed: <id> (mismatch)` on the wrong swarm.
+- A [managed](#managed-licenses-activation-is-a-second-step) license writes the
+  same line as `Managed — …`, and names the exact state because the remedies
+  differ: `activated for <id>, renews <date>`; `renewal overdue, features off
+  in N day(s) (<date>)`; `activation expired <date>`; `not activated for this
+  swarm (<id>)`; `the installed lease is not for this swarm's licence`, when
+  the wrong lease file was pasted; `expected: <id> / Observed: <id>
+  (mismatch)`. Two more are about this host rather than the license: `this
+  host's clock is behind the newest time this swarm has seen`, which no fresh
+  lease lifts, and `this activation does not begin until <timestamp>` for a
+  future-dated lease.
 - `Nodes: 12 of 10 — nothing is switched off`, with a portal link beside it —
   shown only when the swarm has more nodes than `max_nodes`. It is a report and
   not a status: the `Status:` line above is unaffected and every feature stays
@@ -263,6 +439,10 @@ The view also shows:
   licence is over it, and abbreviated into the status bar as well because the
   swarm nobody opens `:license` on is the one that lapses. Also a report and not
   a status. See [Limits](#limits).
+- `Auto-renewal: no licence-renewer service on this swarm` — shown when the
+  swarm was bootstrapped before the `licence-renewer` service existed, so
+  nothing renews the licence while swarmcli is closed. See [Bootstrap — the
+  `Auto-renewal:` warning](bootstrap.md#the-auto-renewal-warning-on-license).
 
 Key bindings inside the view:
 
@@ -310,9 +490,19 @@ swarmcli license id                                  # print the license id supp
 They all read the license from the swarm's Docker Config exactly as the TUI does,
 so they need a Docker context pointing at a swarm manager, and the ones that write
 verify first, so an artifact that does not verify never reaches the swarm from
-here either. `status` prints one `key=value` per line — status, tier, license id,
-binding, the node count and its allowance, the lease's dates, and what the last
-renewal answered — or the same fields as an object with `--json`.
+here either. `status` prints one `key=value` per line, or the same fields as an
+object with `--json`: `status`, `grants`, `tier`, `customer`, `license_id`,
+`bind`, `cluster_id`, `bound_cluster_id`, `expires_at`, `nodes`, `max_nodes`,
+`features`, and — when a lease is installed — `lease_id`, `lease_expires`,
+`lease_hard_stop` and `lease_error`. Every field is omitted rather than zeroed
+when there is nothing to say, so absence is not a state.
+
+`sync` prints the same report plus the fields that only exist once the license
+service has answered: `renewal_at`, `renewal_result`, `renewal_code`,
+`retry_after`, `portal`, and the four [allowance](#limits) fields
+`entitlement_status`, `entitlement_nodes`, `entitlement_max_nodes` and
+`entitlement_term_ends_at`. They are absent from `status` because `status`
+makes no call at all.
 
 The exit codes do not all answer the same question, and that is what makes them
 useful in a cron job. A verb that finishes an activation answers *does this
@@ -412,7 +602,7 @@ binding modes, and `:license` names which one you hold.
   cryptographically valid but Business Edition features disable and
   `:license` shows `Wrong swarm`. Switching back restores it immediately,
   with no waiting period. Every [free-tier](#the-free-tier) key is one of
-  these, which is why a free licence has no activation step.
+  these, which is why a free licence needs no lease.
 - **Managed**: the swarm is named in the key as above, but the binding is also
   kept current — features work only while the swarm holds a live lease, which
   it renews by itself. See
@@ -471,9 +661,17 @@ is refused with *"This license is already bound to a different Swarm. Please
 unbind it first."* A license bound at issuance may be moved this way as often
 as you need. Install the replacement with `:license install <file>`.
 
-**Unbind Cluster** is offered for licenses that carry a subscription. A
-license issued to you outside the dashboard has no unbind button, and moving
-one is still a support request — send the new cluster id.
+**Unbind Cluster** is offered for any bound license, subscription-backed or
+not — it is `swarm_id` that decides whether the button is there, and the
+issuing side checks only that the license is yours. A free-tier license moves
+this way too, and it is the verb to use rather than Delete, which throws the
+one-per-account row away with the binding.
+
+The one restriction is the managed move cap, and it applies to **managed**
+licenses only: a lease that has been issued cannot be recalled, so unbinding is
+refused until the previous swarm's lease window has run out, and the refusal
+names the date the next move becomes possible. A license bound at issuance —
+every free-tier key among them — has no lease and so no cap.
 
 Force-restoring a swarm from a backup of `/var/lib/docker/swarm/` (a
 documented DR procedure with `docker swarm init --force-new-cluster`)
@@ -538,16 +736,22 @@ stateDiagram-v2
 
 | State | BE features | What the user sees |
 |---|---|---|
-| Valid | enabled | normal startup, no prompt |
-| Grace Period | **enabled** | one-line warning printed to stderr at startup, banner in `:license` view |
-| Expired (past grace) | disabled | startup prompt every run until a new key is provided |
-| No license | disabled | startup prompt every run |
-| Invalid | disabled | startup prompt every run |
-| Wrong swarm | disabled | startup prompt naming the expected vs. observed cluster id |
+| Valid | enabled | normal startup, nothing to see |
+| Grace Period | **enabled** | banner in `:license` view, and the days remaining in the status bar |
+| Expired (past grace) | disabled | `No valid license · Community Edition · install via :license` in the status bar, and the prompt when a gated feature is asked for |
+| No license | disabled | the same status-bar suffix, and the same prompt on a gated request |
+| Invalid | disabled | the same status-bar suffix, and the same prompt on a gated request |
+| Wrong swarm | disabled | the prompt names the expected and the observed cluster id |
 | Not activated for this swarm | disabled | `:license` names the swarm and the command that activates it |
 | Activated — renewal overdue | **enabled** | countdown to the day features stop, on `:license` and in the status bar |
 | Activation expired | disabled | `:license` says renew, not activate |
 | Newer than this build | disabled | upgrade swarmcli; the key is fine |
+
+Nothing in that column is a startup prompt: an unlicensed or expired start
+is passive. The edition label drops to *Community Edition*, the status bar
+grows a suffix saying so, and the licence dialog opens just-in-time — when a
+gated feature is actually requested, and not before. So a swarm that nobody
+asks a Business Edition question of never shows a modal at all.
 
 The grace period is **5 days** from `expires_at`. During grace, BE
 features remain enabled — this is deliberate, so a quiet renewal cycle
@@ -632,9 +836,15 @@ key; the `Allowance:` line is what the licence service last recorded and last
 decided. Each names its source, so a stale report beside a fresh count is two
 views of one swarm rather than a contradiction.
 
-Neither of the service's two lines reaches `swarmcli license status`, which
-reports the observed count and the signed `max_nodes` and nothing the service
-said about them.
+`swarmcli license status` does not carry either of the service's two lines: it
+makes no call, so it reports the observed count and the signed `max_nodes` and
+nothing the service said about them. `swarmcli license sync` does make the call,
+and prints what came back as four fields — `entitlement_status`,
+`entitlement_nodes`, `entitlement_max_nodes` and `entitlement_term_ends_at`, the
+last being the date after which the term stops being rolled forward. They are
+the `:license` page's `Allowance:` and `Term:` lines in machine-readable form,
+in both the `key=value` and the `--json` output, and they are absent when the
+answer carried no report.
 
 ## Key versioning
 
@@ -688,7 +898,10 @@ Both requests send:
   integer, and the count the [node allowance](#limits) is judged against; it is
   left out altogether until the first observation lands, because a zero would
   claim a swarm with no nodes rather than a swarm not yet looked at;
-- the **swarmcli version** making the request; and
+- the **product and version** making the request — `swarmcli-be` from this
+  binary or `swarmcli-cd` from the controller, beside the version, because one
+  license covers both products and the service has to know which one is
+  asking; and
 - the time and network origin of the request, as with any HTTPS call.
 
 Nothing else. Not your services, images, users, configuration, node names,

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -11,15 +11,21 @@ general TUI behaviour, see the
 
 ## License
 
-**"Your license key is invalid."** at startup.
+**"Your license key is invalid."** in the license dialog — which opens when a
+license-gated feature is requested, not at startup.
 The key did not verify. Usually it was truncated when copied or picked up an
 extra newline; it can also mean the key was issued for a different product
 build, or is too old for this release to accept. Re-paste it from its source,
 and if that does not help, contact whoever issued it.
 
-**"Your license expired on YYYY-MM-DD. The 5-day grace period has ended."**
-The key is past its grace window. Paste a fresh key at the prompt, or set
-`SWARMCLI_LICENSE` and restart. See [License — Lifecycle](license.md#lifecycle-states).
+**"Your license expired on YYYY-MM-DD. / The 5-day grace period has ended."**
+The key is past its grace window. Paste a fresh key into the dialog, or run
+`swarmcli license install <file>`. Setting `SWARMCLI_LICENSE` and restarting
+does **not** do it: neither the environment variable nor
+`~/.config/swarmcli/license.key` is loaded on its own — they are install-*from*
+sources, offered on the `:license` view as `<e>` and `<m>`, which store the key
+in the swarm. See [License — Activation](license.md#activation) and [License —
+Lifecycle](license.md#lifecycle-states).
 
 **`:license` shows `Nodes: 12 of 10 — nothing is switched off`.**
 The swarm has more nodes than the license allows. Nothing is blocked and no


### PR DESCRIPTION
The licensing pages describe a product we stopped shipping. Two changes are
behind most of it: a paid licence is now signed `managed` rather than `static`
(`swarmcli-website` `backend/src/services/license.ts:807-808` — free rows get
`static`, every other bound licence gets `managed`), and there is a permanent
free tier granting all thirteen entitlements. On top of that, the
`swarmcli-be` → `swarmcli` rename of 2026-08-07 never reached
`docs/installation.md`.

Nineteen corrections and three additions. Every claim below names a file and a
line so it can be checked cheaply.

## The licence prompt does not exist as documented

`docs/license.md` quoted four prompt screens that match **no string in the
product**. The real ones are in `swarmcli-be/views/licensedialog/licensedialog.go`
— `NoLicense` at :379-385 prints the swarm cluster id and `Get a license at:`,
the input label at :308 is `Paste your license key:`, and `WrongCluster` at
:406-419 ends "Switch context (`:contexts`), or request a license for this swarm
at:". Five states were absent entirely: `NotActivated` (:439-444), `LeaseGrace`
(:446-457), `LeaseExpired` (:459-462), `NeedsUpgrade` (:464-467) and
`SaveFailed` (:469+). All re-derived and added.

## There is no startup prompt, and there never was one to warn about

`docs/license.md`, `docs/installation.md` and `docs/troubleshooting.md` all
described a prompt on every run, and the lifecycle table promised a one-line
stderr grace warning. `swarmcli-be/profeatures/init.go:67-71` says the opposite
outright — *"No cold-start blocking modal: an unlicensed/expired start is
surfaced passively via the breadcrumb suffix … and just-in-time when a gated
feature is requested"* — and `middleware/locked_overlay.go:86-94` opens the
dialog only on a gated-feature denial. `docs/license.md:182-184` already stated
this correctly, so the file contradicted itself.

`docs/troubleshooting.md` also offered a remedy that does nothing: "set
`SWARMCLI_LICENSE` and restart". Env is never auto-loaded
(`license/load.go:55-59`, :152-162). The real remedies are `<e>` on `:license`
or `swarmcli license install <file>`.

## Install instructions point at deprecated names and impossible commands

- `brew install …/swarmcli-be`, `scoop install swarmcli-be`,
  `docker pull eldaratech/swarmcli-be` — all renamed on 2026-08-07.
  `swarmcli-be/.goreleaser.yml:227-247` marks the cask `deprecate!` with that
  date, :268-275 prints a Scoop rename notice, :279-289 publishes to
  `eldaratech/swarmcli`. The Upgrade section named the deprecated ones too.
- The artefact name `swarmcli-be_<version>_<os>_<arch>.tar.gz` has no version
  component, a capitalised OS and `x86_64` rather than `amd64` — both
  goreleaser configs set `project_name: swarmcli` and template
  `{{ .ProjectName }}_{{ title .Os }}_x86_64[_oss]`
  (`swarmcli/.goreleaser.yml:139-145`, `swarmcli-be/.goreleaser.yml:141-147`).
- `sha256sum -c checksums.txt` **cannot work**: the file is deliberately never
  produced. It is `checksums-oss.txt` and `checksums-merged.txt`, exactly as
  `docs/editions.md:112-115` already said.
- "Mounting `~/.config/swarmcli` keeps your … license file persistent" — the
  licence lives in the swarm's Raft store as Docker config `swarmcli-license`
  (`license/load.go:32-43`, :87-110). No licence file is ever created.
- "There is no `--version` flag today" — `cli/dispatch.go:95` handles
  `version`, `--version` and `-v`.
- `[CE vs BE](#ce-vs-be)` had no target; the heading is
  `## CE and BE are one download`.

## Four entitlements, where there are thirteen

`docs/features.md:8` and `:341-350` said "four license-gated capabilities".
`swarmcli-be/license/scheme.go:173-189` lists thirteen: eight TUI ones —
`shell`, `reveal-secret`, `port-forward`, `volumes-all-nodes`,
`user-management`, `service-health`, `pull-progress`, `container-stats` — plus
five consumed by swarmcli-cd, since one licence covers both products. Five of
the eight back the nine `RegisterGatedAction` calls under
`swarmcli-be/views/*/register.go`, which is why the counts differ. All three
tiers grant the identical thirteen. The shorter, differently-wrong lists at
`docs/README.md:16-23` (five) and `README.md:151-156` (four) are fixed with it.

## Licensing behaviour stated backwards

- `docs/configuration.md:25` said `SWARMCLI_DISABLE_LICENSE_RENEWAL` has "no
  effect on any other license type, which never make the request at all". It
  switches off **both** requests: `licenseclient/client.go:114-118` returns
  `nil, false` so no client is built at all, and `license/renewalgate.go:128-141`
  shows `TokenRefreshDue` is true for static and unbound licences and *false*
  for managed. `docs/license.md:663-674` already had this right.
- `docs/configuration.md:24`, `:38-39`, `:76` claimed a precedence between
  `SWARMCLI_LICENSE` and `~/.config/swarmcli/license.key`, and said the file is
  "Created by the startup prompt". Neither is auto-loaded (`load.go:55-59`,
  :87-110, :135-138), so there is no precedence, and nothing in production
  writes that file — `SaveKey` at `load.go:216-223` is "Deprecated for
  production use", its only callers being tests and `cmd/testlicenseinstall`.
- `docs/license.md:474-476` said Unbind Cluster is offered only for licences
  carrying a subscription. `swarmcli-website`
  `frontend/src/app/pages/Licenses.tsx` gates on `license.swarm_id` alone and
  carries a comment saying the subscription requirement was removed; the backend
  gates on ownership. The real restriction is the managed move cap, and
  `unbindLicense` in `backend/src/services/license.ts` applies it to
  `bind_mode === 'managed'` only.
- `docs/license.md:81-83` said the free tier has "no lease and no activation
  step". `bind: static` and no lease are right; "no activation step" reads
  across `swarmcli license activate`, which is the free tier's primary issuance
  path — `backend/src/routes/activation/index.ts:80-83`: *"Optional because the
  free tier is chosen before a row for it exists"*.
- `docs/license.md:635-637` said neither of the licence service's lines reaches
  the CLI. True of `status`, which makes no call — but the same renderer prints
  `entitlement_status`, `entitlement_nodes`, `entitlement_max_nodes` and
  `entitlement_term_ends_at` on `sync` and `sync --json`
  (`commands/pro/licensecli.go:612-615`, :780-787). No CE doc mentioned them.
- `docs/license.md:315`'s `status` field list omitted `grants`, `customer`,
  `cluster_id`, `bound_cluster_id`, `expires_at`, `lease_error` and `features`
  (`licensecli.go:765-799`).
- `docs/license.md:243-255`: the binding label is `Bound to: <id>` **with a
  colon** (`views/pro/view.go:772`), and the row omitted six managed arms at
  :781-831 including the clock-rollback and not-yet-started ones. The status
  table omitted `Valid, but not saved: <reason>` (:605-609) and `Newer than
  this build (upgrade swarmcli)` (:619).
- `docs/license.md:679-692` (Privacy) ended "Nothing else." The request body
  also carries a `product` field beside the version
  (`licenseclient/client.go:166-169`, :292-296) — `swarmcli-be` from this
  binary, `swarmcli-cd` from the controller.
- `docs/editions.md:83` said installing a licence on the OSS build "changes
  nothing and reports nothing". There is nothing to install one *with*:
  `license` is registered only by `commands/pro/licensecli.go:34` and
  `:license` only by `views/pro/register.go:10`. Reproducible in this repo:

  ```console
  $ go build -o /tmp/swarmcli . && /tmp/swarmcli license; echo $?
  Error: unknown command "license"
  2
  ```

- `docs/editions.md:132` said the OSS artefact guard runs from `ci.yml` "on
  every change". The job is gated `if: needs.changes.outputs.docker == 'true'`
  (`.github/workflows/ci.yml:136`) on a paths filter of `**.go`, `go.mod`,
  `go.sum`, the Dockerfiles, `ci.yml` and `scripts/check-oss-artefact.sh`
  (:43-52). A docs-only PR — this one — does not run it.

## Three additions

- **`swarmcli license activate` was invisible outside the CLI reference.**
  "Acquiring a key", the first-run section and `README.md` all still described
  manual key-pasting. `docs/license.md` gains a short **Start to finish**
  section, organised by what a user does in order rather than by mechanism, and
  honest that a paid licence is signed `managed` and needs an activation step
  while the free tier does not. The exhaustive internal version already exists
  as `swarmcli-be/docs/licensing-user-flows.md`; this is the customer-facing
  short one, not a second page.
- **The `licence-renewer` service was absent from `docs/bootstrap.md`.**
  `:bootstrap` deploys it (`bootstrap/bootstrap.go:131`, `:141`
  `DefaultRenewerInterval = "6h"`) alone on `swarmcli-renewal-net`, the only
  network in the stack that is not `internal:` because it is the only service
  with a route off the cluster; `--no-renewer` omits it
  (`commands/pro/bootstrap.go:44`) and was missing from the flags table. The
  `Auto-renewal:` warning on `:license` (`views/pro/view.go:517-531`) is
  documented beside it — it is what tells a static free-tier operator that the
  annual roll of their term will never arrive.
- **`.github/UPGRADE_NOTES.md`** covered the trial-expiry change and the `/v2`
  module path only. Extended to cover the free tier, the package/formula/image
  rename (which `.goreleaser.yml`'s own comment points at this file for),
  managed licensing and leases, and `license activate`. Also corrected: the
  mandatory-expiry rule was stated for `trial` alone, but
  `license/scheme.go:216-218` applies it to `free` as well.

## Rejected

- **`RELEASING.md:95` does not make the claim attributed to it.** The audit
  paired it with `docs/editions.md:132` as a second site of "runs from `ci.yml`
  on every change". `RELEASING.md:95` says only *"The per-build hook runs
  `scripts/check-oss-artefact.sh` on every binary as it is produced"*, which is
  correct; `grep -n 'ci.yml' RELEASING.md` returns nothing. `editions.md` was
  the only place the claim lived, and it is fixed there. `RELEASING.md` is
  untouched.

## Not addressed, deliberately

Lease signing is not yet live in production. That is known and tracked, and
`.github/UPGRADE_NOTES.md` says so rather than claiming otherwise. No document
here says a paid licence needs no lease.

## Checks

`go build ./...` and `go test ./...` are clean — no test reads these files. Every
internal link and heading anchor across `docs/`, `README.md` and
`.github/UPGRADE_NOTES.md` was resolved programmatically; all resolve.

---

Machine-generated by an AI agent (Claude Opus 5) and not human-reviewed. Claims carry a file, a line or a reproducible check so they can be verified cheaply.
