### PR TITLE
test(testenv): size the DinD swarm with NODES instead of a fixed pair of workers

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -47,7 +47,7 @@ jobs:
 
     # No `services:` DinD and no DOCKER_HOST override: a single shared DinD
     # container plus `docker swarm init` shadowed the multinode topology —
-    # `test-setup/docker-compose.yml` (manager + worker1/worker2 + joins,
+    # `test-setup/docker-compose.yml` (manager + scaled `worker` replicas,
     # all `privileged: true`) was run *nested* inside it, so every test and
     # the worker-readiness gate talked to the outer single-node swarm while
     # the real multinode swarm was orphaned (CI was silently single-node).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,7 +124,8 @@ explains our implementation to them.
 ## Integration Test Infrastructure
 
 - Tests in `integration-tests/` use `//go:build integration` tag
-- `test-setup/docker-compose.yml`: DinD multi-node Swarm (1 manager on tcp://localhost:22375, 2 workers)
+- `test-setup/docker-compose.yml`: DinD multi-node Swarm (1 manager on tcp://localhost:22375,
+  plus a scaled `worker` service — `NODES=<n> testenv.sh up` sizes the whole swarm, default 3)
 - `test-setup/test-stack.yml`: Demo services (whoami, whoami_single, log_ticker) with volumes, networks, and configs
 - `test-setup/testenv.sh`: Orchestrator script
 - Tests use `gotestsum` as test runner (with `--format=testname` locally, `--format=github-actions` in CI)

--- a/test-setup/README.md
+++ b/test-setup/README.md
@@ -1,6 +1,8 @@
 # 🐳 Local Docker Swarm Test Environment
 
-Spin up a 1× manager + 2× worker Docker‑in‑Docker (DinD) Swarm locally, expose the manager’s Docker API on **localhost:22375**, and interact with it via a Docker context.
+Spin up a 1× manager + N× worker Docker‑in‑Docker (DinD) Swarm locally, expose the manager’s Docker API on **localhost:22375**, and interact with it via a Docker context.
+
+`worker` is a single scaled service, so the size of the swarm is a knob: `NODES=<n> bash test-setup/testenv.sh up` starts an n‑node swarm (the manager counts), and `docker compose up --scale worker=<n-1>` does the same by hand. The default is 3 — 1 manager + 2 workers.
 
 > ⚠️ Security note: this setup binds the Docker API without TLS for local testing only. Do **not** expose it on an untrusted network.
 
@@ -18,22 +20,23 @@ Spin up a 1× manager + 2× worker Docker‑in‑Docker (DinD) Swarm locally, ex
 
 ```bash
 # From the repo folder that contains docker-compose.yml
-docker compose up --build
+docker compose up --build                    # 1 manager + 1 worker
+docker compose up --build --scale worker=4   # 1 manager + 4 workers
 ```
 You may get errors like
 ```
-worker2-1  | WARNING: ca-cert-placeholder.pem does not contain exactly one certificate or CRL: skipping
-worker1-1  | WARNING: ca-cert-corporate-proxy.pem does not contain exactly one certificate or CRL: skipping
+worker-2   | WARNING: ca-cert-placeholder.pem does not contain exactly one certificate or CRL: skipping
+worker-1   | WARNING: ca-cert-corporate-proxy.pem does not contain exactly one certificate or CRL: skipping
 manager-1  | WARNING: ca-cert-corporate-proxy.pem does not contain exactly one certificate or CRL: skipping
-worker2-1  | WARNING: ca-cert-corporate-proxy.pem does not contain exactly one certificate or CRL: skipping
-worker2-1  | time="2025-12-12T08:56:10.038970524Z" level=info msg="Starting up"
-worker1-1  | time="2025-12-12T08:56:10.038970875Z" level=info msg="Starting up"
+worker-2   | WARNING: ca-cert-corporate-proxy.pem does not contain exactly one certificate or CRL: skipping
+worker-2   | time="2025-12-12T08:56:10.038970524Z" level=info msg="Starting up"
+worker-1   | time="2025-12-12T08:56:10.038970875Z" level=info msg="Starting up"
 manager-1  | time="2025-12-12T08:56:10.039031366Z" level=info msg="Starting up"
-worker2-1  | failed to start daemon, ensure docker is not running or delete /var/run/docker.pid: process with PID 1 is still running
+worker-2   | failed to start daemon, ensure docker is not running or delete /var/run/docker.pid: process with PID 1 is still running
 manager-1  | failed to start daemon, ensure docker is not running or delete /var/run/docker.pid: process with PID 1 is still running
-worker1-1  | failed to start daemon, ensure docker is not running or delete /var/run/docker.pid: process with PID 1 is still running
-worker2-1 exited with code 1
-worker1-1 exited with code 1
+worker-1   | failed to start daemon, ensure docker is not running or delete /var/run/docker.pid: process with PID 1 is still running
+worker-2 exited with code 1
+worker-1 exited with code 1
 manager-1 exited with code 1
 dependency failed to start: container test-setup-manager-1 exited (1)
 ```
@@ -49,7 +52,7 @@ Wait ~10–20 seconds for the Swarm to bootstrap (manager + workers join).
 
 Check containers:
 ```bash
-docker compose ps manager worker1 worker2
+docker compose ps manager worker
 ```
 
 Create a Docker context pointing to the manager API on 22375:
@@ -70,7 +73,7 @@ docker --context swarmcli info | sed -n '/Swarm:/,/ClusterID/p'
 docker --context swarmcli node ls
 ```
 
-You should see **Swarm: active** and three nodes (1 manager, 2 workers).
+You should see **Swarm: active** and as many nodes as you scaled `worker` to, plus the manager.
 
 ---
 
@@ -154,7 +157,7 @@ docker compose up -d
   ```bash
   docker compose --project-name test-setup up -d
   ```
-  Then your containers will be `test-manager-1`, `test-worker1-1`, etc.
+  Then your containers will be `test-manager-1`, `test-worker-1`, `test-worker-2`, etc.
 
 - To point the CLI directly without creating a context (temporary):
   ```bash
@@ -167,9 +170,8 @@ docker compose up -d
 ## What’s included
 
 - **manager**: DinD with Docker API published on **22375/tcp** (localhost)
-- **worker1**, **worker2**: DinD workers joining the Swarm
+- **worker**: DinD worker, scaled to as many replicas as you ask for. Each replica waits for the join token and joins the Swarm itself, which is why there is no `worker*-join` sidecar and no per-worker named volume — replicas of one service would share it, and two dockerds on one graph directory is a corrupted store
 - **swarm-init**: one-shot helper to initialize the manager and generate a join token
-- **worker*-join**: one-shot helpers to join the workers
 
 ---
 

--- a/test-setup/docker-compose.yml
+++ b/test-setup/docker-compose.yml
@@ -90,19 +90,36 @@ services:
       net.ipv4.ip_forward: 1
       net.ipv4.conf.all.route_localnet: 1
     command:
-      [
-        "sh","-c",
-        "apk add --no-cache ca-certificates >/dev/null 2>&1 || true; \
-         update-ca-certificates || true; \
-         ( until docker info >/dev/null 2>&1; do sleep 1; done; \
-           until [ -s /shared/worker_token ]; do sleep 1; done; \
-           docker swarm leave >/dev/null 2>&1 || true; \
-           docker swarm join --token \"$(cat /shared/worker_token)\" manager:2377 \
-         ) & \
-         exec dockerd \
-           --host=tcp://0.0.0.0:2375 \
-           --host=unix:///var/run/docker.sock"
-      ]
+      - sh
+      - -c
+      # A block scalar rather than the one-line flow form the other services
+      # use: the join is a sequence with two waits and a retry, and it has to
+      # stay readable. Every step announces itself, because a silent step that
+      # never finishes is indistinguishable from one that never started —
+      # `testenv.sh` dumps this log when the join gate times out.
+      - |
+        apk add --no-cache ca-certificates >/dev/null 2>&1 || true
+        update-ca-certificates || true
+        (
+          # Explicit: this half of the container talks to the daemon the next
+          # line starts, never to a host inherited from the image or the env.
+          export DOCKER_HOST=unix:///var/run/docker.sock
+          echo 'swarm-join: waiting for the local daemon'
+          until docker info >/dev/null 2>&1; do sleep 1; done
+          echo 'swarm-join: waiting for the join token'
+          until [ -s /shared/worker_token ]; do sleep 1; done
+          echo 'swarm-join: joining'
+          # Leave first, in case this replica reused a volume carrying state
+          # from an earlier swarm; retry until the daemon actually reports
+          # membership, so a manager that is not accepting joins yet is a
+          # delay rather than a permanent single-node degrade.
+          docker swarm leave >/dev/null 2>&1 || true
+          until docker info 2>/dev/null | grep -q 'Swarm: active'; do
+            docker swarm join --token "$(cat /shared/worker_token)" manager:2377 || sleep 2
+          done
+          echo 'swarm-join: joined'
+        ) &
+        exec dockerd --host=tcp://0.0.0.0:2375 --host=unix:///var/run/docker.sock
     volumes:
       - /var/lib/docker
       - shared:/shared

--- a/test-setup/docker-compose.yml
+++ b/test-setup/docker-compose.yml
@@ -64,8 +64,23 @@ services:
          tail -f /dev/null"
       ]
 
-  # ===== Worker #1 (dockerd-in-docker) =====
-  worker1:
+  # ===== Workers (dockerd-in-docker) =====
+  #
+  # One service scaled to as many replicas as the run asks for: `testenv.sh
+  # up` passes `--scale worker=$((NODES - 1))`, so the size of the swarm is a
+  # knob rather than a fixed pair of services.
+  #
+  # Each replica joins the swarm itself instead of being joined by a
+  # `worker<i>-join` sidecar. A sidecar cannot survive scaling: every replica
+  # of it would resolve the `worker` DNS name round-robin, so several would
+  # join whichever daemon answered first and the rest of the swarm would never
+  # be joined at all.
+  #
+  # /var/lib/docker is anonymous rather than a named volume for the same
+  # reason — replicas of one service share a named volume, and two dockerds on
+  # one graph directory is a corrupted store. `compose down -v` removes
+  # anonymous volumes too, so teardown is unchanged.
+  worker:
     image: docker:29-dind
     privileged: true
     environment:
@@ -79,108 +94,31 @@ services:
         "sh","-c",
         "apk add --no-cache ca-certificates >/dev/null 2>&1 || true; \
          update-ca-certificates || true; \
+         ( until docker info >/dev/null 2>&1; do sleep 1; done; \
+           until [ -s /shared/worker_token ]; do sleep 1; done; \
+           docker swarm leave >/dev/null 2>&1 || true; \
+           docker swarm join --token \"$(cat /shared/worker_token)\" manager:2377 \
+         ) & \
          exec dockerd \
            --host=tcp://0.0.0.0:2375 \
            --host=unix:///var/run/docker.sock"
       ]
     volumes:
-      - worker1-data:/var/lib/docker
+      - /var/lib/docker
       - shared:/shared
       - ../.devcontainer/certs:/usr/local/share/ca-certificates:ro
     networks:
-      swarmnet:
-        aliases: [worker1]
+      - swarmnet
     healthcheck:
       test: ["CMD-SHELL", "docker -H localhost:2375 info >/dev/null 2>&1"]
       interval: 2s
       timeout: 2s
       retries: 60
       start_period: 2s
-
-  # Joins worker1 to the Swarm
-  worker1-join:
-    image: docker:29
-    depends_on:
-      worker1:
-        condition: service_healthy
-      swarm-init:
-        condition: service_started
-    environment:
-      DOCKER_HOST: tcp://worker1:2375
-    volumes:
-      - shared:/shared
-    networks:
-      - swarmnet
-    command:
-      [
-        "sh","-exc",
-        "until [ -s /shared/worker_token ]; do sleep 1; done; \
-         docker swarm leave >/dev/null 2>&1 || true; \
-         docker swarm join --token \"$(cat /shared/worker_token)\" manager:2377; \
-         tail -f /dev/null"
-      ]
-
-  # ===== Worker #2 (dockerd-in-docker) =====
-  worker2:
-    image: docker:29-dind
-    privileged: true
-    environment:
-      DOCKER_TLS_CERTDIR:
-      <<: *proxy_env
-    sysctls:
-      net.ipv4.ip_forward: 1
-      net.ipv4.conf.all.route_localnet: 1
-    command:
-      [
-        "sh","-c",
-        "apk add --no-cache ca-certificates >/dev/null 2>&1 || true; \
-         update-ca-certificates || true; \
-         exec dockerd \
-           --host=tcp://0.0.0.0:2375 \
-           --host=unix:///var/run/docker.sock"
-      ]
-    volumes:
-      - worker2-data:/var/lib/docker
-      - shared:/shared
-      - ../.devcontainer/certs:/usr/local/share/ca-certificates:ro
-    networks:
-      swarmnet:
-        aliases: [worker2]
-    healthcheck:
-      test: ["CMD-SHELL", "docker -H localhost:2375 info >/dev/null 2>&1"]
-      interval: 2s
-      timeout: 2s
-      retries: 60
-      start_period: 2s
-
-  # Joins worker2 to the Swarm
-  worker2-join:
-    image: docker:29
-    depends_on:
-      worker2:
-        condition: service_healthy
-      swarm-init:
-        condition: service_started
-    environment:
-      DOCKER_HOST: tcp://worker2:2375
-    volumes:
-      - shared:/shared
-    networks:
-      - swarmnet
-    command:
-      [
-        "sh","-exc",
-        "until [ -s /shared/worker_token ]; do sleep 1; done; \
-         docker swarm leave >/dev/null 2>&1 || true; \
-         docker swarm join --token \"$(cat /shared/worker_token)\" manager:2377; \
-         tail -f /dev/null"
-      ]
 
 networks:
   swarmnet:
 
 volumes:
   manager-data:
-  worker1-data:
-  worker2-data:
   shared:

--- a/test-setup/testenv.sh
+++ b/test-setup/testenv.sh
@@ -101,6 +101,10 @@ wait_for_workers() {
   done
   err "Only ${ready:-0}/${expected} worker node(s) Ready after $((retries * wait_sec))s. Swarm state:"
   docker -H "$MANAGER_HOST" node ls >&2 || true
+  # Each replica joins the swarm itself, so the reason it did not is in its
+  # own log and nowhere else — `node ls` above can only report the absence.
+  err "Worker logs:"
+  $DOCKER_COMPOSE logs --tail=40 worker >&2 || true
   exit 1
 }
 

--- a/test-setup/testenv.sh
+++ b/test-setup/testenv.sh
@@ -10,6 +10,12 @@ MANAGER_HOST="tcp://localhost:22375"
 KEEP="${KEEP:-0}"
 FOLLOW="${FOLLOW:-0}"
 SERVICE="${SERVICE:-}"
+# How big a swarm to start, counted the way the Docker API counts it: the
+# manager plus every worker, which is also the number a licence's node
+# allowance is compared against. 3 is the topology this file has always
+# brought up (1 manager + 2 workers), so leaving NODES unset changes nothing.
+# `worker` is a single scaled compose service, so any N >= 1 works.
+NODES="${NODES:-3}"
 DOCKER_COMPOSE="docker compose -f $COMPOSE_FILE"
 CONTEXT_NAME="swarmcli"
 
@@ -55,26 +61,26 @@ wait_for_manager() {
 
 # Wait until every worker DinD node has joined the swarm and reports Ready.
 #
-# The compose file declares a manager + N `worker<i>-join` containers that run
-# `docker swarm join`. Those joins are asynchronous: before this gate, `up`
-# returned as soon as the manager API was reachable, so `deploy` (worker image
-# distribution) and the integration tests frequently ran against an
-# effectively single-node swarm, so worker-placement tests had nothing to
-# exercise. Blocking here makes the
-# swarm match its declared topology so those tests are real, not skipped.
+# Each `worker` replica joins the swarm itself, and that join is asynchronous:
+# before this gate, `up` returned as soon as the manager API was reachable, so
+# `deploy` (worker image distribution) and the integration tests frequently ran
+# against an effectively single-node swarm, so worker-placement tests had
+# nothing to exercise. Blocking here makes the swarm match the topology that
+# was asked for, so those tests are real, not skipped.
 #
-# Expected worker count is derived from the compose file (one per
-# `worker<i>-join` service) so it stays correct if the topology changes.
+# Expected worker count is NODES minus the manager — the same number cmd_up
+# scales the `worker` service to, so the gate and the topology cannot drift.
 # `SKIP_WORKER_WAIT=1` bypasses the gate for deliberately single-node local
-# runs. A worker that never joins becomes a loud, diagnosable failure here
-# rather than a silent single-node degrade later.
+# runs, and `EXPECT_WORKERS` pins it for a trimmed topology. A worker that
+# never joins becomes a loud, diagnosable failure here rather than a silent
+# single-node degrade later.
 wait_for_workers() {
   if [ "${SKIP_WORKER_WAIT:-0}" = "1" ]; then
     warn "SKIP_WORKER_WAIT=1: not waiting for worker nodes (single-node run)"
     return
   fi
   local expected
-  expected="${EXPECT_WORKERS:-$(grep -cE '^[[:space:]]{2}worker[0-9]+-join:' "$COMPOSE_FILE")}"
+  expected="${EXPECT_WORKERS:-$((NODES - 1))}"
   if [ "$expected" -eq 0 ]; then
     return
   fi
@@ -127,10 +133,16 @@ cleanup_port() {
 # === Commands ==============================================================
 
 cmd_up() {
+  if ! [[ "$NODES" =~ ^[1-9][0-9]*$ ]]; then
+    err "NODES must be a positive integer (got '$NODES'). It counts the whole"
+    err "swarm, manager included, so NODES=1 is a manager on its own."
+    exit 1
+  fi
+
   cleanup_port  # <<< ensure old manager gone
 
-  info "🚀 Starting multinode Swarm environment..."
-  $DOCKER_COMPOSE up -d
+  info "🚀 Starting Swarm environment: ${NODES} node(s) (1 manager + $((NODES - 1)) worker(s))..."
+  $DOCKER_COMPOSE up -d --scale "worker=$((NODES - 1))"
   $DOCKER_COMPOSE ps
 
   info "🔧 Ensuring Docker context..."

--- a/test-setup/testenv.sh
+++ b/test-setup/testenv.sh
@@ -104,7 +104,7 @@ wait_for_workers() {
   # Each replica joins the swarm itself, so the reason it did not is in its
   # own log and nowhere else — `node ls` above can only report the absence.
   err "Worker logs:"
-  $DOCKER_COMPOSE logs --tail=40 worker >&2 || true
+  $DOCKER_COMPOSE logs --tail=200 worker >&2 || true
   exit 1
 }
 


### PR DESCRIPTION
## What

`test-setup/docker-compose.yml` declared `worker1` and `worker2`, each with its own named volume, network alias and `worker<i>-join` sidecar. The swarm was three nodes and could not be anything else.

`worker` is now **one service**, and `testenv.sh up` scales it:

```bash
bash test-setup/testenv.sh up            # 3 nodes — 1 manager + 2 workers, as before
NODES=5 bash test-setup/testenv.sh up    # 5 nodes — 1 manager + 4 workers
NODES=1 bash test-setup/testenv.sh up    # manager on its own
docker compose -f test-setup/docker-compose.yml up -d --scale worker=4   # by hand
```

`NODES` counts the **whole swarm, manager included** — the number `docker info` reports. `wait_for_workers` derives its expectation from the same `NODES` instead of counting `worker<i>-join:` lines in the compose file, so the gate and the topology cannot drift apart. `EXPECT_WORKERS` and `SKIP_WORKER_WAIT=1` keep working unchanged.

## Why

Eldara-Tech/swarmcli-be#434 wants to vary the node count to exercise a licence's node allowance, which is compared against the node count the manager reports. A swarm of fixed size cannot reach that comparison at all.

## Two details the scaling forced

Both are commented in the compose file:

- **Each replica joins the swarm itself** rather than being joined by a sidecar. A scaled sidecar cannot work: every replica of it would resolve the `worker` DNS name round-robin, so several would pile onto whichever daemon answered first and the rest of the swarm would never be joined.
- **`/var/lib/docker` is an anonymous volume**, not a named one. Replicas of one service *share* a named volume, and two dockerds on one graph directory is a corrupted store. `compose down -v` removes anonymous volumes too, so teardown is unchanged.

## The first attempt failed, and why the join looks the way it does

The first CI run started both replicas, started both daemons, and joined neither — with **no trace in the container logs of why**, because every step of the join was silent and the gate only printed `node ls`, which can report absence and nothing else. The join also ran exactly once, inheriting the old sidecar's assumption that a `depends_on: service_healthy` gate had already made a single attempt safe. Nothing gates it now.

So three things changed together (b9a0f1e… `da5d00e`): every step announces itself, the client target is set explicitly (`DOCKER_HOST=unix:///var/run/docker.sock`) rather than inherited from the image or the environment, and the join **retries until the daemon reports membership**.

**Which of the three was load-bearing was not isolated** — the run went green with all three in place and the passing run does not dump worker logs. The retry is the part that matters going forward regardless: a manager not yet accepting joins is now a delay rather than a permanent single-node degrade, and the marker lines mean a step that never finishes is distinguishable from one that never started.

`testenv.sh` now dumps `compose logs --tail=200 worker` when the gate times out. That dump is what diagnosed this, and it is the reason the gate is no longer a dead end.

## Blast radius

Nothing addresses a worker by its compose name. `swarmcli-be/test-setup/build-cache.sh` finds workers through `docker node inspect … .Status.Addr`, so image distribution already scales to any N. A repo-wide grep for `worker1`/`worker2`/`worker*-join` across all six repos found only this file, its README, and two workflow comments — all updated here. `swarmcli-cd` does not use this compose file.

The default is unchanged: unset `NODES` is 3, which is `--scale worker=2`, which is the topology this file has always started. The one behaviour change is a bare `docker compose up` with no `--scale`, which now gives 1 worker instead of 2; the README states this and shows the flag.

## Verification

**CI, on this branch:** `Run integration tests`, `Run locked-swarm integration test` and `Run ssh-context integration test` all pass. Both replicas join in 13s (`All 2 worker node(s) joined and Ready`). swarmcli-be#441 validates the same compose through `Depends-On` and is green too.

**CI exercises `NODES=3` only** — the default. Higher counts are not run anywhere. What carries the extrapolation is that the only N-dependent pieces are `--scale worker=N-1` (compose's own feature), `wait_for_workers` expecting `N-1` (arithmetic), and a join that is replica-agnostic — and that last one, the only part that could plausibly break at higher N, is exactly what two *independent* replicas of one service joining demonstrates.

**Locally** (no Docker daemon in the authoring environment):

- `docker compose config` parses the file and renders the worker command to exactly the intended script.
- That script passes `sh -n` and `bash -n`, and was **run end to end against a stub `docker`** that fails `info` twice, then fails the first `swarm join` and succeeds on the second: the markers print in order, both waits terminate, the retry recovers, and the loop exits on `Swarm: active`.
- `--scale worker=<n>` resolves the service pre-daemon for n in 0, 4 — and `--scale worker1=4` now correctly fails `no such service`, which is what proves the check is real.
- `bash -n` and `shellcheck -x` on `testenv.sh`: clean, no new findings.
- Merged with swarmcli-be's `docker-compose.agent.yml` overlay, `config` resolves and the manager still publishes 22375 and 2376.

`deploy.replicas: 2` was considered, to keep a bare `compose up` at two workers. It was left out deliberately: I could not verify locally that `--scale` overrides it rather than the reverse, and that failure mode would silently pin the swarm at 3 nodes while reporting N.

Refs: Eldara-Tech/swarmcli-be#434
