### PR TITLE
ci(build): the release-image guard could not run for a Dockerfile-only diff

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,7 +133,17 @@ jobs:
 
   build:
     needs: [changes, test]
-    if: needs.changes.outputs.docker == 'true'
+    # `test` is gated on the `code` filter, this job on `docker`, and the two
+    # are not the same set: a diff touching only the Dockerfiles leaves `test`
+    # skipped, and a skipped `needs` skips the dependent job whatever its own
+    # `if:` says. So the one job that ever runs `docker build`, and the only
+    # place the release-image guard below fires, could not run for exactly the
+    # diff it was written for — #631 bumped both Dockerfiles and `changes` read
+    # `code = false, docker = true`, leaving neither file built. `!cancelled()`
+    # keeps the needs edge for ordering while tolerating a skipped `test`; a
+    # failed one still skips this job, so a Docker build never runs on a tree
+    # whose tests are red.
+    if: ${{ !cancelled() && needs.changes.outputs.docker == 'true' && needs.test.result != 'failure' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code


### PR DESCRIPTION
`build` is the only job that runs `docker build` on either Dockerfile, and the
only place the #548 guard fires — the one asserting the release base still
provides `ca-certificates` and `ssh`, and that `swarmcli version` actually runs
inside the image. It is gated on the `docker` filter, but it also
`needs: test`, which is gated on `code`, and the two filters are not the same
set. A diff touching only the Dockerfiles leaves `test` skipped, and **a
skipped `needs` skips the dependent job whatever its own `if:` evaluates to**.
So the guard was unreachable for precisely the change it was written for.

#631 is that change. Dependabot bumped `FROM golang` and the `docker:29-cli`
digest; `changes` read `code = false, docker = true`; `build`, `fmt`, `lint`,
`test` and `vet` were all skipped — and since `build` is a required check, a
skipped one is a passing one. The green Integration Tests build neither file:
they stand up `test-setup/docker-compose.yml`. Nothing had built either
Dockerfile, and on that shape of diff nothing ever would.

## The change

```yaml
-    if: needs.changes.outputs.docker == 'true'
+    if: ${{ !cancelled() && needs.changes.outputs.docker == 'true' && needs.test.result != 'failure' }}
```

`!cancelled()` keeps the `needs` edge for ordering while tolerating a *skipped*
`test`. A *failed* `test` still skips this job, so a Docker build never runs on
a tree whose unit tests are red — which is what the `needs` was there for.

## Scope

`ci.yml` is in both filters, so this PR itself runs the full set including
`build`; what it cannot exercise from here is the skipped-`test` path, which by
construction needs a Dockerfile-only diff. The next Dependabot base-image bump
is that test, and it is the case this exists for.

Found while reviewing #631, which is handled separately: that PR now carries a
`go.mod` bump, which trips `code` and makes `build` run there by side effect.
This is the fix for every Dockerfile-only diff that does not happen to come
with one.
