### PR TITLE
docs(license): say the key names an account, not a person

### DIFF
--- a/docs/license.md
+++ b/docs/license.md
@@ -24,7 +24,13 @@ step on top — never verification, and there is an offline path for both.
 
 What a key records about you:
 
-- **Who it is for** — your customer identifier.
+- **Who it is for** — an identifier for the *account* the key was issued to, not
+  for you personally. It is deliberately not your e-mail address: a key is
+  exportable by design and lives on your swarm, where anyone who can read a file
+  on a node can read every field listed here. Quote the [license
+  id](#license-id) rather than this when you contact support — it names one key
+  rather than one account. A key signed before this was settled may still carry
+  an address; the daily token refresh replaces it (see [Privacy](#privacy)).
 - **Which tier** — `be` (Business Edition), `free` or `trial`. All three grant
   the same feature set today, so the tier does not decide which features you
   get; it decides what surrounds the key. A `trial` and a `free` key must carry


### PR DESCRIPTION
`docs/license.md` lists what a key records about you, and the first entry was *"**Who it is for** — your customer identifier."* A reader holding a key could not tell from that whether it holds their e-mail address. For the last week it did: swarmcli-website#129 signed the account's address into `customer_id`, and swarmcli-website!278 takes it back out in favour of the account id.

A key is exportable by design and lives on the customer's swarm, so every field in that list is readable by anyone who can read a file on a node — a contractor, a colleague, whoever inherits the cluster. That is the fact the entry now states, along with what the identifier is, that older keys may still carry an address and how they stop carrying it (the daily token refresh), and a pointer to the licence id for support.

The **License id** section already said the other half of this — *"Quote it when you contact support. Your customer identifier names you, and a customer running three swarms holds three keys that differ only in which swarm they name"* — so no change was needed there; the two entries now agree.

Docs only. No code, no behaviour, nothing to verify beyond the prose.
