### PR TITLE
test(testenv): a teardown that leaves nothing behind, and a join token that cannot go stale

### DIFF
--- a/test-setup/docker-compose.yml
+++ b/test-setup/docker-compose.yml
@@ -28,7 +28,6 @@ services:
       - "22375:2375"                     # expose manager Docker API to host
     volumes:
       - manager-data:/var/lib/docker
-      - shared:/shared
       - ../.devcontainer/certs:/usr/local/share/ca-certificates:ro
     networks:
       swarmnet:
@@ -41,7 +40,10 @@ services:
       start_period: 2s
 
 
-  # Initializes Swarm on manager and writes worker join token to the shared volume
+  # Initializes Swarm on the manager. It publishes nothing: each worker asks
+  # the manager for its own join token (see `worker`), so there is no token
+  # file, and no volume shared between services to carry one run's token into
+  # the next.
   swarm-init:
     image: docker:29
     depends_on:
@@ -49,8 +51,6 @@ services:
         condition: service_healthy
     environment:
       DOCKER_HOST: tcp://manager:2375
-    volumes:
-      - shared:/shared
     networks:
       - swarmnet
     command:
@@ -60,7 +60,6 @@ services:
          if ! docker info 2>/dev/null | grep -q 'Swarm: active'; then \
            docker swarm init --advertise-addr eth0; \
          fi; \
-         docker swarm join-token -q worker > /shared/worker_token; \
          tail -f /dev/null"
       ]
 
@@ -93,8 +92,8 @@ services:
       - sh
       - -c
       # A block scalar rather than the one-line flow form the other services
-      # use: the join is a sequence with two waits and a retry, and it has to
-      # stay readable. Every step announces itself, because a silent step that
+      # use: the join is a wait followed by a retry, and it has to stay
+      # readable. Every step announces itself, because a silent step that
       # never finishes is indistinguishable from one that never started —
       # `testenv.sh` dumps this log when the join gate times out.
       - |
@@ -106,23 +105,30 @@ services:
           export DOCKER_HOST=unix:///var/run/docker.sock
           echo 'swarm-join: waiting for the local daemon'
           until docker info >/dev/null 2>&1; do sleep 1; done
-          echo 'swarm-join: waiting for the join token'
-          until [ -s /shared/worker_token ]; do sleep 1; done
           echo 'swarm-join: joining'
           # Leave first, in case this replica reused a volume carrying state
           # from an earlier swarm; retry until the daemon actually reports
           # membership, so a manager that is not accepting joins yet is a
           # delay rather than a permanent single-node degrade.
+          #
+          # The token is fetched from the manager on every attempt rather than
+          # read from a file the two services share. A shared volume outlives
+          # the swarm that filled it — a teardown that cannot remove it hands
+          # the next run a token for a swarm that no longer exists — and it is
+          # a token for *this* manager or the attempt fails and retries. Before
+          # `swarm init` lands the fetch is empty and the join fails, which is
+          # the same delay as any other not-yet-ready manager.
           docker swarm leave >/dev/null 2>&1 || true
           until docker info 2>/dev/null | grep -q 'Swarm: active'; do
-            docker swarm join --token "$(cat /shared/worker_token)" manager:2377 || sleep 2
+            docker swarm join --token \
+              "$(docker -H tcp://manager:2375 swarm join-token -q worker 2>/dev/null)" \
+              manager:2377 || sleep 2
           done
           echo 'swarm-join: joined'
         ) &
         exec dockerd --host=tcp://0.0.0.0:2375 --host=unix:///var/run/docker.sock
     volumes:
       - /var/lib/docker
-      - shared:/shared
       - ../.devcontainer/certs:/usr/local/share/ca-certificates:ro
     networks:
       - swarmnet
@@ -138,4 +144,3 @@ networks:
 
 volumes:
   manager-data:
-  shared:

--- a/test-setup/testenv.sh
+++ b/test-setup/testenv.sh
@@ -146,7 +146,12 @@ cmd_up() {
   cleanup_port  # <<< ensure old manager gone
 
   info "🚀 Starting Swarm environment: ${NODES} node(s) (1 manager + $((NODES - 1)) worker(s))..."
-  $DOCKER_COMPOSE up -d --scale "worker=$((NODES - 1))"
+  # --remove-orphans: this project's service names are not stable across
+  # checkouts — the fixed worker1/worker2 pair became one scaled `worker`.
+  # Containers of a service this file no longer declares are left running
+  # otherwise, and they keep holding the `shared` volume, which is what makes
+  # a later `down -v` report it as still in use.
+  $DOCKER_COMPOSE up -d --remove-orphans --scale "worker=$((NODES - 1))"
   $DOCKER_COMPOSE ps
 
   info "🔧 Ensuring Docker context..."
@@ -231,8 +236,11 @@ cmd_down() {
   # Remove the stack (ignore errors if it doesn't exist)
   run_or_warn docker --context "$CONTEXT_NAME" stack rm demo
 
-  # Bring down compose services and volumes
-  run_or_warn $DOCKER_COMPOSE down -v
+  # Bring down compose services and volumes. --remove-orphans for the same
+  # reason cmd_up passes it: a container left over from an earlier service
+  # layout still references `shared`, and the volume removal fails with
+  # "Resource is still in use" while the teardown reports success.
+  run_or_warn $DOCKER_COMPOSE down -v --remove-orphans
 
   ok "Swarm environment torn down."
 }


### PR DESCRIPTION
`testenv.sh down` reported

```
! Volume test-setup_shared          Resource is still in use
```

with every container it had just removed reported as removed. The volume was
genuinely still referenced — by containers this file no longer declares.

#635 replaced `worker1`/`worker2` and their `worker<i>-join` sidecars with one
scaled `worker`, and **all four of the services it deleted mounted `shared`**.
Anything still running from an `up` before that pull is an orphan, and
`docker compose down` leaves containers for services not in the current file
alone unless asked otherwise — without printing anything. `manager` and
`swarm-init` kept their names, which is exactly why `manager-data` came away
cleanly in the same run and `shared` did not.

## Two changes

**`--remove-orphans` on both `up` and `down`.** The fix for the reported
symptom. Service names in this project are not stable across checkouts, and a
rename should not strand a container that holds a volume.

**The `shared` volume is gone.** It existed to carry one file — the worker join
token — from `swarm-init` to the workers, and a volume that outlives its swarm
hands the next run a token for a swarm that no longer exists. Clearing the
token at the start of `swarm-init` would not have fixed that: `swarm-init`
waits on `manager: service_healthy` and then `sleep 1` + `docker swarm init`,
so it publishes ~2–3s *after* a worker — which has no `depends_on` at all —
reaches the file. The clear would lose that race in the ordinary case.

Instead the worker asks the manager for the token on each join attempt, inside
the retry loop it already had:

```sh
until docker info 2>/dev/null | grep -q 'Swarm: active'; do
  docker swarm join --token \
    "$(docker -H tcp://manager:2375 swarm join-token -q worker 2>/dev/null)" \
    manager:2377 || sleep 2
done
```

The token is for *this* manager or the join fails and retries; before
`swarm init` lands the fetch is empty and the attempt is the same delay as any
other not-yet-ready manager. With the handshake gone the volume has no
remaining user, so it and four mounts leave the file with it. A volume that
does not exist cannot be still in use.

## Verification

No Docker daemon was available where this was written, so it is verified by
`docker compose config` rather than a run:

- `config --services` → `manager`, `swarm-init`, `worker` (unchanged, so
  `swarmcli-be`'s `^worker[0-9]*$` service probe and its
  `^  worker:$` shape check still match)
- `config --volumes` → `manager-data` only
- the rendered `worker` command matches the source; the `$$(…)` in `config`
  output is its own re-escaping, identical to what `$(cat /shared/worker_token)`
  rendered as before
- `grep shared test-setup/` finds only prose; `/shared` and `worker_token` had
  no reader anywhere else in either repo

Integration CI is the real check.

Reported as `swarmcli-be` issue 449.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K6rpsEukXUrSrzKepaexq3
