### PR TITLE
fix(secrets): the create dialog accepted names Swarm then refused

### DIFF
--- a/docker/names.go
+++ b/docker/names.go
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package docker
+
+import (
+	"fmt"
+	"regexp"
+)
+
+// MaxSwarmObjectNameLen is the length swarmkit's
+// validateConfigOrSecretAnnotations allows a secret or config name. Services
+// and networks are held to a stricter 63 by a different validator, so this is
+// not a limit for swarm objects in general.
+const MaxSwarmObjectNameLen = 64
+
+// swarmObjectNameRe is swarmkit's own expression for a secret or config name.
+var swarmObjectNameRe = regexp.MustCompile(`^[a-zA-Z0-9]+(?:[a-zA-Z0-9-_.]*[a-zA-Z0-9])?$`)
+
+// ValidateSwarmObjectName reports why the daemon would refuse this name for a
+// secret or a config, so the dialog asking for it can say so rather than
+// letting a create round-trip and come back as a raw daemon error. kind names
+// the object in the message ("secret", "config").
+func ValidateSwarmObjectName(kind, name string) error {
+	switch {
+	case name == "":
+		return fmt.Errorf("%s name cannot be empty", kind)
+	case len(name) > MaxSwarmObjectNameLen:
+		return fmt.Errorf("%s name must be %d characters or fewer (this one is %d)", kind, MaxSwarmObjectNameLen, len(name))
+	case !swarmObjectNameRe.MatchString(name):
+		return fmt.Errorf("%s name may contain only letters, digits, '-', '_' and '.', and must start and end with a letter or a digit", kind)
+	}
+	return nil
+}

--- a/docker/names_test.go
+++ b/docker/names_test.go
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package docker
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateSwarmObjectName_Accepts(t *testing.T) {
+	for _, name := range []string{
+		"a",
+		"my-secret",
+		"my.api.key",
+		"swarmcli_staging_SUPABASE_PUBLISHABLE_KEY",
+		strings.Repeat("a", MaxSwarmObjectNameLen),
+	} {
+		require.NoError(t, ValidateSwarmObjectName("secret", name), "name %q", name)
+	}
+}
+
+func TestValidateSwarmObjectName_Rejects(t *testing.T) {
+	for name, want := range map[string]string{
+		"": "cannot be empty",
+		strings.Repeat("a", MaxSwarmObjectNameLen+1): "64 characters or fewer",
+		"has space":      "may contain only",
+		"has/slash":      "may contain only",
+		"-leading-dash":  "start and end",
+		"trailing-dash-": "start and end",
+		".leading.dot":   "start and end",
+	} {
+		err := ValidateSwarmObjectName("secret", name)
+		require.Error(t, err, "name %q", name)
+		require.Contains(t, err.Error(), want, "name %q", name)
+	}
+}
+
+// The kind names the object in every message, so the configs dialog does not
+// tell an operator about secrets.
+func TestValidateSwarmObjectName_NamesTheKind(t *testing.T) {
+	require.ErrorContains(t, ValidateSwarmObjectName("config", ""), "config name")
+}

--- a/views/configs/model.go
+++ b/views/configs/model.go
@@ -284,16 +284,7 @@ func (m *Model) HasErrors() bool {
 	return false
 }
 
-// validateConfigName validates a config name
+// validateConfigName rejects, in the dialog, the names the daemon would refuse.
 func validateConfigName(name string) error {
-	if name == "" {
-		return fmt.Errorf("config name cannot be empty")
-	}
-	if strings.ContainsAny(name, " \t\n") {
-		return fmt.Errorf("config name cannot contain whitespace")
-	}
-	if strings.ContainsAny(name, "/\\:*?\"<>|") {
-		return fmt.Errorf("config name contains invalid characters")
-	}
-	return nil
+	return docker.ValidateSwarmObjectName("config", name)
 }

--- a/views/configs/model_test.go
+++ b/views/configs/model_test.go
@@ -5,6 +5,7 @@ package configsview
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -233,6 +234,9 @@ func TestValidateConfigName(t *testing.T) {
 	require.Error(t, validateConfigName(""))
 	require.Error(t, validateConfigName("has space"))
 	require.Error(t, validateConfigName("has/slash"))
+	// swarmcli-be#353: the daemon caps a config name at 64, and the dialog used
+	// to let one through and report the daemon's refusal instead.
+	require.Error(t, validateConfigName(strings.Repeat("a", 65)))
 }
 
 func TestSelectedConfig_Empty(t *testing.T) {

--- a/views/secrets/model.go
+++ b/views/secrets/model.go
@@ -295,16 +295,7 @@ func revealHelpDesc() string {
 	return view.BEHelpDesc("reveal-secret", "Reveal")
 }
 
-// validateSecretName validates a secret name
+// validateSecretName rejects, in the dialog, the names the daemon would refuse.
 func validateSecretName(name string) error {
-	if name == "" {
-		return fmt.Errorf("secret name cannot be empty")
-	}
-	if strings.ContainsAny(name, " \t\n") {
-		return fmt.Errorf("secret name cannot contain whitespace")
-	}
-	if strings.ContainsAny(name, "/\\:*?\"<>|") {
-		return fmt.Errorf("secret name contains invalid characters")
-	}
-	return nil
+	return docker.ValidateSwarmObjectName("secret", name)
 }

--- a/views/secrets/model_test.go
+++ b/views/secrets/model_test.go
@@ -5,6 +5,7 @@ package secretsview
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -234,6 +235,9 @@ func TestValidateSecretName(t *testing.T) {
 	require.Error(t, validateSecretName(""))
 	require.Error(t, validateSecretName("has space"))
 	require.Error(t, validateSecretName("has/slash"))
+	// swarmcli-be#353: the daemon caps a secret name at 64, and the dialog used
+	// to let one through and report the daemon's refusal instead.
+	require.Error(t, validateSecretName(strings.Repeat("a", 65)))
 }
 
 func TestSelectedSecret_Empty(t *testing.T) {

--- a/views/secrets/update_test.go
+++ b/views/secrets/update_test.go
@@ -6,6 +6,7 @@ package secretsview
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -383,7 +384,19 @@ func TestCreateDialog_DetailsFile_Enter_InvalidName_ShowsError(t *testing.T) {
 	m.createNameInput.SetValue("bad/name")
 
 	m.Update(key("enter"))
-	require.Contains(t, m.createDialogError, "invalid")
+	require.Contains(t, m.createDialogError, "may contain only")
+}
+
+// swarmcli-be#353: a name the daemon would refuse for its length used to reach
+// the daemon, which reported it after the dialog had already closed.
+func TestCreateDialog_DetailsFile_Enter_OverlongName_ShowsError(t *testing.T) {
+	m := testModel()
+	m.createDialogActive = true
+	m.createDialogStep = "details-file"
+	m.createNameInput.SetValue(strings.Repeat("a", 65))
+
+	m.Update(key("enter"))
+	require.Contains(t, m.createDialogError, "64 characters or fewer")
 }
 
 func TestCreateDialog_DetailsFile_Enter_NoPath_ShowsError(t *testing.T) {


### PR DESCRIPTION
Refs Eldara-Tech/swarmcli-be#353 — the CE half of that investigation.

### The gap

`validateSecretName` (`views/secrets/model.go`) checked emptiness, whitespace and `/\:*?"<>|`. The daemon applies something different — swarmkit's `validateConfigOrSecretAnnotations`:

- at most **64** characters
- `^[a-zA-Z0-9]+(?:[a-zA-Z0-9-_.]*[a-zA-Z0-9])?$` — letters, digits, `-`, `_` and `.`, starting and ending alphanumeric

The create dialog's name input allows 100 characters, so a 65-character name was accepted by the dialog, sent, and refused by the daemon — the operator learning it was too long from a raw daemon error after the dialog had already closed. A leading dash or a trailing dot behaved the same way.

`validateConfigName` was the same function with the same gap, and configs go through the same daemon-side validator.

### The change

`docker.ValidateSwarmObjectName(kind, name)` holds swarmkit's rule once; both dialogs ask it, and both keep their own thin wrapper so the call sites and their tests are untouched. The messages name the object, so the configs dialog does not talk about secrets:

```
secret name must be 64 characters or fewer (this one is 65)
secret name may contain only letters, digits, '-', '_' and '.', and must start and end with a letter or a digit
```

The input's `CharLimit` is deliberately left at 100: capping it at 64 would silently swallow the tail of a pasted name, where the message says what is wrong.

### Tests

`docker/names_test.go` covers the accepted set (including a dotted name and one exactly 64 long) and each rejection with the reason it gives. `views/secrets` and `views/configs` each gain a length case on their validator, and the secrets create dialog gains one asserting an over-long name is reported in the dialog rather than by the daemon.

### Not in this PR

The bug that started the investigation is in swarmcli-be: revealing a secret builds a service named `swarmcli-reveal-<secret>-<unix>`, and Swarm holds a *service* to 63 characters and to a DNS label — a stricter rule than the one its secret name passed. Fixed separately in `swarmcli-be`.

---
Machine-generated by an AI agent (Claude Opus 5) via the `eldara-cruncher` bot account, and not human-reviewed. Claims carry a file, a line or a reproducible check so they can be verified cheaply.
