### PR TITLE
fix(secrets): the create dialog base64-encoded every secret by default

### DIFF
--- a/views/secrets/model.go
+++ b/views/secrets/model.go
@@ -109,7 +109,7 @@ func New(width, height int) *Model {
 		visible:            true,
 		sortField:          SortByName,
 		sortAscending:      true,
-		createEncodeSecret: true,
+		createEncodeSecret: false,
 	}
 
 	cols := m.buildColumns()

--- a/views/secrets/update_test.go
+++ b/views/secrets/update_test.go
@@ -426,6 +426,14 @@ func TestCreateDialog_DetailsInline_Esc_Closes(t *testing.T) {
 	require.False(t, m.createDialogActive)
 }
 
+// #628: the default must stay off. With encoding on, the stored secret is
+// base64 *of* the credential and nothing decodes it again — a consumer reading
+// /run/secrets/<name> gets bytes that are printable and plausible enough to
+// survive every check but a prefix comparison.
+func TestCreateDialog_EncodeDefaultsOff(t *testing.T) {
+	require.False(t, testModel().createEncodeSecret)
+}
+
 func TestCreateDialog_DetailsFile_Space_TogglesEncode(t *testing.T) {
 	m := testModel()
 	m.createDialogActive = true

--- a/views/secrets/view.go
+++ b/views/secrets/view.go
@@ -204,7 +204,7 @@ func (m *Model) renderCreateDialog() string {
 			encodeText = dialog.ItemStyle.Render(encodeText)
 		}
 		lines = append(lines, encodeText)
-		lines = append(lines, dialog.ItemStyle.Render("  (Secrets need to be base64 encoded. Disable this if already encoded.)"))
+		lines = append(lines, dialog.ItemStyle.Render("  (Base64-encode the value. Leave off unless the consumer decodes it.)"))
 		lines = append(lines, dialog.ItemStyle.Render(""))
 
 		// Change help text based on error state
@@ -270,7 +270,7 @@ func (m *Model) renderCreateDialog() string {
 			encodeText = dialog.ItemStyle.Render(encodeText)
 		}
 		lines = append(lines, encodeText)
-		lines = append(lines, dialog.ItemStyle.Render("  (Secrets need to be base64 encoded. Disable this if already encoded.)"))
+		lines = append(lines, dialog.ItemStyle.Render("  (Base64-encode the value. Leave off unless the consumer decodes it.)"))
 		lines = append(lines, dialog.ItemStyle.Render(""))
 
 		// Change help text based on error state


### PR DESCRIPTION
Closes #628.

The secret-create dialog's **Encode secret** toggle initialised to ON, and the help text beside it asserted `(Secrets need to be base64 encoded. Disable this if already encoded.)`. That requirement is Kubernetes', where `Secret.data` is defined as base64. A Swarm secret is arbitrary bytes mounted as a file. So the default and the text agreed with each other and both were wrong, and a credential typed into the TUI was stored as base64 *of* the credential.

## What this changes

- `views/secrets/model.go:112` — `createEncodeSecret` now initialises `false`.
- `views/secrets/view.go:207` and `:273` — both copies of the help string become `(Base64-encode the value. Leave off unless the consumer decodes it.)`.
- `views/secrets/update_test.go` — `TestCreateDialog_EncodeDefaultsOff` pins the default so it cannot regress silently.

Encoding stays available on the toggle for a consumer that genuinely decodes; it is now the deliberate choice rather than the accident.

## Why the default, not just the wording

Nothing in this repo decodes it back. `docker.SecretWithDecodedData.Data` is `nil` at every construction site — `docker/secret.go:124`, `views/secrets/actions.go:38`, `:91`, `:255`, `:282` — so the encode is strictly one-way, and there is no round-trip symmetry to preserve. SwarmCLI's own programmatic secret creation doesn't encode either: `swarmcli-be/bootstrap/bootstrap.go:233` passes raw bytes to `docker.CreateSecret`. The dialog was the only encoding path in the ecosystem and the one that defaulted on.

## Why it stays invisible

The stored value is printable, and it passes a control-character or non-printable-byte audit because base64 output is entirely `[A-Za-z0-9+/=]`. BE's reveal makes it worse rather than better: `views/revealsecret/format.go:48` speculatively decodes and `revealsecret.go:187` renders `Encoded (base64): … Decoded: …`, so the one UI that shows secret material displays the broken secret directly above the plaintext it should have been.

Observed in practice: two Stripe secrets on a staging swarm were created this way. Every Stripe call was rejected, so no product resolved, the price cache stayed empty, and the pricing page rendered its own hard-coded fallbacks — which reads, to a human, as a working page. Diagnosis needed a hex dump after eliminating a stale cache, an API version mismatch, the product catalogue and the account.

## Not done

The issue's third suggestion — warn when the input already looks base64-decodable and encoding is on — is deliberately skipped. It needs the `decodeIfBase64` heuristic, and #308 already established that heuristic is unreliable: every hex digit is in the base64 alphabet, so a 64-character hex token decodes cleanly into 48 bytes and would draw a warning on exactly the values that are correct.

## Verification

`go build ./...`, `go vet ./...`, `golangci-lint run ./views/secrets/... --build-tags=integration` (0 issues), and the full `go test -race -count=1 -timeout 5m ./...` all pass. No existing test asserted the old default — `update_test.go:434` and `:518` compare against a captured `initial`/`before`, so they are indifferent to which way it starts and still assert that space toggles it.

---
Machine-generated by an AI agent (Claude Opus 5), and not human-reviewed. Claims carry a file, a line or a reproducible check so they can be verified cheaply.
