### PR TITLE
fix(docker): count only constraint-eligible nodes for a global service

### DIFF
--- a/docker/convergence.go
+++ b/docker/convergence.go
@@ -52,17 +52,33 @@ type ServiceConvergence struct {
 	NewestTaskAge time.Duration
 }
 
-// activeNodeIDs returns the nodes that can currently run tasks. A task pinned to
-// a node that is down never converges, so counting it in the denominator would
-// make a release hang until timeout for a reason no redeploy can fix.
-func activeNodeIDs(snap *SwarmSnapshot) map[string]struct{} {
-	active := make(map[string]struct{}, len(snap.Nodes))
+// schedulableNodes returns the nodes that can currently run tasks. A task pinned
+// to a node that is down never converges, so counting it in the denominator
+// would make a release hang until timeout for a reason no redeploy can fix.
+//
+// The predicate is swarmkit's own (orchestrator/global.updateNode): drained and
+// down, nothing else. A stricter one that also demanded Ready and Active split
+// the two halves of the ratio apart — a paused node's running task was counted
+// in the numerator while the node itself was dropped from the denominator, so a
+// healthy global service read 3/2.
+func schedulableNodes(snap *SwarmSnapshot) []swarm.Node {
+	out := make([]swarm.Node, 0, len(snap.Nodes))
 	for _, n := range snap.Nodes {
-		if n.Status.State == swarm.NodeStateReady && n.Spec.Availability == swarm.NodeAvailabilityActive {
-			active[n.ID] = struct{}{}
+		if n.Spec.Availability == swarm.NodeAvailabilityDrain || n.Status.State == swarm.NodeStateDown {
+			continue
 		}
+		out = append(out, n)
 	}
-	return active
+	return out
+}
+
+// nodeIDSet indexes nodes by ID, for callers filtering tasks by node.
+func nodeIDSet(nodes []swarm.Node) map[string]struct{} {
+	ids := make(map[string]struct{}, len(nodes))
+	for _, n := range nodes {
+		ids[n.ID] = struct{}{}
+	}
+	return ids
 }
 
 // LoadStackConvergence returns per-service convergence facts for a stack.
@@ -84,7 +100,8 @@ func LoadStackConvergence(stackName string) []ServiceConvergence {
 // so a caller polling one specific swarm for convergence does not read another
 // swarm's tasks out of the process-wide cache.
 func (snap *SwarmSnapshot) StackConvergence(stackName string) []ServiceConvergence {
-	active := activeNodeIDs(snap)
+	schedulable := schedulableNodes(snap)
+	active := nodeIDSet(schedulable)
 
 	var out []ServiceConvergence
 	for _, svc := range snap.Services {
@@ -133,7 +150,7 @@ func (snap *SwarmSnapshot) StackConvergence(stackName string) []ServiceConvergen
 			Running:       running,
 			Completed:     completed,
 			Job:           job,
-			Desired:       desiredOverActiveNodes(svc, len(active)),
+			Desired:       desiredOverNodes(svc, schedulable),
 			UpdateState:   updateState(svc),
 			Monitor:       monitorWindow(svc),
 			NewestTaskAge: ageSince(newest),
@@ -181,20 +198,25 @@ func isJobService(svc swarm.Service) bool {
 // DesiredReplicas is the service's target task count against this snapshot: the
 // declared replicas, or for a global service one per node that can currently run
 // one. Exported for callers outside this package that would otherwise duplicate
-// the mode switch and get the global case wrong (issue #480).
+// the mode switch and get the global case wrong (issues #480, #643).
 func (snap *SwarmSnapshot) DesiredReplicas(svc swarm.Service) int {
-	return desiredOverActiveNodes(svc, len(activeNodeIDs(snap)))
+	return desiredOverNodes(svc, schedulableNodes(snap))
 }
 
-// desiredOverActiveNodes is the target task count. For a global service that is
-// one per active node, so draining a node lowers the target rather than making
-// the service permanently short.
-func desiredOverActiveNodes(svc swarm.Service, activeNodes int) int {
+// desiredOverNodes is the target task count. For a global service that is one
+// per schedulable node the placement constraints admit, so draining a node
+// lowers the target rather than making the service permanently short, and a
+// service pinned to the managers is not measured against the workers too.
+//
+// A replicated service's declared count is its target wherever the replicas can
+// land, which is what swarm reports and what --wait must keep waiting for: a
+// constraint no node satisfies leaves it pending, not converged.
+func desiredOverNodes(svc swarm.Service, nodes []swarm.Node) int {
 	switch {
 	case svc.Spec.Mode.Replicated != nil && svc.Spec.Mode.Replicated.Replicas != nil:
 		return int(*svc.Spec.Mode.Replicated.Replicas)
 	case svc.Spec.Mode.Global != nil:
-		return activeNodes
+		return eligibleNodeCount(svc, nodes)
 	default:
 		return 1
 	}

--- a/docker/convergence_test.go
+++ b/docker/convergence_test.go
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package docker
+
+import (
+	"testing"
+
+	"github.com/docker/docker/api/types/swarm"
+	"github.com/stretchr/testify/require"
+)
+
+func globalSvcInStack(id, stack string, constraints ...string) swarm.Service {
+	svc := svcInStack(id, stack)
+	svc.Spec.Mode = swarm.ServiceMode{Global: &swarm.GlobalService{}}
+	if len(constraints) > 0 {
+		svc.Spec.TaskTemplate.Placement = &swarm.Placement{Constraints: constraints}
+	}
+	return svc
+}
+
+// --wait must not sit out its timeout on a global service that is already fully
+// deployed. Measuring it against the workers it is forbidden to run on made
+// every manager-pinned agent look permanently half-rolled-out (issue #643).
+func TestStackConvergenceGlobalHonoursPlacementConstraints(t *testing.T) {
+	mgr, wrk := readyNode("m1"), readyNode("w1")
+	mgr.Spec.Role, wrk.Spec.Role = swarm.NodeRoleManager, swarm.NodeRoleWorker
+
+	snap := &SwarmSnapshot{
+		Nodes:    []swarm.Node{mgr, wrk},
+		Services: []swarm.Service{globalSvcInStack("agent", "mystack", "node.role == manager")},
+		Tasks: []swarm.Task{
+			taskInState("agent", "m1", swarm.TaskStateRunning, swarm.TaskStateRunning),
+		},
+	}
+
+	conv := snap.StackConvergence("mystack")
+	require.Len(t, conv, 1)
+	require.Equal(t, 1, conv[0].Running)
+	require.Equal(t, 1, conv[0].Desired)
+}
+
+// Swarm keeps a paused node's tasks running, so both halves of the ratio must
+// count it. Dropping the node from the denominator while its task still counted
+// in the numerator reported 2/1.
+func TestStackConvergenceCountsPausedNodes(t *testing.T) {
+	paused := readyNode("n2")
+	paused.Spec.Availability = swarm.NodeAvailabilityPause
+
+	snap := &SwarmSnapshot{
+		Nodes:    []swarm.Node{readyNode("n1"), paused},
+		Services: []swarm.Service{globalSvcInStack("agent", "mystack")},
+		Tasks: []swarm.Task{
+			taskInState("agent", "n1", swarm.TaskStateRunning, swarm.TaskStateRunning),
+			taskInState("agent", "n2", swarm.TaskStateRunning, swarm.TaskStateRunning),
+		},
+	}
+
+	conv := snap.StackConvergence("mystack")
+	require.Len(t, conv, 1)
+	require.Equal(t, 2, conv[0].Running)
+	require.Equal(t, 2, conv[0].Desired)
+}
+
+// A drained node runs nothing and is not waited for.
+func TestStackConvergenceSkipsDrainedNodes(t *testing.T) {
+	drained := readyNode("n2")
+	drained.Spec.Availability = swarm.NodeAvailabilityDrain
+
+	snap := &SwarmSnapshot{
+		Nodes:    []swarm.Node{readyNode("n1"), drained},
+		Services: []swarm.Service{globalSvcInStack("agent", "mystack")},
+		Tasks: []swarm.Task{
+			taskInState("agent", "n1", swarm.TaskStateRunning, swarm.TaskStateRunning),
+			taskInState("agent", "n2", swarm.TaskStateRunning, swarm.TaskStateRunning),
+		},
+	}
+
+	conv := snap.StackConvergence("mystack")
+	require.Len(t, conv, 1)
+	require.Equal(t, 1, conv[0].Running, "a drained node's task is not waited for")
+	require.Equal(t, 1, conv[0].Desired)
+}

--- a/docker/placement.go
+++ b/docker/placement.go
@@ -1,0 +1,159 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package docker
+
+import (
+	"net"
+	"regexp"
+	"strings"
+
+	"github.com/docker/docker/api/types/swarm"
+)
+
+// Placement-constraint matching, ported from swarmkit's manager/constraint.
+//
+// A global service does not target every node: swarm's global orchestrator
+// creates one task per schedulable node that also satisfies the service's
+// placement constraints. Reporting the bare node count made a service pinned to
+// `node.role == manager` on a 3+3 swarm read 3/6 forever (issue #643).
+//
+// The port is deliberate rather than a dependency: swarmkit's constraint package
+// matches against its own protobuf node type, not the API's swarm.Node, and
+// pulling the module in for one file would drag grpc and raft behind it. Keeping
+// the semantics identical is therefore this file's job — including the parts
+// that look like quirks: matching is case-insensitive, an absent label matches
+// the empty string (so `!=` succeeds where `==` fails), and a key swarm does not
+// recognise matches nothing.
+
+const (
+	nodeLabelPrefix   = "node.labels."
+	engineLabelPrefix = "engine.labels."
+)
+
+var (
+	// constraintKey and constraintValue are swarmkit's own validation patterns.
+	// The value pattern excludes the characters reserved for current and future
+	// operators.
+	constraintKey   = regexp.MustCompile(`^(?i)[a-z_][a-z0-9\-_.]+$`)
+	constraintValue = regexp.MustCompile(`^(?i)[a-z0-9:\-_\s\.\*\(\)\?\+\[\]\\\^\$\|\/]+$`)
+)
+
+// nodeConstraint is one parsed `key == value` or `key != value` expression.
+type nodeConstraint struct {
+	key   string
+	exp   string
+	equal bool
+}
+
+// parseConstraints parses a service's placement constraints.
+//
+// It returns nil if any expression is malformed, matching swarmkit's Parse,
+// which discards the whole list on the first error. The daemon validates
+// constraints when the service is created, so an unparseable one cannot reach a
+// live service; the fallback is simply to filter nothing.
+func parseConstraints(exprs []string) []nodeConstraint {
+	out := make([]nodeConstraint, 0, len(exprs))
+	for _, e := range exprs {
+		c, ok := parseConstraint(e)
+		if !ok {
+			return nil
+		}
+		out = append(out, c)
+	}
+	return out
+}
+
+func parseConstraint(e string) (nodeConstraint, bool) {
+	for _, op := range []string{"==", "!="} {
+		if !strings.Contains(e, op) {
+			continue
+		}
+		parts := strings.SplitN(e, op, 2)
+		key := strings.TrimSpace(parts[0])
+		exp := strings.TrimSpace(parts[1])
+		if !constraintKey.MatchString(key) || !constraintValue.MatchString(exp) {
+			return nodeConstraint{}, false
+		}
+		return nodeConstraint{key: key, exp: exp, equal: op == "=="}, true
+	}
+	return nodeConstraint{}, false
+}
+
+// match reports whether the node's value for this constraint's key satisfies it.
+func (c nodeConstraint) match(what string) bool {
+	return strings.EqualFold(c.exp, what) == c.equal
+}
+
+// nodeMatches reports whether a node satisfies every constraint.
+func nodeMatches(constraints []nodeConstraint, n swarm.Node) bool {
+	for _, c := range constraints {
+		var ok bool
+		switch {
+		case strings.EqualFold(c.key, "node.id"):
+			ok = c.match(n.ID)
+		case strings.EqualFold(c.key, "node.hostname"):
+			ok = c.match(n.Description.Hostname)
+		case strings.EqualFold(c.key, "node.ip"):
+			ok = c.matchIP(n.Status.Addr)
+		case strings.EqualFold(c.key, "node.role"):
+			ok = c.match(string(n.Spec.Role))
+		case strings.EqualFold(c.key, "node.platform.os"):
+			ok = c.match(n.Description.Platform.OS)
+		case strings.EqualFold(c.key, "node.platform.arch"):
+			ok = c.match(n.Description.Platform.Architecture)
+		case hasPrefixFold(c.key, nodeLabelPrefix):
+			ok = c.match(n.Spec.Labels[c.key[len(nodeLabelPrefix):]])
+		case hasPrefixFold(c.key, engineLabelPrefix):
+			ok = c.match(n.Description.Engine.Labels[c.key[len(engineLabelPrefix):]])
+		default:
+			// A key swarm cannot interpret schedules nothing, so neither
+			// operator can be satisfied.
+			return false
+		}
+		if !ok {
+			return false
+		}
+	}
+	return true
+}
+
+// matchIP compares against a single address or a CIDR subnet. A malformed
+// expression matches nothing, whichever operator it carries.
+func (c nodeConstraint) matchIP(addr string) bool {
+	nodeIP := net.ParseIP(addr)
+	if ip := net.ParseIP(c.exp); ip != nil {
+		return ip.Equal(nodeIP) == c.equal
+	}
+	if _, subnet, err := net.ParseCIDR(c.exp); err == nil {
+		return subnet.Contains(nodeIP) == c.equal
+	}
+	return false
+}
+
+// hasPrefixFold is strings.HasPrefix with the case-insensitivity swarmkit
+// applies to constraint keys. The key must be longer than the prefix: a bare
+// "node.labels." names no label.
+func hasPrefixFold(key, prefix string) bool {
+	return len(key) > len(prefix) && strings.EqualFold(key[:len(prefix)], prefix)
+}
+
+// eligibleNodeCount is how many of the given nodes swarm would place a global
+// service's task on.
+func eligibleNodeCount(svc swarm.Service, nodes []swarm.Node) int {
+	pl := svc.Spec.TaskTemplate.Placement
+	if pl == nil || len(pl.Constraints) == 0 {
+		return len(nodes)
+	}
+	constraints := parseConstraints(pl.Constraints)
+	if constraints == nil {
+		return len(nodes)
+	}
+	count := 0
+	for _, n := range nodes {
+		if nodeMatches(constraints, n) {
+			count++
+		}
+	}
+	return count
+}

--- a/docker/placement_test.go
+++ b/docker/placement_test.go
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Eldara Tech
+
+package docker
+
+import (
+	"testing"
+
+	"github.com/docker/docker/api/types/swarm"
+	"github.com/stretchr/testify/require"
+)
+
+// constraintNode is a node carrying every field a constraint can read.
+func constraintNode() swarm.Node {
+	return swarm.Node{
+		ID: "abc123",
+		Spec: swarm.NodeSpec{
+			Annotations: swarm.Annotations{Labels: map[string]string{"az": "eu-1", "tier": "gold"}},
+			Role:        swarm.NodeRoleManager,
+		},
+		Description: swarm.NodeDescription{
+			Hostname: "mgr-1",
+			Platform: swarm.Platform{OS: "linux", Architecture: "x86_64"},
+			Engine:   swarm.EngineDescription{Labels: map[string]string{"gpu": "yes"}},
+		},
+		Status: swarm.NodeStatus{State: swarm.NodeStateReady, Addr: "10.0.1.7"},
+	}
+}
+
+func TestNodeMatches(t *testing.T) {
+	cases := []struct {
+		name       string
+		constraint string
+		want       bool
+	}{
+		{"id equal", "node.id == abc123", true},
+		{"id not equal", "node.id != abc123", false},
+		{"hostname equal", "node.hostname == mgr-1", true},
+		{"hostname other", "node.hostname == wrk-1", false},
+		{"role manager", "node.role == manager", true},
+		{"role worker", "node.role == worker", false},
+		{"role not worker", "node.role != worker", true},
+		{"os", "node.platform.os == linux", true},
+		{"arch", "node.platform.arch == x86_64", true},
+		{"arch mismatch", "node.platform.arch == arm64", false},
+		{"node label", "node.labels.az == eu-1", true},
+		{"node label mismatch", "node.labels.az == eu-2", false},
+		{"engine label", "engine.labels.gpu == yes", true},
+		{"ip literal", "node.ip == 10.0.1.7", true},
+		{"ip literal mismatch", "node.ip == 10.0.1.8", false},
+		{"ip subnet", "node.ip == 10.0.1.0/24", true},
+		{"ip outside subnet", "node.ip == 10.0.2.0/24", false},
+		{"ip not in subnet", "node.ip != 10.0.2.0/24", true},
+
+		// Values are compared case-insensitively, so a constraint written
+		// against a differently-cased hostname still schedules.
+		{"case insensitive value", "node.hostname == MGR-1", true},
+
+		// An absent label is the empty string: == cannot match it, != always
+		// can. This is what lets `node.labels.foo != bar` schedule everywhere
+		// rather than nowhere.
+		{"absent label equal", "node.labels.missing == x", false},
+		{"absent label not equal", "node.labels.missing != x", true},
+
+		// Swarm schedules nothing for a key it cannot interpret, so neither
+		// operator is satisfiable.
+		{"unknown key equal", "node.zone == eu-1", false},
+		{"unknown key not equal", "node.zone != eu-1", false},
+
+		// A bare prefix names no label and is not a key swarm knows.
+		{"bare label prefix", "node.labels. == x", false},
+
+		// A malformed address matches nothing whichever operator it carries.
+		{"malformed ip", "node.ip == not-an-ip", false},
+		{"malformed ip negated", "node.ip != not-an-ip", false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cs := parseConstraints([]string{tc.constraint})
+			require.NotNil(t, cs, "constraint should parse")
+			require.Equal(t, tc.want, nodeMatches(cs, constraintNode()))
+		})
+	}
+}
+
+// Every constraint must hold, not just one.
+func TestNodeMatches_AllConstraintsMustHold(t *testing.T) {
+	n := constraintNode()
+	require.True(t, nodeMatches(parseConstraints([]string{"node.role == manager", "node.labels.tier == gold"}), n))
+	require.False(t, nodeMatches(parseConstraints([]string{"node.role == manager", "node.labels.tier == bronze"}), n))
+}
+
+func TestNodeMatches_NoConstraints(t *testing.T) {
+	require.True(t, nodeMatches(nil, constraintNode()))
+}
+
+func TestParseConstraints_SpacingIsOptional(t *testing.T) {
+	spaced := parseConstraints([]string{"node.role == manager"})
+	tight := parseConstraints([]string{"node.role==manager"})
+	require.Equal(t, spaced, tight)
+}
+
+// One malformed expression discards the whole list, as swarmkit's parser does.
+// The daemon rejects these at service-create time, so the fallback only decides
+// what an impossible input degrades to: filtering nothing.
+func TestParseConstraints_RejectsMalformed(t *testing.T) {
+	for _, expr := range []string{"node.role manager", "node.role > manager", "== manager", "1bad == x"} {
+		require.Nil(t, parseConstraints([]string{expr}), expr)
+	}
+	require.Nil(t, parseConstraints([]string{"node.role == manager", "node.role manager"}))
+}
+
+func TestEligibleNodeCount(t *testing.T) {
+	mgr, wrk := constraintNode(), constraintNode()
+	wrk.ID, wrk.Spec.Role = "wrk1", swarm.NodeRoleWorker
+	nodes := []swarm.Node{mgr, wrk}
+
+	global := func(constraints ...string) swarm.Service {
+		svc := swarm.Service{Spec: swarm.ServiceSpec{Mode: swarm.ServiceMode{Global: &swarm.GlobalService{}}}}
+		if len(constraints) > 0 {
+			svc.Spec.TaskTemplate.Placement = &swarm.Placement{Constraints: constraints}
+		}
+		return svc
+	}
+
+	require.Equal(t, 2, eligibleNodeCount(global(), nodes))
+	require.Equal(t, 1, eligibleNodeCount(global("node.role == manager"), nodes))
+	require.Equal(t, 0, eligibleNodeCount(global("node.labels.az == nowhere"), nodes))
+	require.Equal(t, 2, eligibleNodeCount(global("node.role manager"), nodes),
+		"an unparseable constraint must not shrink the count")
+
+	// A placement carrying only preferences constrains nothing.
+	prefs := global()
+	prefs.Spec.TaskTemplate.Placement = &swarm.Placement{
+		Preferences: []swarm.PlacementPreference{{Spread: &swarm.SpreadOver{SpreadDescriptor: "node.labels.az"}}},
+	}
+	require.Equal(t, 2, eligibleNodeCount(prefs, nodes))
+}

--- a/docker/service_test.go
+++ b/docker/service_test.go
@@ -88,6 +88,80 @@ func TestGetServiceStackAndDesired_GlobalIgnoresInactiveNodes(t *testing.T) {
 	require.Equal(t, 2, desired)
 }
 
+// A global service targets the nodes its placement constraints admit, not every
+// node in the swarm. A service pinned to the managers of a 3+3 swarm read 3/6
+// and never converged in the eyes of the UI (issue #643).
+func TestGetServiceStackAndDesired_GlobalHonoursPlacementConstraints(t *testing.T) {
+	svc := globalService("node.role == manager")
+	snap := &SwarmSnapshot{Nodes: []swarm.Node{
+		roleNode("m1", swarm.NodeRoleManager), roleNode("m2", swarm.NodeRoleManager), roleNode("m3", swarm.NodeRoleManager),
+		roleNode("w1", swarm.NodeRoleWorker), roleNode("w2", swarm.NodeRoleWorker), roleNode("w3", swarm.NodeRoleWorker),
+	}}
+	_, desired := getServiceStackAndDesired(svc, snap)
+	require.Equal(t, 3, desired)
+}
+
+// Constraints and node state compose: draining an eligible node lowers the
+// target, draining an ineligible one changes nothing.
+func TestGetServiceStackAndDesired_GlobalConstrainedAndDrained(t *testing.T) {
+	drained := roleNode("m2", swarm.NodeRoleManager)
+	drained.Spec.Availability = swarm.NodeAvailabilityDrain
+	snap := &SwarmSnapshot{Nodes: []swarm.Node{
+		roleNode("m1", swarm.NodeRoleManager), drained, roleNode("w1", swarm.NodeRoleWorker),
+	}}
+	_, desired := getServiceStackAndDesired(globalService("node.role == manager"), snap)
+	require.Equal(t, 1, desired)
+}
+
+// A constraint no node satisfies means swarm wants zero tasks, and the services
+// view renders a zero target as "—" rather than a false shortfall.
+func TestGetServiceStackAndDesired_GlobalUnsatisfiableConstraint(t *testing.T) {
+	snap := &SwarmSnapshot{Nodes: []swarm.Node{activeNode("n1"), activeNode("n2")}}
+	_, desired := getServiceStackAndDesired(globalService("node.labels.absent == true"), snap)
+	require.Equal(t, 0, desired)
+}
+
+// A replicated service's declared count is its target wherever the replicas can
+// land. Filtering it by constraints would report an unschedulable service as
+// converged — the opposite of what --wait must do.
+func TestGetServiceStackAndDesired_ReplicatedIgnoresConstraints(t *testing.T) {
+	three := uint64(3)
+	svc := swarm.Service{Spec: swarm.ServiceSpec{
+		Mode:         swarm.ServiceMode{Replicated: &swarm.ReplicatedService{Replicas: &three}},
+		TaskTemplate: swarm.TaskSpec{Placement: &swarm.Placement{Constraints: []string{"node.labels.absent == true"}}},
+	}}
+	snap := &SwarmSnapshot{Nodes: []swarm.Node{activeNode("n1"), activeNode("n2")}}
+	_, desired := getServiceStackAndDesired(svc, snap)
+	require.Equal(t, 3, desired)
+}
+
+// Swarm keeps a paused node's global task running, so the node belongs in the
+// denominator its task is counted against. Excluding it read 3/2.
+func TestGetServiceStackAndDesired_GlobalCountsPausedNodes(t *testing.T) {
+	paused := activeNode("n2")
+	paused.Spec.Availability = swarm.NodeAvailabilityPause
+	snap := &SwarmSnapshot{Nodes: []swarm.Node{activeNode("n1"), paused}}
+	_, desired := getServiceStackAndDesired(globalService(), snap)
+	require.Equal(t, 2, desired)
+}
+
+func globalService(constraints ...string) swarm.Service {
+	svc := swarm.Service{Spec: swarm.ServiceSpec{
+		Annotations: swarm.Annotations{Labels: map[string]string{"com.docker.stack.namespace": "mystack"}},
+		Mode:        swarm.ServiceMode{Global: &swarm.GlobalService{}},
+	}}
+	if len(constraints) > 0 {
+		svc.Spec.TaskTemplate.Placement = &swarm.Placement{Constraints: constraints}
+	}
+	return svc
+}
+
+func roleNode(id string, role swarm.NodeRole) swarm.Node {
+	n := activeNode(id)
+	n.Spec.Role = role
+	return n
+}
+
 func activeNode(id string) swarm.Node {
 	return swarm.Node{
 		ID:     id,

--- a/views/stacks/update.go
+++ b/views/stacks/update.go
@@ -1285,13 +1285,11 @@ func (m *Model) setStacks(stacks []docker.StackEntry) {
 					svcToStack[svc.ID] = stackName
 				}
 			}
-			desired := 1
-			if svc.Spec.Mode.Replicated != nil && svc.Spec.Mode.Replicated.Replicas != nil {
-				desired = int(*svc.Spec.Mode.Replicated.Replicas)
-			} else if svc.Spec.Mode.Global != nil {
-				desired = len(snap.Nodes)
-			}
-			svcDesired[svc.ID] = desired
+			// Shared with the loaders rather than duplicated: counting every
+			// node as a global service's target painted an error badge on a
+			// healthy service for as long as one node stayed drained, and on
+			// every service pinned by a placement constraint (issues #480, #643).
+			svcDesired[svc.ID] = snap.DesiredReplicas(svc)
 			// Initialize svcRunning with 0 for all services
 			svcRunning[svc.ID] = 0
 		}


### PR DESCRIPTION
Fixes #643.

A global service's target count was the whole active node count, ignoring `TaskTemplate.Placement.Constraints`. A service pinned to `node.role == manager` on a 3+3 swarm read `3/6` and never looked converged — in the REPLICAS column, in the services and stacks error badges, and in `--wait`.

Swarm's global orchestrator filters twice: drop drained and down nodes, then `constraint.NodeMatches`. SwarmCLI implemented the first half only.

### Choices

**Ported swarmkit's constraint matcher instead of depending on it.** Its `manager/constraint` package matches against swarmkit's protobuf node type, not the API's `swarm.Node`, and the module drags grpc and raft behind it. `docker/placement.go` keeps the semantics exactly, including the parts that look like quirks: case-insensitive comparison, an absent label matching the empty string, and an unrecognised key matching no node. All keys are covered — `node.id`, `node.hostname`, `node.ip` (address or CIDR), `node.role`, `node.platform.os`, `node.platform.arch`, `node.labels.*`, `engine.labels.*` — so counts agree with `docker service ls`.

**Computed locally rather than reading `ServiceStatus.DesiredTasks` from the daemon.** That field counts tasks whose desired state is not Shutdown, so a downed node keeps counting for ~24h — which would undo #480 and hang `--wait` again.

**Replicated services are untouched.** A declared replica count is the target wherever the replicas can land. Filtering it would report an unschedulable service as converged, the opposite of what `--wait` is for.

**Widened the node predicate to swarm's own** — drained and down, nothing else, where SwarmCLI additionally demanded Ready and Active. The two halves of the ratio had come apart: a paused node's running task was counted in the numerator while the node was dropped from the denominator, so a healthy service read `3/2`.

**Deduplicated the stacks view.** It carried its own copy of the mode switch using `len(snap.Nodes)`, so it had this bug and #480's as well; it now calls the shared helper.

### Follow-up, not in this PR

`swarmcli-be/bootstrap/health.go` has the same duplicated switch and needs the same swap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EzRRCjxpsL5aCpomrcTCsA
